### PR TITLE
docs: codify manual repo governance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,21 @@
 
 ADAM-EDU se mantiene con un flujo estricto por pull request. `main` es la rama estable y nadie debe empujar cambios directos a esa rama.
 
+## Manual Governance
+
+Mientras GitHub no fuerce toda la proteccion de rama en este plan, el equipo adopta estas reglas como politica operativa:
+
+- si no hay PR, el cambio no existe
+- `main` no recibe pushes directos
+- el autor no mergea hasta revisar checks y contexto del cambio
+- el merge operativo es `Squash and merge`
+- los 5 checks requeridos son:
+  - `backend-test`
+  - `backend-typecheck`
+  - `frontend-build`
+  - `frontend-lint`
+  - `frontend-test`
+
 ## Flujo de trabajo
 
 1. Crea una rama desde `main`.
@@ -43,3 +58,10 @@ npm --prefix frontend run test
 - El cambio debe ser legible y acotado.
 - El PR debe explicar qué cambió, por qué cambió y cómo se validó.
 - Si cambias contratos, flujos o setup, actualiza también la documentación relevante.
+- Si el PR toca más de un subsistema, déjalo como draft hasta cerrar alcance y validación.
+
+## Permisos mínimos recomendados
+
+- colaboradores normales: `Write`
+- admins: solo quienes necesiten gestionar settings o secrets
+- agentes: trabajo por rama y PR, sin bypass sobre `main`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ No incluye runtime de estudiante, super admin, auth real ni despliegue cloud end
 
 Este repositorio evoluciona hoy como `ADAM-EDU`. El proyecto deriva del quickstart original de Gemini/LangGraph y conserva esa procedencia para fines de atribucion y trazabilidad, pero su desarrollo activo, gobernanza y flujo de colaboracion viven ya en esta linea de producto.
 
+## Working Agreement
+
+Mientras el repo opere sin enforcement completo de branch protection, `main` se trata como rama protegida por acuerdo operativo:
+
+- nadie empuja directo a `main`
+- todo cambio entra por pull request
+- un PR solo se mergea con los 5 checks de CI en verde
+- el merge operativo estandar es `Squash and merge`
+
+La referencia viva para estas reglas esta en `CONTRIBUTING.md` y `docs/repo-governance.md`.
+
 ## Alcance actual
 
 - `backend/src/case_generator/`: grafo LangGraph, prompts, schemas y servicios de authoring.

--- a/docs/repo-governance.md
+++ b/docs/repo-governance.md
@@ -1,0 +1,53 @@
+# Repository Governance
+
+`ADAM-EDU` opera hoy con gobernanza manual equivalente a una rama protegida, aunque GitHub no aplique todas las restricciones automáticamente en este plan.
+
+## Reglas operativas
+
+- `main` se considera rama protegida.
+- Nadie hace push directo a `main`.
+- Todo cambio entra por pull request.
+- Todo PR debe pasar estos checks antes de mergear:
+  - `backend-test`
+  - `backend-typecheck`
+  - `frontend-build`
+  - `frontend-lint`
+  - `frontend-test`
+- El mecanismo de merge por defecto es `Squash and merge`.
+- Si no hay PR, el cambio no existe.
+
+## Permisos recomendados
+
+- Developers humanos: `Write`
+- Administradores: solo quienes necesiten settings, teams o secrets
+- Agentes: rama + PR; nunca push directo a `main`
+
+## Metadata recomendada del repo
+
+Descripcion sugerida:
+
+`Teacher authoring and preview MVP for pedagogical business cases built on LangGraph.`
+
+Topics sugeridos:
+
+- `langgraph`
+- `fastapi`
+- `react`
+- `vite`
+- `education`
+
+## Labels base sugeridos
+
+- `bug`
+- `enhancement`
+- `dependencies`
+- `ci`
+- `docs`
+
+## Validación mínima por PR
+
+1. El cambio vive en una rama corta y temática.
+2. CI corre completo.
+3. El autor revisa el diff final antes del merge.
+4. El merge se hace por squash.
+5. La rama se elimina después del merge.


### PR DESCRIPTION
- Documenta la gobernanza manual del repo mientras main no puede protegerse completamente por plan.
- Incluye working agreement en README, reglas operativas en CONTRIBUTING y guía en docs/repo-governance.md.

## Summary

- What changed?
- Why was it necessary?

## Validation

- [ ] `uv run --directory backend pytest -q`
- [ ] `uv run --directory backend mypy src`
- [ ] `npm --prefix frontend run lint`
- [ ] `npm --prefix frontend run build`
- [ ] `npm --prefix frontend run test`

## Checklist

- [ ] Single-purpose PR
- [ ] No secrets added
- [ ] Docs updated if behavior or setup changed
- [ ] Ready for squash merge
