### PR TITLE
docs(devx): standardize local postgres port to 5434

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ docker compose up -d adam-edu-postgres
 Con el `docker-compose.yml` actual, los defaults locales quedan asi:
 
 - host: `localhost`
-- puerto: `5433`
+- puerto: `5434`
 - usuario: `postgres`
 - password: `postgres`
 - base: `postgres`
@@ -128,7 +128,7 @@ Con el `docker-compose.yml` actual, los defaults locales quedan asi:
 2. Completa al menos estas variables:
 
 ```env
-DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5433/postgres
+DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres
 GEMINI_API_KEY=tu_api_key
 ```
 
@@ -176,7 +176,7 @@ Servicios esperados:
 
 Puertos por defecto:
 
-- PostgreSQL: `localhost:5433`
+- PostgreSQL: `localhost:5434`
 - API: `localhost:8123`
 
 Notas:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,12 +16,12 @@ LANGSMITH_TRACING=false
 DB_USER=postgres
 DB_PASSWORD=postgres
 DB_HOST=localhost
-DB_PORT=5433
+DB_PORT=5434
 DB_NAME=postgres
 
 # DATABASE_URL - required by shared.database.Settings
 # Defaults below match the repo root docker-compose.yml.
-DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5433/postgres
+DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres
 
 # -- Connection Pooling -------------------------------------------
 # Use DB_MAX_OVERFLOW=2 on Cloud Run (ephemeral instances).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     container_name: adam-edu-postgres
     restart: unless-stopped
     ports:
-      - "${POSTGRES_HOST_PORT:-5433}:5432"
+      - "${POSTGRES_HOST_PORT:-5434}:5432"
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}


### PR DESCRIPTION
## Summary

- What changed?
- Why was it necessary?

## Validation

- [ ] `uv run --directory backend pytest -q`
- [ ] `uv run --directory backend mypy src`
- [ ] `npm --prefix frontend run lint`
- [ ] `npm --prefix frontend run build`
- [ ] `npm --prefix frontend run test`

## Checklist

- [ ] Single-purpose PR
- [ ] No secrets added
- [ ] Docs updated if behavior or setup changed
- [ ] Ready for squash merge
