### PR TITLE
chore(devx): repo-scoped orchestrator, subagents, and pinned gstack bootstrap

### DIFF
--- a/.agents/skills/adam-orchestrator/SKILL.md
+++ b/.agents/skills/adam-orchestrator/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: adam-orchestrator
+description: |
+  Shared workflow router for ADAM-EDU. Converts natural-language requests into the
+  right gstack sprint stage without making the user memorize skill names. Use when
+  the request is about planning, implementing, debugging, reviewing, QA, browser
+  testing, shipping, or release follow-through in this repo. Keep small read-only
+  questions inline when no workflow is needed.
+---
+
+# ADAM Orchestrator
+
+Use this as the first stop for substantial work in ADAM-EDU.
+
+## Goal
+
+Route by intent, not by command memorization. The user should be able to say:
+
+- "piensa esta idea"
+- "esto se rompio"
+- "revisame esta rama"
+- "haz QA de staging"
+- "dejalo listo para PR"
+
+and get the right workflow automatically.
+
+## Runtime expectations
+
+- This repo-scoped skill lives in `.agents/skills/adam-orchestrator/`.
+- Repo-scoped custom subagents live in `.codex/agents/`.
+- gstack is materialized locally by bootstrap into:
+  - `.agents/skills/gstack*` for Codex
+  - `.claude/skills/*` for Claude compatibility
+- If the local gstack runtime is missing, tell the user to run:
+  - `pwsh -File scripts/agents/bootstrap.ps1`
+  - or `./scripts/agents/bootstrap.sh`
+
+## Routing rules
+
+If the request is small, read-only, or purely explanatory, answer directly.
+
+If the request needs a workflow, route to one primary gstack stage:
+
+- Idea, brainstorming, "is this worth building", user problem framing:
+  - `office-hours`
+  - then `autoplan` or `plan-*` if the user wants the plan locked in
+- Product scope, ambition, prioritization:
+  - `plan-ceo-review`
+- Architecture, execution plan, tests, edge cases:
+  - `plan-eng-review`
+- Design system, visual exploration, mockups:
+  - `design-consultation`, `design-shotgun`, `plan-design-review`, `design-html`, `design-review`
+- Bug, regression, stack trace, broken behavior:
+  - `investigate`
+- Code review, diff review, pre-landing review:
+  - `review`
+- QA pass, browser verification, staging validation:
+  - `qa` or `qa-only`
+- Browser-heavy manual flows:
+  - `browse`, `connect-chrome`, `setup-browser-cookies`
+- Security review:
+  - `cso`
+- PR prep, release prep, deploy:
+  - `ship`
+  - then `land-and-deploy`, `canary`, `document-release` when the stage calls for it
+- Weekly summary or what shipped:
+  - `retro`
+
+## Pipeline defaults
+
+Prefer stage-based pipelines:
+
+- Think -> Plan -> Build -> Review -> Test -> Ship -> Reflect
+- Bug fix -> `investigate` -> implementation -> `review` -> `qa` -> `ship`
+- Feature release -> implementation -> `review` -> `qa` -> `ship`
+- Approved PR -> `land-and-deploy` -> `canary` -> `document-release`
+
+Do not make the user choose the skill unless the request is genuinely ambiguous.
+
+## Subagent policy
+
+One agent owns the branch and final decision path.
+
+If Codex custom subagents are available, use them only for bounded parallel sidecars:
+
+- `pr_explorer` for read-only code-path exploration before changes
+- `reviewer` for independent read-only review of correctness, security, and tests
+- `code_mapper` for read-only frontend/backend flow mapping before edits
+
+Do not use subagents for:
+
+- merge or deploy authority
+- scope decisions
+- conflicting writes in the same area
+- parallel edits in `backend/src/case_generator/**`
+
+## Repo policy reminders
+
+- Work on a branch, never directly on `main`.
+- Changes to agent tooling belong in dedicated `agent/...` PRs.
+- If setup, workflow, or contributor behavior changes, update `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and `CLAUDE.md` in the same change.

--- a/.agents/skills/adam-orchestrator/agents/openai.yaml
+++ b/.agents/skills/adam-orchestrator/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "adam-orchestrator"
+  short_description: "Route ADAM-EDU work by intent into the right gstack workflow."
+  default_prompt: "Use $adam-orchestrator to route this ADAM-EDU request into the right gstack workflow."
+policy:
+  allow_implicit_invocation: true

--- a/.codex/agents/code_mapper.toml
+++ b/.codex/agents/code_mapper.toml
@@ -1,0 +1,11 @@
+name = "code_mapper"
+description = "Read-only codebase explorer for locating the relevant frontend and backend code paths before edits."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Map the code that owns the requested flow or bug.
+Identify entry points, state transitions, data flow, and likely files before the worker starts editing.
+Stay read-only and return a concise map with file references.
+"""
+nickname_candidates = ["Maple", "Vector", "Trace"]

--- a/.codex/agents/pr_explorer.toml
+++ b/.codex/agents/pr_explorer.toml
@@ -1,0 +1,12 @@
+name = "pr_explorer"
+description = "Read-only codebase explorer for gathering evidence before changes are proposed."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Stay in exploration mode.
+Trace the real execution path, cite files and symbols, and avoid proposing fixes unless the parent agent asks for them.
+Prefer fast search and targeted file reads over broad scans.
+Do not edit files.
+"""
+nickname_candidates = ["Atlas", "Delta", "Echo"]

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,12 @@
+name = "reviewer"
+description = "PR reviewer focused on correctness, security, and missing tests."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Review code like an owner.
+Prioritize correctness, security, behavior regressions, and missing test coverage.
+Lead with concrete findings, include reproduction steps when possible, and avoid style-only comments unless they hide a real bug.
+Do not edit files.
+"""
+nickname_candidates = ["Iris", "Beacon", "Northstar"]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -201,8 +201,15 @@ cython_debug/
 
 backend/.langgraph_api
 backend/.data/
-.claude/
 .python-version
 backend/.python-version
 skills-lock.json
-.agents/
+.claude/
+.agents/*
+!.agents/skills/
+.agents/skills/*
+!.agents/skills/adam-orchestrator/
+!.agents/skills/adam-orchestrator/**
+.codex/*
+!.codex/agents/
+!.codex/agents/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,35 @@ This repository does not currently include a student runtime, full authenticatio
 - `docs/repo-governance.md`: repository governance and merge policy
 - `CLAUDE.md`: equivalent agent guidance for Claude-oriented tooling
 
+## Shared Agent Tooling
+
+- This repo is Codex-first. Claude remains a supported compatibility path, but it does not define the canonical repo layout.
+- The repo-scoped routing skill lives in `.agents/skills/adam-orchestrator/`.
+- Repo-scoped custom subagents live in `.codex/agents/`.
+- `scripts/agents/gstack.lock.json` pins the upstream gstack repository, ref, commit, and version used by the team.
+- `.agents/skills/gstack*` and `.claude/skills/*` are generated local runtimes. Keep them out of git and rebuild them with:
+  - `pwsh -File scripts/agents/bootstrap.ps1`
+  - or `./scripts/agents/bootstrap.sh`
+- Changes to agent tooling belong in dedicated `agent/...` branches and PRs.
+- If agent tooling changes, update `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and `CLAUDE.md` in the same PR.
+
+## Skill Routing
+
+- For substantial implementation, debugging, review, QA, release, ideation, design, or security work, invoke `adam-orchestrator` first.
+- `adam-orchestrator` routes the request into the right gstack workflow. Do not make the user memorize individual skills.
+- Small read-only questions, code explanations, and narrow factual requests can be answered directly without a workflow.
+- Dispatch defaults:
+  - ideas and brainstorming -> `office-hours`, then `autoplan` or `plan-*`
+  - bugs, errors, regressions -> `investigate`
+  - review of a diff, branch, or PR -> `review`
+  - QA or staging verification -> `qa` or `qa-only`
+  - release preparation -> `ship`, then `land-and-deploy`, `canary`, `document-release`
+  - visual work -> `design-*`
+  - security review -> `cso`
+  - browser-heavy QA -> `browse`, `connect-chrome`, `setup-browser-cookies`
+- One agent owns the branch and final decision path. Use repo-scoped subagents only for bounded read-only sidecars such as `pr_explorer`, `reviewer`, `code_mapper`, independent report-only QA, benchmark, read-only exploration, or post-ship docs.
+- Do not use subagents for merge or deploy authority, scope decisions, conflicting writes, or parallel edits in `backend/src/case_generator/**`.
+
 ## Architecture Boundaries
 
 - `backend/src/case_generator/` owns authoring business logic, prompts, schemas, and graph execution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,43 @@ This repository does not currently publish a student runtime, full authenticatio
 - Default merge mode is `Squash and merge`.
 - If a change affects setup, contracts, workflows, or contributor expectations, update the relevant documentation in the same change.
 
+## Shared Agent Tooling
+
+- The repo-scoped routing skill lives in `.agents/skills/adam-orchestrator/`.
+- Repo-scoped custom subagents live in `.codex/agents/`.
+- `scripts/agents/gstack.lock.json` pins the upstream gstack repository, ref, commit, and version used by the team.
+- `.agents/skills/gstack*` and `.claude/skills/*` are generated local runtimes. Rebuild them with:
+  - `pwsh -File scripts/agents/bootstrap.ps1`
+  - or `./scripts/agents/bootstrap.sh`
+- Changes to agent tooling belong in dedicated `agent/...` branches and PRs.
+- If agent tooling changes, update `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and `CLAUDE.md` in the same PR.
+
+## gstack
+
+Use the repo-driven gstack runtime materialized from the pinned lock in `scripts/agents/gstack.lock.json`.
+
+- This repo is Codex-first. Claude support is kept as a compatible bootstrap path, not as the canonical source-of-truth layout.
+- Start substantial work through `adam-orchestrator`.
+- Let `adam-orchestrator` dispatch to the right gstack skill by intent.
+- Use gstack browser skills for browser-heavy QA and manual verification flows.
+
+## Skill routing
+
+- For implementation, debugging, review, QA, release, ideation, design, or security work, invoke `adam-orchestrator` first.
+- `adam-orchestrator` routes the request into the correct gstack workflow. Do not force the user to memorize slash commands.
+- Small read-only questions, code explanations, and narrow factual requests can be answered directly without invoking a workflow.
+- Dispatch defaults:
+  - ideas and brainstorming -> `office-hours`, then `autoplan` or `plan-*`
+  - bugs, errors, regressions -> `investigate`
+  - review of a diff, branch, or PR -> `review`
+  - QA or staging verification -> `qa` or `qa-only`
+  - release preparation -> `ship`, then `land-and-deploy`, `canary`, `document-release`
+  - visual work -> `design-*`
+  - security review -> `cso`
+  - browser-heavy QA -> `browse`, `connect-chrome`, `setup-browser-cookies`
+- One agent owns the branch and final decision path. Use repo-scoped subagents only for bounded read-only sidecars such as `pr_explorer`, `reviewer`, `code_mapper`, independent report-only QA, benchmark, read-only exploration, or post-ship docs.
+- Do not use subagents for merge or deploy authority, scope decisions, conflicting writes, or parallel edits in `backend/src/case_generator/**`.
+
 ## Domain Map
 
 - `backend/src/case_generator/`: authoring business logic, LangGraph orchestration, prompts, schemas, and downstream generation services.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ ADAM-EDU se mantiene con un flujo estricto por pull request. `main` es la rama e
 
 ## Manual Governance
 
-Mientras GitHub no fuerce toda la proteccion de rama en este plan, el equipo adopta estas reglas como politica operativa:
+Mientras GitHub no fuerce toda la proteccion de rama, el equipo adopta estas reglas como politica operativa:
 
 - si no hay PR, el cambio no existe
 - `main` no recibe pushes directos
@@ -25,10 +25,10 @@ Mientras GitHub no fuerce toda la proteccion de rama en este plan, el equipo ado
    - `fix/...`
    - `chore/...`
    - `agent/...`
-3. Mantén cada cambio enfocado. No mezcles funcionalidad, refactor y housekeeping en el mismo PR.
+3. Manten cada cambio enfocado. No mezcles funcionalidad, refactor y housekeeping en el mismo PR.
 4. Ejecuta los checks locales antes de abrir el PR.
 5. Abre un pull request.
-6. Usa `squash merge` cuando el PR esté aprobado y con checks verdes.
+6. Usa `squash merge` cuando el PR este aprobado y con checks verdes.
 
 ## Checks locales obligatorios
 
@@ -44,10 +44,35 @@ npm --prefix frontend run test
 
 - Los agentes trabajan solo por rama y PR.
 - Un agente no debe empujar directo a `main`.
-- Si el cambio toca más de un subsistema, el PR debe abrirse como draft.
-- Si un agente encuentra cambios ajenos en el árbol, debe preservarlos y trabajar alrededor de ellos.
+- Si el cambio toca mas de un subsistema, el PR debe abrirse como draft.
+- Si un agente encuentra cambios ajenos en el arbol, debe preservarlos y trabajar alrededor de ellos.
 
-- Tooling local de agentes, como `.agents/`, no debe commitearse como parte de cambios de producto salvo que el objetivo del PR sea mantener ese tooling deliberadamente.
+- La skill local del proyecto vive en `.agents/skills/adam-orchestrator/`.
+- Los subagentes repo-scoped viven en `.codex/agents/`.
+- El lock y bootstrap de gstack viven en `scripts/agents/`.
+- `.agents/skills/gstack*` y `.claude/skills/*` son runtimes locales generados. No deben commitearse.
+- Si cambias agent tooling, usa rama `agent/...` y PR dedicado.
+- Despues de tocar agent tooling, rerun `bootstrap` y valida el runtime local antes de abrir el PR.
+
+## Workflow compartido de agentes
+
+El equipo trabaja por etapas, no por skills sueltas:
+
+- Think -> Plan -> Build -> Review -> Test -> Ship -> Reflect
+
+El entrypoint por defecto para trabajo sustancial es `adam-orchestrator`. Esa skill decide si el request debe ir a `office-hours`, `investigate`, `review`, `qa`, `ship` u otra skill de `gstack`.
+
+Comandos de bootstrap:
+
+```powershell
+pwsh -File scripts/agents/bootstrap.ps1
+```
+
+```bash
+./scripts/agents/bootstrap.sh
+```
+
+Si una persona ya tiene una instalacion global personal de `gstack`, puede mantenerla como fallback, pero la referencia compartida del equipo sigue siendo el lock pinneado y la configuracion repo-scoped de este repo.
 
 ## Secretos y entorno
 
@@ -55,14 +80,14 @@ npm --prefix frontend run test
 - Usa `backend/.env.example` como plantilla.
 - Los valores reales deben vivir en entornos locales o en GitHub Actions Secrets.
 
-## Criterio de revisión
+## Criterio de revision
 
 - El cambio debe ser legible y acotado.
-- El PR debe explicar qué cambió, por qué cambió y cómo se validó.
-- Si cambias contratos, flujos o setup, actualiza también la documentación relevante.
-- Si el PR toca más de un subsistema, déjalo como draft hasta cerrar alcance y validación.
+- El PR debe explicar que cambio, por que cambio y como se valido.
+- Si cambias contratos, flujos o setup, actualiza tambien la documentacion relevante.
+- Si el PR toca mas de un subsistema, dejalo como draft hasta cerrar alcance y validacion.
 
-## Permisos mínimos recomendados
+## Permisos minimos recomendados
 
 - colaboradores normales: `Write`
 - admins: solo quienes necesiten gestionar settings o secrets

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ La zona funcional principal del generador vive en `backend/src/case_generator/` 
 
 ### Root hygiene
 
-La raiz del repo se mantiene minima y operativa. Artefactos locales como `.claude/`, `.vscode/`, `.mypy_cache/` y `.python-version` no forman parte del repo publicado y no deben usarse como documentacion del proyecto.
+La raiz del repo se mantiene minima y operativa. Artefactos locales generados como `.claude/`, `.vscode/`, `.mypy_cache/` y `.python-version` no forman parte del repo publicado. Las excepciones intencionales de agent tooling son `.agents/skills/adam-orchestrator/`, `.codex/agents/` y `scripts/agents/`.
 
 ## Mapa del backend
 
@@ -97,46 +97,69 @@ El flujo recomendado para contributors es:
 
 Ese flujo da mejor feedback para desarrollo diario, evita rebuilds del contenedor en cada cambio y deja el entorno mas facil de depurar.
 
-## Tooling opcional para Codex
+## Shared agent tooling
 
-La opcion recomendada para el equipo es instalar `gstack` globalmente por usuario, no dentro del repo del producto.
+El repo usa un workflow de agentes Codex-first. La superficie oficial compartida es pequena y auditable:
 
-Eso evita:
+- skill local del proyecto: `.agents/skills/adam-orchestrator/`
+- subagentes repo-scoped: `.codex/agents/`
+- bootstrap y lock pinneado de gstack: `scripts/agents/`
 
-- ensuciar `git status` del proyecto
-- diferencias de line endings o archivos regenerados por `setup`
-- binarios pesados o artefactos locales dentro del repo
-- ruido en PRs y revisiones
+Los runtimes generados siguen siendo locales:
 
-Instalacion recomendada en Windows:
+- Codex: `.agents/skills/gstack*`
+- Claude: `.claude/skills/*`
+
+No edites esos runtimes a mano. Rebuildlos con bootstrap.
+
+Bootstrap recomendado en Windows:
 
 ```powershell
-git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git $HOME\gstack
-cd $HOME\gstack
-& "C:\Program Files\Git\bin\bash.exe" -lc "./setup --host codex"
+pwsh -File scripts/agents/bootstrap.ps1
+pwsh -File scripts/agents/bootstrap.ps1 -RuntimeHost codex
+pwsh -File scripts/agents/bootstrap.ps1 -RuntimeHost claude
 ```
 
-Instalacion equivalente en entornos bash:
+Bootstrap equivalente en entornos bash:
 
 ```bash
-git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack
-cd ~/gstack
-./setup --host codex
+./scripts/agents/bootstrap.sh
+./scripts/agents/bootstrap.sh --host codex
+./scripts/agents/bootstrap.sh --host claude
 ```
 
-Luego reinicia la sesion de Codex para que redescubra las skills.
+`bootstrap`:
 
-En este entorno, las skills se invocan con prefijo `$`, por ejemplo:
+1. lee `scripts/agents/gstack.lock.json`
+2. clona o actualiza `gstack` al commit pinneado dentro del runtime ignorado por git
+3. ejecuta `setup` para el host correspondiente
+4. copia `adam-orchestrator` a `.claude/skills/adam-orchestrator` cuando se pide compatibilidad con Claude
 
-- `$gstack-review`
-- `$gstack-qa`
-- `$gstack-ship`
+El workflow esperado es natural-language-first. El equipo no deberia depender de memorizar skills una por una. El estandar oficial del repo es Codex-first, con Claude como compatibilidad derivada del mismo bootstrap. Para trabajo sustancial:
 
-Nota operativa:
+- el primer router es `adam-orchestrator`
+- `adam-orchestrator` despacha a la skill correcta de `gstack`
+- preguntas pequenas, read-only o puramente explicativas pueden resolverse inline
 
-- `.agents/` se trata como tooling local y no forma parte del flujo normal de versionado del repo.
-- No corras `setup` de `gstack` dentro del repo del producto como rutina diaria.
-- Si necesitas actualizar tu instalacion local de `gstack`, hazlo en tu copia global (`$HOME\gstack` o `~/gstack`), no en `ADAM-EDU`.
+Ver guia completa: [docs/agent-workflow.md](docs/agent-workflow.md)
+
+### Actualizar el pin de gstack
+
+Hazlo solo en un PR dedicado `agent/...`:
+
+```powershell
+pwsh -File scripts/agents/update-gstack-lock.ps1
+```
+
+```bash
+./scripts/agents/update-gstack-lock.sh
+```
+
+Luego rerun `bootstrap` y valida el runtime local.
+
+### Fallback individual
+
+Si alguien prefiere una instalacion global fuera del repo, puede mantenerla como entorno personal. No es la ruta principal del equipo y no sustituye el lock pinneado ni la skill local versionada en este repo.
 
 ### Prerrequisitos
 
@@ -252,7 +275,7 @@ docker compose down -v
 - `CORS_ALLOWED_ORIGIN`: origen extra permitido en produccion.
 - `STORYTELLER_MODEL`: override opcional del modelo usado por `/api/suggest`.
 
-Base de ejemplo: [backend/.env.example](C:/Users/Juan%20Camilo%20Dorado/Downloads/ADAM-EDU/backend/.env.example)
+Base de ejemplo: [backend/.env.example](backend/.env.example)
 
 ## Validacion
 
@@ -275,4 +298,5 @@ La suite default no debe tocar Gemini ni depender de side effects externos. Los 
 
 ## Para contributors
 
-Lee [CLAUDE.md](C:/Users/Juan%20Camilo%20Dorado/Downloads/ADAM-EDU/CLAUDE.md) antes de abrir cambios grandes.
+Lee [CLAUDE.md](CLAUDE.md) antes de abrir cambios grandes.
+Lee [docs/agent-workflow.md](docs/agent-workflow.md) si vas a trabajar con Codex, Claude o tooling de agentes.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,115 @@
+# Shared Agent Workflow
+
+ADAM-EDU uses a Codex-first agent workflow so the team can share the same routing contract without vendoring third-party runtime trees into the repository.
+
+## Official repo surfaces
+
+- `.agents/skills/adam-orchestrator/` is the repo-scoped skill that routes substantial work by intent.
+- `.codex/agents/` holds the repo-scoped custom subagents for bounded read-only sidecars.
+- `scripts/agents/gstack.lock.json` pins the upstream gstack repository, ref, commit, and version.
+- `scripts/agents/bootstrap.ps1` and `scripts/agents/bootstrap.sh` materialize the local runtime trees.
+
+The generated runtimes stay local and mostly ignored by git:
+
+- `.agents/skills/gstack*` for Codex
+- `.claude/skills/*` for Claude compatibility
+
+Do not hand-edit those generated trees. Rebuild them from the bootstrap scripts.
+
+## Bootstrap
+
+Windows PowerShell:
+
+```powershell
+pwsh -File scripts/agents/bootstrap.ps1
+pwsh -File scripts/agents/bootstrap.ps1 -RuntimeHost codex
+pwsh -File scripts/agents/bootstrap.ps1 -RuntimeHost claude
+```
+
+Bash:
+
+```bash
+./scripts/agents/bootstrap.sh
+./scripts/agents/bootstrap.sh --host codex
+./scripts/agents/bootstrap.sh --host claude
+```
+
+What bootstrap does:
+
+1. Reads the pinned gstack lock file.
+2. Clones or refreshes gstack into the ignored runtime tree for the selected host.
+3. Checks out the pinned commit.
+4. Runs upstream `setup` for that host.
+5. Copies `adam-orchestrator` into `.claude/skills/adam-orchestrator` when Claude compatibility is requested.
+
+On Windows, Git Bash is required because gstack `setup` is a bash entrypoint.
+
+## How the team should work
+
+Default workflow:
+
+- Think -> Plan -> Build -> Review -> Test -> Ship -> Reflect
+
+Natural-language-first examples:
+
+- "piensa esta idea" -> `office-hours`, then `autoplan` or `plan-*`
+- "esto se rompio" -> `investigate`
+- "revisame esta rama" -> `review`
+- "haz QA de staging" -> `qa` or `qa-only`
+- "dejalo listo para PR" -> `review` -> `qa` -> `ship`
+
+The user should not need to memorize gstack commands. `adam-orchestrator` is the first router for substantial work.
+
+## Manual escape hatches
+
+If someone wants an explicit entrypoint instead of natural language:
+
+- use `adam-orchestrator` to route the task
+- use the underlying gstack skill directly when the stage is already obvious
+
+Small read-only questions can still be answered inline without invoking a workflow.
+
+## Subagents
+
+One agent owns the branch and the final change set.
+
+Repo-scoped custom subagents:
+
+- `pr_explorer`: read-only code-path exploration before changes
+- `reviewer`: read-only review focused on correctness, security, and missing tests
+- `code_mapper`: read-only mapping of frontend/backend ownership before edits
+
+Allowed parallel sidecars:
+
+- independent review
+- report-only QA
+- benchmark or health checks
+- read-only exploration
+- post-ship documentation updates
+
+Do not parallelize:
+
+- merge or deploy authority
+- scope decisions
+- conflicting write scopes
+- sensitive edits in `backend/src/case_generator/**`
+
+## Updating the pinned gstack lock
+
+Use a dedicated `agent/...` branch and PR:
+
+```powershell
+pwsh -File scripts/agents/update-gstack-lock.ps1
+```
+
+```bash
+./scripts/agents/update-gstack-lock.sh
+```
+
+After updating:
+
+1. rerun bootstrap
+2. validate the local runtime
+3. update `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and `CLAUDE.md` in the same PR if the workflow contract changed
+
+Update when a new gstack version adds skills the team needs or fixes a bug that affects the workflow. There is no fixed cadence; the `agent/...` PR gate is the review mechanism.

--- a/docs/repo-governance.md
+++ b/docs/repo-governance.md
@@ -15,6 +15,8 @@
   - `frontend-test`
 - El mecanismo de merge por defecto es `Squash and merge`.
 - Si no hay PR, el cambio no existe.
+- Cambios a tooling compartido de agentes (`.agents/skills/adam-orchestrator/`, `.codex/agents/`, `scripts/agents/`) deben entrar por ramas `agent/...` y PR dedicado.
+- Los runtimes locales `.agents/skills/gstack*` y `.claude/skills/*` no forman parte del arbol versionado del producto.
 
 ## Permisos recomendados
 

--- a/scripts/agents/bootstrap.ps1
+++ b/scripts/agents/bootstrap.ps1
@@ -1,0 +1,223 @@
+param(
+    [ValidateSet("both", "codex", "claude")]
+    [string]$RuntimeHost = "both"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Require-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command not found: $Name"
+    }
+}
+
+function Get-BashPath {
+    $paths = @(
+        "C:\Program Files\Git\bin\bash.exe",
+        "C:\Program Files\Git\usr\bin\bash.exe"
+    )
+    $bashCommand = Get-Command bash -ErrorAction SilentlyContinue
+    if ($bashCommand) {
+        $paths += $bashCommand.Source
+    }
+
+    foreach ($candidate in $paths | Select-Object -Unique) {
+        if (-not $candidate -or -not (Test-Path -LiteralPath $candidate)) {
+            continue
+        }
+
+        try {
+            $probe = & $candidate -lc "printf ok" 2>$null
+            if ($LASTEXITCODE -eq 0 -and $probe -eq "ok") {
+                return $candidate
+            }
+        }
+        catch {
+            continue
+        }
+    }
+
+    throw "Git Bash is required on Windows to run gstack setup. Install Git for Windows or make bash available on PATH."
+}
+
+function Convert-ToGitBashPath {
+    param([Parameter(Mandatory = $true)][string]$WindowsPath)
+
+    $resolved = (Resolve-Path -LiteralPath $WindowsPath).Path
+    if ($resolved -notmatch '^(?<drive>[A-Za-z]):(?<rest>.*)$') {
+        throw "Cannot convert path for Git Bash: $WindowsPath"
+    }
+
+    $drive = $Matches.drive.ToLowerInvariant()
+    $rest = $Matches.rest -replace '\\', '/'
+    return "/$drive$rest"
+}
+
+function Remove-PathIfExists {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path -Recurse -Force
+    }
+}
+
+function Copy-Tree {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    Remove-PathIfExists -Path $Destination
+    $parent = Split-Path -Parent $Destination
+    if ($parent) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+
+    Copy-Item -LiteralPath $Source -Destination $Destination -Recurse -Force
+}
+
+function Test-GitCommitPresent {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryPath,
+        [Parameter(Mandatory = $true)][string]$Commit
+    )
+
+    & git -C $RepositoryPath rev-parse --verify "$Commit^{commit}" *> $null
+    return $LASTEXITCODE -eq 0
+}
+
+function Clone-GstackRepo {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryUrl,
+        [Parameter(Mandatory = $true)][string]$Ref,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    $parent = Split-Path -Parent $Destination
+    if ($parent) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+
+    & git clone --single-branch --branch $Ref --depth 1 $RepositoryUrl $Destination | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to clone gstack into $Destination"
+    }
+}
+
+function Ensure-GstackRepoAtCommit {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryUrl,
+        [Parameter(Mandatory = $true)][string]$Ref,
+        [Parameter(Mandatory = $true)][string]$Commit,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    $gitDir = Join-Path $Destination ".git"
+    if ((Test-Path -LiteralPath $Destination) -and -not (Test-Path -LiteralPath $gitDir)) {
+        Remove-PathIfExists -Path $Destination
+    }
+
+    if (-not (Test-Path -LiteralPath $gitDir)) {
+        Clone-GstackRepo -RepositoryUrl $RepositoryUrl -Ref $Ref -Destination $Destination
+    }
+    else {
+        $origin = (& git -C $Destination remote get-url origin 2>$null).Trim()
+        if ($LASTEXITCODE -ne 0 -or $origin -ne $RepositoryUrl) {
+            Remove-PathIfExists -Path $Destination
+            Clone-GstackRepo -RepositoryUrl $RepositoryUrl -Ref $Ref -Destination $Destination
+        }
+    }
+
+    $currentCommit = (& git -C $Destination rev-parse HEAD).Trim()
+    if ($currentCommit -ne $Commit) {
+        & git -C $Destination fetch --depth 1 origin $Ref | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to fetch gstack ref '$Ref'"
+        }
+
+        if (-not (Test-GitCommitPresent -RepositoryPath $Destination -Commit $Commit)) {
+            & git -C $Destination fetch --depth 1 origin $Commit | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to fetch pinned gstack commit '$Commit'"
+            }
+        }
+
+        & git -C $Destination checkout --force --detach $Commit | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to checkout pinned gstack commit '$Commit'"
+        }
+
+        & git -C $Destination clean -fdx | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to clean gstack runtime at $Destination"
+        }
+    }
+}
+
+function Clear-CodexRuntime {
+    param([Parameter(Mandatory = $true)][string]$SkillsRoot)
+
+    New-Item -ItemType Directory -Path $SkillsRoot -Force | Out-Null
+    Get-ChildItem -LiteralPath $SkillsRoot -Force -Filter "gstack-*" | ForEach-Object {
+        Remove-PathIfExists -Path $_.FullName
+    }
+}
+
+function Clear-ClaudeRuntime {
+    param([Parameter(Mandatory = $true)][string]$SkillsRoot)
+
+    Remove-PathIfExists -Path $SkillsRoot
+    New-Item -ItemType Directory -Path $SkillsRoot -Force | Out-Null
+}
+
+function Invoke-GstackSetup {
+    param(
+        [Parameter(Mandatory = $true)][string]$RuntimePath,
+        [Parameter(Mandatory = $true)][string]$TargetHost
+    )
+
+    $bashPath = Convert-ToGitBashPath -WindowsPath $RuntimePath
+    & $BashExe -lc "cd '$bashPath' && ./setup --host '$TargetHost'"
+    if ($LASTEXITCODE -ne 0) {
+        throw "gstack setup failed for host '$TargetHost'"
+    }
+}
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$LockPath = Join-Path $RepoRoot "scripts\agents\gstack.lock.json"
+$AdamSkillRoot = Join-Path $RepoRoot ".agents\skills\adam-orchestrator"
+$CodexSkillsRoot = Join-Path $RepoRoot ".agents\skills"
+$ClaudeSkillsRoot = Join-Path $RepoRoot ".claude\skills"
+
+Require-Command -Name "git"
+if (-not (Test-Path -LiteralPath $LockPath)) {
+    throw "gstack lock file not found at $LockPath"
+}
+if (-not (Test-Path -LiteralPath $AdamSkillRoot)) {
+    throw "Tracked adam-orchestrator skill not found at $AdamSkillRoot"
+}
+
+$Lock = Get-Content -LiteralPath $LockPath -Raw | ConvertFrom-Json
+$BashExe = Get-BashPath
+
+if ($RuntimeHost -in @("both", "codex")) {
+    Clear-CodexRuntime -SkillsRoot $CodexSkillsRoot
+    $codexGstackRoot = Join-Path $CodexSkillsRoot "gstack"
+    Ensure-GstackRepoAtCommit -RepositoryUrl $Lock.repository -Ref $Lock.ref -Commit $Lock.commit -Destination $codexGstackRoot
+    Invoke-GstackSetup -RuntimePath $codexGstackRoot -TargetHost "codex"
+}
+
+if ($RuntimeHost -in @("both", "claude")) {
+    Clear-ClaudeRuntime -SkillsRoot $ClaudeSkillsRoot
+    $claudeGstackRoot = Join-Path $ClaudeSkillsRoot "gstack"
+    Ensure-GstackRepoAtCommit -RepositoryUrl $Lock.repository -Ref $Lock.ref -Commit $Lock.commit -Destination $claudeGstackRoot
+    Invoke-GstackSetup -RuntimePath $claudeGstackRoot -TargetHost "claude"
+    Copy-Tree -Source $AdamSkillRoot -Destination (Join-Path $ClaudeSkillsRoot "adam-orchestrator")
+}
+
+Write-Host "Agent bootstrap complete."
+Write-Host "  repo root: $RepoRoot"
+Write-Host "  host(s):   $RuntimeHost"
+Write-Host "Restart Codex or Claude if the current session had already loaded skills."

--- a/scripts/agents/bootstrap.sh
+++ b/scripts/agents/bootstrap.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_host="both"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --host)
+      runtime_host="${2:-}"
+      shift 2
+      ;;
+    --host=*)
+      runtime_host="${1#--host=}"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$runtime_host" in
+  both|codex|claude) ;;
+  *)
+    echo "Invalid --host value: $runtime_host (expected both, codex, or claude)" >&2
+    exit 1
+    ;;
+esac
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Required command not found: $1" >&2
+    exit 1
+  }
+}
+
+json_value() {
+  local key="$1"
+  sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$LOCK_FILE" | head -n 1
+}
+
+remove_path_if_exists() {
+  local path="$1"
+  [ -e "$path" ] || [ -L "$path" ] || return 0
+  rm -rf "$path"
+}
+
+copy_tree() {
+  local source="$1"
+  local destination="$2"
+
+  remove_path_if_exists "$destination"
+  mkdir -p "$(dirname "$destination")"
+  cp -R "$source" "$destination"
+}
+
+clone_gstack_repo() {
+  local repository_url="$1"
+  local ref="$2"
+  local destination="$3"
+
+  mkdir -p "$(dirname "$destination")"
+  git clone --single-branch --branch "$ref" --depth 1 "$repository_url" "$destination" >/dev/null
+}
+
+ensure_gstack_repo_at_commit() {
+  local repository_url="$1"
+  local ref="$2"
+  local commit="$3"
+  local destination="$4"
+
+  if [ -e "$destination" ] && [ ! -d "$destination/.git" ]; then
+    remove_path_if_exists "$destination"
+  fi
+
+  if [ ! -d "$destination/.git" ]; then
+    clone_gstack_repo "$repository_url" "$ref" "$destination"
+  else
+    local origin
+    origin="$(git -C "$destination" remote get-url origin 2>/dev/null || true)"
+    if [ "$origin" != "$repository_url" ]; then
+      remove_path_if_exists "$destination"
+      clone_gstack_repo "$repository_url" "$ref" "$destination"
+    fi
+  fi
+
+  local current_commit
+  current_commit="$(git -C "$destination" rev-parse HEAD)"
+  if [ "$current_commit" != "$commit" ]; then
+    git -C "$destination" fetch --depth 1 origin "$ref" >/dev/null
+    if ! git -C "$destination" rev-parse --verify "${commit}^{commit}" >/dev/null 2>&1; then
+      git -C "$destination" fetch --depth 1 origin "$commit" >/dev/null
+    fi
+    git -C "$destination" checkout --force --detach "$commit" >/dev/null
+    git -C "$destination" clean -fdx >/dev/null
+  fi
+}
+
+clear_codex_runtime() {
+  local skills_root="$1"
+
+  mkdir -p "$skills_root"
+  shopt -s nullglob
+  for path in "$skills_root"/gstack-*; do
+    remove_path_if_exists "$path"
+  done
+  shopt -u nullglob
+}
+
+clear_claude_runtime() {
+  local skills_root="$1"
+
+  remove_path_if_exists "$skills_root"
+  mkdir -p "$skills_root"
+}
+
+invoke_gstack_setup() {
+  local runtime_path="$1"
+  local target_host="$2"
+
+  (
+    cd "$runtime_path"
+    ./setup --host "$target_host"
+  )
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LOCK_FILE="$REPO_ROOT/scripts/agents/gstack.lock.json"
+ADAM_SKILL_ROOT="$REPO_ROOT/.agents/skills/adam-orchestrator"
+CODEX_SKILLS_ROOT="$REPO_ROOT/.agents/skills"
+CLAUDE_SKILLS_ROOT="$REPO_ROOT/.claude/skills"
+
+require_command git
+
+if [ ! -f "$LOCK_FILE" ]; then
+  echo "gstack lock file not found at $LOCK_FILE" >&2
+  exit 1
+fi
+
+if [ ! -f "$ADAM_SKILL_ROOT/SKILL.md" ]; then
+  echo "Tracked adam-orchestrator skill not found at $ADAM_SKILL_ROOT" >&2
+  exit 1
+fi
+
+repository_url="$(json_value repository)"
+ref="$(json_value ref)"
+commit="$(json_value commit)"
+
+if [ "$runtime_host" = "both" ] || [ "$runtime_host" = "codex" ]; then
+  clear_codex_runtime "$CODEX_SKILLS_ROOT"
+  codex_gstack_root="$CODEX_SKILLS_ROOT/gstack"
+  ensure_gstack_repo_at_commit "$repository_url" "$ref" "$commit" "$codex_gstack_root"
+  invoke_gstack_setup "$codex_gstack_root" "codex"
+fi
+
+if [ "$runtime_host" = "both" ] || [ "$runtime_host" = "claude" ]; then
+  clear_claude_runtime "$CLAUDE_SKILLS_ROOT"
+  claude_gstack_root="$CLAUDE_SKILLS_ROOT/gstack"
+  ensure_gstack_repo_at_commit "$repository_url" "$ref" "$commit" "$claude_gstack_root"
+  invoke_gstack_setup "$claude_gstack_root" "claude"
+  copy_tree "$ADAM_SKILL_ROOT" "$CLAUDE_SKILLS_ROOT/adam-orchestrator"
+fi
+
+echo "Agent bootstrap complete."
+echo "  repo root: $REPO_ROOT"
+echo "  host(s):   $runtime_host"
+echo "Restart Codex or Claude if the current session had already loaded skills."

--- a/scripts/agents/gstack.lock.json
+++ b/scripts/agents/gstack.lock.json
@@ -1,0 +1,7 @@
+{
+  "repository": "https://github.com/garrytan/gstack.git",
+  "ref": "main",
+  "commit": "6169273d16b7ab8690943241fa802e5a1ca85305",
+  "version": "0.15.1.0",
+  "updated_utc": "2026-04-02T00:12:50.8470118Z"
+}

--- a/scripts/agents/update-gstack-lock.ps1
+++ b/scripts/agents/update-gstack-lock.ps1
@@ -1,0 +1,47 @@
+param(
+    [string]$RepositoryUrl = "https://github.com/garrytan/gstack.git",
+    [string]$Ref = "main"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$LockPath = Join-Path $RepoRoot "scripts\agents\gstack.lock.json"
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("adam-gstack-" + [guid]::NewGuid().ToString("N"))
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    throw "Required command not found: git"
+}
+
+try {
+    & git clone --single-branch --branch $Ref --depth 1 $RepositoryUrl $TempRoot | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to clone gstack from $RepositoryUrl"
+    }
+
+    $commit = (& git -C $TempRoot rev-parse HEAD).Trim()
+    $version = (Get-Content -LiteralPath (Join-Path $TempRoot "VERSION") -Raw).Trim()
+    $updatedUtc = (Get-Date).ToUniversalTime().ToString("o")
+
+    $lock = @"
+{
+  "repository": "$RepositoryUrl",
+  "ref": "$Ref",
+  "commit": "$commit",
+  "version": "$version",
+  "updated_utc": "$updatedUtc"
+}
+"@
+    Set-Content -LiteralPath $LockPath -Value $lock -NoNewline
+}
+finally {
+    if (Test-Path -LiteralPath $TempRoot) {
+        Remove-Item -LiteralPath $TempRoot -Recurse -Force
+    }
+}
+
+Write-Host "Pinned gstack lock updated."
+Write-Host "  repository: $RepositoryUrl"
+Write-Host "  ref:        $Ref"
+Write-Host "  lock:       $LockPath"
+Write-Host "Run bootstrap again before validating local runtimes."

--- a/scripts/agents/update-gstack-lock.sh
+++ b/scripts/agents/update-gstack-lock.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_url="${1:-https://github.com/garrytan/gstack.git}"
+ref="${2:-main}"
+
+command -v git >/dev/null 2>&1 || {
+  echo "Required command not found: git" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LOCK_FILE="$REPO_ROOT/scripts/agents/gstack.lock.json"
+TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/adam-gstack-XXXXXX")"
+
+cleanup() {
+  rm -rf "$TEMP_ROOT"
+}
+trap cleanup EXIT
+
+git clone --single-branch --branch "$ref" --depth 1 "$repository_url" "$TEMP_ROOT" >/dev/null
+commit="$(git -C "$TEMP_ROOT" rev-parse HEAD)"
+version="$(tr -d '\r\n' < "$TEMP_ROOT/VERSION")"
+updated_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+cat > "$LOCK_FILE" <<EOF
+{
+  "repository": "$repository_url",
+  "ref": "$ref",
+  "commit": "$commit",
+  "version": "$version",
+  "updated_utc": "$updated_utc"
+}
+EOF
+
+echo "Pinned gstack lock updated."
+echo "  repository: $repository_url"
+echo "  ref:        $ref"
+echo "  lock:       $LOCK_FILE"
+echo "Run bootstrap again before validating local runtimes."


### PR DESCRIPTION
## Summary

- Add `adam-orchestrator` skill as natural-language router for ADAM-EDU workflows
- Add read-only Codex subagents (`code_mapper`, `pr_explorer`, `reviewer`)
- Add `gstack.lock.json` + cross-platform bootstrap/update scripts (`ps1` + `sh`) to pin and share the same agent tooling version across the team
- Update `.gitignore` to track only orchestrator and subagent configs
- Add `.gitattributes` for LF line endings on shell scripts
- Update `README`, `AGENTS`, `CLAUDE`, `CONTRIBUTING`, `repo-governance` docs
- Add `docs/agent-workflow.md` with full team workflow guide

## Test plan

- [ ] Run `pwsh -File scripts/agents/bootstrap.ps1` on Windows — verify local gstack runtime materializes correctly
- [ ] Run `./scripts/agents/bootstrap.sh` on Unix — verify same outcome
- [ ] Verify `.agents/skills/adam-orchestrator/SKILL.md` is present after bootstrap
- [ ] Verify `.codex/agents/` subagent configs are present
- [ ] Confirm `scripts/agents/gstack.lock.json` pins the correct ref/commit
- [ ] Invoke `/adam-orchestrator` in Claude Code and confirm routing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)