### PR TITLE
feat: add issue 23 identity substrate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,14 @@ npm --prefix frontend run test
 npm --prefix frontend run build
 ```
 
+Issue 23 adds a migration test that creates and drops temporary databases. In the default
+local Docker Postgres this works with the `postgres` user. On other Postgres environments,
+the backend test suite now assumes `CREATE DATABASE` and `DROP DATABASE` privileges.
+
+Issue 23 also introduces `backend/sql/rls_policies.sql` as a separate artifact. Alembic
+does not apply that file. Treat it as an explicit secondary-RLS deployment step only for
+Supabase or another environment that exposes compatible Auth helpers like `auth.uid()`.
+
 ## Sensitive Areas
 
 - `backend/src/case_generator/**` is the most sensitive part of the repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,14 @@ Use the repo-driven gstack runtime materialized from the pinned lock in `scripts
 - Frontend tests: `npm --prefix frontend run test`
 - Frontend build: `npm --prefix frontend run build`
 
+Issue 23 adds a migration test that creates and drops temporary databases. In the default
+local Docker Postgres this works with the `postgres` user. On other Postgres environments,
+the backend test suite now assumes `CREATE DATABASE` and `DROP DATABASE` privileges.
+
+Issue 23 also introduces `backend/sql/rls_policies.sql` as a separate artifact. Alembic
+does not apply that file. Treat it as an explicit secondary-RLS deployment step only for
+Supabase or another environment that exposes compatible Auth helpers like `auth.uid()`.
+
 Only run live LLM tests explicitly:
 
 - `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,10 @@ Si una migracion nueva endurece contratos de identidad o esquema, no parchees da
 a mano para forzar que pase. Resetea la base local y vuelve a sembrarla antes de rerun
 `uv run --directory backend alembic upgrade head`.
 
+Si el cambio introduce SQL operativo fuera de Alembic, como `backend/sql/rls_policies.sql`,
+documenta explicitamente como y donde se aplica. No asumas que `alembic upgrade head`
+cubre artefactos SQL separados.
+
 ## Checks locales obligatorios
 
 ```powershell
@@ -43,6 +47,10 @@ npm --prefix frontend run lint
 npm --prefix frontend run build
 npm --prefix frontend run test
 ```
+
+Nota: la prueba de migracion del Issue 23 crea y elimina bases temporales. En el entorno
+local default eso funciona con el usuario `postgres`, pero en otros entornos necesitaras
+permisos `CREATE DATABASE` y `DROP DATABASE` para que `pytest` pase completo.
 
 ## Reglas para agentes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ Mientras GitHub no fuerce toda la proteccion de rama, el equipo adopta estas reg
 5. Abre un pull request.
 6. Usa `squash merge` cuando el PR este aprobado y con checks verdes.
 
+Si una migracion nueva endurece contratos de identidad o esquema, no parchees datos locales
+a mano para forzar que pase. Resetea la base local y vuelve a sembrarla antes de rerun
+`uv run --directory backend alembic upgrade head`.
+
 ## Checks locales obligatorios
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -272,11 +272,23 @@ docker compose down -v
 ## Variables de entorno
 
 - `DATABASE_URL`: DSN principal de PostgreSQL para `shared.database`.
+- `SUPABASE_URL`: metadata del proyecto Supabase usada desde la fase de auth substrate en adelante.
+- `SUPABASE_PROJECT_REF`: ref del proyecto Supabase para tooling y validaciones operativas de auth.
 - `GEMINI_API_KEY`: requerido para authoring real, `/api/suggest` y tests `live_llm`.
 - `CORS_ALLOWED_ORIGIN`: origen extra permitido en produccion.
 - `STORYTELLER_MODEL`: override opcional del modelo usado por `/api/suggest`.
 
 Base de ejemplo: [backend/.env.example](backend/.env.example)
+
+### Nota para Issue 23
+
+El sustrato de identidad de GitHub `#23` mantiene el bridge `users.id == auth.users.id`
+como contrato de datos, pero el entorno local actual sigue usando PostgreSQL por Docker,
+no Supabase Auth local. Eso significa:
+
+- valida esquema y migraciones localmente con PostgreSQL normal
+- valida bridge real contra `auth.users` solo cuando apuntes a Supabase alojado o a una futura ruta `supabase start`
+- si tu base local vieja todavia tiene IDs fake como `teacher-123`, reseteala y reseedala antes de correr la migracion de Issue 23
 
 ## Validacion
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ no Supabase Auth local. Eso significa:
 - valida esquema y migraciones localmente con PostgreSQL normal
 - valida bridge real contra `auth.users` solo cuando apuntes a Supabase alojado o a una futura ruta `supabase start`
 - si tu base local vieja todavia tiene IDs fake como `teacher-123`, reseteala y reseedala antes de correr la migracion de Issue 23
+- `backend/sql/rls_policies.sql` es un entregable separado de Alembic y no se aplica con `uv run alembic upgrade head`
+- esas policies dependen de `auth.uid()`, asi que solo deben aplicarse en Supabase o en un entorno local que realmente exponga el schema Auth compatible
 
 ## Validacion
 
@@ -304,6 +306,8 @@ no Supabase Auth local. Eso significa:
   `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q`
 
 La suite default no debe tocar Gemini ni depender de side effects externos. Los tests `live_llm` quedan aislados detras de `RUN_LIVE_LLM_TESTS=1`.
+
+La prueba de migracion de Issue 23 crea y elimina bases temporales para validar upgrade y downgrade de Alembic. Con los defaults locales funciona porque el usuario `postgres` tiene permisos amplios sobre el contenedor local. Si apuntas a otro Postgres, asegurate de tener permisos `CREATE DATABASE` y `DROP DATABASE` o esa prueba fallara aunque el codigo este bien.
 
 ## Nota historica
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,6 +36,11 @@ DB_POOL_RECYCLE=1800
 # production  -> Google Cloud Tasks (Cloud Run)
 ENVIRONMENT=development
 
+# -- Supabase metadata (Issue 23+ auth substrate scaffolding) -----
+# Optional for the current teacher-only MVP, required once auth work starts.
+SUPABASE_URL=
+SUPABASE_PROJECT_REF=
+
 # -- Google Cloud Tasks (required only when ENVIRONMENT=production)
 SERVICE_URL=
 CLOUD_TASKS_PROJECT=

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -50,6 +50,7 @@ uv run pytest -m live_llm -q
 - Keep `backend/.env.example` aligned with actual local defaults.
 - If a change affects setup or schema expectations, update `README.md` in the same PR.
 - Tests may bootstrap schema differently from the app runtime; do not treat that as permission to skip migrations in real app flows.
+- If a migration tightens identity-bridge assumptions, prefer reset/reseed of local data over hand-editing legacy rows to bypass the migration.
 
 ## Sensitive Areas
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -17,8 +17,10 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Set the SQLAlchemy URL from our application settings safely
-config.set_main_option("sqlalchemy.url", settings.database_url)
+# Allow tests to override the URL explicitly while keeping app settings as the default.
+configured_url = config.get_main_option("sqlalchemy.url")
+if not configured_url or configured_url == "driver://user:pass@localhost/dbname":
+    config.set_main_option("sqlalchemy.url", settings.database_url)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/backend/alembic/versions/4c8660e9e4d1_issue23_identity_substrate.py
+++ b/backend/alembic/versions/4c8660e9e4d1_issue23_identity_substrate.py
@@ -84,6 +84,12 @@ def upgrade() -> None:
     connection = op.get_bind()
     _normalize_roles(connection)
     _validate_legacy_bridge_ids(connection)
+    op.create_check_constraint("ck_users_id_auth_uuid", "users", f"id ~* '{UUID_TEXT_PATTERN}'")
+    op.create_check_constraint(
+        "ck_users_role",
+        "users",
+        "role IN ('teacher', 'student', 'university_admin')",
+    )
 
     op.create_table(
         "profiles",
@@ -192,6 +198,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade schema."""
+    op.drop_constraint("ck_users_role", "users", type_="check")
+    op.drop_constraint("ck_users_id_auth_uuid", "users", type_="check")
     op.drop_index("ix_course_memberships_membership_id", table_name="course_memberships")
     op.drop_index("ix_course_memberships_course_id", table_name="course_memberships")
     op.drop_table("course_memberships")

--- a/backend/alembic/versions/4c8660e9e4d1_issue23_identity_substrate.py
+++ b/backend/alembic/versions/4c8660e9e4d1_issue23_identity_substrate.py
@@ -1,0 +1,206 @@
+"""Issue 23 identity substrate
+
+Revision ID: 4c8660e9e4d1
+Revises: 1571dcf87c69
+Create Date: 2026-04-02 18:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "4c8660e9e4d1"
+down_revision: Union[str, Sequence[str], None] = "1571dcf87c69"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+UUID_TEXT_PATTERN = r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+
+
+def _normalize_roles(connection: sa.Connection) -> None:
+    """Normalize legacy role values before adding new auth-layer tables."""
+    connection.execute(
+        sa.text(
+            """
+            UPDATE users
+            SET role = CASE
+                WHEN lower(trim(role)) = 'teacher' THEN 'teacher'
+                WHEN lower(trim(role)) = 'student' THEN 'student'
+                WHEN replace(lower(trim(role)), ' ', '') IN ('universityadmin', 'university_admin')
+                    THEN 'university_admin'
+                ELSE role
+            END
+            """
+        )
+    )
+
+    unexpected_roles = connection.execute(
+        sa.text(
+            """
+            SELECT DISTINCT role
+            FROM users
+            WHERE role NOT IN ('teacher', 'student', 'university_admin')
+            ORDER BY role
+            """
+        )
+    ).scalars().all()
+    if unexpected_roles:
+        raise RuntimeError(
+            "Issue #23 cannot continue with unmapped legacy roles. "
+            f"Reset/reseed local data or map these roles first: {unexpected_roles}"
+        )
+
+
+def _validate_legacy_bridge_ids(connection: sa.Connection) -> None:
+    """Fail fast if legacy ids are not compatible with the auth bridge contract."""
+    invalid_ids = connection.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM users
+            WHERE id IS NOT NULL
+              AND id !~* :uuid_pattern
+            ORDER BY id
+            LIMIT 5
+            """
+        ),
+        {"uuid_pattern": UUID_TEXT_PATTERN},
+    ).scalars().all()
+    if invalid_ids:
+        raise RuntimeError(
+            "Issue #23 assumes reset/reseed of pre-auth local data. "
+            "Found legacy users.id values that are not auth-compatible UUID text: "
+            f"{invalid_ids}. Reset the local database and reseed with UUID ids before retrying."
+        )
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    connection = op.get_bind()
+    _normalize_roles(connection)
+    _validate_legacy_bridge_ids(connection)
+
+    op.create_table(
+        "profiles",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("full_name", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "memberships",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("user_id", sa.Text(), nullable=False),
+        sa.Column("university_id", sa.String(length=36), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("must_rotate_password", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("role IN ('teacher', 'student', 'university_admin')", name="ck_memberships_role"),
+        sa.CheckConstraint("status IN ('active', 'suspended')", name="ck_memberships_status"),
+        sa.ForeignKeyConstraint(["university_id"], ["tenants.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["profiles.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "university_id", "role", name="uix_membership_user_university_role"),
+    )
+    op.create_index("ix_memberships_user_id", "memberships", ["user_id"], unique=False)
+    op.create_index("ix_memberships_university_id", "memberships", ["university_id"], unique=False)
+
+    op.create_table(
+        "allowed_email_domains",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("university_id", sa.String(length=36), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["university_id"], ["tenants.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("university_id", "domain", name="uix_allowed_email_domain"),
+    )
+    op.create_index("ix_allowed_email_domains_university_id", "allowed_email_domains", ["university_id"], unique=False)
+
+    op.create_table(
+        "university_sso_configs",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("university_id", sa.String(length=36), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("azure_tenant_id", sa.Text(), nullable=False),
+        sa.Column("client_id", sa.Text(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("provider IN ('azure')", name="ck_university_sso_provider"),
+        sa.ForeignKeyConstraint(["university_id"], ["tenants.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("university_id", "provider", name="uix_university_sso_config"),
+    )
+
+    op.create_table(
+        "courses",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("university_id", sa.String(length=36), nullable=False),
+        sa.Column("teacher_membership_id", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["teacher_membership_id"], ["memberships.id"]),
+        sa.ForeignKeyConstraint(["university_id"], ["tenants.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "invites",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("token_hash", sa.Text(), nullable=False),
+        sa.Column("email", sa.Text(), nullable=False),
+        sa.Column("university_id", sa.String(length=36), nullable=False),
+        sa.Column("course_id", sa.Text(), nullable=True),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("role IN ('teacher', 'student')", name="ck_invites_role"),
+        sa.CheckConstraint("status IN ('pending', 'consumed', 'expired', 'revoked')", name="ck_invites_status"),
+        sa.CheckConstraint("role <> 'student' OR course_id IS NOT NULL", name="ck_invites_student_requires_course"),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"]),
+        sa.ForeignKeyConstraint(["university_id"], ["tenants.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash"),
+    )
+
+    op.create_table(
+        "course_memberships",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("course_id", sa.Text(), nullable=False),
+        sa.Column("membership_id", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"]),
+        sa.ForeignKeyConstraint(["membership_id"], ["memberships.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("course_id", "membership_id", name="uix_course_membership"),
+    )
+    op.create_index("ix_course_memberships_course_id", "course_memberships", ["course_id"], unique=False)
+    op.create_index("ix_course_memberships_membership_id", "course_memberships", ["membership_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_course_memberships_membership_id", table_name="course_memberships")
+    op.drop_index("ix_course_memberships_course_id", table_name="course_memberships")
+    op.drop_table("course_memberships")
+    op.drop_table("invites")
+    op.drop_table("courses")
+    op.drop_table("university_sso_configs")
+    op.drop_index("ix_allowed_email_domains_university_id", table_name="allowed_email_domains")
+    op.drop_table("allowed_email_domains")
+    op.drop_index("ix_memberships_university_id", table_name="memberships")
+    op.drop_index("ix_memberships_user_id", table_name="memberships")
+    op.drop_table("memberships")
+    op.drop_table("profiles")

--- a/backend/sql/rls_policies.sql
+++ b/backend/sql/rls_policies.sql
@@ -1,0 +1,59 @@
+-- Issue #23 secondary RLS policies.
+-- Backend SQLAlchemy remains the primary authorization boundary.
+-- Any invite token hash comparison performed outside SQL must use
+-- hmac.compare_digest() in the backend auth flows introduced after this issue.
+
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE courses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE course_memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE invites ENABLE ROW LEVEL SECURITY;
+ALTER TABLE allowed_email_domains ENABLE ROW LEVEL SECURITY;
+ALTER TABLE university_sso_configs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY profiles_self ON profiles
+  FOR ALL
+  USING (id = auth.uid()::text)
+  WITH CHECK (id = auth.uid()::text);
+
+CREATE POLICY memberships_self ON memberships
+  FOR SELECT
+  USING (user_id = auth.uid()::text);
+
+CREATE POLICY courses_by_university ON courses
+  FOR SELECT
+  USING (
+    university_id IN (
+      SELECT m.university_id
+      FROM memberships m
+      WHERE m.user_id = auth.uid()::text
+        AND m.status = 'active'
+    )
+  );
+
+CREATE POLICY course_memberships_self ON course_memberships
+  FOR SELECT
+  USING (
+    membership_id IN (
+      SELECT m.id
+      FROM memberships m
+      WHERE m.user_id = auth.uid()::text
+        AND m.status = 'active'
+    )
+  );
+
+-- Backend-managed tables stay deny-all from client-side access.
+CREATE POLICY deny_all ON invites
+  FOR ALL
+  USING (false)
+  WITH CHECK (false);
+
+CREATE POLICY deny_all ON allowed_email_domains
+  FOR ALL
+  USING (false)
+  WITH CHECK (false);
+
+CREATE POLICY deny_all ON university_sso_configs
+  FOR ALL
+  USING (false)
+  WITH CHECK (false);

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -116,7 +116,7 @@ def create_authoring_job(
             db.add(tenant)
             db.commit()
             db.refresh(tenant)
-        teacher = User(id=req.teacher_id, tenant_id=tenant.id, email=f"{req.teacher_id}@adam.edu", role="Teacher")
+        teacher = User(id=req.teacher_id, tenant_id=tenant.id, email=f"{req.teacher_id}@adam.edu", role="teacher")
         db.add(teacher)
         db.commit()
 

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -27,6 +27,17 @@ from shared.progress_bus import subscribe, unsubscribe
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def normalize_auth_user_id(raw_user_id: str) -> str:
+    """Reject legacy fake ids and keep auth-compatible UUID text canonical."""
+    try:
+        return str(uuid.UUID(raw_user_id))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="teacher_id must be a UUID string compatible with Supabase Auth",
+        ) from exc
+
 # Lifespan management
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -107,8 +118,10 @@ def create_authoring_job(
     Persists the Assignment and queued AuthoringJob, then schedules local
     background execution through AuthoringService.
     """
+    teacher_id = normalize_auth_user_id(req.teacher_id)
+
     # Resolve the teacher or create a local development record if missing.
-    teacher = db.query(User).filter(User.id == req.teacher_id).first()
+    teacher = db.query(User).filter(User.id == teacher_id).first()
     if not teacher:
         tenant = db.query(Tenant).first()
         if not tenant:
@@ -116,7 +129,7 @@ def create_authoring_job(
             db.add(tenant)
             db.commit()
             db.refresh(tenant)
-        teacher = User(id=req.teacher_id, tenant_id=tenant.id, email=f"{req.teacher_id}@adam.edu", role="teacher")
+        teacher = User(id=teacher_id, tenant_id=tenant.id, email=f"{teacher_id}@adam.edu", role="teacher")
         db.add(teacher)
         db.commit()
 

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -27,6 +27,9 @@ def generate_uuid() -> str:
     return str(uuid.uuid4())
 
 
+UUID_TEXT_CHECK = r"id ~* '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'"
+
+
 # --- TEACHER AUTHORING MVP SCHEMA ---
 # Active persistence layer used by the published teacher authoring flow.
 class Tenant(Base):
@@ -58,6 +61,10 @@ class User(Base):
     """
 
     __tablename__ = "users"
+    __table_args__ = (
+        CheckConstraint(UUID_TEXT_CHECK, name="ck_users_id_auth_uuid"),
+        CheckConstraint("role IN ('teacher', 'student', 'university_admin')", name="ck_users_role"),
+    )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
     tenant_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -4,7 +4,18 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import JSON, DateTime, Float, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -34,11 +45,16 @@ class Tenant(Base):
     )
 
     users: Mapped[list["User"]] = relationship(back_populates="tenant")
+    memberships: Mapped[list["Membership"]] = relationship(back_populates="university")
+    invites: Mapped[list["Invite"]] = relationship(back_populates="university")
+    allowed_email_domains: Mapped[list["AllowedEmailDomain"]] = relationship(back_populates="university")
+    courses: Mapped[list["Course"]] = relationship(back_populates="university")
+    sso_configs: Mapped[list["UniversitySsoConfig"]] = relationship(back_populates="university")
 
 
 class User(Base):
     """
-    System user, representing roles for both 'Teacher' and 'Student'.
+    Legacy bridge user record. Role values are normalized to lowercase.
     """
 
     __tablename__ = "users"
@@ -55,6 +71,173 @@ class User(Base):
     tenant: Mapped["Tenant"] = relationship(back_populates="users")
     assignments: Mapped[list["Assignment"]] = relationship(back_populates="teacher")
     artifacts: Mapped[list["ArtifactManifest"]] = relationship(back_populates="owner")
+
+
+class Profile(Base):
+    """Identity profile keyed by the Supabase Auth user id stored as text."""
+
+    __tablename__ = "profiles"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    full_name: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    memberships: Mapped[list["Membership"]] = relationship(back_populates="user")
+
+
+class Membership(Base):
+    """University membership keyed off the identity profile, not legacy teacher ids."""
+
+    __tablename__ = "memberships"
+    __table_args__ = (
+        UniqueConstraint("user_id", "university_id", "role", name="uix_membership_user_university_role"),
+        CheckConstraint("role IN ('teacher', 'student', 'university_admin')", name="ck_memberships_role"),
+        CheckConstraint("status IN ('active', 'suspended')", name="ck_memberships_status"),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
+    user_id: Mapped[str] = mapped_column(Text, ForeignKey("profiles.id"), nullable=False, index=True)
+    university_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False, index=True)
+    role: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="active")
+    must_rotate_password: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    user: Mapped["Profile"] = relationship(back_populates="memberships")
+    university: Mapped["Tenant"] = relationship(back_populates="memberships")
+    courses_as_teacher: Mapped[list["Course"]] = relationship(back_populates="teacher_membership")
+    course_memberships: Mapped[list["CourseMembership"]] = relationship(back_populates="membership")
+
+
+class AllowedEmailDomain(Base):
+    """Institutional domains allowed for invite-gated student activation."""
+
+    __tablename__ = "allowed_email_domains"
+    __table_args__ = (
+        UniqueConstraint("university_id", "domain", name="uix_allowed_email_domain"),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
+    university_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False, index=True)
+    domain: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    university: Mapped["Tenant"] = relationship(back_populates="allowed_email_domains")
+
+
+class Course(Base):
+    """Course ownership moves through teacher memberships, not legacy user ids."""
+
+    __tablename__ = "courses"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
+    university_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
+    teacher_membership_id: Mapped[str] = mapped_column(Text, ForeignKey("memberships.id"), nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    university: Mapped["Tenant"] = relationship(back_populates="courses")
+    teacher_membership: Mapped["Membership"] = relationship(back_populates="courses_as_teacher")
+    invites: Mapped[list["Invite"]] = relationship(back_populates="course")
+    course_memberships: Mapped[list["CourseMembership"]] = relationship(back_populates="course")
+
+
+class Invite(Base):
+    """Invite is the only pre-activation artifact in the auth substrate."""
+
+    __tablename__ = "invites"
+    __table_args__ = (
+        CheckConstraint("role IN ('teacher', 'student')", name="ck_invites_role"),
+        CheckConstraint("status IN ('pending', 'consumed', 'expired', 'revoked')", name="ck_invites_status"),
+        CheckConstraint("role <> 'student' OR course_id IS NOT NULL", name="ck_invites_student_requires_course"),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
+    token_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    email: Mapped[str] = mapped_column(Text, nullable=False)
+    university_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
+    course_id: Mapped[str | None] = mapped_column(Text, ForeignKey("courses.id"), nullable=True)
+    role: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="pending")
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    university: Mapped["Tenant"] = relationship(back_populates="invites")
+    course: Mapped["Course | None"] = relationship(back_populates="invites")
+
+
+class CourseMembership(Base):
+    """Enrollment links a course to a membership, never directly to a user id."""
+
+    __tablename__ = "course_memberships"
+    __table_args__ = (
+        UniqueConstraint("course_id", "membership_id", name="uix_course_membership"),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
+    course_id: Mapped[str] = mapped_column(Text, ForeignKey("courses.id"), nullable=False, index=True)
+    membership_id: Mapped[str] = mapped_column(Text, ForeignKey("memberships.id"), nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    course: Mapped["Course"] = relationship(back_populates="course_memberships")
+    membership: Mapped["Membership"] = relationship(back_populates="course_memberships")
+
+
+class UniversitySsoConfig(Base):
+    """University-scoped SSO configuration, even while rollout stays single-tenant."""
+
+    __tablename__ = "university_sso_configs"
+    __table_args__ = (
+        UniqueConstraint("university_id", "provider", name="uix_university_sso_config"),
+        CheckConstraint("provider IN ('azure')", name="ck_university_sso_provider"),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
+    university_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
+    provider: Mapped[str] = mapped_column(Text, nullable=False)
+    azure_tenant_id: Mapped[str] = mapped_column(Text, nullable=False)
+    client_id: Mapped[str] = mapped_column(Text, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    university: Mapped["Tenant"] = relationship(back_populates="sso_configs")
 
 
 class Assignment(Base):

--- a/backend/tests/test_issue23_identity_schema.py
+++ b/backend/tests/test_issue23_identity_schema.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+import uuid
+
+from alembic import command
+from alembic.config import Config
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.exc import IntegrityError
+
+from shared.database import settings
+
+
+ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
+PRE_ISSUE23_REVISION = "1571dcf87c69"
+
+
+def _make_temp_database_urls() -> tuple[str, URL, URL]:
+    base_url = make_url(settings.database_url)
+    temp_name = f"issue23_{uuid.uuid4().hex[:10]}"
+    temp_url = base_url.set(database=temp_name)
+    admin_url = base_url.set(database="postgres")
+    return temp_name, temp_url, admin_url
+
+
+@contextmanager
+def temporary_database() -> str:
+    db_name, temp_url, admin_url = _make_temp_database_urls()
+    admin_engine = create_engine(admin_url.render_as_string(hide_password=False), isolation_level="AUTOCOMMIT")
+    temp_engine = None
+    try:
+        with admin_engine.connect() as conn:
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+        temp_engine = create_engine(temp_url.render_as_string(hide_password=False))
+        yield temp_url.render_as_string(hide_password=False)
+    finally:
+        if temp_engine is not None:
+            temp_engine.dispose()
+        with admin_engine.connect() as conn:
+            conn.execute(
+                text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :db_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"db_name": db_name},
+            )
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        admin_engine.dispose()
+
+
+def _alembic_config(db_url: str) -> Config:
+    config = Config(str(ALEMBIC_INI))
+    config.set_main_option("sqlalchemy.url", db_url)
+    return config
+
+
+def test_issue23_alembic_upgrade_and_downgrade() -> None:
+    with temporary_database() as db_url:
+        config = _alembic_config(db_url)
+
+        command.upgrade(config, PRE_ISSUE23_REVISION)
+
+        engine = create_engine(db_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO tenants (id, name, created_at)
+                    VALUES (:id, :name, NOW())
+                    """
+                ),
+                {"id": "10000000-0000-0000-0000-000000000001", "name": "Issue 23 Tenant"},
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO users (id, tenant_id, email, role, created_at)
+                    VALUES (:id, :tenant_id, :email, :role, NOW())
+                    """
+                ),
+                {
+                    "id": "20000000-0000-0000-0000-000000000001",
+                    "tenant_id": "10000000-0000-0000-0000-000000000001",
+                    "email": "teacher@example.edu",
+                    "role": "Teacher",
+                },
+            )
+
+        command.upgrade(config, "head")
+
+        inspector = inspect(engine)
+        tables = set(inspector.get_table_names())
+        assert {
+            "profiles",
+            "memberships",
+            "invites",
+            "allowed_email_domains",
+            "courses",
+            "course_memberships",
+            "university_sso_configs",
+        }.issubset(tables)
+
+        with engine.begin() as conn:
+            role = conn.execute(
+                text("SELECT role FROM users WHERE id = :id"),
+                {"id": "20000000-0000-0000-0000-000000000001"},
+            ).scalar_one()
+            assert role == "teacher"
+
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO profiles (id, full_name, created_at, updated_at)
+                    VALUES (:id, :full_name, NOW(), NOW())
+                    """
+                ),
+                {"id": "20000000-0000-0000-0000-000000000001", "full_name": "Teacher Example"},
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO memberships (
+                        id, user_id, university_id, role, status, must_rotate_password, created_at, updated_at
+                    ) VALUES (
+                        :id, :user_id, :university_id, :role, :status, :must_rotate_password, NOW(), NOW()
+                    )
+                    """
+                ),
+                {
+                    "id": "30000000-0000-0000-0000-000000000001",
+                    "user_id": "20000000-0000-0000-0000-000000000001",
+                    "university_id": "10000000-0000-0000-0000-000000000001",
+                    "role": "teacher",
+                    "status": "active",
+                    "must_rotate_password": False,
+                },
+            )
+
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO courses (id, university_id, teacher_membership_id, title, created_at)
+                    VALUES (:id, :university_id, :teacher_membership_id, :title, NOW())
+                    """
+                ),
+                {
+                    "id": "40000000-0000-0000-0000-000000000001",
+                    "university_id": "10000000-0000-0000-0000-000000000001",
+                    "teacher_membership_id": "30000000-0000-0000-0000-000000000001",
+                    "title": "Course A",
+                },
+            )
+
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO invites (
+                        id, token_hash, email, university_id, course_id, role, status, expires_at, consumed_at, created_at
+                    ) VALUES (
+                        :id, :token_hash, :email, :university_id, :course_id, :role, :status, NOW() + INTERVAL '1 day', NULL, NOW()
+                    )
+                    """
+                ),
+                {
+                    "id": "50000000-0000-0000-0000-000000000001",
+                    "token_hash": "teacher-token-hash",
+                    "email": "teacher-invite@example.edu",
+                    "university_id": "10000000-0000-0000-0000-000000000001",
+                    "course_id": None,
+                    "role": "teacher",
+                    "status": "pending",
+                },
+            )
+
+        with engine.begin() as conn:
+            with pytest.raises(IntegrityError):
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO invites (
+                            id, token_hash, email, university_id, course_id, role, status, expires_at, consumed_at, created_at
+                        ) VALUES (
+                            :id, :token_hash, :email, :university_id, :course_id, :role, :status, NOW() + INTERVAL '1 day', NULL, NOW()
+                        )
+                        """
+                    ),
+                    {
+                        "id": "50000000-0000-0000-0000-000000000002",
+                        "token_hash": "student-token-hash",
+                        "email": "student-invite@example.edu",
+                        "university_id": "10000000-0000-0000-0000-000000000001",
+                        "course_id": None,
+                        "role": "student",
+                        "status": "pending",
+                    },
+                )
+
+        command.downgrade(config, PRE_ISSUE23_REVISION)
+        inspector = inspect(engine)
+        assert "profiles" not in inspector.get_table_names()
+        engine.dispose()
+
+
+def test_issue23_rls_sql_exists() -> None:
+    sql_path = Path(__file__).resolve().parents[1] / "sql" / "rls_policies.sql"
+    content = sql_path.read_text(encoding="utf-8")
+    assert "ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;" in content
+    assert "hmac.compare_digest()" in content

--- a/backend/tests/test_issue23_identity_schema.py
+++ b/backend/tests/test_issue23_identity_schema.py
@@ -61,6 +61,41 @@ def _alembic_config(db_url: str) -> Config:
     return config
 
 
+def _seed_legacy_tenant_and_user(
+    engine,
+    *,
+    user_id: str,
+    email: str,
+    role: str,
+    tenant_id: str = "10000000-0000-0000-0000-000000000001",
+) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO tenants (id, name, created_at)
+                VALUES (:id, :name, NOW())
+                ON CONFLICT (id) DO NOTHING
+                """
+            ),
+            {"id": tenant_id, "name": "Issue 23 Tenant"},
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO users (id, tenant_id, email, role, created_at)
+                VALUES (:id, :tenant_id, :email, :role, NOW())
+                """
+            ),
+            {
+                "id": user_id,
+                "tenant_id": tenant_id,
+                "email": email,
+                "role": role,
+            },
+        )
+
+
 def test_issue23_alembic_upgrade_and_downgrade() -> None:
     with temporary_database() as db_url:
         config = _alembic_config(db_url)
@@ -68,30 +103,24 @@ def test_issue23_alembic_upgrade_and_downgrade() -> None:
         command.upgrade(config, PRE_ISSUE23_REVISION)
 
         engine = create_engine(db_url)
-        with engine.begin() as conn:
-            conn.execute(
-                text(
-                    """
-                    INSERT INTO tenants (id, name, created_at)
-                    VALUES (:id, :name, NOW())
-                    """
-                ),
-                {"id": "10000000-0000-0000-0000-000000000001", "name": "Issue 23 Tenant"},
-            )
-            conn.execute(
-                text(
-                    """
-                    INSERT INTO users (id, tenant_id, email, role, created_at)
-                    VALUES (:id, :tenant_id, :email, :role, NOW())
-                    """
-                ),
-                {
-                    "id": "20000000-0000-0000-0000-000000000001",
-                    "tenant_id": "10000000-0000-0000-0000-000000000001",
-                    "email": "teacher@example.edu",
-                    "role": "Teacher",
-                },
-            )
+        _seed_legacy_tenant_and_user(
+            engine,
+            user_id="20000000-0000-0000-0000-000000000001",
+            email="teacher@example.edu",
+            role="Teacher",
+        )
+        _seed_legacy_tenant_and_user(
+            engine,
+            user_id="20000000-0000-0000-0000-000000000002",
+            email="student@example.edu",
+            role="Student",
+        )
+        _seed_legacy_tenant_and_user(
+            engine,
+            user_id="20000000-0000-0000-0000-000000000003",
+            email="admin@example.edu",
+            role="UniversityAdmin",
+        )
 
         command.upgrade(config, "head")
 
@@ -108,11 +137,22 @@ def test_issue23_alembic_upgrade_and_downgrade() -> None:
         }.issubset(tables)
 
         with engine.begin() as conn:
-            role = conn.execute(
-                text("SELECT role FROM users WHERE id = :id"),
-                {"id": "20000000-0000-0000-0000-000000000001"},
-            ).scalar_one()
-            assert role == "teacher"
+            roles = dict(
+                conn.execute(
+                    text(
+                        """
+                        SELECT id, role
+                        FROM users
+                        ORDER BY id
+                        """
+                    )
+                ).all()
+            )
+            assert roles == {
+                "20000000-0000-0000-0000-000000000001": "teacher",
+                "20000000-0000-0000-0000-000000000002": "student",
+                "20000000-0000-0000-0000-000000000003": "university_admin",
+            }
 
             conn.execute(
                 text(
@@ -213,3 +253,41 @@ def test_issue23_rls_sql_exists() -> None:
     content = sql_path.read_text(encoding="utf-8")
     assert "ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;" in content
     assert "hmac.compare_digest()" in content
+
+
+def test_issue23_migration_rejects_unknown_legacy_roles() -> None:
+    with temporary_database() as db_url:
+        config = _alembic_config(db_url)
+        command.upgrade(config, PRE_ISSUE23_REVISION)
+
+        engine = create_engine(db_url)
+        _seed_legacy_tenant_and_user(
+            engine,
+            user_id="20000000-0000-0000-0000-000000000010",
+            email="dean@example.edu",
+            role="Dean",
+        )
+
+        with pytest.raises(RuntimeError, match="unmapped legacy roles"):
+            command.upgrade(config, "head")
+
+        engine.dispose()
+
+
+def test_issue23_migration_rejects_non_uuid_legacy_user_ids() -> None:
+    with temporary_database() as db_url:
+        config = _alembic_config(db_url)
+        command.upgrade(config, PRE_ISSUE23_REVISION)
+
+        engine = create_engine(db_url)
+        _seed_legacy_tenant_and_user(
+            engine,
+            user_id="teacher-123",
+            email="legacy-teacher@example.edu",
+            role="Teacher",
+        )
+
+        with pytest.raises(RuntimeError, match="auth-compatible UUID text"):
+            command.upgrade(config, "head")
+
+        engine.dispose()

--- a/backend/tests/test_phase1a_smoke.py
+++ b/backend/tests/test_phase1a_smoke.py
@@ -141,6 +141,19 @@ def test_intake_and_idempotency_workflow():
     assert response_data.get("status") == "bypassed"
     assert "idempotency_barrier" in response_data.get("reason", "")
 
+
+def test_intake_rejects_non_uuid_teacher_ids() -> None:
+    payload = {
+        "teacher_id": "teacher-123",
+        "assignment_title": "Should Fail",
+    }
+
+    with patch("fastapi.BackgroundTasks.add_task"):
+        response = client.post("/api/authoring/jobs", json=payload)
+
+    assert response.status_code == 422
+    assert "teacher_id must be a UUID string compatible with Supabase Auth" in response.text
+
 if __name__ == "__main__":
     print("Running Smoke Tests...")
     test_database_connection()

--- a/backend/tests/test_phase1a_smoke.py
+++ b/backend/tests/test_phase1a_smoke.py
@@ -7,6 +7,8 @@ from shared.models import Assignment, AuthoringJob
 
 client = TestClient(app)
 
+TEACHER_ID = "00000000-0000-0000-0000-000000000101"
+
 def test_database_connection():
     """Verify that we can connect to the database and tables exist."""
     db = SessionLocal()
@@ -26,7 +28,7 @@ def test_intake_and_idempotency_workflow():
     """
     # 1. Test Intake Endpoint
     payload = {
-        "teacher_id": "smoke-test-teacher",
+        "teacher_id": TEACHER_ID,
         "assignment_title": "Post-Hardening Smoke Test Verification"
     }
     with patch("fastapi.BackgroundTasks.add_task"):

--- a/backend/tests/test_phase1b_integration.py
+++ b/backend/tests/test_phase1b_integration.py
@@ -10,6 +10,9 @@ from shared.models import Assignment, AuthoringJob
 
 client = TestClient(app)
 
+TEACHER_ID = "00000000-0000-0000-0000-000000000102"
+ERROR_TEACHER_ID = "00000000-0000-0000-0000-000000000103"
+
 
 async def _successful_astream(*args, **kwargs):
     """Stub the LangGraph stream with a single final state."""
@@ -32,7 +35,7 @@ def test_phase1b_intake_and_authoring_stubbed() -> None:
     The LangGraph stream is stubbed so BackgroundTasks can execute deterministically.
     """
     payload = {
-        "teacher_id": "phase1b-test-teacher",
+        "teacher_id": TEACHER_ID,
         "assignment_title": "Phase 1B Integration Test Title",
     }
 
@@ -101,7 +104,7 @@ def test_phase1b_intake_and_authoring_stubbed() -> None:
 def test_phase1b_authoring_service_failure() -> None:
     """Test how the system handles exceptions from LangGraph stream execution."""
     payload = {
-        "teacher_id": "phase1b-error-teacher",
+        "teacher_id": ERROR_TEACHER_ID,
         "assignment_title": "Phase 1B Error Test Title",
     }
 

--- a/backend/tests/test_phase2_fragmentation.py
+++ b/backend/tests/test_phase2_fragmentation.py
@@ -35,9 +35,9 @@ def _setup_mock_job(db, job_status="pending"):
         db.add(tenant)
         db.commit()
 
-    teacher = db.query(User).filter(User.role == "Teacher").first()
+    teacher = db.query(User).filter(User.role == "teacher").first()
     if not teacher:
-        teacher = User(tenant_id=tenant.id, email=f"test{uuid.uuid4()}@adam.edu", role="Teacher")
+        teacher = User(tenant_id=tenant.id, email=f"test{uuid.uuid4()}@adam.edu", role="teacher")
         db.add(teacher)
         db.commit()
 

--- a/backend/tests/test_phase3_status_api.py
+++ b/backend/tests/test_phase3_status_api.py
@@ -8,6 +8,7 @@ from shared.database import SessionLocal, Base, engine
 from shared.models import AuthoringJob, Assignment, User, Tenant
 
 client = TestClient(app)
+TEACHER_ID = "00000000-0000-0000-0000-000000000104"
 
 def setup_db():
     Base.metadata.create_all(bind=engine)
@@ -21,7 +22,7 @@ def setup_db():
         
     teacher = db.query(User).filter(User.email=="teacher@test.edu").first()
     if not teacher:
-        teacher = User(id="teacher-123", tenant_id=tenant.id, email="teacher@test.edu", role="Teacher")
+        teacher = User(id=TEACHER_ID, tenant_id=tenant.id, email="teacher@test.edu", role="teacher")
         db.add(teacher)
         db.commit()
     
@@ -32,7 +33,7 @@ from unittest.mock import patch
 def test_polling_happy_path(db):
     print("\n--- Test 1: Polling Happy Path ---")
     intake_data = {
-        "teacher_id": "teacher-123",
+        "teacher_id": TEACHER_ID,
         "assignment_title": "Test Phase 3",
         "subject": "Finance",
         "academic_level": "MBA",
@@ -127,7 +128,7 @@ def test_job_not_found():
 def test_failed_job_path(db):
     print("\n--- Test 3: Failed Job Status & Trace ---")
     intake_data = {
-        "teacher_id": "teacher-123",
+        "teacher_id": TEACHER_ID,
         "assignment_title": "Fail Test"
     }
     with patch("fastapi.BackgroundTasks.add_task"):


### PR DESCRIPTION
## Summary
- add the Issue 23 identity substrate tables, migration, and secondary RLS SQL artifact
- harden the legacy bridge so `users.id` stays auth-compatible UUID text and the authoring intake rejects non-UUID teacher ids
- sync repo docs with the new migration and RLS operating constraints

## What Changed
- added `profiles`, `memberships`, `invites`, `allowed_email_domains`, `courses`, `course_memberships`, and `university_sso_configs`
- normalized legacy `users.role` values to lowercase during migration and fail fast on unknown roles or non-UUID legacy ids
- enforced the bridge contract with `users` check constraints and request-side UUID normalization in `/api/authoring/jobs`
- delivered `backend/sql/rls_policies.sql` as a separate secondary-RLS artifact for Supabase/Auth-compatible environments
- expanded tests to cover migration upgrade/downgrade, role backfill, invite constraints, unknown-role rejection, and invalid legacy ids

## Validation
- `uv run --directory backend pytest -q`
- `uv run --directory backend mypy src`

## Notes
- `backend/sql/rls_policies.sql` is not applied by Alembic and must be applied separately in Supabase or another environment exposing `auth.uid()`
- the migration test creates and drops temporary databases, so non-default Postgres environments need `CREATE DATABASE` and `DROP DATABASE`

Closes #23
