### PR TITLE
chore: close issue 32 local dev auth setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ This repository does not currently include a student runtime, full authenticatio
 
 - `README.md`: onboarding, local setup, Docker, Alembic, runtime commands
 - `CONTRIBUTING.md`: branch, PR, validation, and collaboration workflow
+- `docs/runbooks/`: runbooks operativos, incluido el setup local canonico de auth y authoring
 - `docs/adr/`: accepted architecture decisions, including the Fase 1 auth perimeter ADR
 - `docs/repo-governance.md`: repository governance and merge policy
 - `CLAUDE.md`: equivalent agent guidance for Claude-oriented tooling
@@ -50,14 +51,15 @@ This repository does not currently include a student runtime, full authenticatio
 - Dispatch defaults:
   - ideas and brainstorming -> `office-hours`, then `autoplan` or `plan-*`
   - bugs, errors, regressions -> `investigate`
-  - review of a diff, branch, or PR -> `review`
-  - QA or staging verification -> `qa` or `qa-only`
-  - release preparation -> `ship`, then `land-and-deploy`, `canary`, `document-release`
+- review of a diff, branch, or PR -> `review`
+- QA or staging verification -> `qa` or `qa-only`
+- release preparation -> `ship`, then `land-and-deploy`, `canary`, `document-release`
   - visual work -> `design-*`
   - security review -> `cso`
   - browser-heavy QA -> `browse`, `connect-chrome`, `setup-browser-cookies`
 - One agent owns the branch and final decision path. Use repo-scoped subagents only for bounded read-only sidecars such as `pr_explorer`, `reviewer`, `code_mapper`, independent report-only QA, benchmark, read-only exploration, or post-ship docs.
 - Do not use subagents for merge or deploy authority, scope decisions, conflicting writes, or parallel edits in `backend/src/case_generator/**`.
+- Do not run `document-release` before `uv run --directory backend pytest -q` is green. Pre-PR docs sync belongs in the implementation diff itself.
 
 ## Architecture Boundaries
 
@@ -111,3 +113,14 @@ More specific rules live in:
 - `frontend/AGENTS.md`
 
 Files closer to the working directory are intended to add or override guidance for that area.
+
+## Local Dev Auth
+
+Cuando el cambio toque setup local o auth:
+
+- usa `docs/runbooks/local-dev-auth.md` como fuente canonica
+- distingue siempre los dos planos locales:
+  - app DB del repo por `docker compose` en `5434`
+  - auth/session local por `supabase start` en `54321`
+- no documentes `5432` como puerto host local por defecto del repo
+- no permitas ejemplos donde `DATABASE_URL` apunte al Postgres interno de Supabase local en `54322`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,14 +49,15 @@ Use the repo-driven gstack runtime materialized from the pinned lock in `scripts
 - Dispatch defaults:
   - ideas and brainstorming -> `office-hours`, then `autoplan` or `plan-*`
   - bugs, errors, regressions -> `investigate`
-  - review of a diff, branch, or PR -> `review`
-  - QA or staging verification -> `qa` or `qa-only`
-  - release preparation -> `ship`, then `land-and-deploy`, `canary`, `document-release`
+- review of a diff, branch, or PR -> `review`
+- QA or staging verification -> `qa` or `qa-only`
+- release preparation -> `ship`, then `land-and-deploy`, `canary`, `document-release`
   - visual work -> `design-*`
   - security review -> `cso`
   - browser-heavy QA -> `browse`, `connect-chrome`, `setup-browser-cookies`
 - One agent owns the branch and final decision path. Use repo-scoped subagents only for bounded read-only sidecars such as `pr_explorer`, `reviewer`, `code_mapper`, independent report-only QA, benchmark, read-only exploration, or post-ship docs.
 - Do not use subagents for merge or deploy authority, scope decisions, conflicting writes, or parallel edits in `backend/src/case_generator/**`.
+- Do not run `document-release` before `uv run --directory backend pytest -q` is green. Pre-PR docs sync belongs in the implementation diff itself.
 
 ## Domain Map
 
@@ -128,11 +129,20 @@ Only run live LLM tests explicitly:
 
 ## Local Environment Expectations
 
+For local auth + backend work, treat the repo as two local planes:
+
+- app DB local via `docker compose up -d adam-edu-postgres` on host `5434`
+- auth/session local via `supabase start` on `http://localhost:54321`
+
+Use `docs/runbooks/local-dev-auth.md` as the canonical runbook when setup or auth-local
+workflow changes.
+
 For a normal backend local session:
 
 ```powershell
 cd C:\Users\Juan Camilo Dorado\Downloads\ADAM-EDU
 docker compose up -d adam-edu-postgres
+supabase start
 
 cd backend
 uv sync --dev
@@ -141,3 +151,4 @@ uv run uvicorn shared.app:app --reload --host 0.0.0.0 --port 8000
 ```
 
 `docker compose up` starts PostgreSQL, but does not apply migrations. Alembic bootstrap is required before using the API locally.
+`DATABASE_URL` stays on `localhost:5434`. Do not point it at the Supabase local database on `54322`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,56 @@ npm --prefix frontend run build
 npm --prefix frontend run test
 ```
 
+La suite backend actual debe correr en serie. No uses `pytest-xdist` ni `pytest -n ...`
+mientras el harness siga compartiendo una sola base de datos local.
+
 Nota: la prueba de migracion del Issue 23 crea y elimina bases temporales. En el entorno
 local default eso funciona con el usuario `postgres`, pero en otros entornos necesitaras
 permisos `CREATE DATABASE` y `DROP DATABASE` para que `pytest` pase completo.
+
+## Bootstrap local canonico
+
+El setup local canonico vive en:
+
+- [docs/runbooks/local-dev-auth.md](docs/runbooks/local-dev-auth.md)
+
+Antes de empezar, asume estos prerrequisitos fuera del conteo de comandos:
+
+- Docker Desktop o Docker Engine funcionando
+- Supabase CLI instalada
+- `uv` instalado
+- Node.js 22 + npm
+
+Resumen del arranque:
+
+1. `docker compose up -d adam-edu-postgres`
+2. `supabase start`
+3. `supabase status -o env`
+4. prepara `backend/.env` y `frontend/.env` desde sus ejemplos con el mapping local correcto
+5. `uv sync --directory backend --dev`
+6. `uv run --directory backend alembic upgrade head`
+7. `uv run --directory backend uvicorn shared.app:app --reload --host 0.0.0.0 --port 8000`
+8. `npm --prefix frontend install`
+9. `npm --prefix frontend run dev`
+
+Puntos no negociables:
+
+- `DATABASE_URL` local del repo apunta al Postgres del repo en `5434`
+- `supabase start` levanta auth/session local en `54321`, no la base principal del repo
+- `5432` solo aparece como referencia remota de session mode, nunca como default local del repo
+- el frontend no recibe `SUPABASE_SERVICE_ROLE_KEY`
+- login UI, callback UX y guards finales siguen en Issue 5
+- la suite backend se ejecuta en serie hasta que exista aislamiento de DB por worker
+
+## Restriccion temporal de la suite backend
+
+La suite backend actual comparte una sola base local. Hasta que exista aislamiento por
+worker:
+
+- corre `uv run --directory backend pytest -q` en serie
+- no uses `pytest -n auto` ni otra variante con `pytest-xdist`
+- si alguien fuerza `xdist`, la suite debe fallar rapido con un mensaje explicito
+- no dejes backend local, shells `psql` u otras sesiones conectadas a la misma DB mientras corre la suite
 
 ## Reglas para agentes
 
@@ -65,6 +112,7 @@ permisos `CREATE DATABASE` y `DROP DATABASE` para que `pytest` pase completo.
 - `.agents/skills/gstack*` y `.claude/skills/*` son runtimes locales generados. No deben commitearse.
 - Si cambias agent tooling, usa rama `agent/...` y PR dedicado.
 - Despues de tocar agent tooling, rerun `bootstrap` y valida el runtime local antes de abrir el PR.
+- No corras `document-release` antes de que `uv run --directory backend pytest -q` este en verde.
 
 ## Workflow compartido de agentes
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ La zona funcional principal del generador vive en `backend/src/case_generator/` 
 - `Dockerfile`: build contenedorizado del stack publicado. Se conserva para empaquetado del backend con el frontend compilado.
 - `Makefile`: atajos opcionales para desarrollo en entornos Unix-like. Es conveniencia local, no la ruta principal de trabajo en Windows.
 - `docs/adr/`: architecture decision records aceptados. Aqui vive la decision canonica del auth perimeter de Fase 1.
+- `docs/runbooks/`: runbooks operativos del repo. Aqui vive el setup local canonico de auth y authoring.
 - `docs/archive/MASTER_AUDIT_PLAN.md`: auditoria historica archivada. Se conserva como referencia, pero ya no gobierna el alcance operativo del repo.
 
 ### Root hygiene
@@ -93,12 +94,16 @@ El frontend usa ese flujo para renderizar el timeline y el `CasePreview` del pro
 
 ## Setup local
 
-El flujo recomendado para contributors es:
+El setup local canonico vive en [docs/runbooks/local-dev-auth.md](docs/runbooks/local-dev-auth.md).
 
-1. levantar solo PostgreSQL con Docker
-2. correr backend y frontend localmente
+Resumen corto:
 
-Ese flujo da mejor feedback para desarrollo diario, evita rebuilds del contenedor en cada cambio y deja el entorno mas facil de depurar.
+- plano `authoring/app DB local`: `docker compose up -d adam-edu-postgres` en `5434`
+- plano `auth local`: `supabase start` con API `54321`, DB `54322`, Studio `54323` y Mailpit `54324`
+- referencias remotas: `5432` para session mode y `6543` para transaction mode, nunca como default local del repo
+
+El error mas comun en esta fase es apuntar `DATABASE_URL` al Postgres de Supabase local.
+No lo hagas. `DATABASE_URL` local del repo sigue apuntando a `localhost:5434`.
 
 ## Shared agent tooling
 
@@ -166,89 +171,25 @@ Si alguien prefiere una instalacion global fuera del repo, puede mantenerla como
 
 ### Prerrequisitos
 
-- Docker Desktop o Docker Engine con Compose
+- Docker Desktop o Docker Engine con Compose funcionando
+- Supabase CLI instalada
 - Python 3.12
 - `uv`
 - Node.js 22 + npm
 
-### Opcion A: desarrollo recomendado (PostgreSQL en Docker, app local)
+`npx supabase ...` puede servir como fallback personal, pero la ruta principal del repo
+asume CLI instalada y scaffold committeado.
 
-#### 1. Levantar solo PostgreSQL
+### Arranque recomendado
 
-Ejecuta esto desde la raiz del repo, no desde `backend/`:
+Sigue el runbook:
 
-```powershell
-docker compose up -d adam-edu-postgres
-```
+- [docs/runbooks/local-dev-auth.md](docs/runbooks/local-dev-auth.md)
 
-Con el `docker-compose.yml` actual, los defaults locales quedan asi:
+Ese runbook deja el flujo operativo en menos de 10 comandos reales y mantiene los
+prerrequisitos fuera del conteo.
 
-- host: `localhost`
-- puerto: `5434`
-- usuario: `postgres`
-- password: `postgres`
-- base: `postgres`
-
-#### 2. Configurar el backend
-
-1. Copia `backend/.env.example` a `backend/.env`.
-2. Completa al menos estas variables:
-
-```env
-DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres
-GEMINI_API_KEY=tu_api_key
-SUPABASE_URL=https://tu-proyecto.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=tu_service_role_key
-SUPABASE_JWT_SECRET=solo_dev_si_necesitas_fallback_local
-```
-
-3. Instala dependencias:
-
-```powershell
-cd backend
-uv sync --dev
-```
-
-4. Aplica las migraciones del esquema:
-
-```powershell
-uv run alembic upgrade head
-```
-
-Este paso es obligatorio. `docker compose up` levanta PostgreSQL, pero no crea las tablas de la aplicacion.
-
-5. Arranca la API:
-
-```powershell
-uv run uvicorn shared.app:app --reload --host 0.0.0.0 --port 8000
-```
-
-La API queda disponible en `http://localhost:8000`.
-
-#### 3. Levantar el frontend
-
-En otra terminal:
-
-```powershell
-cd frontend
-npm install
-npm run dev
-```
-
-El frontend queda disponible segun la salida de Vite, normalmente en `http://localhost:5173/app/`.
-
-La ruta funcional actual del profesor vive bajo `/app/teacher`, porque Vite y React Router usan `base` y `basename` en `/app/`.
-
-Para usar el flujo docente protegido despues de Issue 30, copia `frontend/.env.example` a `frontend/.env` y completa:
-
-```env
-VITE_SUPABASE_URL=https://tu-proyecto.supabase.co
-VITE_SUPABASE_ANON_KEY=tu_publishable_o_anon_key
-```
-
-Esta issue no agrega login UI ni callback OAuth. El frontend adjunta bearer auth solo si ya existe una sesion Supabase valida en el browser; si no existe sesion, el authoring quedara fail-closed con `401/403`.
-
-### Opcion B: stack contenedorizado completo
+### Stack contenedorizado opcional
 
 Si quieres probar la API y PostgreSQL por Docker, el compose ya construye la imagen automaticamente desde el repo:
 
@@ -269,7 +210,10 @@ Puertos por defecto:
 Notas:
 
 - Para esta opcion, `GEMINI_API_KEY` debe existir en tu shell o en un archivo `.env` de la raiz usado por Docker Compose.
-- Si solo necesitas base de datos para desarrollo, usa la Opcion A; es la ruta principal recomendada.
+- Esta ruta no sustituye el runbook canonico de auth local. El compose deja la API alineada con `DATABASE_URL`, pero el flujo recomendado sigue siendo backend/frontend locales + `supabase start`.
+- Si quieres que la API en Docker use auth local, debes inyectar `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` y `SUPABASE_JWT_SECRET` de forma explicita. No se asume como happy path del repo.
+- Dentro del contenedor, `SUPABASE_URL=http://localhost:54321` es incorrecto porque `localhost` apunta al propio contenedor. En Docker Desktop usa una URL alcanzable desde el contenedor, por ejemplo `http://host.docker.internal:54321`; en otros entornos Docker usa el hostname equivalente de tu host.
+- Si solo necesitas base de datos para desarrollo, usa el runbook canonico; esa es la ruta principal recomendada.
 
 ### Apagar el entorno Docker
 
@@ -285,16 +229,21 @@ docker compose down -v
 
 ## Variables de entorno
 
-- `DATABASE_URL`: DSN principal de PostgreSQL para `shared.database`.
-- `SUPABASE_URL`: metadata del proyecto Supabase usada desde la fase de auth substrate en adelante.
-- `SUPABASE_PROJECT_REF`: ref del proyecto Supabase para tooling y validaciones operativas de auth.
-- `SUPABASE_SERVICE_ROLE_KEY`: clave backend-only para activation/password y operaciones admin de Supabase Auth.
-- `SUPABASE_JWT_SECRET`: fallback de desarrollo para JWT locales. No sustituye JWKS en produccion.
+- `DATABASE_URL`: DSN principal del Postgres local del repo. En local apunta a `localhost:5434`, no a `54322`.
+- `SUPABASE_URL`: URL del plano de auth/session. En local via Supabase CLI apunta a `http://localhost:54321`.
+- `SUPABASE_PROJECT_REF`: ref documental para tooling y validaciones. En local la convencion del repo es `local`.
+- `SUPABASE_SERVICE_ROLE_KEY`: clave backend-only para activation/password y operaciones admin. Sale de `supabase status -o env`.
+- `SUPABASE_JWT_SECRET`: fallback de desarrollo para JWT locales. Sale de `supabase status -o env`. No sustituye JWKS en produccion.
+- `MICROSOFT_TENANT_ID`: placeholder para la configuracion local/remota de Azure en las siguientes issues.
+- `INVITE_TEACHER_TTL_HOURS`: TTL de invitaciones de docentes.
+- `INVITE_STUDENT_TTL_HOURS`: TTL de invitaciones de estudiantes.
 - `GEMINI_API_KEY`: requerido para authoring real, `/api/suggest` y tests `live_llm`.
 - `CORS_ALLOWED_ORIGIN`: origen extra permitido en produccion.
 - `STORYTELLER_MODEL`: override opcional del modelo usado por `/api/suggest`.
-- `VITE_SUPABASE_URL`: URL publica del proyecto Supabase usada por el frontend para resolver la sesion del browser.
-- `VITE_SUPABASE_ANON_KEY`: publishable/anon key usada por el frontend para leer la sesion actual.
+- `VITE_SUPABASE_URL`: URL publica del plano auth/session. En local apunta a `http://localhost:54321`.
+- `VITE_SUPABASE_ANON_KEY`: anon/publishable key usada por el frontend para leer la sesion actual. Sale de `supabase status -o env`.
+
+Nunca expongas `SUPABASE_SERVICE_ROLE_KEY` en frontend, browser, ejemplos de Vite o docs de UI.
 
 Base de ejemplo: [backend/.env.example](backend/.env.example)
 Frontend base de ejemplo: [frontend/.env.example](frontend/.env.example)
@@ -302,11 +251,17 @@ Frontend base de ejemplo: [frontend/.env.example](frontend/.env.example)
 ### Nota para Issue 23
 
 El sustrato de identidad de GitHub `#23` mantiene el bridge `users.id == auth.users.id`
-como contrato de datos, pero el entorno local actual sigue usando PostgreSQL por Docker,
-no Supabase Auth local. Eso significa:
+como contrato de datos. El entorno local actual usa dos planos distintos y los dos son
+obligatorios:
 
-- valida esquema y migraciones localmente con PostgreSQL normal
-- valida bridge real contra `auth.users` solo cuando apuntes a Supabase alojado o a una futura ruta `supabase start`
+- Postgres del repo por Docker en `5434`
+- Supabase CLI para auth local en `54321`
+
+Eso significa:
+
+- valida esquema y migraciones de la app contra el Postgres del repo
+- valida auth/session local contra Supabase CLI
+- no apuntes `DATABASE_URL` al Postgres interno de Supabase CLI en `54322`
 - si tu base local vieja todavia tiene IDs fake como `teacher-123`, reseteala y reseedala antes de correr la migracion de Issue 23
 - `backend/sql/rls_policies.sql` es un entregable separado de Alembic y no se aplica con `uv run alembic upgrade head`
 - esas policies dependen de `auth.uid()`, asi que solo deben aplicarse en Supabase o en un entorno local que realmente exponga el schema Auth compatible

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,13 +38,19 @@ ENVIRONMENT=development
 
 # -- Supabase auth perimeter (Issue 23 + Issue 30) ----------------
 # Required for JWT verification, activation flows and admin auth operations.
-SUPABASE_URL=
-SUPABASE_PROJECT_REF=
+# Local auth/session dev uses `supabase start` at http://localhost:54321.
+# Do not point DATABASE_URL at the Supabase local DB on 54322.
+SUPABASE_URL=http://localhost:54321
+SUPABASE_PROJECT_REF=local
+# Obtain from `supabase status -o env` (SERVICE_ROLE_KEY). Backend-only, never browser.
 SUPABASE_SERVICE_ROLE_KEY=
 
 # Development-only JWT fallback for local verification. Do not use as the
-# production verification path.
+# production verification path. Obtain from `supabase status -o env` (JWT_SECRET).
 SUPABASE_JWT_SECRET=
+MICROSOFT_TENANT_ID=
+INVITE_TEACHER_TTL_HOURS=72
+INVITE_STUDENT_TTL_HOURS=168
 
 # -- Google Cloud Tasks (required only when ENVIRONMENT=production)
 SERVICE_URL=

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -11,6 +11,7 @@ For a normal local backend session:
 ```powershell
 cd C:\Users\Juan Camilo Dorado\Downloads\ADAM-EDU
 docker compose up -d adam-edu-postgres
+supabase start
 
 cd backend
 uv sync --dev
@@ -19,6 +20,8 @@ uv run uvicorn shared.app:app --reload --host 0.0.0.0 --port 8000
 ```
 
 `docker compose up` starts PostgreSQL, but it does not apply migrations. `uv run alembic upgrade head` is required for a usable local schema.
+Supabase CLI owns auth/session local on `http://localhost:54321`. The repo app database
+stays on `localhost:5434`, not the Supabase local database on `54322`.
 
 ## Validation
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,9 +8,12 @@ import uuid
 
 import jwt
 import pytest
+from fastapi.testclient import TestClient
 from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import close_all_sessions
 
+from shared.app import app
 from shared.auth import get_auth_settings, get_jwt_verifier, get_supabase_admin_auth_client
 from shared.database import SessionLocal, engine
 from shared.models import Base, Course, Invite, Membership, Profile, Tenant, User
@@ -54,28 +57,40 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             item.add_marker(skip_missing_key)
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    numprocesses = getattr(config.option, "numprocesses", None)
+    if getattr(config, "workerinput", None) is not None:
+        raise pytest.UsageError(
+            "The backend test suite uses a shared database and must run in serial. "
+            "Do not use pytest-xdist (-n) until the harness isolates one database per worker."
+        )
+    if numprocesses == "auto" or (isinstance(numprocesses, int) and numprocesses > 0):
+        raise pytest.UsageError(
+            "The backend test suite uses a shared database and must run in serial. "
+            "Do not use pytest-xdist (-n) until the harness isolates one database per worker."
+        )
+
+
+def _truncate_all_tables() -> None:
+    table_names = ", ".join(table.name for table in Base.metadata.sorted_tables)
+    if not table_names:
+        return
+    truncate_sql = text(f"TRUNCATE TABLE {table_names} RESTART IDENTITY CASCADE")
+    close_all_sessions()
+    # The backend suite assumes exclusive ownership of the local test DB while it runs.
+    with engine.begin() as connection:
+        connection.execute(truncate_sql)
+
+
 @pytest.fixture(autouse=True)
 def clean_db(ensure_db_schema: None, request: pytest.FixtureRequest) -> Generator[None, None, None]:
     if request.node.module.__name__.endswith("test_issue23_identity_schema"):
         yield
         return
 
-    table_names = ", ".join(table.name for table in Base.metadata.sorted_tables)
-    truncate_sql = text(f"TRUNCATE TABLE {table_names} RESTART IDENTITY CASCADE")
-
-    session = SessionLocal()
-    try:
-        session.execute(truncate_sql)
-        session.commit()
-    finally:
-        session.close()
+    _truncate_all_tables()
     yield
-    session = SessionLocal()
-    try:
-        session.execute(truncate_sql)
-        session.commit()
-    finally:
-        session.close()
+    _truncate_all_tables()
 
 
 @pytest.fixture
@@ -84,7 +99,14 @@ def db(ensure_db_schema: None):
     try:
         yield session
     finally:
+        session.rollback()
         session.close()
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    with TestClient(app) as test_client:
+        yield test_client
 
 
 @pytest.fixture

--- a/backend/tests/test_issue30_auth_perimeter.py
+++ b/backend/tests/test_issue30_auth_perimeter.py
@@ -7,15 +7,11 @@ from unittest.mock import patch
 import httpx
 import jwt
 import pytest
-from fastapi.testclient import TestClient
 from jwt.exceptions import PyJWKClientError
 from sqlalchemy import select
 
-from shared.app import app
 from shared.auth import AuthError, AuthSettings, JwtVerifier, SupabaseAdminAuthClient
 from shared.models import Assignment, AuthoringJob, CourseMembership, Membership, Profile, Tenant
-
-client = TestClient(app)
 
 
 def build_auth_settings(*, environment: str = "development", jwt_secret: str = "test-jwt-secret-with-sufficient-length-123") -> AuthSettings:
@@ -27,7 +23,21 @@ def build_auth_settings(*, environment: str = "development", jwt_secret: str = "
     )
 
 
-def test_auth_me_rejects_invalid_issuer(auth_headers_factory, seed_identity) -> None:
+def test_health_returns_ok(client) -> None:
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "service": "adam-v8.0"}
+
+
+def test_auth_me_requires_bearer_token(client) -> None:
+    response = client.get("/api/auth/me")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "invalid_token"
+
+
+def test_auth_me_rejects_invalid_issuer(client, auth_headers_factory, seed_identity) -> None:
     user_id = str(uuid.uuid4())
     email = "issuer@example.edu"
     seed_identity(user_id=user_id, email=email, role="teacher")
@@ -38,7 +48,7 @@ def test_auth_me_rejects_invalid_issuer(auth_headers_factory, seed_identity) -> 
     assert response.json()["detail"] == "invalid_token"
 
 
-def test_auth_me_rejects_invalid_audience(auth_headers_factory, seed_identity) -> None:
+def test_auth_me_rejects_invalid_audience(client, auth_headers_factory, seed_identity) -> None:
     user_id = str(uuid.uuid4())
     email = "audience@example.edu"
     seed_identity(user_id=user_id, email=email, role="teacher")
@@ -149,7 +159,7 @@ def test_supabase_admin_get_user_by_email_paginates_across_list_users_pages() ->
     assert admin_client.client.auth.admin.calls == [(1, 200), (2, 200)]
 
 
-def test_auth_me_profile_incomplete(auth_headers_factory, seed_identity) -> None:
+def test_auth_me_profile_incomplete(client, auth_headers_factory, seed_identity) -> None:
     user_id = str(uuid.uuid4())
     email = "noprofile@example.edu"
     seed_identity(
@@ -166,7 +176,7 @@ def test_auth_me_profile_incomplete(auth_headers_factory, seed_identity) -> None
     assert response.json()["detail"] == "profile_incomplete"
 
 
-def test_auth_me_membership_required(auth_headers_factory, db) -> None:
+def test_auth_me_membership_required(client, auth_headers_factory, db) -> None:
     user_id = str(uuid.uuid4())
     email = "nomembership@example.edu"
     db.add(Profile(id=user_id, full_name="No Membership"))
@@ -178,7 +188,7 @@ def test_auth_me_membership_required(auth_headers_factory, db) -> None:
     assert response.json()["detail"] == "membership_required"
 
 
-def test_auth_me_account_suspended(auth_headers_factory, seed_identity) -> None:
+def test_auth_me_account_suspended(client, auth_headers_factory, seed_identity) -> None:
     user_id = str(uuid.uuid4())
     email = "suspended@example.edu"
     seed_identity(user_id=user_id, email=email, role="teacher", membership_status="suspended")
@@ -189,7 +199,7 @@ def test_auth_me_account_suspended(auth_headers_factory, seed_identity) -> None:
     assert response.json()["detail"] == "account_suspended"
 
 
-def test_auth_me_returns_memberships_and_primary_role(auth_headers_factory, seed_identity) -> None:
+def test_auth_me_returns_memberships_and_primary_role(client, auth_headers_factory, seed_identity) -> None:
     user_id = str(uuid.uuid4())
     email = "multirole@example.edu"
     first = seed_identity(user_id=user_id, email=email, role="student", university_id="10000000-0000-0000-0000-000000000010")
@@ -206,7 +216,7 @@ def test_auth_me_returns_memberships_and_primary_role(auth_headers_factory, seed
     assert first["profile"].full_name == payload["profile"]["full_name"]
 
 
-def test_authoring_denies_student(auth_headers_factory, seed_identity) -> None:
+def test_authoring_denies_student(client, auth_headers_factory, seed_identity) -> None:
     user_id = str(uuid.uuid4())
     email = "student@example.edu"
     seed_identity(user_id=user_id, email=email, role="student")
@@ -217,7 +227,7 @@ def test_authoring_denies_student(auth_headers_factory, seed_identity) -> None:
     assert response.json()["detail"] == "authoring_forbidden"
 
 
-def test_authoring_requires_legacy_bridge(auth_headers_factory, seed_identity) -> None:
+def test_authoring_requires_legacy_bridge(client, auth_headers_factory, seed_identity) -> None:
     user_id = str(uuid.uuid4())
     email = "bridge@example.edu"
     seed_identity(user_id=user_id, email=email, role="teacher", create_legacy_user=False)
@@ -228,7 +238,7 @@ def test_authoring_requires_legacy_bridge(auth_headers_factory, seed_identity) -
     assert response.json()["detail"] == "legacy_bridge_missing"
 
 
-def test_authoring_progress_requires_auth(seed_identity, db) -> None:
+def test_authoring_progress_requires_auth(client, seed_identity, db) -> None:
     teacher_id = str(uuid.uuid4())
     email = "progress-owner@example.edu"
     seed_identity(user_id=teacher_id, email=email, role="teacher")
@@ -245,7 +255,7 @@ def test_authoring_progress_requires_auth(seed_identity, db) -> None:
     assert response.json()["detail"] == "invalid_token"
 
 
-def test_authoring_progress_denies_student(auth_headers_factory, seed_identity, db) -> None:
+def test_authoring_progress_denies_student(client, auth_headers_factory, seed_identity, db) -> None:
     teacher_id = str(uuid.uuid4())
     owner_email = "progress-teacher@example.edu"
     seed_identity(user_id=teacher_id, email=owner_email, role="teacher")
@@ -267,7 +277,7 @@ def test_authoring_progress_denies_student(auth_headers_factory, seed_identity, 
     assert response.json()["detail"] == "authoring_forbidden"
 
 
-def test_authoring_progress_hides_jobs_from_other_teachers(auth_headers_factory, seed_identity, db) -> None:
+def test_authoring_progress_hides_jobs_from_other_teachers(client, auth_headers_factory, seed_identity, db) -> None:
     owner_id = str(uuid.uuid4())
     owner_email = "owner-teacher@example.edu"
     seed_identity(user_id=owner_id, email=owner_email, role="teacher")
@@ -289,7 +299,7 @@ def test_authoring_progress_hides_jobs_from_other_teachers(auth_headers_factory,
     assert response.json()["detail"] == "Job not found"
 
 
-def test_invite_resolve_returns_status_and_expiry(db, seed_invite) -> None:
+def test_invite_resolve_returns_status_and_expiry(client, db, seed_invite) -> None:
     university_id = "10000000-0000-0000-0000-000000000031"
     db.add(Tenant(id=university_id, name="Resolve University"))
     db.commit()
@@ -309,13 +319,14 @@ def test_invite_resolve_returns_status_and_expiry(db, seed_invite) -> None:
     assert payload["email_masked"].endswith("@example.edu")
 
 
-def test_invite_resolve_invalid() -> None:
+def test_invite_resolve_invalid(client) -> None:
     response = client.post("/api/invites/resolve", json={"invite_token": "missing"})
     assert response.status_code == 404
     assert response.json()["detail"] == "invalid_invite"
 
 
 def test_activate_password_success_and_retry(
+    client,
     db,
     fake_admin_client,
     seed_course,
@@ -388,7 +399,7 @@ def test_activate_password_success_and_retry(
     assert retry_response.json()["status"] == "activated"
 
 
-def test_activate_password_compensation_failure(fake_admin_client, db, seed_invite) -> None:
+def test_activate_password_compensation_failure(client, fake_admin_client, db, seed_invite) -> None:
     tenant = Tenant(id="10000000-0000-0000-0000-000000000060", name="Compensation University")
     db.add(tenant)
     db.commit()
@@ -414,7 +425,7 @@ def test_activate_password_compensation_failure(fake_admin_client, db, seed_invi
     assert response.json()["detail"] == "activation_failed"
 
 
-def test_activate_password_does_not_delete_preexisting_user_on_failure(fake_admin_client, db, seed_invite) -> None:
+def test_activate_password_does_not_delete_preexisting_user_on_failure(client, fake_admin_client, db, seed_invite) -> None:
     tenant = Tenant(id="10000000-0000-0000-0000-000000000062", name="Existing User University")
     db.add(tenant)
     db.commit()
@@ -440,7 +451,7 @@ def test_activate_password_does_not_delete_preexisting_user_on_failure(fake_admi
     assert fake_admin_client.get_user_by_id(existing_user.id) is not None
 
 
-def test_activate_password_derives_profile_name_when_full_name_missing(fake_admin_client, db, seed_invite) -> None:
+def test_activate_password_derives_profile_name_when_full_name_missing(client, fake_admin_client, db, seed_invite) -> None:
     tenant = Tenant(id="10000000-0000-0000-0000-000000000061", name="Derived Name University")
     db.add(tenant)
     db.commit()
@@ -466,7 +477,7 @@ def test_activate_password_derives_profile_name_when_full_name_missing(fake_admi
     assert profile.full_name == "derived.name"
 
 
-def test_activate_password_reactivates_existing_membership(fake_admin_client, db, seed_invite) -> None:
+def test_activate_password_reactivates_existing_membership(client, fake_admin_client, db, seed_invite) -> None:
     tenant = Tenant(id="10000000-0000-0000-0000-000000000063", name="Reactivation University")
     db.add(tenant)
     db.commit()
@@ -512,6 +523,7 @@ def test_activate_password_reactivates_existing_membership(fake_admin_client, db
 
 
 def test_redeem_rolls_back_if_invite_cannot_be_consumed(
+    client,
     db,
     auth_headers_factory,
     seed_course,
@@ -563,6 +575,7 @@ def test_redeem_rolls_back_if_invite_cannot_be_consumed(
 
 
 def test_redeem_success_and_repeat_is_idempotent(
+    client,
     seed_course,
     seed_identity,
     seed_invite,
@@ -619,7 +632,7 @@ def test_redeem_success_and_repeat_is_idempotent(
     assert refreshed_invite.status == "consumed"
 
 
-def test_activate_oauth_complete_mismatch_does_not_delete_existing_auth_user(fake_admin_client, seed_invite, db) -> None:
+def test_activate_oauth_complete_mismatch_does_not_delete_existing_auth_user(client, fake_admin_client, seed_invite, db) -> None:
     tenant = Tenant(id="10000000-0000-0000-0000-000000000070", name="OAuth University")
     db.add(tenant)
     db.commit()
@@ -653,7 +666,7 @@ def test_activate_oauth_complete_mismatch_does_not_delete_existing_auth_user(fak
     assert fake_admin_client.get_user_by_id(oauth_user_id) is fake_user
 
 
-def test_activate_oauth_complete_mismatch_skips_delete_even_if_admin_delete_would_fail(fake_admin_client, seed_invite, db) -> None:
+def test_activate_oauth_complete_mismatch_skips_delete_even_if_admin_delete_would_fail(client, fake_admin_client, seed_invite, db) -> None:
     tenant = Tenant(id="10000000-0000-0000-0000-000000000071", name="OAuth Failure University")
     db.add(tenant)
     db.commit()
@@ -688,7 +701,7 @@ def test_activate_oauth_complete_mismatch_skips_delete_even_if_admin_delete_woul
     assert fake_admin_client.get_user_by_id(oauth_user_id) is fake_user
 
 
-def test_activate_oauth_complete_success(seed_invite, auth_headers_factory, db) -> None:
+def test_activate_oauth_complete_success(client, seed_invite, auth_headers_factory, db) -> None:
     tenant = Tenant(id="10000000-0000-0000-0000-000000000072", name="OAuth Success University")
     db.add(tenant)
     db.commit()

--- a/backend/tests/test_phase1a_smoke.py
+++ b/backend/tests/test_phase1a_smoke.py
@@ -1,13 +1,8 @@
 from unittest.mock import patch
 import uuid
 
-from fastapi.testclient import TestClient
-
-from shared.app import app
 from shared.database import SessionLocal
 from shared.models import Assignment, AuthoringJob
-
-client = TestClient(app)
 
 
 def test_database_connection() -> None:
@@ -18,7 +13,7 @@ def test_database_connection() -> None:
         db.close()
 
 
-def test_intake_and_idempotency_workflow(auth_headers_factory, seed_identity) -> None:
+def test_intake_and_idempotency_workflow(client, auth_headers_factory, seed_identity) -> None:
     teacher_id = "00000000-0000-0000-0000-000000000101"
     teacher_email = "teacher101@example.edu"
     seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
@@ -130,7 +125,7 @@ def test_intake_and_idempotency_workflow(auth_headers_factory, seed_identity) ->
     assert retry_response.json()["status"] == "bypassed"
 
 
-def test_intake_requires_bearer_auth() -> None:
+def test_intake_requires_bearer_auth(client) -> None:
     payload = {"assignment_title": f"Case {uuid.uuid4()}"}
     response = client.post("/api/authoring/jobs", json=payload)
     assert response.status_code == 401

--- a/backend/tests/test_phase1b_integration.py
+++ b/backend/tests/test_phase1b_integration.py
@@ -2,13 +2,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from fastapi.testclient import TestClient
-
-from shared.app import app
 from shared.database import SessionLocal
 from shared.models import Assignment, AuthoringJob
-
-client = TestClient(app)
 
 TEACHER_ID = "00000000-0000-0000-0000-000000000102"
 ERROR_TEACHER_ID = "00000000-0000-0000-0000-000000000103"
@@ -27,7 +22,7 @@ async def _failing_astream(*args, **kwargs):
     yield {}
 
 
-def test_phase1b_intake_and_authoring_stubbed(auth_headers_factory, seed_identity) -> None:
+def test_phase1b_intake_and_authoring_stubbed(client, auth_headers_factory, seed_identity) -> None:
     teacher_email = "teacher102@example.edu"
     seed_identity(user_id=TEACHER_ID, email=teacher_email, role="teacher")
     headers = auth_headers_factory(sub=TEACHER_ID, email=teacher_email)
@@ -64,7 +59,7 @@ def test_phase1b_intake_and_authoring_stubbed(auth_headers_factory, seed_identit
         db.close()
 
 
-def test_phase1b_authoring_service_failure(auth_headers_factory, seed_identity) -> None:
+def test_phase1b_authoring_service_failure(client, auth_headers_factory, seed_identity) -> None:
     teacher_email = "teacher103@example.edu"
     seed_identity(user_id=ERROR_TEACHER_ID, email=teacher_email, role="teacher")
     headers = auth_headers_factory(sub=ERROR_TEACHER_ID, email=teacher_email)

--- a/backend/tests/test_phase1b_real.py
+++ b/backend/tests/test_phase1b_real.py
@@ -1,19 +1,13 @@
 import os
-import json
 import uuid
-import asyncio
-from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
-from shared.app import app
 from shared.database import SessionLocal
 from shared.models import AuthoringJob, Assignment
 
-client = TestClient(app)
 pytestmark = pytest.mark.live_llm
 
-def test_real_success_and_idempotency(auth_headers_factory, seed_identity):
+def test_real_success_and_idempotency(client, auth_headers_factory, seed_identity):
     print("\n--- Testing Real Success ---")
     teacher_id = str(uuid.uuid4())
     teacher_email = f"{teacher_id}@example.edu"
@@ -66,7 +60,7 @@ def test_real_success_and_idempotency(auth_headers_factory, seed_identity):
         db.close()
 
 
-def test_real_failure_handling(auth_headers_factory, seed_identity):
+def test_real_failure_handling(client, auth_headers_factory, seed_identity):
     print("\n--- Testing Real Failure (Invalid API Key) ---")
     teacher_id = str(uuid.uuid4())
     teacher_email = f"{teacher_id}@example.edu"
@@ -108,7 +102,7 @@ def test_real_failure_handling(auth_headers_factory, seed_identity):
         db.close()
 
 
-def test_legacy_suggest():
+def test_legacy_suggest(client):
     print("\n--- Testing Legacy /suggest Endpoint ---")
     
     # We use a dummy payload that matches the Pydantic SuggestRequest exactly
@@ -138,40 +132,4 @@ def test_legacy_suggest():
     else:
         print(f"Error Response: {resp.text}")
         assert False, "Legacy /suggest failed."
-
-
-if __name__ == "__main__":
-    # Ensure stdout uses utf-8 just in case
-    import sys
-    sys.stdout.reconfigure(encoding='utf-8')
-    
-    print("==================================================")
-    print("STARTING REAL PHASE 1B VERIFICATION")
-    print("==================================================")
-    
-    try:
-        test_legacy_suggest()
-        print("Legacy Endpoint OK\n")
-        
-        test_real_failure_handling()
-        print("Failure Handling OK\n")
-        
-        test_real_success_and_idempotency()
-        print("Success & Idempotency OK\n")
-        
-        print("==================================================")
-        print("ALL REAL TESTS PASSED. PHASE 1B API FULLY FUNCTIONAL.")
-        print("==================================================")
-        
-    except AssertionError as e:
-        print(f"\n[FAIL] TEST FAILED: {str(e)}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)
-    except Exception as e:
-        print(f"\n[ERROR] UNEXPECTED ERROR: {str(e)}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)
-
 

--- a/backend/tests/test_phase3_status_api.py
+++ b/backend/tests/test_phase3_status_api.py
@@ -1,42 +1,32 @@
 import uuid
-from unittest.mock import patch
 
-from fastapi.testclient import TestClient
-
-from shared.app import app
-from shared.database import SessionLocal
 from shared.models import Assignment, AuthoringJob
 
-client = TestClient(app)
-TEACHER_ID = "00000000-0000-0000-0000-000000000104"
 
-
-def test_polling_happy_path(db, auth_headers_factory, seed_identity) -> None:
+def test_polling_happy_path(client, db, auth_headers_factory, seed_identity) -> None:
+    teacher_id = str(uuid.uuid4())
     teacher_email = "teacher104@example.edu"
-    seed_identity(user_id=TEACHER_ID, email=teacher_email, role="teacher")
-    headers = auth_headers_factory(sub=TEACHER_ID, email=teacher_email)
-    intake_data = {
-        "assignment_title": "Test Phase 3",
-        "subject": "Finance",
-        "academic_level": "MBA",
-        "industry": "Banking",
-        "student_profile": "business",
-        "case_type": "harvard_only",
-    }
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+    assignment = Assignment(teacher_id=teacher_id, title="Test Phase 3", status="draft")
+    db.add(assignment)
+    db.flush()
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status="pending",
+        task_payload={},
+    )
+    db.add(job)
+    db.commit()
 
-    with patch("fastapi.BackgroundTasks.add_task"):
-        response = client.post("/api/authoring/jobs", json=intake_data, headers=headers)
-    assert response.status_code == 202, response.text
-    job_id = response.json()["job_id"]
-
-    status_response = client.get(f"/api/authoring/jobs/{job_id}", headers=headers)
+    status_response = client.get(f"/api/authoring/jobs/{job.id}", headers=headers)
     assert status_response.status_code == 200
     assignment_id = status_response.json()["assignment_id"]
 
-    result_response = client.get(f"/api/authoring/jobs/{job_id}/result", headers=headers)
+    result_response = client.get(f"/api/authoring/jobs/{job.id}/result", headers=headers)
     assert result_response.status_code == 409
 
-    job = db.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
     assignment = db.query(Assignment).filter(Assignment.id == assignment_id).first()
     assert job is not None
     assert assignment is not None
@@ -82,16 +72,16 @@ def test_polling_happy_path(db, auth_headers_factory, seed_identity) -> None:
     }
     db.commit()
 
-    completed_status_response = client.get(f"/api/authoring/jobs/{job_id}", headers=headers)
+    completed_status_response = client.get(f"/api/authoring/jobs/{job.id}", headers=headers)
     assert completed_status_response.status_code == 200
     assert completed_status_response.json()["status"] == "completed"
 
-    completed_result_response = client.get(f"/api/authoring/jobs/{job_id}/result", headers=headers)
+    completed_result_response = client.get(f"/api/authoring/jobs/{job.id}/result", headers=headers)
     assert completed_result_response.status_code == 200
     assert completed_result_response.json()["blueprint"]["version"] == "adam-v8.0"
 
 
-def test_job_not_found(auth_headers_factory, seed_identity) -> None:
+def test_job_not_found(client, auth_headers_factory, seed_identity) -> None:
     teacher_email = "teacher404@example.edu"
     user_id = str(uuid.uuid4())
     seed_identity(user_id=user_id, email=teacher_email, role="teacher")
@@ -102,33 +92,36 @@ def test_job_not_found(auth_headers_factory, seed_identity) -> None:
     assert client.get(f"/api/authoring/jobs/{fake_id}/result", headers=headers).status_code == 404
 
 
-def test_failed_job_path(db, auth_headers_factory, seed_identity) -> None:
+def test_failed_job_path(client, db, auth_headers_factory, seed_identity) -> None:
     teacher_email = "teacherfailed@example.edu"
     user_id = str(uuid.uuid4())
     seed_identity(user_id=user_id, email=teacher_email, role="teacher")
     headers = auth_headers_factory(sub=user_id, email=teacher_email)
-    intake_data = {"assignment_title": "Fail Test"}
+    assignment = Assignment(teacher_id=user_id, title="Fail Test", status="draft")
+    db.add(assignment)
+    db.flush()
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status="pending",
+        task_payload={},
+    )
+    db.add(job)
+    db.commit()
 
-    with patch("fastapi.BackgroundTasks.add_task"):
-        response = client.post("/api/authoring/jobs", json=intake_data, headers=headers)
-    assert response.status_code == 202
-    job_id = response.json()["job_id"]
-
-    job = db.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
-    assert job is not None
     job.status = "failed"
     job.task_payload = {"error_trace": "ValueError: LLM crashed in isolated test"}
     db.commit()
 
-    status_response = client.get(f"/api/authoring/jobs/{job_id}", headers=headers)
+    status_response = client.get(f"/api/authoring/jobs/{job.id}", headers=headers)
     assert status_response.status_code == 200
     assert status_response.json()["error_trace"] == "ValueError: LLM crashed in isolated test"
 
-    result_response = client.get(f"/api/authoring/jobs/{job_id}/result", headers=headers)
+    result_response = client.get(f"/api/authoring/jobs/{job.id}/result", headers=headers)
     assert result_response.status_code == 409
 
 
-def test_authoring_owner_isolated(auth_headers_factory, seed_identity) -> None:
+def test_authoring_owner_isolated(client, db, auth_headers_factory, seed_identity) -> None:
     owner_id = str(uuid.uuid4())
     owner_email = "owner@example.edu"
     other_id = str(uuid.uuid4())
@@ -137,11 +130,17 @@ def test_authoring_owner_isolated(auth_headers_factory, seed_identity) -> None:
     seed_identity(user_id=other_id, email=other_email, role="teacher")
     owner_headers = auth_headers_factory(sub=owner_id, email=owner_email)
     other_headers = auth_headers_factory(sub=other_id, email=other_email)
+    assignment = Assignment(teacher_id=owner_id, title="Owned", status="draft")
+    db.add(assignment)
+    db.flush()
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status="pending",
+        task_payload={},
+    )
+    db.add(job)
+    db.commit()
 
-    with patch("fastapi.BackgroundTasks.add_task"):
-        response = client.post("/api/authoring/jobs", json={"assignment_title": "Owned"}, headers=owner_headers)
-    assert response.status_code == 202
-    job_id = response.json()["job_id"]
-
-    assert client.get(f"/api/authoring/jobs/{job_id}", headers=other_headers).status_code == 404
-    assert client.get(f"/api/authoring/jobs/{job_id}/result", headers=other_headers).status_code == 404
+    assert client.get(f"/api/authoring/jobs/{job.id}", headers=other_headers).status_code == 404
+    assert client.get(f"/api/authoring/jobs/{job.id}/result", headers=other_headers).status_code == 404

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     container_name: adam-edu-postgres
     restart: unless-stopped
     ports:
+      # Host port 5434 is the repo's app/authoring DB. Container port 5432 stays internal to Docker.
       - "${POSTGRES_HOST_PORT:-5434}:5432"
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
@@ -42,6 +43,12 @@ services:
     ports:
       - "${API_HOST_PORT:-8123}:8000"
     environment:
+      DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@adam-edu-postgres:5432/${POSTGRES_DB:-postgres}
+      ENVIRONMENT: ${ENVIRONMENT:-development}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       LANGSMITH_API_KEY: ${LANGSMITH_API_KEY:-}
-      POSTGRES_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@adam-edu-postgres:5432/${POSTGRES_DB:-postgres}?sslmode=disable
+      # Optional only: when the API runs in Docker and auth runs on the host via Supabase CLI,
+      # inject a host-reachable URL such as http://host.docker.internal:54321. Do not use localhost here.
+      SUPABASE_URL: ${SUPABASE_URL:-}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
+      SUPABASE_JWT_SECRET: ${SUPABASE_JWT_SECRET:-}

--- a/docs/runbooks/local-dev-auth.md
+++ b/docs/runbooks/local-dev-auth.md
@@ -1,0 +1,140 @@
+# Local Dev Auth Runbook
+
+Este runbook fija el setup local canonico para auth y authoring despues de Issue 30.
+Hay dos planos locales distintos. No los mezcles.
+
+## Antes de empezar
+
+- Docker Desktop o Docker Engine con Compose funcionando
+- Supabase CLI instalada
+- `uv` instalado
+- Node.js 22 + npm
+
+Opcional:
+
+- `npx supabase ...` como fallback si no quieres una instalacion global
+
+## Plano 1: authoring y app DB local
+
+Este repo mantiene su base principal local fuera de Supabase CLI.
+
+- Servicio: `adam-edu-postgres`
+- Comando: `docker compose up -d adam-edu-postgres`
+- Host: `localhost`
+- Puerto host del repo: `5434`
+- DSN backend local:
+  `postgresql+psycopg://postgres:postgres@localhost:5434/postgres`
+
+`DATABASE_URL` siempre apunta a este Postgres del repo cuando trabajas localmente.
+No lo apuntes al Postgres interno de Supabase CLI.
+
+## Plano 2: auth local y tooling de Supabase
+
+Supabase CLI se usa para auth/session local y para obtener claves del stack local.
+
+- Comando: `supabase start`
+- API URL: `http://localhost:54321`
+- DB URL interna del stack Supabase: `postgresql://postgres:postgres@localhost:54322/postgres`
+- Studio: `http://localhost:54323`
+- Mailpit: `http://localhost:54324`
+
+El Postgres de Supabase CLI en `54322` no reemplaza la base principal del repo. Sirve
+para el stack local de Supabase, no para `DATABASE_URL`.
+
+El scaffold de `supabase/config.toml` solo deja activas rutas que el frontend actual ya
+puede servir. Los callbacks y pantallas finales de activation/join siguen como trabajo
+posterior de Issue 5.
+
+## Puertos remotos y de produccion
+
+- `5432`: Supavisor session mode o conexion remota equivalente. No es el default local del repo.
+- `6543`: Supavisor transaction mode remoto/serverless. No es setup local.
+
+## Flujo recomendado en menos de 10 comandos
+
+Los prerrequisitos anteriores no cuentan dentro de este flujo.
+
+1. `docker compose up -d adam-edu-postgres`
+2. `supabase start`
+3. `supabase status -o env`
+4. preparar `backend/.env` y `frontend/.env` desde sus ejemplos, con el mapping local correcto
+5. `uv sync --directory backend --dev`
+6. `uv run --directory backend alembic upgrade head`
+7. `uv run --directory backend uvicorn shared.app:app --reload --host 0.0.0.0 --port 8000`
+8. `npm --prefix frontend install`
+9. `npm --prefix frontend run dev`
+
+## Traduccion de `supabase status -o env`
+
+Usa `supabase status -o env` como fuente de verdad local para extraer los valores del
+stack Supabase. Traducelos al naming del repo asi:
+
+| Output Supabase CLI | Repo backend/frontend |
+| --- | --- |
+| `API_URL` | `SUPABASE_URL` y `VITE_SUPABASE_URL` |
+| `ANON_KEY` | `VITE_SUPABASE_ANON_KEY` |
+| `SERVICE_ROLE_KEY` | `SUPABASE_SERVICE_ROLE_KEY` |
+| `JWT_SECRET` | `SUPABASE_JWT_SECRET` |
+
+Convencion local del repo:
+
+- `SUPABASE_PROJECT_REF=local`
+
+## Variables a completar
+
+Backend:
+
+- `DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres`
+- `SUPABASE_URL=http://localhost:54321`
+- `SUPABASE_PROJECT_REF=local`
+- `SUPABASE_SERVICE_ROLE_KEY=<SERVICE_ROLE_KEY desde supabase status -o env>`
+- `SUPABASE_JWT_SECRET=<JWT_SECRET desde supabase status -o env>`
+- `MICROSOFT_TENANT_ID=`
+- `INVITE_TEACHER_TTL_HOURS=72`
+- `INVITE_STUDENT_TTL_HOURS=168`
+
+Frontend:
+
+- `VITE_SUPABASE_URL=http://localhost:54321`
+- `VITE_SUPABASE_ANON_KEY=<ANON_KEY desde supabase status -o env>`
+
+Nunca lleves `SUPABASE_SERVICE_ROLE_KEY` al browser ni a ejemplos frontend.
+
+## Smoke minimo
+
+Este issue documenta y valida infraestructura local. No promete login productivo final.
+
+- `GET /health` responde `200`
+- `GET /api/auth/me` sin bearer responde `401`
+
+Eso confirma:
+
+- backend levantado
+- auth perimeter fail-closed activo
+- frontend listo para usar Supabase local como origen de sesion cuando llegue Issue 5
+
+## Limite explicito de esta issue
+
+Todavia no existe:
+
+- login UI final
+- callback UX final
+- guards finales por rol
+
+Todo eso sigue en Issue 5.
+
+## Microsoft OAuth local
+
+El scaffold local de `supabase/config.toml` deja preparado el bloque Azure, pero no lo
+habilita en esta issue.
+
+- usa `localhost`, no `127.0.0.1`, para redirect URIs locales
+- las rutas activas hoy en el scaffold local son solo `/app/` y `/app/teacher`
+- completa client id/secret y activa el provider antes de Issue 5
+- callback local esperado: `http://localhost:54321/auth/v1/callback`
+
+## Nota sobre RLS separada
+
+`backend/sql/rls_policies.sql` no forma parte del happy path local de este repo. Alembic
+no aplica ese archivo y solo debe usarse como paso separado cuando el entorno realmente
+exponga helpers compatibles como `auth.uid()`.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,4 @@
-VITE_SUPABASE_URL=
+# Local browser auth/session uses the Supabase CLI API URL on port 54321.
+VITE_SUPABASE_URL=http://localhost:54321
+# Obtain from `supabase status -o env` (ANON_KEY). Never use SERVICE_ROLE_KEY in the browser.
 VITE_SUPABASE_ANON_KEY=

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,195 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+project_id = "adam-edu"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+external_url = "http://localhost:54321"
+
+[api.tls]
+enabled = false
+
+[db]
+port = 54322
+shadow_port = 54320
+health_timeout = "2m"
+major_version = 17
+
+[db.pooler]
+enabled = false
+port = 54329
+pool_mode = "transaction"
+default_pool_size = 20
+max_client_conn = 100
+
+[db.migrations]
+enabled = true
+schema_paths = []
+
+[db.seed]
+enabled = true
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+enabled = false
+allowed_cidrs = ["0.0.0.0/0"]
+allowed_cidrs_v6 = ["::/0"]
+
+[realtime]
+enabled = true
+
+[studio]
+enabled = true
+port = 54323
+api_url = "http://127.0.0.1"
+openai_api_key = "env(OPENAI_API_KEY)"
+
+[inbucket]
+enabled = true
+port = 54324
+
+[storage]
+enabled = true
+file_size_limit = "50MiB"
+
+[storage.s3_protocol]
+enabled = true
+
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+[auth]
+enabled = true
+# Keep the local auth stack centered on localhost so future OAuth callbacks match Issue 5.
+site_url = "http://localhost:5173/app/"
+# Current runnable routes only. Issue 5 will add dedicated callback and activation URLs.
+# Future placeholders:
+# - http://localhost:5173/app/auth/callback
+# - http://localhost:5173/app/teacher/activate
+# - http://localhost:5173/app/join
+additional_redirect_urls = [
+  "http://localhost:5173/app/",
+  "http://localhost:5173/app/teacher",
+]
+jwt_expiry = 3600
+enable_refresh_token_rotation = true
+refresh_token_reuse_interval = 10
+enable_signup = true
+enable_anonymous_sign_ins = false
+enable_manual_linking = false
+minimum_password_length = 6
+password_requirements = ""
+
+[auth.rate_limit]
+email_sent = 2
+sms_sent = 30
+anonymous_users = 30
+token_refresh = 150
+sign_in_sign_ups = 30
+token_verifications = 30
+web3 = 30
+
+[auth.email]
+enable_signup = true
+double_confirm_changes = true
+enable_confirmations = false
+secure_password_change = false
+max_frequency = "1s"
+otp_length = 6
+otp_expiry = 3600
+
+[auth.sms]
+enable_signup = false
+enable_confirmations = false
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+[auth.mfa]
+max_enrolled_factors = 10
+
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Prepare Azure OAuth wiring now so Issue 5 does not start with a hidden local config blocker.
+# Keep it disabled until the team sets real values and validates redirect URLs.
+[auth.external.azure]
+enabled = false
+client_id = "env(SUPABASE_AUTH_EXTERNAL_AZURE_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_AZURE_SECRET)"
+redirect_uri = "http://localhost:54321/auth/v1/callback"
+url = ""
+skip_nonce_check = false
+email_optional = false
+
+[auth.external.apple]
+enabled = false
+client_id = ""
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+redirect_uri = ""
+url = ""
+skip_nonce_check = false
+email_optional = false
+
+[auth.web3.solana]
+enabled = false
+
+[auth.third_party.firebase]
+enabled = false
+
+[auth.third_party.auth0]
+enabled = false
+
+[auth.third_party.aws_cognito]
+enabled = false
+
+[auth.third_party.clerk]
+enabled = false
+
+[auth.oauth_server]
+enabled = false
+authorization_url_path = "/oauth/consent"
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+policy = "per_worker"
+inspector_port = 8083
+deno_version = 2
+
+[analytics]
+enabled = true
+port = 54327
+backend = "postgres"
+
+[experimental]
+orioledb_version = ""
+s3_host = "env(S3_HOST)"
+s3_region = "env(S3_REGION)"
+s3_access_key = "env(S3_ACCESS_KEY)"
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,3 @@
+-- Issue 32 scaffold seed.
+-- Keep this file intentionally minimal so `supabase start` and reset flows
+-- remain reproducible from a clean clone.


### PR DESCRIPTION
## Summary
- add a canonical local auth + authoring runbook and commit the minimum Supabase CLI scaffold required for reproducible `supabase start`
- align `README.md`, `CONTRIBUTING.md`, agent docs, and backend/frontend env examples around the two local planes: repo Postgres on `5434` and Supabase local auth on `54321`
- fix the optional Docker Compose API path so it uses `DATABASE_URL`, documents host/container auth caveats correctly, and no longer implies a misleading auth-ready default
- stabilize the backend test harness by moving to a fixture-based `TestClient`, enforcing serial execution, and making DB cleanup repeatable for reruns
- decouple the phase 3 status tests from intake happy-path assumptions so they validate status/result/ownership behavior directly

## Validation
- `uv run --directory backend pytest -q` -> `45 passed, 12 skipped`
- `uv run --directory backend mypy src`
- `npm --prefix frontend run lint` -> 3 pre-existing warnings, 0 errors
- `npm --prefix frontend run test`
- `npm --prefix frontend run build`

## Notes
- `document-release` was intentionally not run before tests were green
- the canonical local path remains backend/frontend local plus `supabase start`; Docker Compose stays optional

Closes #32
