### PR TITLE
FIX: se arreglo la identacion de las skills para los agentes CC y Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,9 @@ This repository does not currently include a student runtime, full authenticatio
 - Dispatch defaults:
   - ideas and brainstorming -> `office-hours`, then `autoplan` or `plan-*`
   - bugs, errors, regressions -> `investigate`
-- review of a diff, branch, or PR -> `review`
-- QA or staging verification -> `qa` or `qa-only`
-- release preparation -> `ship`, then `land-and-deploy`, `canary`, `document-release`
+  - review of a diff, branch, or PR -> `review`
+  - QA or staging verification -> `qa` or `qa-only`
+  - release preparation -> `ship`, then `land-and-deploy`, `canary`, `document-release`
   - visual work -> `design-*`
   - security review -> `cso`
   - browser-heavy QA -> `browse`, `connect-chrome`, `setup-browser-cookies`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,9 @@ Use the repo-driven gstack runtime materialized from the pinned lock in `scripts
 - Dispatch defaults:
   - ideas and brainstorming -> `office-hours`, then `autoplan` or `plan-*`
   - bugs, errors, regressions -> `investigate`
-- review of a diff, branch, or PR -> `review`
-- QA or staging verification -> `qa` or `qa-only`
-- release preparation -> `ship`, then `land-and-deploy`, `canary`, `document-release`
+  - review of a diff, branch, or PR -> `review`
+  - QA or staging verification -> `qa` or `qa-only`
+  - release preparation -> `ship`, then `land-and-deploy`, `canary`, `document-release`
   - visual work -> `design-*`
   - security review -> `cso`
   - browser-heavy QA -> `browse`, `connect-chrome`, `setup-browser-cookies`


### PR DESCRIPTION
## Summary

- What changed?
- Why was it necessary?

## Validation

- [ ] `uv run --directory backend pytest -q`
- [ ] `uv run --directory backend mypy src`
- [ ] `npm --prefix frontend run lint`
- [ ] `npm --prefix frontend run build`
- [ ] `npm --prefix frontend run test`

## Checklist

- [ ] Single-purpose PR
- [ ] No secrets added
- [ ] Docs updated if behavior or setup changed
- [ ] Ready for squash merge
