### PR TITLE
feat: shell frontend auth-aware y rutas reales por rol (Issue #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 ## ADAM EDU v8.0
 
-ADAM EDU, en este corte, es un Teacher Authoring + Preview MVP. El repositorio publica el flujo docente que ya funciona: sugerencias para el formulario, generacion asincrona del caso con LangGraph, timeline por SSE y preview final para el profesor.
+ADAM EDU es un Teacher Authoring + Preview MVP en transicion a una plataforma multi-rol con autenticacion real. El repositorio incluye:
 
-No incluye runtime de estudiante, super admin, auth real ni despliegue cloud endurecido. Esos frentes quedan fuera del alcance de esta subida para mantener el repo pequeno, honesto y estable.
+- Flujo docente completo: sugerencias en formulario, generacion asincrona con LangGraph, timeline por SSE y preview del caso.
+- Shell frontend auth-aware (Issue #5): `AuthProvider`, guards por rol, rutas reales para teacher/student/admin, callback OAuth PKCE, helper `sessionStorage` de activacion con TTL 5 minutos.
+- Auth perimeter backend (Issue #3): verificacion JWT via JWKS, actor resolution por memberships, `GET /api/auth/me`, endpoints de activacion body-only.
+
+Los flujos de negocio completos de teacher activation, student join y admin provisioning siguen en Issues #6, #7 y #8 respectivamente. El shell actual deja listos los placeholders y contratos de routing para esas historias.
 
 Este repositorio evoluciona hoy como `ADAM-EDU`. El proyecto deriva del quickstart original de Gemini/LangGraph y conserva esa procedencia para fines de atribucion y trazabilidad, pero su desarrollo activo, gobernanza y flujo de colaboracion viven ya en esta linea de producto.
 

--- a/docs/runbooks/local-dev-auth.md
+++ b/docs/runbooks/local-dev-auth.md
@@ -41,9 +41,9 @@ Supabase CLI se usa para auth/session local y para obtener claves del stack loca
 El Postgres de Supabase CLI en `54322` no reemplaza la base principal del repo. Sirve
 para el stack local de Supabase, no para `DATABASE_URL`.
 
-El scaffold de `supabase/config.toml` solo deja activas rutas que el frontend actual ya
-puede servir. Los callbacks y pantallas finales de activation/join siguen como trabajo
-posterior de Issue 5.
+El `supabase/config.toml` incluye las rutas del shell auth-aware de Issue 5:
+`/app/auth/callback`, `/app/teacher/activate`, `/app/join`. Para que los cambios de
+`config.toml` tengan efecto local, reinicia Supabase: `supabase stop && supabase start`.
 
 ## Puertos remotos y de produccion
 
@@ -97,31 +97,30 @@ Frontend:
 
 - `VITE_SUPABASE_URL=http://localhost:54321`
 - `VITE_SUPABASE_ANON_KEY=<ANON_KEY desde supabase status -o env>`
+- `VITE_AUTH_CALLBACK_URL=http://localhost:5173/app/auth/callback`
+- `VITE_APP_BASE_URL=http://localhost:5173/app`
 
 Nunca lleves `SUPABASE_SERVICE_ROLE_KEY` al browser ni a ejemplos frontend.
 
 ## Smoke minimo
 
-Este issue documenta y valida infraestructura local. No promete login productivo final.
-
 - `GET /health` responde `200`
 - `GET /api/auth/me` sin bearer responde `401`
+- `http://localhost:5173/app/` sin sesion muestra la landing con 3 entrypoints por rol
+- `http://localhost:5173/app/teacher` sin sesion redirige a `/teacher/login`
+- `http://localhost:5173/app/auth/callback` muestra spinner de "Completando inicio de sesion"
 
-Eso confirma:
+## Prerequisito manual para produccion
 
-- backend levantado
-- auth perimeter fail-closed activo
-- frontend listo para usar Supabase local como origen de sesion cuando llegue Issue 5
+En Supabase Dashboard → Authentication → URL Configuration, agregar:
 
-## Limite explicito de esta issue
+- `https://<TU-DOMINIO>/app/auth/callback`
 
-Todavia no existe:
+Para Microsoft OAuth (Issue #6), agregar ademas en Azure AD la Redirect URI:
 
-- login UI final
-- callback UX final
-- guards finales por rol
+- `https://<TU-SUPABASE-PROJECT>.supabase.co/auth/v1/callback`
 
-Todo eso sigue en Issue 5.
+No incluir secretos de provider en el frontend ni en este runbook.
 
 ## Microsoft OAuth local
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,3 +2,10 @@
 VITE_SUPABASE_URL=http://localhost:54321
 # Obtain from `supabase status -o env` (ANON_KEY). Never use SERVICE_ROLE_KEY in the browser.
 VITE_SUPABASE_ANON_KEY=
+
+# OAuth callback URL — must match Supabase Dashboard > Authentication > URL Configuration
+# and supabase/config.toml additional_redirect_urls for local dev.
+VITE_AUTH_CALLBACK_URL=http://localhost:5173/app/auth/callback
+
+# Base URL of the app (used for constructing absolute URLs when needed)
+VITE_APP_BASE_URL=http://localhost:5173/app

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.5.0",
         "@types/plotly.js": "^3.0.10",
         "@types/react": "^19.1.2",
@@ -38,11 +41,60 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "jsdom": "^26.1.0",
         "tw-animate-css": "^1.2.9",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.26.1",
         "vite": "^6.3.4",
         "vitest": "^4.1.2"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -64,6 +116,121 @@
       },
       "bin": {
         "findup": "bin/findup.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3502,6 +3669,96 @@
         "vite": "^5.2.0 || ^6"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@turf/area": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.4.tgz",
@@ -3573,6 +3830,14 @@
       "funding": {
         "url": "https://opencollective.com/turf"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -4112,6 +4377,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -4127,6 +4402,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -4162,6 +4448,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-bounds": {
@@ -4643,11 +4939,32 @@
       "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA==",
       "license": "MIT"
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
       "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -4771,6 +5088,20 @@
       "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -4787,6 +5118,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.1.0",
@@ -4859,6 +5197,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/draw-svg-path": {
       "version": "1.0.0",
@@ -4938,6 +5284,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -6116,6 +6475,19 @@
       "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
       "license": "CC0-1.0"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -6124,6 +6496,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iceberg-js": {
@@ -6202,6 +6602,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -6380,6 +6790,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-string-blank": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
@@ -6431,6 +6848,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -6785,6 +7242,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/lucide-react": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
@@ -6792,6 +7256,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -7848,6 +8323,16 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -7998,6 +8483,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8141,6 +8633,19 @@
       "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
       "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -8357,6 +8862,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -8560,6 +9095,14 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-markdown": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
@@ -8753,6 +9296,20 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/refractor": {
       "version": "5.0.0",
@@ -9034,6 +9591,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9097,6 +9661,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -9294,6 +9871,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9417,6 +10007,13 @@
         "svg-path-bounds": "^1.0.1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
@@ -9536,6 +10133,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-float32": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
@@ -9576,6 +10193,32 @@
         "topo2geo": "bin/topo2geo",
         "topomerge": "bin/topomerge",
         "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -10106,6 +10749,19 @@
         "pbf": "^3.2.1"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/weak-map": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
@@ -10119,6 +10775,67 @@
       "license": "MIT",
       "dependencies": {
         "get-canvas-context": "^1.0.1"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -10199,6 +10916,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.5.0",
     "@types/plotly.js": "^3.0.10",
     "@types/react": "^19.1.2",
@@ -41,6 +44,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "jsdom": "^26.1.0",
     "tw-animate-css": "^1.2.9",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -3,24 +3,68 @@ import { SiteHeader } from "@/shared/SiteHeader";
 import { useToast } from "@/shared/Toast";
 
 import { TeacherAuthoringPage } from "@/features/teacher-authoring/TeacherAuthoringPage";
+import { AuthCallbackPage } from "@/features/auth-callback/AuthCallbackPage";
+import { TeacherLoginPage } from "@/features/teacher-auth/TeacherLoginPage";
+import { TeacherActivatePage } from "@/features/teacher-auth/TeacherActivatePage";
+import { StudentLoginPage } from "@/features/student-auth/StudentLoginPage";
+import { StudentJoinPage } from "@/features/student-auth/StudentJoinPage";
+import { AdminLoginPage } from "@/features/admin-auth/AdminLoginPage";
+import { AdminChangePasswordPage } from "@/features/admin-auth/AdminChangePasswordPage";
+
+import { RootRedirect } from "./auth/RootRedirect";
+import { RequireRole } from "./auth/RequireRole";
+import { RequirePasswordRotation } from "./auth/RequirePasswordRotation";
 
 function App() {
-  const { ToastContainer } = useToast();
+    const { ToastContainer } = useToast();
 
-  return (
-    <div className="flex min-h-screen flex-col bg-bg-page font-sans type-body">
-      <SiteHeader />
+    return (
+        <div className="flex min-h-screen flex-col bg-bg-page font-sans type-body">
+            <SiteHeader />
 
-      <main className="flex-1">
-        <Routes>
-          <Route path="/" element={<Navigate to="/teacher" replace />} />
-          <Route path="/teacher/*" element={<TeacherAuthoringPage />} />
-        </Routes>
-      </main>
+            <main className="flex-1">
+                <Routes>
+                    {/* Root — redirects by session/role or shows landing */}
+                    <Route path="/" element={<RootRedirect />} />
 
-      <ToastContainer />
-    </div>
-  );
+                    {/* Teacher routes */}
+                    <Route path="/teacher/login" element={<TeacherLoginPage />} />
+                    <Route path="/teacher/activate" element={<TeacherActivatePage />} />
+                    <Route
+                        path="/teacher/*"
+                        element={
+                            <RequireRole role="teacher">
+                                <TeacherAuthoringPage />
+                            </RequireRole>
+                        }
+                    />
+
+                    {/* Student routes */}
+                    <Route path="/student/login" element={<StudentLoginPage />} />
+                    <Route path="/join" element={<StudentJoinPage />} />
+
+                    {/* Admin routes */}
+                    <Route path="/admin/login" element={<AdminLoginPage />} />
+                    <Route
+                        path="/admin/change-password"
+                        element={
+                            <RequirePasswordRotation>
+                                <AdminChangePasswordPage />
+                            </RequirePasswordRotation>
+                        }
+                    />
+
+                    {/* OAuth callback — PKCE code exchange handled by Supabase */}
+                    <Route path="/auth/callback" element={<AuthCallbackPage />} />
+
+                    {/* Catch-all */}
+                    <Route path="*" element={<Navigate to="/" replace />} />
+                </Routes>
+            </main>
+
+            <ToastContainer />
+        </div>
+    );
 }
 
 export default App;

--- a/frontend/src/app/AppLanding.tsx
+++ b/frontend/src/app/AppLanding.tsx
@@ -1,0 +1,36 @@
+import { Link } from "react-router-dom";
+
+/**
+ * Root landing page shown to unauthenticated users.
+ * Provides real entry-point links per role — no demo toggles.
+ */
+export function AppLanding() {
+    return (
+        <div className="flex flex-col items-center justify-center gap-8 px-4 py-24">
+            <h1 className="text-2xl font-semibold tracking-tight">ADAM-EDU</h1>
+            <p className="text-sm text-muted-foreground">
+                Selecciona tu perfil para continuar
+            </p>
+            <nav className="flex flex-col gap-3 w-full max-w-xs">
+                <Link
+                    to="/teacher/login"
+                    className="flex items-center justify-center rounded-input bg-adam-accent px-6 py-3 text-sm font-medium text-white hover:opacity-90 transition-opacity"
+                >
+                    Ingresar como docente
+                </Link>
+                <Link
+                    to="/student/login"
+                    className="flex items-center justify-center rounded-input border border-border px-6 py-3 text-sm font-medium hover:bg-muted transition-colors"
+                >
+                    Ingresar como estudiante
+                </Link>
+                <Link
+                    to="/admin/login"
+                    className="flex items-center justify-center rounded-input border border-border px-6 py-3 text-sm font-medium hover:bg-muted transition-colors"
+                >
+                    Portal administrador
+                </Link>
+            </nav>
+        </div>
+    );
+}

--- a/frontend/src/app/auth/AuthContext.tsx
+++ b/frontend/src/app/auth/AuthContext.tsx
@@ -1,0 +1,127 @@
+import {
+    createContext,
+    useCallback,
+    useEffect,
+    useState,
+    type ReactNode,
+} from "react";
+import { getSupabaseClient } from "@/shared/supabaseClient";
+import { apiFetch } from "@/shared/api";
+import type { AuthContextValue, AuthMeActor, Session } from "./auth-types";
+
+export const AuthContext = createContext<AuthContextValue | undefined>(
+    undefined,
+);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+    const [session, setSession] = useState<Session | null>(null);
+    const [actor, setActor] = useState<AuthMeActor | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchActor = useCallback(async (): Promise<AuthMeActor | null> => {
+        try {
+            const res = await apiFetch("/auth/me");
+            return (await res.json()) as AuthMeActor;
+        } catch {
+            return null;
+        }
+    }, []);
+
+    const refreshActor = useCallback(async () => {
+        const next = await fetchActor();
+        setActor(next);
+    }, [fetchActor]);
+
+    useEffect(() => {
+        const supabase = getSupabaseClient();
+        if (!supabase) {
+            setLoading(false);
+            return;
+        }
+
+        let cancelled = false;
+
+        async function bootstrap() {
+            const { data, error: sessionError } =
+                await supabase!.auth.getSession();
+
+            if (cancelled) return;
+
+            if (sessionError) {
+                setError(sessionError.message);
+                setLoading(false);
+                return;
+            }
+
+            const currentSession = data.session ?? null;
+            setSession(currentSession);
+
+            if (currentSession) {
+                const resolvedActor = await fetchActor();
+                if (!cancelled) {
+                    setActor(resolvedActor);
+                    if (!resolvedActor) {
+                        setError(
+                            "No se pudo cargar tu perfil. Intenta iniciar sesión de nuevo.",
+                        );
+                    }
+                }
+            }
+
+            if (!cancelled) {
+                setLoading(false);
+            }
+        }
+
+        void bootstrap();
+
+        const { data: listenerData } = supabase.auth.onAuthStateChange(
+            async (event, nextSession) => {
+                if (cancelled) return;
+
+                if (
+                    event === "SIGNED_IN" ||
+                    event === "TOKEN_REFRESHED" ||
+                    event === "INITIAL_SESSION"
+                ) {
+                    setSession(nextSession);
+                    if (nextSession) {
+                        const resolvedActor = await fetchActor();
+                        if (!cancelled) {
+                            setActor(resolvedActor);
+                            setError(null);
+                        }
+                    }
+                } else if (event === "SIGNED_OUT") {
+                    setSession(null);
+                    setActor(null);
+                    setError(null);
+                }
+            },
+        );
+
+        return () => {
+            cancelled = true;
+            listenerData.subscription.unsubscribe();
+        };
+    }, [fetchActor]);
+
+    const signOut = useCallback(async () => {
+        const supabase = getSupabaseClient();
+        if (supabase) {
+            await supabase.auth.signOut();
+        }
+        setSession(null);
+        setActor(null);
+        setError(null);
+    }, []);
+
+    return (
+        <AuthContext.Provider
+            value={{ session, actor, loading, error, signOut, refreshActor }}
+        >
+            {children}
+        </AuthContext.Provider>
+    );
+}

--- a/frontend/src/app/auth/AuthProvider.test.tsx
+++ b/frontend/src/app/auth/AuthProvider.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { AuthProvider } from "./AuthContext";
+import { useAuth } from "./useAuth";
+import type { AuthMeActor } from "./auth-types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockGetSession = vi.fn();
+const mockSignOut = vi.fn();
+const mockOnAuthStateChange = vi.fn(() => ({
+    data: { subscription: { unsubscribe: vi.fn() } },
+}));
+
+vi.mock("@/shared/supabaseClient", () => ({
+    getSupabaseClient: () => ({
+        auth: {
+            getSession: mockGetSession,
+            signOut: mockSignOut,
+            onAuthStateChange: mockOnAuthStateChange,
+        },
+    }),
+}));
+
+const mockActor: AuthMeActor = {
+    auth_user_id: "user-1",
+    profile: { id: "user-1", full_name: "Test User" },
+    memberships: [
+        {
+            id: "mem-1",
+            university_id: "uni-1",
+            role: "teacher",
+            status: "active",
+            must_rotate_password: false,
+        },
+    ],
+    must_rotate_password: false,
+    primary_role: "teacher",
+};
+
+vi.mock("@/shared/api", () => ({
+    apiFetch: vi.fn().mockResolvedValue({
+        json: () => Promise.resolve(mockActor),
+    }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helper component
+// ---------------------------------------------------------------------------
+
+function Probe() {
+    const { session, actor, loading, error } = useAuth();
+    return (
+        <div>
+            <span data-testid="loading">{String(loading)}</span>
+            <span data-testid="session">{session ? "yes" : "no"}</span>
+            <span data-testid="actor">{actor ? actor.profile.full_name : "none"}</span>
+            <span data-testid="error">{error ?? "none"}</span>
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AuthProvider", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockOnAuthStateChange.mockReturnValue({
+            data: { subscription: { unsubscribe: vi.fn() } },
+        });
+    });
+
+    it("starts with loading=true and resolves to loading=false when no session", async () => {
+        mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
+
+        render(
+            <AuthProvider>
+                <Probe />
+            </AuthProvider>,
+        );
+
+        // loading starts true
+        expect(screen.getByTestId("loading").textContent).toBe("true");
+
+        await waitFor(() =>
+            expect(screen.getByTestId("loading").textContent).toBe("false"),
+        );
+        expect(screen.getByTestId("session").textContent).toBe("no");
+        expect(screen.getByTestId("actor").textContent).toBe("none");
+    });
+
+    it("fetches actor from /api/auth/me when session exists", async () => {
+        const fakeSession = { access_token: "jwt-abc" };
+        mockGetSession.mockResolvedValue({
+            data: { session: fakeSession },
+            error: null,
+        });
+
+        render(
+            <AuthProvider>
+                <Probe />
+            </AuthProvider>,
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId("loading").textContent).toBe("false"),
+        );
+        expect(screen.getByTestId("session").textContent).toBe("yes");
+        expect(screen.getByTestId("actor").textContent).toBe("Test User");
+    });
+
+    it("clears actor on SIGNED_OUT event", async () => {
+        const fakeSession = { access_token: "jwt-abc" };
+        mockGetSession.mockResolvedValue({
+            data: { session: fakeSession },
+            error: null,
+        });
+
+        type AuthChangeCallback = (event: string, session: unknown) => void;
+        let capturedCallback: AuthChangeCallback | null = null;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockOnAuthStateChange as any).mockImplementation((cb: AuthChangeCallback) => {
+            capturedCallback = cb;
+            return { data: { subscription: { unsubscribe: vi.fn() } } };
+        });
+
+        render(
+            <AuthProvider>
+                <Probe />
+            </AuthProvider>,
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId("actor").textContent).toBe("Test User"),
+        );
+
+        // Simulate sign-out event
+        capturedCallback!("SIGNED_OUT", null);
+
+        await waitFor(() =>
+            expect(screen.getByTestId("actor").textContent).toBe("none"),
+        );
+        expect(screen.getByTestId("session").textContent).toBe("no");
+    });
+});

--- a/frontend/src/app/auth/RequirePasswordRotation.tsx
+++ b/frontend/src/app/auth/RequirePasswordRotation.tsx
@@ -1,0 +1,21 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "./useAuth";
+import type { ReactNode } from "react";
+
+interface Props {
+    children: ReactNode;
+}
+
+/**
+ * Only allows navigation to the wrapped route when must_rotate_password is true.
+ * Prevents accessing /admin/change-password when the flag is already cleared.
+ */
+export function RequirePasswordRotation({ children }: Props) {
+    const { session, actor, loading } = useAuth();
+
+    if (loading) return null;
+    if (!session) return <Navigate to="/admin/login" replace />;
+    if (!actor?.must_rotate_password) return <Navigate to="/" replace />;
+
+    return <>{children}</>;
+}

--- a/frontend/src/app/auth/RequireRole.test.tsx
+++ b/frontend/src/app/auth/RequireRole.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { RequireRole } from "./RequireRole";
+import type { AuthMeActor } from "./auth-types";
+
+vi.mock("./useAuth");
+import { useAuth } from "./useAuth";
+
+const baseCtx = {
+    error: null,
+    signOut: vi.fn(),
+    refreshActor: vi.fn(),
+};
+
+const teacherActor: AuthMeActor = {
+    auth_user_id: "u1",
+    profile: { id: "u1", full_name: "Docente Test" },
+    memberships: [
+        {
+            id: "m1",
+            university_id: "uni1",
+            role: "teacher",
+            status: "active",
+            must_rotate_password: false,
+        },
+    ],
+    must_rotate_password: false,
+    primary_role: "teacher",
+};
+
+const studentActor: AuthMeActor = {
+    auth_user_id: "u2",
+    profile: { id: "u2", full_name: "Estudiante Test" },
+    memberships: [
+        {
+            id: "m2",
+            university_id: "uni1",
+            role: "student",
+            status: "active",
+            must_rotate_password: false,
+        },
+    ],
+    must_rotate_password: false,
+    primary_role: "student",
+};
+
+const adminRotateActor: AuthMeActor = {
+    auth_user_id: "u3",
+    profile: { id: "u3", full_name: "Admin Test" },
+    memberships: [
+        {
+            id: "m3",
+            university_id: "uni1",
+            role: "university_admin",
+            status: "active",
+            must_rotate_password: true,
+        },
+    ],
+    must_rotate_password: true,
+    primary_role: "university_admin",
+};
+
+describe("RequireRole", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders children when actor has the correct active membership", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: { access_token: "jwt" } as never,
+            actor: teacherActor,
+            loading: false,
+        });
+
+        render(
+            <MemoryRouter>
+                <RequireRole role="teacher">
+                    <span data-testid="child">teacher area</span>
+                </RequireRole>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId("child")).toBeTruthy();
+    });
+
+    it("does not render children when actor has a different role (student denied on teacher route)", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: { access_token: "jwt" } as never,
+            actor: studentActor,
+            loading: false,
+        });
+
+        render(
+            <MemoryRouter>
+                <RequireRole role="teacher">
+                    <span data-testid="child">teacher area</span>
+                </RequireRole>
+            </MemoryRouter>,
+        );
+
+        expect(screen.queryByTestId("child")).toBeNull();
+    });
+
+    it("redirects to /admin/change-password when must_rotate_password=true (precedes role check)", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: { access_token: "jwt" } as never,
+            actor: adminRotateActor,
+            loading: false,
+        });
+
+        render(
+            <MemoryRouter initialEntries={["/admin/dashboard"]}>
+                <RequireRole role="university_admin">
+                    <span data-testid="child">admin area</span>
+                </RequireRole>
+            </MemoryRouter>,
+        );
+
+        // Child must NOT render; redirect to change-password takes over
+        expect(screen.queryByTestId("child")).toBeNull();
+    });
+
+    it("renders nothing while loading", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: null,
+            actor: null,
+            loading: true,
+        });
+
+        const { container } = render(
+            <MemoryRouter>
+                <RequireRole role="teacher">
+                    <span data-testid="child">protected</span>
+                </RequireRole>
+            </MemoryRouter>,
+        );
+
+        expect(container.firstChild).toBeNull();
+    });
+});

--- a/frontend/src/app/auth/RequireRole.tsx
+++ b/frontend/src/app/auth/RequireRole.tsx
@@ -1,0 +1,49 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "./useAuth";
+import type { MembershipSnapshot } from "./auth-types";
+import type { ReactNode } from "react";
+
+type Role = MembershipSnapshot["role"];
+
+const ROLE_LOGIN_PATH: Record<Role, string> = {
+    teacher: "/teacher/login",
+    student: "/student/login",
+    university_admin: "/admin/login",
+};
+
+interface Props {
+    role: Role;
+    children: ReactNode;
+}
+
+/**
+ * Authorizes by active membership, NOT by primary_role alone.
+ *
+ * Redirect precedence (non-negotiable per Issue #33):
+ *  1. must_rotate_password=true  → /admin/change-password (always wins)
+ *  2. no session                 → role-specific login page
+ *  3. no active membership       → root landing
+ */
+export function RequireRole({ role, children }: Props) {
+    const { session, actor, loading } = useAuth();
+
+    if (loading) return null;
+
+    if (!session) {
+        return <Navigate to={ROLE_LOGIN_PATH[role]} replace />;
+    }
+
+    if (actor?.must_rotate_password) {
+        return <Navigate to="/admin/change-password" replace />;
+    }
+
+    const hasRole = actor?.memberships.some(
+        (m) => m.role === role && m.status === "active",
+    );
+
+    if (!hasRole) {
+        return <Navigate to="/" replace />;
+    }
+
+    return <>{children}</>;
+}

--- a/frontend/src/app/auth/RequireSession.test.tsx
+++ b/frontend/src/app/auth/RequireSession.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { RequireSession } from "./RequireSession";
+
+vi.mock("./useAuth");
+import { useAuth } from "./useAuth";
+
+const baseCtx = {
+    actor: null,
+    error: null,
+    signOut: vi.fn(),
+    refreshActor: vi.fn(),
+};
+
+describe("RequireSession", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders children when session exists", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: { access_token: "jwt" } as never,
+            loading: false,
+        });
+
+        render(
+            <MemoryRouter>
+                <RequireSession>
+                    <span data-testid="child">protected</span>
+                </RequireSession>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId("child")).toBeTruthy();
+    });
+
+    it("renders nothing while loading", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: null,
+            loading: true,
+        });
+
+        const { container } = render(
+            <MemoryRouter>
+                <RequireSession>
+                    <span data-testid="child">protected</span>
+                </RequireSession>
+            </MemoryRouter>,
+        );
+
+        expect(container.firstChild).toBeNull();
+    });
+
+    it("does not render children when no session", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: null,
+            loading: false,
+        });
+
+        render(
+            <MemoryRouter initialEntries={["/teacher"]}>
+                <RequireSession>
+                    <span data-testid="child">protected</span>
+                </RequireSession>
+            </MemoryRouter>,
+        );
+
+        expect(screen.queryByTestId("child")).toBeNull();
+    });
+});

--- a/frontend/src/app/auth/RequireSession.tsx
+++ b/frontend/src/app/auth/RequireSession.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "./useAuth";
+import type { ReactNode } from "react";
+
+interface Props {
+    children: ReactNode;
+}
+
+/**
+ * Blocks unauthenticated access. Redirects to the root landing page (which
+ * shows role-based entrypoints) when no session is present.
+ *
+ * Shows nothing while the auth bootstrap is in flight to avoid flash-of-wrong-route.
+ */
+export function RequireSession({ children }: Props) {
+    const { session, loading } = useAuth();
+
+    if (loading) return null;
+    if (!session) return <Navigate to="/" replace />;
+
+    return <>{children}</>;
+}

--- a/frontend/src/app/auth/RootRedirect.tsx
+++ b/frontend/src/app/auth/RootRedirect.tsx
@@ -1,0 +1,35 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "./useAuth";
+import { AppLanding } from "@/app/AppLanding";
+
+/**
+ * Handles the root route `/app/`.
+ *
+ * Redirect precedence (deterministic, per Issue #33):
+ *  1. must_rotate_password=true      → /admin/change-password  (always wins)
+ *  2. primary_role=university_admin  → /admin/dashboard (placeholder)
+ *  3. primary_role=teacher           → /teacher
+ *  4. primary_role=student           → /student/login (full experience in Issue #7)
+ *  5. no session or unknown role     → AppLanding (role entrypoints)
+ */
+export function RootRedirect() {
+    const { session, actor, loading } = useAuth();
+
+    if (loading) return null;
+    if (!session) return <AppLanding />;
+
+    if (actor?.must_rotate_password) {
+        return <Navigate to="/admin/change-password" replace />;
+    }
+
+    switch (actor?.primary_role) {
+        case "university_admin":
+            return <Navigate to="/admin/dashboard" replace />;
+        case "teacher":
+            return <Navigate to="/teacher" replace />;
+        case "student":
+            return <Navigate to="/student/login" replace />;
+        default:
+            return <AppLanding />;
+    }
+}

--- a/frontend/src/app/auth/auth-types.ts
+++ b/frontend/src/app/auth/auth-types.ts
@@ -1,0 +1,29 @@
+import type { Session } from "@supabase/supabase-js";
+
+export type { Session };
+
+export interface MembershipSnapshot {
+    id: string;
+    university_id: string;
+    role: "teacher" | "student" | "university_admin";
+    status: "active" | "suspended";
+    must_rotate_password: boolean;
+}
+
+/** Mirrors the shape returned by GET /api/auth/me */
+export interface AuthMeActor {
+    auth_user_id: string;
+    profile: { id: string; full_name: string };
+    memberships: MembershipSnapshot[];
+    must_rotate_password: boolean;
+    primary_role: "teacher" | "student" | "university_admin";
+}
+
+export interface AuthContextValue {
+    session: Session | null;
+    actor: AuthMeActor | null;
+    loading: boolean;
+    error: string | null;
+    signOut: () => Promise<void>;
+    refreshActor: () => Promise<void>;
+}

--- a/frontend/src/app/auth/useAuth.ts
+++ b/frontend/src/app/auth/useAuth.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { AuthContext } from "./AuthContext";
+import type { AuthContextValue } from "./auth-types";
+
+export function useAuth(): AuthContextValue {
+    const ctx = useContext(AuthContext);
+    if (ctx === undefined) {
+        throw new Error("useAuth must be used inside <AuthProvider>");
+    }
+    return ctx;
+}

--- a/frontend/src/app/main.tsx
+++ b/frontend/src/app/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "./global.css";
 import App from "./App.tsx";
+import { AuthProvider } from "./auth/AuthContext.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter basename="/app/">
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </StrictMode>
 );

--- a/frontend/src/app/vite-env.d.ts
+++ b/frontend/src/app/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_SUPABASE_URL: string;
+    readonly VITE_SUPABASE_ANON_KEY: string;
+    readonly VITE_AUTH_CALLBACK_URL: string;
+    readonly VITE_APP_BASE_URL: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}

--- a/frontend/src/features/admin-auth/AdminChangePasswordPage.tsx
+++ b/frontend/src/features/admin-auth/AdminChangePasswordPage.tsx
@@ -1,0 +1,20 @@
+/**
+ * Admin change-password page — placeholder for Issue #8.
+ *
+ * Protected by RequirePasswordRotation: only reachable when
+ * actor.must_rotate_password === true.
+ *
+ * Issue #8 will implement:
+ * - Password change form (POST /api/auth/change-password or Supabase updateUser)
+ * - On success: clear must_rotate_password flag + redirect to admin dashboard
+ */
+export function AdminChangePasswordPage() {
+    return (
+        <div className="flex flex-col items-center justify-center gap-6 px-4 py-24">
+            <h1 className="text-xl font-semibold">Cambiar contraseña</h1>
+            <p className="text-sm text-muted-foreground max-w-xs text-center">
+                Debes cambiar tu contraseña antes de continuar.
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/features/admin-auth/AdminLoginPage.tsx
+++ b/frontend/src/features/admin-auth/AdminLoginPage.tsx
@@ -1,0 +1,19 @@
+/**
+ * Admin login page — placeholder for Issue #8.
+ *
+ * Issue #8 will implement:
+ * - Password-only login form (no self-registration, no OAuth)
+ * - Redirect to /admin/change-password when must_rotate_password=true
+ * - Redirect to admin dashboard when already authenticated
+ */
+export function AdminLoginPage() {
+    return (
+        <div className="flex flex-col items-center justify-center gap-6 px-4 py-24">
+            <h1 className="text-xl font-semibold">Portal administrador</h1>
+            <p className="text-sm text-muted-foreground max-w-xs text-center">
+                El inicio de sesión para administradores estará disponible en la
+                próxima versión.
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AuthCallbackPage } from "./AuthCallbackPage";
+import type { AuthMeActor } from "@/app/auth/auth-types";
+
+vi.mock("@/app/auth/useAuth");
+vi.mock("@/shared/activationContext");
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual<typeof import("react-router-dom")>(
+        "react-router-dom",
+    );
+    return { ...actual, useNavigate: vi.fn() };
+});
+
+import { useAuth } from "@/app/auth/useAuth";
+import {
+    readActivationContext,
+    clearActivationContext,
+} from "@/shared/activationContext";
+import { useNavigate } from "react-router-dom";
+
+const mockNavigate = vi.fn();
+
+const teacherActor: AuthMeActor = {
+    auth_user_id: "u1",
+    profile: { id: "u1", full_name: "Docente" },
+    memberships: [
+        {
+            id: "m1",
+            university_id: "uni1",
+            role: "teacher",
+            status: "active",
+            must_rotate_password: false,
+        },
+    ],
+    must_rotate_password: false,
+    primary_role: "teacher",
+};
+
+const baseCtx = {
+    session: { access_token: "jwt" } as never,
+    error: null,
+    loading: false,
+    signOut: vi.fn(),
+    refreshActor: vi.fn(),
+};
+
+describe("AuthCallbackPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useNavigate).mockReturnValue(mockNavigate);
+        vi.mocked(readActivationContext).mockReturnValue(null);
+        vi.mocked(clearActivationContext).mockImplementation(() => undefined);
+    });
+
+    it("shows loading state while auth is in flight", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            loading: true,
+            actor: null,
+        });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText(/completando inicio de sesión/i)).toBeTruthy();
+    });
+
+    it("redirects teacher to /teacher after successful auth", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            actor: teacherActor,
+        });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith("/teacher", {
+                replace: true,
+            }),
+        );
+    });
+
+    it("always clears activation context", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            actor: teacherActor,
+        });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(clearActivationContext).toHaveBeenCalledTimes(1),
+        );
+    });
+
+    it("redirects to / when no session after loading", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: null,
+            actor: null,
+        });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }),
+        );
+    });
+
+    it("redirects to /admin/change-password when must_rotate_password", async () => {
+        const rotateActor: AuthMeActor = {
+            ...teacherActor,
+            must_rotate_password: true,
+            primary_role: "university_admin",
+        };
+
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            actor: rotateActor,
+        });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith(
+                "/admin/change-password",
+                { replace: true },
+            ),
+        );
+    });
+
+    it("shows error message when auth error is present", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            error: "Token inválido",
+            session: null,
+            actor: null,
+        });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        expect(
+            screen.getByText(/no se pudo completar el inicio de sesión/i),
+        ).toBeTruthy();
+    });
+});

--- a/frontend/src/features/auth-callback/AuthCallbackPage.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/app/auth/useAuth";
+import {
+    readActivationContext,
+    clearActivationContext,
+} from "@/shared/activationContext";
+
+/**
+ * OAuth PKCE callback page — /app/auth/callback
+ *
+ * Supabase completes the PKCE code exchange automatically via getSession()
+ * in the AuthProvider bootstrap. This page waits for that to finish, reads
+ * any short-lived activation context from sessionStorage, cleans it up, and
+ * redirects the user to the appropriate destination.
+ *
+ * Security rules:
+ * - invite_token is never read from the URL (not in state, path, or query)
+ * - activation context is always cleared after this page runs (success or error)
+ * - no redirect happens while loading is true (prevents race conditions)
+ */
+export function AuthCallbackPage() {
+    const { session, actor, loading, error } = useAuth();
+    const navigate = useNavigate();
+    const handled = useRef(false);
+
+    useEffect(() => {
+        if (loading) return;
+        if (handled.current) return;
+        handled.current = true;
+
+        const ctx = readActivationContext();
+
+        // Always clean up the activation context — both success and error paths.
+        // Issues #6 and #7 will add the actual backend activation call here
+        // before clearActivationContext() when ctx is present.
+        clearActivationContext();
+
+        if (!session || !actor) {
+            // Auth failed or was cancelled — return to landing
+            navigate("/", { replace: true });
+            return;
+        }
+
+        // Determine redirect destination using the same precedence as RootRedirect
+        if (actor.must_rotate_password) {
+            navigate("/admin/change-password", { replace: true });
+            return;
+        }
+
+        // ctx is available here for Issues #6/#7 to call their activation endpoints
+        void ctx;
+
+        switch (actor.primary_role) {
+            case "university_admin":
+                navigate("/admin/dashboard", { replace: true });
+                break;
+            case "teacher":
+                navigate("/teacher", { replace: true });
+                break;
+            case "student":
+                navigate("/student/login", { replace: true });
+                break;
+            default:
+                navigate("/", { replace: true });
+        }
+    }, [loading, session, actor, navigate]);
+
+    if (error) {
+        return (
+            <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
+                <p className="text-sm text-danger">
+                    No se pudo completar el inicio de sesión. Intenta de nuevo.
+                </p>
+                <a href="/app/" className="text-sm underline hover:opacity-80">
+                    Volver al inicio
+                </a>
+            </div>
+        );
+    }
+
+    // Show spinner while waiting for PKCE exchange + actor resolution
+    return (
+        <div className="flex items-center justify-center py-24">
+            <span className="text-sm text-muted-foreground">
+                Completando inicio de sesión…
+            </span>
+        </div>
+    );
+}

--- a/frontend/src/features/student-auth/StudentJoinPage.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+import {
+    saveActivationContext,
+    clearActivationContext,
+} from "@/shared/activationContext";
+
+/**
+ * Student course join page — placeholder for Issue #7.
+ *
+ * Reads #invite_token from the URL hash and persists it in the short-lived
+ * sessionStorage context.
+ *
+ * Issue #7 will implement:
+ * - POST /api/invites/resolve to show course info and masked email
+ * - Domain validation against allowed_email_domains
+ * - New account creation (password) or login for existing accounts
+ * - POST /api/invites/redeem after authentication
+ */
+export function StudentJoinPage() {
+    useEffect(() => {
+        const hash = window.location.hash;
+        const params = new URLSearchParams(hash.replace(/^#/, ""));
+        const inviteToken = params.get("invite_token");
+
+        if (inviteToken) {
+            saveActivationContext({
+                flow: "student_join",
+                invite_token: inviteToken,
+                role: "student",
+            });
+            // Clean the token from the URL — never leave it in history
+            window.history.replaceState(null, "", window.location.pathname);
+        } else {
+            clearActivationContext();
+        }
+    }, []);
+
+    return (
+        <div className="flex flex-col items-center justify-center gap-6 px-4 py-24">
+            <h1 className="text-xl font-semibold">Unirse a un curso</h1>
+            <p className="text-sm text-muted-foreground max-w-xs text-center">
+                El flujo de inscripción completo estará disponible en la próxima
+                versión.
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/features/student-auth/StudentLoginPage.tsx
+++ b/frontend/src/features/student-auth/StudentLoginPage.tsx
@@ -1,0 +1,18 @@
+/**
+ * Student login page — placeholder for Issue #7.
+ *
+ * Issue #7 will implement:
+ * - "Already have an account" password login branch
+ * - Redirect to active course after login
+ */
+export function StudentLoginPage() {
+    return (
+        <div className="flex flex-col items-center justify-center gap-6 px-4 py-24">
+            <h1 className="text-xl font-semibold">Acceso estudiantes</h1>
+            <p className="text-sm text-muted-foreground max-w-xs text-center">
+                El inicio de sesión completo para estudiantes estará disponible en la
+                próxima versión.
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import {
+    saveActivationContext,
+    clearActivationContext,
+} from "@/shared/activationContext";
+
+/**
+ * Teacher activation page — placeholder for Issue #6.
+ *
+ * Reads #invite_token from the URL hash and persists it in the short-lived
+ * sessionStorage context so it is available after the OAuth redirect without
+ * ever appearing in a query string, path, or OAuth state.
+ *
+ * Issue #6 will implement:
+ * - POST /api/invites/resolve call to show masked email + university info
+ * - Microsoft OAuth initiation (saveActivationContext then signInWithOAuth)
+ * - Password activation form (POST /api/auth/activate/password)
+ */
+export function TeacherActivatePage() {
+    useEffect(() => {
+        const hash = window.location.hash;
+        const params = new URLSearchParams(hash.replace(/^#/, ""));
+        const inviteToken = params.get("invite_token");
+
+        if (inviteToken) {
+            saveActivationContext({
+                flow: "teacher_activate",
+                invite_token: inviteToken,
+                role: "teacher",
+            });
+            // Clean the token from the URL — never leave it in history
+            window.history.replaceState(null, "", window.location.pathname);
+        } else {
+            // No token present — clear any stale context
+            clearActivationContext();
+        }
+    }, []);
+
+    return (
+        <div className="flex flex-col items-center justify-center gap-6 px-4 py-24">
+            <h1 className="text-xl font-semibold">Activación de cuenta docente</h1>
+            <p className="text-sm text-muted-foreground max-w-xs text-center">
+                El flujo de activación completo estará disponible en la próxima
+                versión.
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/features/teacher-auth/TeacherLoginPage.tsx
+++ b/frontend/src/features/teacher-auth/TeacherLoginPage.tsx
@@ -1,0 +1,18 @@
+/**
+ * Teacher login page — placeholder for Issue #6.
+ *
+ * Issue #6 will implement:
+ * - Microsoft OAuth initiation (signInWithOAuth + saveActivationContext for activation flow)
+ * - Password-based login for existing accounts
+ */
+export function TeacherLoginPage() {
+    return (
+        <div className="flex flex-col items-center justify-center gap-6 px-4 py-24">
+            <h1 className="text-xl font-semibold">Acceso docentes</h1>
+            <p className="text-sm text-muted-foreground max-w-xs text-center">
+                El inicio de sesión completo para docentes estará disponible en la
+                próxima versión.
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/shared/SiteHeader.tsx
+++ b/frontend/src/shared/SiteHeader.tsx
@@ -1,22 +1,50 @@
 /** ADAM — Sticky site header, always visible */
+import { useAuth } from "@/app/auth/useAuth";
+import type { AuthMeActor } from "@/app/auth/auth-types";
+
+const ROLE_LABEL: Record<AuthMeActor["primary_role"], string> = {
+    teacher: "Portal Docente",
+    student: "Portal Estudiante",
+    university_admin: "Admin",
+};
 
 export function SiteHeader() {
+    const { actor, signOut } = useAuth();
+
+    const roleLabel = actor ? ROLE_LABEL[actor.primary_role] : "ADAM-EDU";
+
     return (
         <header className="sticky top-0 z-50 flex h-[58px] items-center justify-between bg-[#0144a0] px-5 shadow-md">
             {/* Logo */}
             <div className="flex items-center gap-2.5">
                 <div className="flex h-8 w-8 items-center justify-center rounded-md bg-white">
-                    <span className="font-sans text-[1.0625rem] font-bold tracking-tight text-[#0144a0]">A</span>
+                    <span className="font-sans text-[1.0625rem] font-bold tracking-tight text-[#0144a0]">
+                        A
+                    </span>
                 </div>
                 <span className="type-body font-semibold text-white tracking-[-0.01em]">
                     ADAM <span className="text-white/80 font-medium">Edu</span>
                 </span>
             </div>
 
-            {/* Right label */}
-            <span className="type-overline text-white/70">
-                Portal Profesor
-            </span>
+            {/* Right section */}
+            <div className="flex items-center gap-4">
+                {actor && (
+                    <span className="type-overline text-white/80 hidden sm:inline">
+                        {actor.profile.full_name}
+                    </span>
+                )}
+                <span className="type-overline text-white/70">{roleLabel}</span>
+                {actor && (
+                    <button
+                        onClick={() => void signOut()}
+                        className="type-overline text-white/60 hover:text-white transition-colors underline underline-offset-2"
+                        type="button"
+                    >
+                        Cerrar sesión
+                    </button>
+                )}
+            </div>
         </header>
     );
 }

--- a/frontend/src/shared/activationContext.test.ts
+++ b/frontend/src/shared/activationContext.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+    saveActivationContext,
+    readActivationContext,
+    clearActivationContext,
+} from "./activationContext";
+
+describe("activationContext", () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("save → read returns the correct value", () => {
+        saveActivationContext({
+            flow: "teacher_activate",
+            invite_token: "tok_abc123",
+            role: "teacher",
+        });
+
+        const ctx = readActivationContext();
+        expect(ctx).not.toBeNull();
+        expect(ctx?.flow).toBe("teacher_activate");
+        expect(ctx?.invite_token).toBe("tok_abc123");
+        expect(ctx?.role).toBe("teacher");
+        expect(typeof ctx?.expires_at).toBe("number");
+    });
+
+    it("returns null when nothing is stored", () => {
+        expect(readActivationContext()).toBeNull();
+    });
+
+    it("clearActivationContext removes the stored context", () => {
+        saveActivationContext({
+            flow: "student_join",
+            invite_token: "tok_xyz",
+            role: "student",
+        });
+        clearActivationContext();
+        expect(readActivationContext()).toBeNull();
+    });
+
+    it("returns null and removes the entry when TTL has expired", () => {
+        vi.useFakeTimers();
+        saveActivationContext({
+            flow: "teacher_activate",
+            invite_token: "tok_expired",
+            role: "teacher",
+        });
+
+        // Advance clock past the 5-minute TTL
+        vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+        expect(readActivationContext()).toBeNull();
+        // The key must be cleaned up
+        expect(sessionStorage.getItem("adam_activation_ctx")).toBeNull();
+    });
+
+    it("returns null and removes the entry for malformed JSON", () => {
+        sessionStorage.setItem("adam_activation_ctx", "{invalid-json}");
+        expect(readActivationContext()).toBeNull();
+        expect(sessionStorage.getItem("adam_activation_ctx")).toBeNull();
+    });
+});

--- a/frontend/src/shared/activationContext.ts
+++ b/frontend/src/shared/activationContext.ts
@@ -1,0 +1,54 @@
+/**
+ * Short-lived activation context stored in sessionStorage.
+ *
+ * Used to carry invite_token across an OAuth redirect without placing it
+ * in the URL, OAuth state param, localStorage, or any server-side store.
+ *
+ * TTL is hard-coded at 5 minutes. Expired contexts are silently dropped and
+ * treated as non-existent. The token is cleared by AuthCallbackPage after
+ * the activation flow completes (success or terminal error).
+ *
+ * invite_token MUST NOT appear in query strings, path params, OAuth state,
+ * breadcrumbs, or logs at any point.
+ */
+
+const STORAGE_KEY = "adam_activation_ctx";
+const TTL_MS = 5 * 60 * 1000;
+
+interface ActivationContext {
+    flow: "teacher_activate" | "student_join";
+    invite_token: string;
+    role: "teacher" | "student";
+    expires_at: number; // epoch ms
+}
+
+export function saveActivationContext(
+    ctx: Omit<ActivationContext, "expires_at">,
+): void {
+    const value: ActivationContext = {
+        ...ctx,
+        expires_at: Date.now() + TTL_MS,
+    };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+}
+
+export function readActivationContext(): ActivationContext | null {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    try {
+        const ctx = JSON.parse(raw) as ActivationContext;
+        if (Date.now() > ctx.expires_at) {
+            sessionStorage.removeItem(STORAGE_KEY);
+            return null;
+        }
+        return ctx;
+    } catch {
+        sessionStorage.removeItem(STORAGE_KEY);
+        return null;
+    }
+}
+
+export function clearActivationContext(): void {
+    sessionStorage.removeItem(STORAGE_KEY);
+}

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -24,6 +24,10 @@ describe("api auth + stream glue", () => {
     beforeEach(() => {
         resetApiClientForTests();
         getSessionMock.mockReset();
+        // Default: no active session. Tests that need a token set this explicitly.
+        // Required because jsdom defines `window`, so getSupabaseClient() no longer
+        // short-circuits on `typeof window === "undefined"`.
+        getSessionMock.mockResolvedValue({ data: { session: null }, error: null });
         createClientMock.mockClear();
         vi.unstubAllEnvs();
         vi.unstubAllGlobals();

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -1,4 +1,4 @@
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { getSupabaseClient, resetSupabaseClientForTests } from "@/shared/supabaseClient";
 
 import type {
     AuthoringJobCreateRequest,
@@ -14,6 +14,8 @@ import type {
  * Centralized API client for the teacher authoring flow.
  * The backend now expects bearer auth on protected routes when a Supabase session exists.
  */
+export { resetSupabaseClientForTests as resetApiClientForTests };
+
 export const API_BASE = "/api";
 
 type ApiErrorCode =
@@ -41,44 +43,6 @@ export class ApiError extends Error {
     }
 }
 
-let supabaseClient: SupabaseClient | null | undefined;
-
-function getSupabaseEnv() {
-    return {
-        url: import.meta.env.VITE_SUPABASE_URL?.trim(),
-        anonKey: import.meta.env.VITE_SUPABASE_ANON_KEY?.trim(),
-    };
-}
-
-function getSupabaseClient() {
-    if (supabaseClient !== undefined) {
-        return supabaseClient;
-    }
-
-    if (typeof window === "undefined") {
-        supabaseClient = null;
-        return supabaseClient;
-    }
-
-    const { url, anonKey } = getSupabaseEnv();
-    if (!url || !anonKey) {
-        supabaseClient = null;
-        return supabaseClient;
-    }
-
-    supabaseClient = createClient(url, anonKey, {
-        auth: {
-            autoRefreshToken: true,
-            detectSessionInUrl: true,
-            persistSession: true,
-        },
-    });
-    return supabaseClient;
-}
-
-export function resetApiClientForTests() {
-    supabaseClient = undefined;
-}
 
 export async function getBearerToken(): Promise<string | null> {
     const client = getSupabaseClient();
@@ -157,7 +121,7 @@ async function readErrorDetail(res: Response): Promise<string | undefined> {
     }
 }
 
-async function apiFetch(path: string, init?: RequestInit) {
+export async function apiFetch(path: string, init?: RequestInit) {
     const headers = await createAuthorizedHeaders(init?.headers);
     const response = await fetch(`${API_BASE}${path}`, {
         ...init,

--- a/frontend/src/shared/supabaseClient.test.ts
+++ b/frontend/src/shared/supabaseClient.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getSupabaseClient, resetSupabaseClientForTests } from "./supabaseClient";
+
+vi.mock("@supabase/supabase-js", () => ({
+    createClient: vi.fn(() => ({ isMockClient: true })),
+}));
+
+describe("getSupabaseClient", () => {
+    const originalEnv = import.meta.env;
+
+    beforeEach(() => {
+        resetSupabaseClientForTests();
+    });
+
+    afterEach(() => {
+        resetSupabaseClientForTests();
+        vi.unstubAllEnvs();
+    });
+
+    it("returns null when VITE_SUPABASE_URL is missing", () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "test-key");
+        expect(getSupabaseClient()).toBeNull();
+    });
+
+    it("returns null when VITE_SUPABASE_ANON_KEY is missing", () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "http://localhost:54321");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "");
+        expect(getSupabaseClient()).toBeNull();
+    });
+
+    it("returns a client when env vars are present", () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "http://localhost:54321");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "test-anon-key");
+        const client = getSupabaseClient();
+        expect(client).not.toBeNull();
+    });
+
+    it("returns the same instance on repeated calls (singleton)", () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "http://localhost:54321");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "test-anon-key");
+        const first = getSupabaseClient();
+        const second = getSupabaseClient();
+        expect(first).toBe(second);
+    });
+
+    // Suppress unused-var warning — originalEnv is needed to satisfy no-unused-vars but
+    // the actual restore is handled by vi.unstubAllEnvs().
+    void originalEnv;
+});

--- a/frontend/src/shared/supabaseClient.ts
+++ b/frontend/src/shared/supabaseClient.ts
@@ -1,0 +1,45 @@
+/**
+ * Supabase client — auth and session management ONLY.
+ * Never use this client for domain queries. PostgREST is not in scope.
+ *
+ * Single lazy-initialized instance shared across the entire frontend.
+ * AuthProvider, getBearerToken(), and any other auth consumer must import
+ * getSupabaseClient() from this module — never call createClient() directly.
+ */
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let _client: SupabaseClient | null | undefined;
+
+export function getSupabaseClient(): SupabaseClient | null {
+    if (_client !== undefined) {
+        return _client;
+    }
+
+    if (typeof window === "undefined") {
+        _client = null;
+        return null;
+    }
+
+    const url = import.meta.env.VITE_SUPABASE_URL?.trim();
+    const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim();
+
+    if (!url || !anonKey) {
+        _client = null;
+        return null;
+    }
+
+    _client = createClient(url, anonKey, {
+        auth: {
+            flowType: "pkce",
+            autoRefreshToken: true,
+            persistSession: true,
+        },
+    });
+
+    return _client;
+}
+
+/** For use in tests only — resets the singleton so env mocks take effect. */
+export function resetSupabaseClientForTests(): void {
+    _client = undefined;
+}

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,7 +22,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src","vite.config.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
-import { defineConfig } from "vite";
+// defineConfig from vitest/config re-exports vite's defineConfig and adds the
+// typed `test` field so TypeScript recognises test configuration.
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -9,6 +11,14 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   base: "/app/",
   resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test-setup.ts"],
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -74,14 +74,12 @@ max_indexes = 5
 enabled = true
 # Keep the local auth stack centered on localhost so future OAuth callbacks match Issue 5.
 site_url = "http://localhost:5173/app/"
-# Current runnable routes only. Issue 5 will add dedicated callback and activation URLs.
-# Future placeholders:
-# - http://localhost:5173/app/auth/callback
-# - http://localhost:5173/app/teacher/activate
-# - http://localhost:5173/app/join
 additional_redirect_urls = [
   "http://localhost:5173/app/",
   "http://localhost:5173/app/teacher",
+  "http://localhost:5173/app/auth/callback",
+  "http://localhost:5173/app/teacher/activate",
+  "http://localhost:5173/app/join",
 ]
 jwt_expiry = 3600
 enable_refresh_token_rotation = true


### PR DESCRIPTION
## Summary

- Extrae cliente Supabase de `api.ts` a `supabaseClient.ts` con `flowType: 'pkce'` — elimina el único origen de cliente duplicado
- Crea `AuthProvider` + `useAuth` como única fuente de verdad de `session`, `actor`, `loading`, `error`; bootstrap `getSession → GET /api/auth/me → onAuthStateChange`
- Guards `RequireSession`, `RequireRole` (verifica `memberships[]` activos, no solo `primary_role`), `RequirePasswordRotation`
- Precedencia de redirección determinista: `must_rotate_password` → `university_admin` → `teacher` → `student`
- `RootRedirect` en `/` según sesión y rol efectivo; `AppLanding` con 3 entrypoints reales sin textos de demo
- `AuthCallbackPage` en `/app/auth/callback` para flujo PKCE — sin `invite_token` en URL/state
- Helper `activationContext.ts` en `sessionStorage` con TTL 5 min, interfaz cerrada (`saveActivationContext` / `readActivationContext` / `clearActivationContext`)
- 6 páginas placeholder por rol con scaffold de hash-reading listo para Issues #6/#7/#8
- `SiteHeader` auth-aware: label dinámico por rol, nombre de usuario, botón "Cerrar sesión"
- `supabase/config.toml`: activa las URLs `/app/auth/callback`, `/app/teacher/activate`, `/app/join` que estaban comentadas como placeholder
- Env vars tipadas en `vite-env.d.ts`, `.env.example` actualizado con `VITE_AUTH_CALLBACK_URL` y `VITE_APP_BASE_URL`
- `@testing-library/react` + `jsdom` instalados y configurados; 40/40 tests en verde

## Pre-Landing Review

No issues found.

- Pass 1 (Critical): Sin SQL, sin violación de LLM trust boundary, sin shell injection. Completitud de enums verificada: los 3 roles cubiertos en `ROLE_LABEL`, `ROLE_LOGIN_PATH`, `RootRedirect` y `RequireRole`. Flag `cancelled` en `AuthContext` previene actualizaciones de estado post-unmount.
- Pass 2 (Informational): `VITE_AUTH_CALLBACK_URL`/`VITE_APP_BASE_URL` declarados en tipos pero no leídos aún — intencional, documentado como uso futuro. Sin estilos inline, sin lookups O(n²).

## Prerequisito manual post-merge

Reiniciar Supabase local para recargar `config.toml`: `supabase stop && supabase start`

En producción: agregar `https://<DOMINIO>/app/auth/callback` en Supabase Dashboard → Authentication → URL Configuration.

## Test plan

- [x] `npm --prefix frontend run test` — 40/40 tests (9 test files)
- [x] `npm --prefix frontend run lint` — 0 errores
- [x] `npm --prefix frontend run build` — build exitoso
- [x] Rama actualizada con `origin/main` antes de tests

## Desbloquea

- #6 Teacher flow (TeacherActivatePage + AuthCallbackPage listos)
- #7 Student flow (StudentJoinPage + activationContext listos)
- #8 Admin flow (AdminChangePasswordPage + RequirePasswordRotation listos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)