### PR TITLE
feat: activación e inicio de sesión docente híbrido (Issue #37)

### DIFF
--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -728,6 +728,7 @@ class ActivatePasswordRequest(BaseModel):
 class ActivatePasswordResponse(BaseModel):
     status: str
     next_step: str
+    email: str
 
 
 @app.post("/api/auth/activate/password", response_model=ActivatePasswordResponse, status_code=201)
@@ -746,7 +747,7 @@ def activate_password(
     existing_user = admin_client.find_user_by_email(invite.email)
     effective_status = invite_effective_status(invite)
     if effective_status == "consumed" and existing_user and activation_state_exists(db, invite, existing_user.id):
-        return ActivatePasswordResponse(status="activated", next_step="sign_in")
+        return ActivatePasswordResponse(status="activated", next_step="sign_in", email=invite.email)
     if effective_status != "pending":
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_invite")
 
@@ -765,7 +766,7 @@ def activate_password(
         if not consume_invite_if_pending(db, invite):
             db.rollback()
             if activation_state_exists(db, invite, auth_user.id):
-                return ActivatePasswordResponse(status="activated", next_step="sign_in")
+                return ActivatePasswordResponse(status="activated", next_step="sign_in", email=invite.email)
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_invite")
         db.commit()
     except HTTPException:
@@ -797,7 +798,7 @@ def activate_password(
         http_status=status.HTTP_201_CREATED,
         reason="activated",
     )
-    return ActivatePasswordResponse(status="activated", next_step="sign_in")
+    return ActivatePasswordResponse(status="activated", next_step="sign_in", email=invite.email)
 
 
 class ActivateOAuthCompleteRequest(BaseModel):

--- a/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
@@ -12,6 +12,25 @@ vi.mock("react-router-dom", async () => {
     );
     return { ...actual, useNavigate: vi.fn() };
 });
+vi.mock("@/shared/api", () => ({
+    api: {
+        auth: {
+            activateOAuthComplete: vi.fn(),
+            resolveInvite: vi.fn(),
+            activatePassword: vi.fn(),
+        },
+    },
+    ApiError: class ApiError extends Error {
+        status: number;
+        detail?: string;
+        constructor(status: number, message: string, detail?: string) {
+            super(message);
+            this.name = "ApiError";
+            this.status = status;
+            this.detail = detail;
+        }
+    },
+}));
 
 import { useAuth } from "@/app/auth/useAuth";
 import {
@@ -19,6 +38,7 @@ import {
     clearActivationContext,
 } from "@/shared/activationContext";
 import { useNavigate } from "react-router-dom";
+import { api } from "@/shared/api";
 
 const mockNavigate = vi.fn();
 
@@ -38,12 +58,14 @@ const teacherActor: AuthMeActor = {
     primary_role: "teacher",
 };
 
+const mockRefreshActor = vi.fn();
+
 const baseCtx = {
     session: { access_token: "jwt" } as never,
     error: null,
     loading: false,
     signOut: vi.fn(),
-    refreshActor: vi.fn(),
+    refreshActor: mockRefreshActor,
 };
 
 describe("AuthCallbackPage", () => {
@@ -52,6 +74,8 @@ describe("AuthCallbackPage", () => {
         vi.mocked(useNavigate).mockReturnValue(mockNavigate);
         vi.mocked(readActivationContext).mockReturnValue(null);
         vi.mocked(clearActivationContext).mockImplementation(() => undefined);
+        vi.mocked(mockRefreshActor).mockResolvedValue(undefined);
+        vi.mocked(api.auth.activateOAuthComplete).mockResolvedValue({ status: "activated" });
     });
 
     it("shows loading state while auth is in flight", () => {
@@ -167,5 +191,90 @@ describe("AuthCallbackPage", () => {
         expect(
             screen.getByText(/no se pudo completar el inicio de sesión/i),
         ).toBeTruthy();
+    });
+
+    // ---- New cases for Issue #37 OAuth activation ----
+
+    it("calls activateOAuthComplete then refreshActor then navigates to /teacher when ctx.flow === teacher_activate", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            actor: null, // not yet activated
+        });
+        vi.mocked(api.auth.activateOAuthComplete).mockResolvedValue({ status: "activated" });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(api.auth.activateOAuthComplete).toHaveBeenCalledWith("tok-abc"),
+        );
+        await waitFor(() => expect(mockRefreshActor).toHaveBeenCalled());
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith("/teacher", { replace: true }),
+        );
+    });
+
+    it("shows activation error UI (not / redirect) when activateOAuthComplete fails", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            actor: null,
+        });
+        vi.mocked(api.auth.activateOAuthComplete).mockRejectedValue(
+            Object.assign(new Error("email_mismatch"), {
+                detail: "email_mismatch",
+                status: 422,
+            }),
+        );
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByText(/no coincide con la invitación/i),
+            ).toBeTruthy(),
+        );
+
+        // Must NOT redirect to /
+        expect(mockNavigate).not.toHaveBeenCalledWith("/", { replace: true });
+
+        // Must show link back to /teacher/activate
+        expect(screen.getByText(/volver a activación/i)).toBeTruthy();
+    });
+
+    it("redirects to /teacher for regular login (no ctx, teacher actor)", async () => {
+        vi.mocked(readActivationContext).mockReturnValue(null);
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            actor: teacherActor,
+        });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith("/teacher", { replace: true }),
+        );
     });
 });

--- a/frontend/src/features/auth-callback/AuthCallbackPage.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/app/auth/useAuth";
+import { api, ApiError } from "@/shared/api";
 import {
     readActivationContext,
     clearActivationContext,
@@ -19,10 +20,23 @@ import {
  * - activation context is always cleared after this page runs (success or error)
  * - no redirect happens while loading is true (prevents race conditions)
  */
+
+function parseActivationError(err: ApiError): string {
+    switch (err.detail) {
+        case "invalid_invite":
+            return "Esta invitación ya no es válida. Solicita una nueva.";
+        case "email_mismatch":
+            return "El correo de tu cuenta Microsoft no coincide con la invitación.";
+        default:
+            return "No se pudo completar la activación. Intenta de nuevo.";
+    }
+}
+
 export function AuthCallbackPage() {
-    const { session, actor, loading, error } = useAuth();
+    const { session, actor, loading, error, refreshActor } = useAuth();
     const navigate = useNavigate();
     const handled = useRef(false);
+    const [activationError, setActivationError] = useState<string | null>(null);
 
     useEffect(() => {
         if (loading) return;
@@ -30,26 +44,36 @@ export function AuthCallbackPage() {
         handled.current = true;
 
         const ctx = readActivationContext();
-
-        // Always clean up the activation context — both success and error paths.
-        // Issues #6 and #7 will add the actual backend activation call here
-        // before clearActivationContext() when ctx is present.
         clearActivationContext();
 
-        if (!session || !actor) {
-            // Auth failed or was cancelled — return to landing
+        if (!session) {
             navigate("/", { replace: true });
             return;
         }
 
-        // Determine redirect destination using the same precedence as RootRedirect
+        if (ctx?.flow === "teacher_activate") {
+            async function runActivation() {
+                try {
+                    await api.auth.activateOAuthComplete(ctx!.invite_token);
+                    await refreshActor();
+                    navigate("/teacher", { replace: true });
+                } catch (err: unknown) {
+                    setActivationError(parseActivationError(err as ApiError));
+                }
+            }
+            void runActivation();
+            return;
+        }
+
+        if (!actor) {
+            navigate("/", { replace: true });
+            return;
+        }
+
         if (actor.must_rotate_password) {
             navigate("/admin/change-password", { replace: true });
             return;
         }
-
-        // ctx is available here for Issues #6/#7 to call their activation endpoints
-        void ctx;
 
         switch (actor.primary_role) {
             case "university_admin":
@@ -64,7 +88,7 @@ export function AuthCallbackPage() {
             default:
                 navigate("/", { replace: true });
         }
-    }, [loading, session, actor, navigate]);
+    }, [loading, session, actor, navigate, refreshActor]);
 
     if (error) {
         return (
@@ -74,6 +98,20 @@ export function AuthCallbackPage() {
                 </p>
                 <a href="/app/" className="text-sm underline hover:opacity-80">
                     Volver al inicio
+                </a>
+            </div>
+        );
+    }
+
+    if (activationError) {
+        return (
+            <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
+                <p className="text-sm text-danger">{activationError}</p>
+                <a
+                    href="/app/teacher/activate"
+                    className="text-sm underline hover:opacity-80"
+                >
+                    Volver a activación
                 </a>
             </div>
         );

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.test.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.test.tsx
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { TeacherActivatePage } from "./TeacherActivatePage";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/shared/activationContext");
+vi.mock("@/shared/supabaseClient");
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual<typeof import("react-router-dom")>(
+        "react-router-dom",
+    );
+    return { ...actual, useNavigate: vi.fn() };
+});
+
+vi.mock("@/shared/api", () => ({
+    api: {
+        auth: {
+            resolveInvite: vi.fn(),
+            activatePassword: vi.fn(),
+            activateOAuthComplete: vi.fn(),
+        },
+    },
+    ApiError: class ApiError extends Error {
+        status: number;
+        detail?: string;
+        constructor(status: number, message: string, detail?: string) {
+            super(message);
+            this.name = "ApiError";
+            this.status = status;
+            this.detail = detail;
+        }
+    },
+}));
+
+import {
+    readActivationContext,
+    clearActivationContext,
+    saveActivationContext,
+} from "@/shared/activationContext";
+import { getSupabaseClient } from "@/shared/supabaseClient";
+import { useNavigate } from "react-router-dom";
+import { api } from "@/shared/api";
+
+const mockNavigate = vi.fn();
+
+const pendingResolveResponse = {
+    role: "teacher" as const,
+    email_masked: "d****@uni.edu",
+    university_name: "Universidad Test",
+    course_title: "Analítica de Datos",
+    status: "pending" as const,
+    expires_at: new Date(Date.now() + 3600000).toISOString(),
+};
+
+function makeSupabaseMock(
+    signInWithPasswordResult: { error: null | { message: string } } = { error: null },
+) {
+    return {
+        auth: {
+            signInWithPassword: vi.fn().mockResolvedValue(signInWithPasswordResult),
+            signInWithOAuth: vi.fn().mockResolvedValue({}),
+        },
+    };
+}
+
+function renderPage() {
+    return render(
+        <MemoryRouter>
+            <TeacherActivatePage />
+        </MemoryRouter>,
+    );
+}
+
+describe("TeacherActivatePage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useNavigate).mockReturnValue(mockNavigate);
+        vi.mocked(readActivationContext).mockReturnValue(null);
+        vi.mocked(clearActivationContext).mockImplementation(() => undefined);
+        vi.mocked(saveActivationContext).mockImplementation(() => undefined);
+        vi.mocked(getSupabaseClient).mockReturnValue(makeSupabaseMock() as never);
+        // Default: resolve hangs (never resolves) unless overridden per test
+        vi.mocked(api.auth.resolveInvite).mockReturnValue(new Promise(() => undefined));
+    });
+
+    // 1. Sin activation context al montar → muestra error de enlace inválido
+    it("shows invalid link error when there is no activation context", () => {
+        vi.mocked(readActivationContext).mockReturnValue(null);
+
+        renderPage();
+
+        expect(
+            screen.getByText(/enlace de activación no es válido/i),
+        ).toBeTruthy();
+    });
+
+    // 2. Con activation context → llama resolveInvite con el invite_token
+    it("calls resolveInvite with the invite_token from activation context", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        await waitFor(() =>
+            expect(api.auth.resolveInvite).toHaveBeenCalledWith("tok-abc"),
+        );
+    });
+
+    // 3. Invite pending → muestra email_masked disabled, universidad y formulario
+    it("renders the activation form with email_masked disabled when invite is pending", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        await waitFor(() =>
+            expect(screen.getByDisplayValue("d****@uni.edu")).toBeTruthy(),
+        );
+
+        const emailInput = screen.getByDisplayValue("d****@uni.edu");
+        expect(emailInput).toHaveProperty("disabled", true);
+        expect(screen.getByText("Universidad Test")).toBeTruthy();
+        expect(screen.getByText(/Activar cuenta/i)).toBeTruthy();
+    });
+
+    // 4. Invite expired → mensaje específico
+    it("shows expired message when invite status is expired", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue({
+            ...pendingResolveResponse,
+            status: "expired",
+        });
+
+        renderPage();
+
+        await waitFor(() =>
+            expect(screen.getByText(/ha expirado/i)).toBeTruthy(),
+        );
+    });
+
+    // 5. Invite consumed → mensaje específico
+    it("shows consumed message when invite status is consumed", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue({
+            ...pendingResolveResponse,
+            status: "consumed",
+        });
+
+        renderPage();
+
+        await waitFor(() =>
+            expect(screen.getByText(/ya fue utilizada/i)).toBeTruthy(),
+        );
+    });
+
+    // 6. Submit con passwords que no coinciden → error client-side, no llama API
+    it("shows client-side error when passwords do not match — does not call activatePassword", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Activar cuenta/i));
+
+        const allInputs = document.querySelectorAll("input[type=password]");
+        fireEvent.change(allInputs[0], { target: { value: "password123" } });
+        fireEvent.change(allInputs[1], { target: { value: "different456" } });
+
+        const form = document.querySelector("form")!;
+        await act(async () => {
+            fireEvent.submit(form);
+        });
+
+        expect(screen.getByText(/contraseñas no coinciden/i)).toBeTruthy();
+        expect(api.auth.activatePassword).not.toHaveBeenCalled();
+    });
+
+    // 7. Submit válido → llama activatePassword, luego signInWithPassword con res.email, navega /teacher
+    it("calls activatePassword then signInWithPassword with res.email and navigates to /teacher", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+        vi.mocked(api.auth.activatePassword).mockResolvedValue({
+            status: "activated",
+            next_step: "sign_in",
+            email: "docente@uni.edu",
+        });
+        const supabaseMock = makeSupabaseMock({ error: null });
+        vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Activar cuenta/i));
+
+        const allInputs = document.querySelectorAll("input[type=password]");
+        fireEvent.change(allInputs[0], { target: { value: "Password123!" } });
+        fireEvent.change(allInputs[1], { target: { value: "Password123!" } });
+
+        const form = document.querySelector("form")!;
+        await act(async () => {
+            fireEvent.submit(form);
+        });
+
+        await waitFor(() => {
+            expect(api.auth.activatePassword).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    invite_token: "tok-abc",
+                    password: "Password123!",
+                    confirm_password: "Password123!",
+                }),
+            );
+        });
+
+        await waitFor(() => {
+            expect(supabaseMock.auth.signInWithPassword).toHaveBeenCalledWith({
+                email: "docente@uni.edu",
+                password: "Password123!",
+            });
+        });
+
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith("/teacher", { replace: true }),
+        );
+    });
+
+    // 8. activatePassword falla con invalid_invite → error inline, permite reintentar
+    it("shows inline error when activatePassword fails with invalid_invite", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+        vi.mocked(api.auth.activatePassword).mockRejectedValue(
+            Object.assign(new Error("invalid_invite"), { detail: "invalid_invite" }),
+        );
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Activar cuenta/i));
+
+        const allInputs = document.querySelectorAll("input[type=password]");
+        fireEvent.change(allInputs[0], { target: { value: "Password123!" } });
+        fireEvent.change(allInputs[1], { target: { value: "Password123!" } });
+
+        const form = document.querySelector("form")!;
+        await act(async () => {
+            fireEvent.submit(form);
+        });
+
+        await waitFor(() =>
+            expect(screen.getByText(/ya no es válida/i)).toBeTruthy(),
+        );
+
+        // Submit button should still be accessible (inline error, not redirect)
+        expect(screen.getByText(/Activar cuenta/i)).toBeTruthy();
+    });
+
+    // 9. Botón Microsoft → llama signInWithOAuth con provider: "azure"
+    it("calls signInWithOAuth with provider azure when Microsoft button is clicked", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+        const supabaseMock = makeSupabaseMock();
+        vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Continuar con Microsoft/i));
+
+        await act(async () => {
+            fireEvent.click(screen.getByText(/Continuar con Microsoft/i));
+        });
+
+        expect(supabaseMock.auth.signInWithOAuth).toHaveBeenCalledWith(
+            expect.objectContaining({ provider: "azure" }),
+        );
+    });
+});

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
@@ -1,48 +1,310 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { api, ApiError } from "@/shared/api";
+import { getSupabaseClient } from "@/shared/supabaseClient";
 import {
     saveActivationContext,
+    readActivationContext,
     clearActivationContext,
 } from "@/shared/activationContext";
+import type { InviteResolveResponse } from "@/shared/adam-types";
+
+function resolveErrorMessage(err: ApiError | null, status?: string): string {
+    if (status === "expired") {
+        return "Este enlace de activación ha expirado. Solicita uno nuevo.";
+    }
+    if (status === "consumed") {
+        return "Esta invitación ya fue utilizada. Si necesitas acceso, contacta al administrador.";
+    }
+    if (status === "revoked") {
+        return "Esta invitación fue revocada. Contacta al administrador de tu universidad.";
+    }
+    if (err) {
+        return "No se pudo validar la invitación. Intenta de nuevo más tarde.";
+    }
+    return "No se pudo validar la invitación. Intenta de nuevo más tarde.";
+}
 
 /**
- * Teacher activation page — placeholder for Issue #6.
+ * Teacher activation page — Issue #6 / #37.
  *
- * Reads #invite_token from the URL hash and persists it in the short-lived
- * sessionStorage context so it is available after the OAuth redirect without
- * ever appearing in a query string, path, or OAuth state.
+ * Reads #invite_token from the URL hash, persists it in sessionStorage
+ * (5-min TTL), calls POST /api/invites/resolve, and renders either the
+ * Microsoft OAuth button or the password activation form.
  *
- * Issue #6 will implement:
- * - POST /api/invites/resolve call to show masked email + university info
- * - Microsoft OAuth initiation (saveActivationContext then signInWithOAuth)
- * - Password activation form (POST /api/auth/activate/password)
+ * Security rules (non-negotiable):
+ * - invite_token never appears in window.location after mount
+ * - email field in the form is always disabled — pre-filled from resolve
+ * - no "Forgot password" CTA
  */
 export function TeacherActivatePage() {
+    const navigate = useNavigate();
+
+    // Initialize from sessionStorage first (covers page refresh with valid TTL context)
+    const [inviteToken, setInviteToken] = useState<string | null>(() => {
+        const ctx = readActivationContext();
+        return ctx?.flow === "teacher_activate" ? ctx.invite_token : null;
+    });
+
+    const [resolving, setResolving] = useState(false);
+    const [resolvedInvite, setResolvedInvite] = useState<InviteResolveResponse | null>(null);
+    const [resolveError, setResolveError] = useState<string | null>(null);
+
+    const [fullName, setFullName] = useState("");
+    const [password, setPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+
+    // Parse hash and save to sessionStorage
     useEffect(() => {
         const hash = window.location.hash;
         const params = new URLSearchParams(hash.replace(/^#/, ""));
-        const inviteToken = params.get("invite_token");
+        const token = params.get("invite_token");
 
-        if (inviteToken) {
+        if (token) {
             saveActivationContext({
                 flow: "teacher_activate",
-                invite_token: inviteToken,
+                invite_token: token,
                 role: "teacher",
             });
-            // Clean the token from the URL — never leave it in history
             window.history.replaceState(null, "", window.location.pathname);
-        } else {
-            // No token present — clear any stale context
+            setInviteToken(token);
+        } else if (!inviteToken) {
             clearActivationContext();
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    // Resolve invite once we have a token
+    useEffect(() => {
+        if (!inviteToken) return;
+
+        let cancelled = false;
+        setResolving(true);
+        setResolveError(null);
+        setResolvedInvite(null);
+
+        api.auth
+            .resolveInvite(inviteToken)
+            .then((res) => {
+                if (cancelled) return;
+                if (res.status !== "pending") {
+                    setResolveError(resolveErrorMessage(null, res.status));
+                } else {
+                    setResolvedInvite(res);
+                }
+            })
+            .catch((err: unknown) => {
+                if (cancelled) return;
+                setResolveError(resolveErrorMessage(err as ApiError));
+            })
+            .finally(() => {
+                if (!cancelled) setResolving(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [inviteToken]);
+
+    async function handleMicrosoftActivation() {
+        const supabase = getSupabaseClient();
+        if (!supabase) return;
+        await supabase.auth.signInWithOAuth({
+            provider: "azure",
+            options: { redirectTo: import.meta.env.VITE_AUTH_CALLBACK_URL },
+        });
+        // signInWithOAuth redirects — no code after this
+    }
+
+    async function handlePasswordSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        setSubmitError(null);
+
+        if (password !== confirmPassword) {
+            setSubmitError("Las contraseñas no coinciden.");
+            return;
+        }
+        if (password.length < 8) {
+            setSubmitError("La contraseña debe tener al menos 8 caracteres.");
+            return;
+        }
+
+        setSubmitting(true);
+        try {
+            const res = await api.auth.activatePassword({
+                invite_token: inviteToken!,
+                password,
+                confirm_password: confirmPassword,
+                full_name: fullName || undefined,
+            });
+
+            const supabase = getSupabaseClient()!;
+            const { error } = await supabase.auth.signInWithPassword({
+                email: res.email,
+                password,
+            });
+
+            if (error) {
+                setSubmitError(
+                    "No se pudo iniciar sesión después de la activación. Intenta de nuevo.",
+                );
+                return;
+            }
+
+            // AuthContext onAuthStateChange fires SIGNED_IN → fetchActor automatically
+            navigate("/teacher", { replace: true });
+        } catch (err: unknown) {
+            const apiErr = err as ApiError;
+            if (apiErr.detail === "invalid_invite") {
+                setSubmitError("Esta invitación ya no es válida. Solicita una nueva al administrador.");
+            } else if (apiErr.detail === "password_mismatch") {
+                setSubmitError("Las contraseñas no coinciden.");
+            } else {
+                setSubmitError("No se pudo completar la activación. Intenta de nuevo más tarde.");
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    // State 1: No activation context
+    if (!inviteToken && !resolving) {
+        return (
+            <div className="flex flex-col items-center justify-center gap-6 px-4 py-24 text-center">
+                <h1 className="text-xl font-semibold">Activación de cuenta docente</h1>
+                <p className="text-sm text-danger max-w-sm">
+                    Este enlace de activación no es válido. Solicita un nuevo enlace al
+                    administrador de tu universidad.
+                </p>
+            </div>
+        );
+    }
+
+    // State 2: Resolving invite
+    if (resolving) {
+        return (
+            <div className="flex flex-col items-center justify-center gap-4 px-4 py-24">
+                <span className="text-sm text-muted-foreground">
+                    Validando invitación…
+                </span>
+            </div>
+        );
+    }
+
+    // State 3: Invite invalid (expired/consumed/revoked/error)
+    if (resolveError) {
+        return (
+            <div className="flex flex-col items-center justify-center gap-6 px-4 py-24 text-center">
+                <h1 className="text-xl font-semibold">Activación de cuenta docente</h1>
+                <p className="text-sm text-danger max-w-sm">{resolveError}</p>
+            </div>
+        );
+    }
+
+    // State 4: Invite valid — show activation form
+    if (!resolvedInvite) return null;
+
     return (
-        <div className="flex flex-col items-center justify-center gap-6 px-4 py-24">
-            <h1 className="text-xl font-semibold">Activación de cuenta docente</h1>
-            <p className="text-sm text-muted-foreground max-w-xs text-center">
-                El flujo de activación completo estará disponible en la próxima
-                versión.
-            </p>
+        <div className="flex flex-col items-center justify-center gap-6 px-4 py-16">
+            <div className="w-full max-w-sm space-y-6">
+                <div className="space-y-1 text-center">
+                    <h1 className="text-xl font-semibold">Activación de cuenta docente</h1>
+                    <p className="text-sm text-muted-foreground">
+                        {resolvedInvite.university_name}
+                    </p>
+                    {resolvedInvite.course_title && (
+                        <p className="text-sm text-muted-foreground">
+                            Curso: {resolvedInvite.course_title}
+                        </p>
+                    )}
+                </div>
+
+                <div className="space-y-2">
+                    <label className="text-sm font-medium">Correo electrónico</label>
+                    <input
+                        type="email"
+                        value={resolvedInvite.email_masked}
+                        disabled
+                        className="w-full rounded-md border border-input bg-muted px-3 py-2 text-sm text-muted-foreground"
+                    />
+                </div>
+
+                {/* Opción A — Microsoft */}
+                <div className="space-y-2">
+                    <p className="text-sm font-medium">Activar con Microsoft (recomendado)</p>
+                    <button
+                        type="button"
+                        onClick={() => void handleMicrosoftActivation()}
+                        className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+                    >
+                        Continuar con Microsoft
+                    </button>
+                </div>
+
+                <div className="relative">
+                    <div className="absolute inset-0 flex items-center">
+                        <span className="w-full border-t border-border" />
+                    </div>
+                    <div className="relative flex justify-center">
+                        <span className="bg-background px-2 text-xs text-muted-foreground">
+                            o usa contraseña
+                        </span>
+                    </div>
+                </div>
+
+                {/* Opción B — Password */}
+                <form onSubmit={(e) => void handlePasswordSubmit(e)} className="space-y-4">
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">
+                            Nombre completo{" "}
+                            <span className="text-muted-foreground">(opcional)</span>
+                        </label>
+                        <input
+                            type="text"
+                            value={fullName}
+                            onChange={(e) => setFullName(e.target.value)}
+                            placeholder="Nombre completo (opcional)"
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        />
+                    </div>
+
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">Contraseña</label>
+                        <input
+                            type="password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            required
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        />
+                    </div>
+
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">Confirmar contraseña</label>
+                        <input
+                            type="password"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            required
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        />
+                    </div>
+
+                    {submitError && (
+                        <p className="text-sm text-danger">{submitError}</p>
+                    )}
+
+                    <button
+                        type="submit"
+                        disabled={submitting}
+                        className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                    >
+                        {submitting ? "Activando…" : "Activar cuenta"}
+                    </button>
+                </form>
+            </div>
         </div>
     );
 }

--- a/frontend/src/features/teacher-auth/TeacherLoginPage.test.tsx
+++ b/frontend/src/features/teacher-auth/TeacherLoginPage.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { TeacherLoginPage } from "./TeacherLoginPage";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/shared/supabaseClient");
+
+import { getSupabaseClient } from "@/shared/supabaseClient";
+
+function makeSupabaseMock(
+    signInWithPasswordResult: { error: null | { message: string } } = { error: null },
+) {
+    return {
+        auth: {
+            signInWithPassword: vi.fn().mockResolvedValue(signInWithPasswordResult),
+            signInWithOAuth: vi.fn().mockResolvedValue({}),
+        },
+    };
+}
+
+function renderPage() {
+    return render(
+        <MemoryRouter>
+            <TeacherLoginPage />
+        </MemoryRouter>,
+    );
+}
+
+describe("TeacherLoginPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getSupabaseClient).mockReturnValue(makeSupabaseMock() as never);
+    });
+
+    // 1. Botón Microsoft → llama signInWithOAuth con provider: "azure"
+    it("calls signInWithOAuth with provider azure when Microsoft button is clicked", async () => {
+        const supabaseMock = makeSupabaseMock();
+        vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
+
+        renderPage();
+
+        await act(async () => {
+            fireEvent.click(screen.getByText(/Continuar con Microsoft/i));
+        });
+
+        expect(supabaseMock.auth.signInWithOAuth).toHaveBeenCalledWith(
+            expect.objectContaining({ provider: "azure" }),
+        );
+    });
+
+    // 2. Submit password form → llama signInWithPassword
+    it("calls signInWithPassword when password form is submitted", async () => {
+        const supabaseMock = makeSupabaseMock({ error: null });
+        vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
+
+        renderPage();
+
+        const emailInput = document.querySelector("input[type=email]")!;
+        const passwordInput = document.querySelector("input[type=password]")!;
+
+        fireEvent.change(emailInput, { target: { value: "docente@uni.edu" } });
+        fireEvent.change(passwordInput, { target: { value: "Password123!" } });
+
+        const form = document.querySelector("form")!;
+        await act(async () => {
+            fireEvent.submit(form);
+        });
+
+        expect(supabaseMock.auth.signInWithPassword).toHaveBeenCalledWith({
+            email: "docente@uni.edu",
+            password: "Password123!",
+        });
+    });
+
+    // 3. signInWithPassword falla → muestra mensaje genérico (sin revelar existencia del email)
+    it("shows generic error when signInWithPassword fails — never reveals email existence", async () => {
+        const supabaseMock = makeSupabaseMock({
+            error: { message: "Invalid login credentials" },
+        });
+        vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
+
+        renderPage();
+
+        const emailInput = document.querySelector("input[type=email]")!;
+        const passwordInput = document.querySelector("input[type=password]")!;
+
+        fireEvent.change(emailInput, { target: { value: "unknown@uni.edu" } });
+        fireEvent.change(passwordInput, { target: { value: "wrongpassword" } });
+
+        const form = document.querySelector("form")!;
+        await act(async () => {
+            fireEvent.submit(form);
+        });
+
+        await waitFor(() =>
+            expect(
+                screen.getByText(/credenciales incorrectas/i),
+            ).toBeTruthy(),
+        );
+
+        // Error must NOT reveal whether email exists
+        expect(screen.queryByText(/email.*existe/i)).toBeNull();
+        expect(screen.queryByText(/usuario.*no.*encontrado/i)).toBeNull();
+    });
+
+    // 4. No existe elemento "Olvidé mi contraseña" en el DOM
+    it("does not render a forgot-password CTA anywhere in the page", () => {
+        renderPage();
+
+        expect(screen.queryByText(/olvidé/i)).toBeNull();
+        expect(screen.queryByText(/olvidaste/i)).toBeNull();
+        expect(screen.queryByText(/forgot/i)).toBeNull();
+        expect(screen.queryByText(/contraseña.*olvidé/i)).toBeNull();
+    });
+});

--- a/frontend/src/features/teacher-auth/TeacherLoginPage.tsx
+++ b/frontend/src/features/teacher-auth/TeacherLoginPage.tsx
@@ -1,18 +1,128 @@
+import { useState } from "react";
+import { getSupabaseClient } from "@/shared/supabaseClient";
+
 /**
- * Teacher login page — placeholder for Issue #6.
+ * Teacher login page — Issue #6 / #37.
  *
- * Issue #6 will implement:
- * - Microsoft OAuth initiation (signInWithOAuth + saveActivationContext for activation flow)
- * - Password-based login for existing accounts
+ * Two paths:
+ * A) Microsoft OAuth — signInWithOAuth redirects to /app/auth/callback,
+ *    which handles role-based navigation via AuthContext.
+ * B) Password — signInWithPassword; AuthContext onAuthStateChange fires
+ *    SIGNED_IN and RequireRole reacts automatically.
+ *
+ * Non-negotiables:
+ * - No "Forgot password" CTA
+ * - Password errors never reveal whether the email exists
  */
 export function TeacherLoginPage() {
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [loginError, setLoginError] = useState<string | null>(null);
+
+    async function handleMicrosoftLogin() {
+        const supabase = getSupabaseClient();
+        if (!supabase) return;
+        await supabase.auth.signInWithOAuth({
+            provider: "azure",
+            options: { redirectTo: import.meta.env.VITE_AUTH_CALLBACK_URL },
+        });
+        // signInWithOAuth redirects — no code after this
+    }
+
+    async function handlePasswordSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        setLoginError(null);
+        setSubmitting(true);
+
+        try {
+            const supabase = getSupabaseClient()!;
+            const { error } = await supabase.auth.signInWithPassword({
+                email,
+                password,
+            });
+
+            if (error) {
+                // Never reveal whether the email exists
+                setLoginError(
+                    "Credenciales incorrectas. Verifica tu email y contraseña.",
+                );
+            }
+            // On success: AuthContext onAuthStateChange fires SIGNED_IN → actor updates
+            // → RootRedirect or RequireRole reacts automatically
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
     return (
-        <div className="flex flex-col items-center justify-center gap-6 px-4 py-24">
-            <h1 className="text-xl font-semibold">Acceso docentes</h1>
-            <p className="text-sm text-muted-foreground max-w-xs text-center">
-                El inicio de sesión completo para docentes estará disponible en la
-                próxima versión.
-            </p>
+        <div className="flex flex-col items-center justify-center gap-6 px-4 py-16">
+            <div className="w-full max-w-sm space-y-6">
+                <div className="text-center">
+                    <h1 className="text-xl font-semibold">Acceso docentes</h1>
+                </div>
+
+                {/* Opción A — Microsoft */}
+                <button
+                    type="button"
+                    onClick={() => void handleMicrosoftLogin()}
+                    className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+                >
+                    Continuar con Microsoft
+                </button>
+
+                <div className="relative">
+                    <div className="absolute inset-0 flex items-center">
+                        <span className="w-full border-t border-border" />
+                    </div>
+                    <div className="relative flex justify-center">
+                        <span className="bg-background px-2 text-xs text-muted-foreground">
+                            o usa contraseña
+                        </span>
+                    </div>
+                </div>
+
+                {/* Opción B — Password */}
+                <form onSubmit={(e) => void handlePasswordSubmit(e)} className="space-y-4">
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">Correo electrónico</label>
+                        <input
+                            type="email"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            required
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        />
+                    </div>
+
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">Contraseña</label>
+                        <input
+                            type="password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            required
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        />
+                    </div>
+
+                    {loginError && (
+                        <p className="text-sm text-danger">{loginError}</p>
+                    )}
+
+                    <button
+                        type="submit"
+                        disabled={submitting}
+                        className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                    >
+                        {submitting ? "Iniciando sesión…" : "Iniciar sesión"}
+                    </button>
+                </form>
+
+                <p className="text-center text-xs text-muted-foreground">
+                    ¿Eres nuevo? Si recibiste un enlace de activación, úsalo directamente.
+                </p>
+            </div>
         </div>
     );
 }

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -229,6 +229,33 @@ export const INDUSTRIAS = [
     "Turismo",
 ];
 
+// Invite and activation API contracts — Issue #37
+export interface InviteResolveResponse {
+    role: "teacher" | "student";
+    email_masked: string;
+    university_name: string;
+    course_title: string | null;
+    status: "pending" | "expired" | "consumed" | "revoked";
+    expires_at: string;
+}
+
+export interface ActivatePasswordRequest {
+    invite_token: string;
+    password: string;
+    confirm_password: string;
+    full_name?: string;
+}
+
+export interface ActivatePasswordResponse {
+    status: string;
+    next_step: string;
+    email: string;
+}
+
+export interface ActivateOAuthCompleteResponse {
+    status: string;
+}
+
 export const EMPTY_FORM: CaseFormData = {
     subject: "",
     academicLevel: "Pregrado",

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -1,11 +1,15 @@
 import { getSupabaseClient, resetSupabaseClientForTests } from "@/shared/supabaseClient";
 
 import type {
+    ActivateOAuthCompleteResponse,
+    ActivatePasswordRequest,
+    ActivatePasswordResponse,
     AuthoringJobCreateRequest,
     AuthoringJobCreateResponse,
     AuthoringJobResultResponse,
     AuthoringJobStatusResponse,
     IntentType,
+    InviteResolveResponse,
     SuggestRequest,
     SuggestResponse,
 } from "@/shared/adam-types";
@@ -274,5 +278,28 @@ export const api = {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ intent, ...data }),
         });
+    },
+    auth: {
+        async resolveInvite(invite_token: string): Promise<InviteResolveResponse> {
+            return parseJsonResponse<InviteResolveResponse>("/invites/resolve", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ invite_token }),
+            });
+        },
+        async activatePassword(req: ActivatePasswordRequest): Promise<ActivatePasswordResponse> {
+            return parseJsonResponse<ActivatePasswordResponse>("/auth/activate/password", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(req),
+            });
+        },
+        async activateOAuthComplete(invite_token: string): Promise<ActivateOAuthCompleteResponse> {
+            return parseJsonResponse<ActivateOAuthCompleteResponse>("/auth/activate/oauth/complete", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ invite_token }),
+            });
+        },
     },
 };


### PR DESCRIPTION
## Summary

- **Backend** — añade `email: str` a `ActivatePasswordResponse` en los 3 puntos de retorno del handler de activación por password, necesario para que el frontend llame `signInWithPassword` con el email real del invite sin depender de un campo editable.
- **Frontend types** — añade `InviteResolveResponse`, `ActivatePasswordRequest`, `ActivatePasswordResponse`, `ActivateOAuthCompleteResponse` a `adam-types.ts`.
- **`api.ts`** — nuevo namespace `api.auth` con `resolveInvite`, `activatePassword`, `activateOAuthComplete`.
- **`AuthCallbackPage`** — reemplaza el seam `void ctx` con el flujo completo de activación OAuth docente: `activateOAuthComplete → refreshActor → navigate("/teacher")`; añade `activationError` state, helper `parseActivationError`, y render de error accionable con link a `/teacher/activate`.
- **`TeacherActivatePage`** — implementación completa: 5 estados (enlace inválido, resolving, invite expirado/consumido/revocado, formulario Microsoft + password); email prellenado y siempre disabled; `invite_token` nunca en la URL después del mount.
- **`TeacherLoginPage`** — implementación completa: Microsoft OAuth + login por password; error genérico sin revelar existencia del email; sin CTA "Olvidé mi contraseña".
- **Tests** — `TeacherActivatePage.test.tsx` (9 casos), `TeacherLoginPage.test.tsx` (4 casos), `AuthCallbackPage.test.tsx` +3 casos para el flujo OAuth de activación.

## Pre-Landing Review

No issues found.

## Eval Results

No prompt-related files changed — evals skipped.

## Test plan

- [x] `uv run --directory backend pytest -q` — 45 passed, 12 skipped
- [x] `npm --prefix frontend run test` — 56 passed (11 archivos)
- [x] `npm --prefix frontend run lint` — 0 errors
- [x] `npm --prefix frontend run build` — sin errores TypeScript

## Criterios de aceptación (Issue #37)

- [x] `POST /api/invites/resolve` es la única fuente del email mostrado en activación
- [x] El campo email en `/teacher/activate` es siempre `disabled`
- [x] `invite_token` no aparece en `window.location`, path ni query string en ningún momento
- [x] Activación Microsoft: `activateOAuthComplete` se llama antes de cualquier redirect
- [x] Activación password: frontend usa `res.email` de `ActivatePasswordResponse`
- [x] Login password: error genérico — nunca revela si el email existe
- [x] Sin CTA "Olvidé mi contraseña" en ninguna página
- [x] Mensajes distintos y accionables para `expired` / `consumed` / `revoked`

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)