### PR TITLE
feat: aprovisionamiento CLI y login de administrador universitario (Plan Issue #8)

### DIFF
--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -590,6 +590,93 @@ def get_auth_me(actor: CurrentActor = Depends(require_current_actor)) -> AuthMeR
     )
 
 
+class ChangePasswordRequest(BaseModel):
+    new_password: str
+
+
+class ChangePasswordResponse(BaseModel):
+    status: str
+
+
+@app.post("/api/auth/change-password", response_model=ChangePasswordResponse)
+def change_admin_password(
+    req: ChangePasswordRequest,
+    actor: CurrentActor = Depends(require_current_actor),
+    db: Session = Depends(get_db),
+) -> ChangePasswordResponse:
+    """Rotate password for a university_admin with must_rotate_password=True.
+
+    FAIL-CLOSED flow:
+      [D] update_user_password → Supabase Auth API   (if fails: 500, DB untouched)
+      [E] UPDATE memberships SET must_rotate_password=False  (if fails: 500, Auth updated)
+
+    Auth update intentionally precedes DB update. If Auth succeeds but DB fails,
+    the admin retries with the new password — flag still True, flow repeats safely.
+    """
+    # [B] Role guard
+    if not actor.has_active_role("university_admin"):
+        audit_log(
+            "admin.change_password",
+            "denied",
+            auth_user_id=actor.auth_user_id,
+            http_status=403,
+            reason="not_admin",
+        )
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin_role_required")
+
+    # [C] Rotation guard — 403 if flag already cleared
+    if not actor.must_rotate_password:
+        audit_log(
+            "admin.change_password",
+            "denied",
+            auth_user_id=actor.auth_user_id,
+            http_status=403,
+            reason="rotation_not_required",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="password_rotation_not_required",
+        )
+
+    # [D] Update Supabase Auth FIRST — fail-closed: DB untouched if this raises
+    admin_client = get_supabase_admin_auth_client()
+    try:
+        admin_client.update_user_password(actor.auth_user_id, req.new_password)
+    except Exception as exc:
+        audit_log(
+            "admin.change_password",
+            "error",
+            auth_user_id=actor.auth_user_id,
+            http_status=500,
+            reason="auth_update_failed",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="password_update_failed",
+        ) from exc
+
+    # [E] Clear must_rotate_password for ALL university_admin memberships of this user.
+    # Auth password is global (not per-university), so all flags clear together.
+    db.execute(
+        update(Membership)
+        .where(
+            Membership.user_id == actor.auth_user_id,
+            Membership.role == "university_admin",
+            Membership.must_rotate_password == True,  # noqa: E712
+        )
+        .values(must_rotate_password=False)
+    )
+    db.commit()
+
+    audit_log(
+        "admin.change_password",
+        "success",
+        auth_user_id=actor.auth_user_id,
+        http_status=200,
+    )
+    return ChangePasswordResponse(status="password_rotated")
+
+
 class InviteResolveRequest(BaseModel):
     invite_token: str
 

--- a/backend/src/shared/auth.py
+++ b/backend/src/shared/auth.py
@@ -378,6 +378,17 @@ class SupabaseAdminAuthClient:
             raise RuntimeError("Supabase admin API is unavailable")
         admin.delete_user(user_id)
 
+    def update_user_password(self, user_id: str, new_password: str) -> None:
+        """Update the Auth password for an existing user via Service Role key.
+
+        FAIL-CLOSED CONTRACT: This must be called BEFORE clearing must_rotate_password
+        in the DB. If this raises, the DB flag must NOT be modified.
+        """
+        admin = getattr(self.client.auth, "admin", None)
+        if admin is None:
+            raise RuntimeError("Supabase admin API is unavailable")
+        admin.update_user_by_id(user_id, {"password": new_password})
+
     @staticmethod
     def _extract_users(response: Any) -> list[AdminAuthUser]:
         payload = response

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -280,6 +280,8 @@ class FakeAdminClient:
     users_by_id: dict[str, FakeAdminUser] = field(default_factory=dict)
     users_by_email: dict[str, FakeAdminUser] = field(default_factory=dict)
     fail_delete: bool = False
+    fail_update_password: bool = False
+    updated_passwords: dict[str, str] = field(default_factory=dict)
 
     def find_user_by_email(self, email: str) -> FakeAdminUser | None:
         return self.users_by_email.get(email.lower())
@@ -306,6 +308,11 @@ class FakeAdminClient:
         user = self.users_by_id.pop(user_id, None)
         if user is not None:
             self.users_by_email.pop(user.email.lower(), None)
+
+    def update_user_password(self, user_id: str, new_password: str) -> None:
+        if self.fail_update_password:
+            raise RuntimeError("Supabase Auth password update failed")
+        self.updated_passwords[user_id] = new_password
 
 
 @pytest.fixture

--- a/backend/tests/test_admin_auth.py
+++ b/backend/tests/test_admin_auth.py
@@ -1,0 +1,395 @@
+"""Tests for admin provisioning and password rotation (Issue #42).
+
+POST /api/auth/change-password fail-closed flow:
+─────────────────────────────────────────────────────────────────
+  [D] update_user_password → Supabase Auth API
+        └─ fails → 500, DB untouched (flag stays True)
+  [E] UPDATE memberships SET must_rotate_password=False
+        └─ Auth already updated (fail-safe: admin retries with new password)
+
+Covered paths:
+  1. Happy path: admin with must_rotate_password=True → 200, flag cleared
+  2. Not admin (teacher): must_rotate_password=True → 403 admin_role_required
+  3. Flag already False: admin → 403 password_rotation_not_required
+  4. Auth API fails: mock raises → 500, DB flag unchanged
+  5. Multi-university admin: both flags cleared in one request
+  6. provision_admin: new user → Auth user + Profile + Membership created
+  7. provision_admin idempotent: existing Auth user → Membership updated, password unchanged
+  8. provision_admin invalid university_id → sys.exit(1), no Auth user created
+"""
+from __future__ import annotations
+
+import sys
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from shared.models import Membership, Profile, Tenant
+
+# Import provision_admin business logic (sys.path already set up by pytest)
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+import provision_admin as _provision_module  # noqa: E402
+
+UNIVERSITY_ID = "10000000-0000-0000-0000-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# Inline fake dataclasses for provision_admin tests
+# (conftest.FakeAdminClient cannot be imported directly in test scope)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeAdminUser:
+    id: str
+    email: str
+
+
+@dataclass
+class _FakeAdminUserResult:
+    user: _FakeAdminUser
+    created: bool
+
+
+# ─────────────────────────────────────────────────────────────────
+# POST /api/auth/change-password
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_change_password_happy_path(
+    client: TestClient,
+    db: Session,
+    seed_identity: Callable[..., dict],
+    auth_headers_factory: Callable[..., dict],
+    fake_admin_client,
+) -> None:
+    """Admin with must_rotate_password=True: 200 + flag cleared in DB."""
+    user_id = str(uuid.uuid4())
+    email = "admin@test.com"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="university_admin",
+        university_id=UNIVERSITY_ID,
+        must_rotate_password=True,
+    )
+
+    headers = auth_headers_factory(sub=user_id, email=email)
+    resp = client.post(
+        "/api/auth/change-password",
+        json={"new_password": "NewSecure123!"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "password_rotated"
+
+    # Flag must be cleared in DB
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.role == "university_admin",
+        )
+    )
+    assert membership is not None
+    assert membership.must_rotate_password is False
+
+    # update_user_password was called with correct user_id
+    assert user_id in fake_admin_client.updated_passwords
+    assert fake_admin_client.updated_passwords[user_id] == "NewSecure123!"
+
+
+def test_change_password_not_admin_returns_403(
+    client: TestClient,
+    seed_identity: Callable[..., dict],
+    auth_headers_factory: Callable[..., dict],
+    fake_admin_client,
+) -> None:
+    """Teacher with must_rotate_password=True is rejected with 403."""
+    user_id = str(uuid.uuid4())
+    email = "teacher@test.com"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="teacher",
+        university_id=UNIVERSITY_ID,
+        must_rotate_password=True,
+    )
+
+    headers = auth_headers_factory(sub=user_id, email=email)
+    resp = client.post(
+        "/api/auth/change-password",
+        json={"new_password": "NewSecure123!"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "admin_role_required"
+    # Auth API must NOT have been called
+    assert user_id not in fake_admin_client.updated_passwords
+
+
+def test_change_password_flag_already_false_returns_403(
+    client: TestClient,
+    seed_identity: Callable[..., dict],
+    auth_headers_factory: Callable[..., dict],
+    fake_admin_client,
+) -> None:
+    """Admin whose must_rotate_password is already False gets 403."""
+    user_id = str(uuid.uuid4())
+    email = "admin2@test.com"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="university_admin",
+        university_id=UNIVERSITY_ID,
+        must_rotate_password=False,
+    )
+
+    headers = auth_headers_factory(sub=user_id, email=email)
+    resp = client.post(
+        "/api/auth/change-password",
+        json={"new_password": "NewSecure123!"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "password_rotation_not_required"
+    assert user_id not in fake_admin_client.updated_passwords
+
+
+def test_change_password_auth_api_failure_returns_500_and_db_untouched(
+    client: TestClient,
+    db: Session,
+    seed_identity: Callable[..., dict],
+    auth_headers_factory: Callable[..., dict],
+    fake_admin_client,
+) -> None:
+    """If Supabase Auth update fails, 500 is returned and DB flag stays True.
+
+    This is the fail-closed guarantee: Auth update precedes DB update.
+    When Auth raises, the DB must remain untouched.
+    """
+    user_id = str(uuid.uuid4())
+    email = "admin3@test.com"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="university_admin",
+        university_id=UNIVERSITY_ID,
+        must_rotate_password=True,
+    )
+    fake_admin_client.fail_update_password = True
+
+    headers = auth_headers_factory(sub=user_id, email=email)
+    resp = client.post(
+        "/api/auth/change-password",
+        json={"new_password": "NewSecure123!"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "password_update_failed"
+
+    # DB flag must still be True — DB was not touched
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.role == "university_admin",
+        )
+    )
+    assert membership is not None
+    assert membership.must_rotate_password is True
+
+
+def test_change_password_clears_all_university_admin_memberships(
+    client: TestClient,
+    db: Session,
+    seed_identity: Callable[..., dict],
+    auth_headers_factory: Callable[..., dict],
+    fake_admin_client,
+) -> None:
+    """Admin in two universities: both must_rotate_password flags cleared.
+
+    Auth password is global (not per-university), so all flags clear together.
+    """
+    user_id = str(uuid.uuid4())
+    email = "multiadmin@test.com"
+    university_id_2 = "20000000-0000-0000-0000-000000000002"
+
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="university_admin",
+        university_id=UNIVERSITY_ID,
+        must_rotate_password=True,
+    )
+    # Add second university membership directly
+    tenant2 = db.get(Tenant, university_id_2)
+    if tenant2 is None:
+        tenant2 = Tenant(id=university_id_2, name="Second University")
+        db.add(tenant2)
+        db.flush()
+    membership2 = Membership(
+        user_id=user_id,
+        university_id=university_id_2,
+        role="university_admin",
+        status="active",
+        must_rotate_password=True,
+    )
+    db.add(membership2)
+    db.commit()
+
+    headers = auth_headers_factory(sub=user_id, email=email)
+    resp = client.post(
+        "/api/auth/change-password",
+        json={"new_password": "NewSecure123!"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+
+    # Both memberships must have flag cleared
+    memberships = db.scalars(
+        select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.role == "university_admin",
+        )
+    ).all()
+    assert len(memberships) == 2
+    assert all(not m.must_rotate_password for m in memberships)
+
+
+# ─────────────────────────────────────────────────────────────────
+# provision_admin CLI
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_provision_admin_creates_new_user(db: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+    """New admin: Auth user created, Profile + Membership seeded with must_rotate_password=True."""
+    # Seed a real university
+    tenant = Tenant(id=UNIVERSITY_ID, name="Test University")
+    db.add(tenant)
+    db.commit()
+
+    fake_user_id = str(uuid.uuid4())
+    fake_email = "newadmin@test.com"
+
+    created_user = _FakeAdminUser(id=fake_user_id, email=fake_email)
+
+    class _FakeClient:
+        updated_passwords: dict[str, str] = {}
+
+        def get_or_create_user_by_email(self, email: str, password: str) -> _FakeAdminUserResult:
+            return _FakeAdminUserResult(user=created_user, created=True)
+
+    fake_client = _FakeClient()
+
+    monkeypatch.setattr(_provision_module, "get_supabase_admin_client", lambda: fake_client)
+    monkeypatch.setattr(_provision_module, "SessionLocal", lambda: db)
+
+    _provision_module.provision_admin(
+        email=fake_email,
+        university_id=UNIVERSITY_ID,
+        full_name="Admin Test",
+    )
+
+    # Profile created
+    profile = db.scalar(select(Profile).where(Profile.id == fake_user_id))
+    assert profile is not None
+    assert profile.full_name == "Admin Test"
+
+    # Membership created with must_rotate_password=True
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == fake_user_id,
+            Membership.role == "university_admin",
+        )
+    )
+    assert membership is not None
+    assert membership.must_rotate_password is True
+    assert membership.status == "active"
+    assert membership.university_id == UNIVERSITY_ID
+
+
+def test_provision_admin_idempotent_existing_user(
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing Auth user: Membership updated to must_rotate_password=True, no password change."""
+    tenant = Tenant(id=UNIVERSITY_ID, name="Test University")
+    db.add(tenant)
+    db.commit()
+
+    existing_user_id = str(uuid.uuid4())
+    fake_email = "existing@test.com"
+
+    existing_user = _FakeAdminUser(id=existing_user_id, email=fake_email)
+
+    class _FakeClient2:
+        updated_passwords: dict[str, str] = {}
+
+        def get_or_create_user_by_email(self, email: str, password: str) -> _FakeAdminUserResult:
+            # Simulates "user already exists" — no password change
+            return _FakeAdminUserResult(user=existing_user, created=False)
+
+    fake_client = _FakeClient2()
+
+    monkeypatch.setattr(_provision_module, "get_supabase_admin_client", lambda: fake_client)
+    monkeypatch.setattr(_provision_module, "SessionLocal", lambda: db)
+
+    _provision_module.provision_admin(
+        email=fake_email,
+        university_id=UNIVERSITY_ID,
+        full_name="Existing Admin",
+    )
+
+    # update_user_password must NOT have been called (FakeAdminClient has no entry)
+    assert existing_user_id not in fake_client.updated_passwords
+
+    # Membership created/updated with must_rotate_password=True
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == existing_user_id,
+            Membership.role == "university_admin",
+        )
+    )
+    assert membership is not None
+    assert membership.must_rotate_password is True
+
+
+def test_provision_admin_invalid_university_id_exits(
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid university_id: sys.exit(1) before creating Auth user."""
+    call_count = {"n": 0}
+
+    class _FakeClient3:
+        updated_passwords: dict[str, str] = {}
+
+        def get_or_create_user_by_email(self, email: str, password: str) -> None:  # type: ignore[return]
+            call_count["n"] += 1
+
+    fake_client = _FakeClient3()
+
+    monkeypatch.setattr(_provision_module, "get_supabase_admin_client", lambda: fake_client)
+    monkeypatch.setattr(_provision_module, "SessionLocal", lambda: db)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _provision_module.provision_admin(
+            email="admin@test.com",
+            university_id="00000000-0000-0000-0000-000000000000",  # does not exist
+            full_name="Ghost Admin",
+        )
+
+    assert exc_info.value.code == 1
+    # Auth API must NOT have been called — fail before Supabase
+    assert call_count["n"] == 0

--- a/frontend/src/features/admin-auth/AdminChangePasswordPage.test.tsx
+++ b/frontend/src/features/admin-auth/AdminChangePasswordPage.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AdminChangePasswordPage } from "./AdminChangePasswordPage";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/app/auth/useAuth");
+vi.mock("@/shared/api");
+
+import { useAuth } from "@/app/auth/useAuth";
+import { api } from "@/shared/api";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+    return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockRefreshActor = vi.fn().mockResolvedValue(undefined);
+const baseCtx = {
+    session: { access_token: "jwt" } as never,
+    actor: null,
+    loading: false,
+    error: null,
+    signOut: vi.fn(),
+    refreshActor: mockRefreshActor,
+};
+
+function renderPage() {
+    return render(
+        <MemoryRouter>
+            <AdminChangePasswordPage />
+        </MemoryRouter>,
+    );
+}
+
+function getPasswordInputs() {
+    const inputs = document.querySelectorAll("input[type=password]");
+    return { newPassword: inputs[0] as HTMLInputElement, confirm: inputs[1] as HTMLInputElement };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AdminChangePasswordPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useAuth).mockReturnValue({ ...baseCtx });
+        vi.mocked(api.auth.changePassword).mockResolvedValue({ status: "password_rotated" });
+    });
+
+    // 1. Passwords don't match → validation error, no API call
+    it("shows validation error when passwords do not match — no API call", async () => {
+        renderPage();
+
+        const { newPassword, confirm } = getPasswordInputs();
+        fireEvent.change(newPassword, { target: { value: "SecurePass123!" } });
+        fireEvent.change(confirm, { target: { value: "DifferentPass!" } });
+
+        await act(async () => {
+            fireEvent.submit(document.querySelector("form")!);
+        });
+
+        await waitFor(() =>
+            expect(screen.getByRole("alert").textContent).toMatch(/contraseñas no coinciden/i),
+        );
+
+        expect(api.auth.changePassword).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    // 2. Password too short → validation error, no API call
+    it("shows validation error when new password is shorter than 8 characters", async () => {
+        renderPage();
+
+        const { newPassword, confirm } = getPasswordInputs();
+        fireEvent.change(newPassword, { target: { value: "short" } });
+        fireEvent.change(confirm, { target: { value: "short" } });
+
+        await act(async () => {
+            fireEvent.submit(document.querySelector("form")!);
+        });
+
+        await waitFor(() =>
+            expect(screen.getByRole("alert").textContent).toMatch(/al menos 8/i),
+        );
+
+        expect(api.auth.changePassword).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    // 3. Valid form + API success → refreshActor called + navigate to /
+    it("calls api.auth.changePassword, refreshActor, and navigates to / on success", async () => {
+        renderPage();
+
+        const { newPassword, confirm } = getPasswordInputs();
+        fireEvent.change(newPassword, { target: { value: "NewSecure123!" } });
+        fireEvent.change(confirm, { target: { value: "NewSecure123!" } });
+
+        await act(async () => {
+            fireEvent.submit(document.querySelector("form")!);
+        });
+
+        await waitFor(() => {
+            expect(api.auth.changePassword).toHaveBeenCalledWith({
+                new_password: "NewSecure123!",
+            });
+        });
+
+        expect(mockRefreshActor).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+    });
+
+    // 4. API failure → shows error, no navigation
+    it("shows error message when API call fails — no navigation", async () => {
+        vi.mocked(api.auth.changePassword).mockRejectedValue(new Error("500 Internal Server Error"));
+
+        renderPage();
+
+        const { newPassword, confirm } = getPasswordInputs();
+        fireEvent.change(newPassword, { target: { value: "NewSecure123!" } });
+        fireEvent.change(confirm, { target: { value: "NewSecure123!" } });
+
+        await act(async () => {
+            fireEvent.submit(document.querySelector("form")!);
+        });
+
+        await waitFor(() =>
+            expect(screen.getByRole("alert").textContent).toMatch(/error al cambiar/i),
+        );
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/features/admin-auth/AdminChangePasswordPage.tsx
+++ b/frontend/src/features/admin-auth/AdminChangePasswordPage.tsx
@@ -1,20 +1,105 @@
 /**
- * Admin change-password page — placeholder for Issue #8.
+ * Admin change-password page — Issue #42 (Plan Issue #8).
  *
- * Protected by RequirePasswordRotation: only reachable when
- * actor.must_rotate_password === true.
+ * Only reachable when actor.must_rotate_password === true
+ * (enforced by RequirePasswordRotation guard in App.tsx).
  *
- * Issue #8 will implement:
- * - Password change form (POST /api/auth/change-password or Supabase updateUser)
- * - On success: clear must_rotate_password flag + redirect to admin dashboard
+ * Calls POST /api/auth/change-password (fail-closed: Auth update precedes DB flag clear).
+ * On success: refreshActor() clears must_rotate_password in context → navigate('/').
  */
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { api } from "@/shared/api";
+import { useAuth } from "@/app/auth/useAuth";
+
+const MIN_PASSWORD_LENGTH = 8;
+
 export function AdminChangePasswordPage() {
+    const navigate = useNavigate();
+    const { refreshActor } = useAuth();
+
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [formError, setFormError] = useState<string | null>(null);
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        setFormError(null);
+
+        if (newPassword !== confirmPassword) {
+            setFormError("Las contraseñas no coinciden.");
+            return;
+        }
+        if (newPassword.length < MIN_PASSWORD_LENGTH) {
+            setFormError(`La contraseña debe tener al menos ${MIN_PASSWORD_LENGTH} caracteres.`);
+            return;
+        }
+
+        setSubmitting(true);
+        try {
+            await api.auth.changePassword({ new_password: newPassword });
+            await refreshActor();
+            navigate("/", { replace: true });
+        } catch {
+            setFormError("Error al cambiar la contraseña. Intenta de nuevo.");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
     return (
-        <div className="flex flex-col items-center justify-center gap-6 px-4 py-24">
-            <h1 className="text-xl font-semibold">Cambiar contraseña</h1>
-            <p className="text-sm text-muted-foreground max-w-xs text-center">
-                Debes cambiar tu contraseña antes de continuar.
-            </p>
+        <div className="flex flex-col items-center justify-center gap-6 px-4 py-16">
+            <div className="w-full max-w-sm space-y-6">
+                <div className="text-center">
+                    <h1 className="text-xl font-semibold">Cambiar contraseña</h1>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                        Por seguridad, debes establecer una nueva contraseña antes de continuar.
+                    </p>
+                </div>
+
+                <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">Nueva contraseña</label>
+                        <input
+                            type="password"
+                            value={newPassword}
+                            onChange={(e) => setNewPassword(e.target.value)}
+                            required
+                            minLength={MIN_PASSWORD_LENGTH}
+                            autoComplete="new-password"
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        />
+                    </div>
+
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">Confirmar contraseña</label>
+                        <input
+                            type="password"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            required
+                            minLength={MIN_PASSWORD_LENGTH}
+                            autoComplete="new-password"
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        />
+                    </div>
+
+                    {formError && (
+                        <p role="alert" className="text-sm text-destructive">
+                            {formError}
+                        </p>
+                    )}
+
+                    <button
+                        type="submit"
+                        disabled={submitting}
+                        className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                    >
+                        {submitting ? "Guardando…" : "Establecer contraseña"}
+                    </button>
+                </form>
+            </div>
         </div>
     );
 }

--- a/frontend/src/features/admin-auth/AdminLoginPage.test.tsx
+++ b/frontend/src/features/admin-auth/AdminLoginPage.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AdminLoginPage } from "./AdminLoginPage";
+import type { AuthMeActor } from "@/app/auth/auth-types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/shared/supabaseClient");
+vi.mock("@/app/auth/useAuth");
+
+import { getSupabaseClient } from "@/shared/supabaseClient";
+import { useAuth } from "@/app/auth/useAuth";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+    return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// ---------------------------------------------------------------------------
+// Fixture actors
+// ---------------------------------------------------------------------------
+
+const adminActorRotate: AuthMeActor = {
+    auth_user_id: "admin-1",
+    profile: { id: "admin-1", full_name: "Admin Test" },
+    memberships: [
+        {
+            id: "m1",
+            university_id: "uni-1",
+            role: "university_admin",
+            status: "active",
+            must_rotate_password: true,
+        },
+    ],
+    must_rotate_password: true,
+    primary_role: "university_admin",
+};
+
+const adminActorNoRotate: AuthMeActor = {
+    ...adminActorRotate,
+    memberships: [{ ...adminActorRotate.memberships[0], must_rotate_password: false }],
+    must_rotate_password: false,
+};
+
+const teacherActor: AuthMeActor = {
+    auth_user_id: "teacher-1",
+    profile: { id: "teacher-1", full_name: "Docente Test" },
+    memberships: [
+        {
+            id: "m2",
+            university_id: "uni-1",
+            role: "teacher",
+            status: "active",
+            must_rotate_password: false,
+        },
+    ],
+    must_rotate_password: false,
+    primary_role: "teacher",
+};
+
+const baseCtx = {
+    session: null,
+    actor: null,
+    loading: false,
+    error: null,
+    signOut: vi.fn(),
+    refreshActor: vi.fn(),
+};
+
+function makeSupabaseMock(
+    signInWithPasswordResult: { error: null | { message: string } } = { error: null },
+) {
+    return {
+        auth: {
+            signInWithPassword: vi.fn().mockResolvedValue(signInWithPasswordResult),
+            signOut: vi.fn().mockResolvedValue({}),
+        },
+    };
+}
+
+function renderPage() {
+    return render(
+        <MemoryRouter>
+            <AdminLoginPage />
+        </MemoryRouter>,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AdminLoginPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getSupabaseClient).mockReturnValue(makeSupabaseMock() as never);
+        vi.mocked(useAuth).mockReturnValue({ ...baseCtx });
+    });
+
+    // 1. Credentials error → generic message (never reveals if email exists)
+    it("shows generic error when signInWithPassword fails — never reveals email existence", async () => {
+        const supabaseMock = makeSupabaseMock({ error: { message: "Invalid login credentials" } });
+        vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
+
+        renderPage();
+
+        fireEvent.change(document.querySelector("input[type=email]")!, {
+            target: { value: "wrong@test.com" },
+        });
+        fireEvent.change(document.querySelector("input[type=password]")!, {
+            target: { value: "badpassword" },
+        });
+
+        await act(async () => {
+            fireEvent.submit(document.querySelector("form")!);
+        });
+
+        await waitFor(() =>
+            expect(screen.getByRole("alert")).toBeTruthy(),
+        );
+
+        expect(screen.getByRole("alert").textContent).toMatch(/credenciales incorrectas/i);
+        // Must NOT leak whether the email exists
+        expect(screen.queryByText(/email.*existe/i)).toBeNull();
+        expect(screen.queryByText(/usuario.*no.*encontrado/i)).toBeNull();
+        // Must NOT have navigated
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    // 2. Successful login + must_rotate_password=true → navigate to /admin/change-password
+    it("navigates to /admin/change-password when actor.must_rotate_password is true after login", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: { access_token: "jwt" } as never,
+            actor: adminActorRotate,
+            loading: false,
+        });
+
+        renderPage();
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith("/admin/change-password", {
+                replace: true,
+            });
+        });
+    });
+
+    // 3. Successful login + must_rotate_password=false → navigate to /
+    it("navigates to / when actor.must_rotate_password is false after login", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: { access_token: "jwt" } as never,
+            actor: adminActorNoRotate,
+            loading: false,
+        });
+
+        renderPage();
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+        });
+    });
+
+    // 4. Successful login with non-admin account → signOut + generic error
+    it("signs out and shows error when logged-in actor has no university_admin role", async () => {
+        const supabaseMock = makeSupabaseMock({ error: null });
+        vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: { access_token: "jwt" } as never,
+            actor: teacherActor,
+            loading: false,
+        });
+
+        renderPage();
+
+        await waitFor(() => {
+            expect(supabaseMock.auth.signOut).toHaveBeenCalled();
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole("alert")).toBeTruthy();
+        });
+
+        // Must NOT have navigated to admin area
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    // 5. No "forgot password" CTA anywhere
+    it("does not render a forgot-password link", () => {
+        renderPage();
+        expect(screen.queryByText(/olvidé/i)).toBeNull();
+        expect(screen.queryByText(/forgot/i)).toBeNull();
+        expect(screen.queryByText(/recuperar/i)).toBeNull();
+    });
+});

--- a/frontend/src/features/admin-auth/AdminLoginPage.tsx
+++ b/frontend/src/features/admin-auth/AdminLoginPage.tsx
@@ -1,19 +1,126 @@
 /**
- * Admin login page — placeholder for Issue #8.
+ * Admin login page — Issue #42 (Plan Issue #8).
  *
- * Issue #8 will implement:
- * - Password-only login form (no self-registration, no OAuth)
- * - Redirect to /admin/change-password when must_rotate_password=true
- * - Redirect to admin dashboard when already authenticated
+ * Password-only. No Microsoft OAuth, no self-registration, no "Forgot password".
+ *
+ * Flow after successful login:
+ *   actor.must_rotate_password=true  → /admin/change-password
+ *   actor.must_rotate_password=false → /
+ *
+ * Non-admin accounts that sign in are signed out silently (no role leak in error text).
  */
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getSupabaseClient } from "@/shared/supabaseClient";
+import { useAuth } from "@/app/auth/useAuth";
+
 export function AdminLoginPage() {
+    const navigate = useNavigate();
+    const { session, actor, loading } = useAuth();
+
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [loginError, setLoginError] = useState<string | null>(null);
+
+    // Redirect when actor is resolved — covers both "already authenticated" and post-login.
+    useEffect(() => {
+        if (loading) return;
+        if (!session || !actor) return;
+
+        const isAdmin = actor.memberships.some(
+            (m) => m.role === "university_admin" && m.status === "active",
+        );
+
+        if (!isAdmin) {
+            // Signed in but not an admin — sign out and show a generic error.
+            const supabase = getSupabaseClient();
+            if (supabase) {
+                void supabase.auth.signOut();
+            }
+            setLoginError("Credenciales incorrectas. Verifica tu email y contraseña.");
+            return;
+        }
+
+        if (actor.must_rotate_password) {
+            navigate("/admin/change-password", { replace: true });
+        } else {
+            navigate("/", { replace: true });
+        }
+    }, [session, actor, loading, navigate]);
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        setLoginError(null);
+        setSubmitting(true);
+
+        try {
+            const supabase = getSupabaseClient()!;
+            const { error } = await supabase.auth.signInWithPassword({
+                email,
+                password,
+            });
+
+            if (error) {
+                // Never reveal whether the email exists
+                setLoginError("Credenciales incorrectas. Verifica tu email y contraseña.");
+            }
+            // On success: AuthContext onAuthStateChange fires SIGNED_IN → actor updates
+            // → useEffect above handles navigation
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    if (loading) return null;
+
     return (
-        <div className="flex flex-col items-center justify-center gap-6 px-4 py-24">
-            <h1 className="text-xl font-semibold">Portal administrador</h1>
-            <p className="text-sm text-muted-foreground max-w-xs text-center">
-                El inicio de sesión para administradores estará disponible en la
-                próxima versión.
-            </p>
+        <div className="flex flex-col items-center justify-center gap-6 px-4 py-16">
+            <div className="w-full max-w-sm space-y-6">
+                <div className="text-center">
+                    <h1 className="text-xl font-semibold">Portal administrador</h1>
+                </div>
+
+                <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">Correo electrónico</label>
+                        <input
+                            type="email"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            required
+                            autoComplete="email"
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        />
+                    </div>
+
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium">Contraseña</label>
+                        <input
+                            type="password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            required
+                            autoComplete="current-password"
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        />
+                    </div>
+
+                    {loginError && (
+                        <p role="alert" className="text-sm text-destructive">
+                            {loginError}
+                        </p>
+                    )}
+
+                    <button
+                        type="submit"
+                        disabled={submitting}
+                        className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                    >
+                        {submitting ? "Iniciando sesión…" : "Iniciar sesión"}
+                    </button>
+                </form>
+            </div>
         </div>
     );
 }

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -262,6 +262,15 @@ export interface ActivateOAuthCompleteResponse {
     status: string;
 }
 
+// Admin password rotation (Issue #8)
+export interface ChangePasswordRequest {
+    new_password: string;
+}
+
+export interface ChangePasswordResponse {
+    status: string;
+}
+
 export const EMPTY_FORM: CaseFormData = {
     subject: "",
     academicLevel: "Pregrado",

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -8,6 +8,8 @@ import type {
     AuthoringJobCreateResponse,
     AuthoringJobResultResponse,
     AuthoringJobStatusResponse,
+    ChangePasswordRequest,
+    ChangePasswordResponse,
     IntentType,
     InviteRedeemResponse,
     InviteResolveResponse,
@@ -307,6 +309,13 @@ export const api = {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ invite_token }),
+            });
+        },
+        async changePassword(req: ChangePasswordRequest): Promise<ChangePasswordResponse> {
+            return parseJsonResponse<ChangePasswordResponse>("/auth/change-password", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(req),
             });
         },
     },

--- a/scripts/provision_admin.py
+++ b/scripts/provision_admin.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+provision_admin.py — Aprovisionamiento CLI de administrador universitario.
+
+Uso:
+    python scripts/provision_admin.py \\
+        --email admin@universidad.edu \\
+        --university-id <uuid> \\
+        --full-name "Ana García"
+
+Reglas de seguridad:
+- Service Role key leída del entorno (.env) — nunca de args CLI.
+- Contraseña temporal impresa en stdout UNA sola vez (solo para usuario nuevo).
+- Sin endpoint HTTP — este script es el único punto de aprovisionamiento.
+- El admin DEBE cambiar contraseña en el primer login (must_rotate_password=True).
+"""
+from __future__ import annotations
+
+import argparse
+import secrets
+import string
+import sys
+from pathlib import Path
+
+# Agregar backend/src al path para imports del proyecto
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "backend" / "src"))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / "backend" / ".env")
+
+from shared.auth import (
+    audit_event,
+    ensure_membership,
+    ensure_profile,
+    get_supabase_admin_client,
+)
+from shared.database import SessionLocal
+from shared.models import Tenant
+
+
+def _generate_temp_password(length: int = 20) -> str:
+    """Generate a cryptographically secure temporary password."""
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def provision_admin(email: str, university_id: str, full_name: str) -> None:
+    """Provision a university_admin account.
+
+    Steps:
+      [1] Validate the university exists in tenants — fail before touching Auth
+      [2] get_or_create_user_by_email in Supabase Auth
+      [3] ensure_profile + ensure_membership(must_rotate_password=True)
+      [4] commit + audit
+    """
+    db = SessionLocal()
+    try:
+        # [1] Validate university exists — fail-fast before creating Auth user
+        tenant = db.query(Tenant).filter(Tenant.id == university_id).first()
+        if tenant is None:
+            print(
+                f"ERROR: No se encontró la universidad con id '{university_id}'.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # [2] Create or reuse Supabase Auth user
+        admin_client = get_supabase_admin_client()
+        temp_password = _generate_temp_password()
+        result = admin_client.get_or_create_user_by_email(email, temp_password)
+        auth_user_id = result.user.id
+
+        # [3] Ensure Profile and Membership exist
+        ensure_profile(db, user_id=auth_user_id, full_name=full_name)
+        ensure_membership(
+            db,
+            user_id=auth_user_id,
+            university_id=university_id,
+            role="university_admin",
+            must_rotate_password=True,
+        )
+        db.commit()
+
+        # [4] Audit
+        audit_event("admin.provision", outcome="success", auth_user_id=auth_user_id)
+
+        if result.created:
+            print(f"✓ Cuenta de administrador creada: {email}")
+            print(f"  Universidad: {tenant.name} ({university_id})")
+            print(f"\n  Contraseña temporal: {temp_password}")
+            print(
+                "\n  IMPORTANTE: Comunica esta contraseña al administrador por un canal"
+                " seguro fuera de banda. No se mostrará de nuevo."
+            )
+        else:
+            print(f"✓ El usuario ya existía en Supabase Auth: {email}")
+            print(f"  Membresía university_admin actualizada (must_rotate_password=True).")
+            print(
+                "  NOTA: La contraseña NO fue modificada."
+                " Usa el dashboard de Supabase para resetearla si es necesario."
+            )
+
+    except SystemExit:
+        raise
+    except Exception as exc:
+        db.rollback()
+        audit_event("admin.provision", outcome="error", reason=str(exc))
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        db.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Provisionar administrador universitario (CLI-only, sin endpoint HTTP)"
+    )
+    parser.add_argument("--email", required=True, help="Email del administrador")
+    parser.add_argument(
+        "--university-id",
+        required=True,
+        dest="university_id",
+        help="UUID de la universidad (tenants.id)",
+    )
+    parser.add_argument("--full-name", required=True, dest="full_name", help="Nombre completo del administrador")
+    args = parser.parse_args()
+
+    provision_admin(
+        email=args.email,
+        university_id=args.university_id,
+        full_name=args.full_name,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Contexto

Implementa el último actor del sistema de auth: el **administrador universitario**.

Los Issues #38 (teacher activation) y #39 (student join) ya están merged. Esta PR cierra el ciclo: un operador puede crear admins via CLI, y el admin puede hacer login con contraseña y rotar su contraseña temporal en el primer acceso.

**Dependencias:** #33 ✅ #38 ✅ #39 ✅  
**Cierra:** #42  
**Desbloquea:** Issue #10 (Security ops + rate limiting)

---

## Qué se implementó

### Backend

**`backend/src/shared/auth.py`**
- `SupabaseAdminAuthClient.update_user_password(user_id, new_password)` — actualiza contraseña via Service Role key. Debe llamarse **siempre antes** de limpiar el flag en DB (contrato fail-closed).

**`backend/src/shared/app.py`**
- `POST /api/auth/change-password` — endpoint fail-closed para rotación de contraseña:
  1. Guard de rol: 403 si no es `university_admin`
  2. Guard de rotación: 403 si `must_rotate_password=False`
  3. `update_user_password()` → Supabase Auth API (si falla: 500, DB sin tocar ✓)
  4. `UPDATE memberships SET must_rotate_password=False WHERE role='university_admin'` — limpia **todas** las memberships del usuario (password es global en Supabase Auth)
  5. Audit log en éxito y error

### CLI (sin endpoint HTTP)

**`scripts/provision_admin.py`**
```bash
python scripts/provision_admin.py \
  --email admin@universidad.edu \
  --university-id <uuid> \
  --full-name "Ana García"
```
- Valida que la universidad exista en `tenants` antes de crear en Supabase Auth
- `get_or_create_user_by_email` → idempotente (usuario existente: membership actualizada, password NO cambia)
- Contraseña temporal impresa en stdout **una sola vez** — comunicar al admin fuera de banda
- Service Role key: solo del entorno `.env`, nunca como argumento CLI

### Frontend

**`AdminLoginPage.tsx`** — password-only, sin OAuth, sin "Olvidé mi contraseña"
- `signInWithPassword` → `onAuthStateChange` dispara → `useEffect` navega:
  - `must_rotate_password=true` → `/admin/change-password`
  - `must_rotate_password=false` → `/`
- Cuenta sin rol `university_admin`: `signOut()` + error genérico (no revela si el email existe)

**`AdminChangePasswordPage.tsx`** — protegida por `RequirePasswordRotation` (ya existía)
- Validación client-side: contraseñas deben coincidir, mínimo 8 caracteres
- `POST /api/auth/change-password` → `refreshActor()` → `navigate('/')`

**`frontend/src/shared/adam-types.ts`** — `ChangePasswordRequest`, `ChangePasswordResponse`  
**`frontend/src/shared/api.ts`** — `api.auth.changePassword()`

---

## Arquitectura fail-closed (no negociable)

```
POST /api/auth/change-password
  [D] update_user_password() → Supabase Auth API
        └─ falla → 500, DB sin tocar ✓ (flag sigue True)
  [E] UPDATE memberships SET must_rotate_password=False
        └─ falla → 500 (Auth ya actualizado — admin reintenta con nueva pw, fail-safe)
```

El orden D → E **nunca debe invertirse**.

---

## Tests

| Suite | Resultado |
|---|---|
| `backend pytest -q` | **62 passed, 12 skipped** (0 regresiones) |
| `npm test` (frontend) | **87 passed** (15 test files) |
| ESLint | 0 errors, 4 warnings pre-existentes |
| `npm run build` | ✅ build exitoso |

**Nuevos tests backend** (`test_admin_auth.py` — 8 casos):
1. Happy path: flag limpiado, Auth actualizado
2. No es admin → 403 `admin_role_required`
3. Flag ya False → 403 `password_rotation_not_required`
4. Auth API falla → 500, DB sin tocar (fail-closed verificado)
5. Multi-universidad: ambas memberships limpiadas
6. `provision_admin`: usuario nuevo → Profile + Membership creados
7. `provision_admin` idempotente: usuario existente → Membership actualizada
8. `provision_admin` university_id inválido → `sys.exit(1)` sin crear Auth user

**Nuevos tests frontend** (9 casos en 2 archivos):
- `AdminLoginPage`: error genérico, redirect flag=T, redirect flag=F, no-admin signout, no CTA "olvidé"
- `AdminChangePasswordPage`: mismatch, too short, success + refreshActor + navigate, API failure

---

## NOT in scope (explícito)

| Item | Razón |
|---|---|
| Rate limiting en `/api/auth/change-password` | Issue #10 (Security ops) |
| Admin dashboard post-login | Fuera de scope Issue #8 |
| Flujo "olvidé contraseña" | Prohibido por plan maestro |
| Microsoft OAuth para admin | Prohibido por plan maestro |
| `User` legacy bridge para admin | No requerido — admins no acceden a authoring |
| Supabase RLS policies | `backend/sql/rls_policies.sql` — deployment step separado |

---

## Checklist para el reviewer

- [ ] Verificar que `POST /api/auth/change-password` devuelve 403 si `must_rotate_password=False`
- [ ] Verificar el orden fail-closed en `change_admin_password()` (`app.py:~593`)
- [ ] Confirmar que `provision_admin.py` no expone la Service Role key como argumento CLI
- [ ] Confirmar que `AdminLoginPage` no tiene ningún link de recuperación de contraseña

---

## Pasos para correr localmente

```bash
# 1. Backend
cd backend
DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5434/postgres" \
GEMINI_API_KEY="dummy" \
uv run pytest tests/test_admin_auth.py -v

# 2. Provisionar un admin de prueba (requiere Supabase local corriendo)
python scripts/provision_admin.py \
  --email admin@test.com \
  --university-id <tenant-uuid> \
  --full-name "Admin Test"

# 3. Frontend
cd frontend && npm test
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)