### PR TITLE
feat(infra): NullPool, OIDC Cloud Tasks, JSON logging y hardening de deploy (Issue #44)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -33,3 +33,35 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** En Issue #39 eng review, el usuario eligió diferir estos tests a TODOS.md (respuesta al TODO candidato 2). El código B3 existe y está cubierto por el test de integración manual, pero no por pytest automatizado.
 
 **Depends on / blocked by:** No bloquea nada. Puede hacerse en cualquier PR de hardening del auth perimeter.
+
+---
+
+## TODO-003: Propagación de `request_id` end-to-end en logs
+
+**What:** Propagar el `request_id` generado por `structured_logging_middleware` (en `app.py`) a los logs de `shared/auth.py` y `case_generator/` para correlación end-to-end en Cloud Logging.
+
+**Why:** Actualmente el `request_id` solo aparece en el log de request del middleware. Los logs de auth events (`audit_log`, `login_failed`, etc.) y los de `AuthoringService` no tienen correlación con el request que los originó, lo que hace el debugging en producción más difícil.
+
+**Pros:** Permite filtrar todos los logs de un request específico en Cloud Logging con un solo query. Detecta latencias anómalas en pasos individuales. Sin esto, debuggear un 5xx en producción requiere correlacionar por timestamp.
+
+**Cons:** Requiere `contextvars.ContextVar` para propagar sin pasar `request_id` como parámetro explícito por toda la cadena de llamadas. Toca `auth.py` (sensible) y potencialmente `case_generator/` (muy sensible). Scope mayor que un issue de infra.
+
+**Context:** Identificado en Issue #44 (plan-eng-review TODO item 2). El middleware ya genera el `request_id` y lo guarda en `request.state.request_id`, pero ningún logger downstream lo lee. La infraestructura de JSON logging ya existe — solo falta el ContextVar bridge.
+
+**Depends on / blocked by:** Issue #44 (completado). Puede hacerse en Issue #11 (Tests y QA gate) o como un issue independiente de observabilidad.
+
+---
+
+## TODO-004: PyJWKClient async para Cloud Tasks OIDC
+
+**What:** Reemplazar la llamada síncrona `_google_jwks_client.get_signing_key_from_jwt(token)` en `shared/internal_tasks.py` con una versión async via `asyncio.get_event_loop().run_in_executor()` o una librería async equivalente.
+
+**Why:** El endpoint `process_authoring_job_task` es `async def`. `PyJWKClient.get_signing_key_from_jwt()` hace I/O de red de forma síncrona cuando la caché expira (~1 vez cada 5 min), bloqueando el event loop durante ese tiempo (~100-200ms).
+
+**Pros:** Elimina el bloqueo del event loop durante el fetch de JWKS. Correcto para un endpoint async con potencial concurrencia alta.
+
+**Cons:** `PyJWKClient` no tiene API async nativa. Requiere wrapping manual con `run_in_executor` o migrar a `python-jose` / `authlib` que soportan async. Con `lifespan=300` y el worker de baja concurrencia actual, el impacto real es despreciable — el bloqueo ocurre ~1 vez cada 5 min.
+
+**Context:** Identificado en Issue #44 (plan-eng-review TODO item 3, decisión 10A: aceptar bloqueo síncrono hoy). La misma restricción existe en `shared/auth.py` con `JwtVerifier`. Resolver ambos juntos tiene más sentido que resolver solo el worker.
+
+**Depends on / blocked by:** Issue #44 (completado). Solo prioritario si el worker escala a alta concurrencia (>10 req/s simultáneos). Post-Fase 1.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -58,3 +58,6 @@ CLOUD_TASKS_PROJECT=
 CLOUD_TASKS_LOCATION=
 CLOUD_TASKS_QUEUE=adam-authoring-jobs
 CLOUD_TASKS_SERVICE_ACCOUNT=
+# OIDC audience for Cloud Tasks token validation (the public-api Cloud Run URL)
+# Required when ENVIRONMENT=production. Leave empty for local dev.
+CLOUD_TASKS_AUDIENCE=

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,0 +1,22 @@
+# authoring-worker image — Issue #9
+#
+# Uses the same base as the main Dockerfile because AuthoringService.run_job
+# depends on LangGraph runtime libraries bundled in langchain/langgraph-api.
+# Using python:3.12-slim would break the LangGraph execution context.
+
+FROM langchain/langgraph-api:3.12
+
+WORKDIR /deps
+
+# Install uv for fast, reproducible dependency installation
+RUN pip install --no-cache-dir uv
+
+# Copy only the backend source (no frontend assets needed for the worker)
+COPY pyproject.toml uv.lock* ./
+COPY src/ src/
+
+# Install production dependencies only
+RUN uv sync --no-dev
+
+# Run the minimal worker entrypoint — no SPA, no auth routes
+CMD ["uvicorn", "shared.worker_app:worker_app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "scipy>=1.17.1",
     "supabase>=2.23.0",
     "cachetools>=5.0.0",
+    "python-json-logger>=2.0.7",
 ]
 
 

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -9,8 +9,11 @@ import logging
 import os
 import pathlib
 import threading
+import time
 from typing import Any
 import uuid
+
+from pythonjsonlogger.json import JsonFormatter
 
 from cachetools import TTLCache
 
@@ -55,11 +58,14 @@ from shared.models import (
     Tenant,
     User,
 )
+from shared.internal_tasks import process_authoring_job_task
 from shared.progress_bus import subscribe, unsubscribe
 
 load_dotenv()
 
-logging.basicConfig(level=logging.INFO)
+_json_handler = logging.StreamHandler()
+_json_handler.setFormatter(JsonFormatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+logging.basicConfig(handlers=[_json_handler], level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)
 
 
@@ -281,6 +287,32 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 app = FastAPI(title="adam-v8.0 - Case Generation API", lifespan=lifespan)
 
+
+@app.middleware("http")
+async def structured_logging_middleware(request: Request, call_next: Any) -> Any:
+    """Emit a structured JSON log line for every HTTP request.
+
+    Fields: request_id (UUID4), method, path, status_code, latency_ms.
+    request_id is stored in request.state for downstream use.
+    """
+    request_id = str(uuid.uuid4())
+    start = time.monotonic()
+    request.state.request_id = request_id
+    response = await call_next(request)
+    latency_ms = round((time.monotonic() - start) * 1000)
+    logger.info(
+        "request",
+        extra={
+            "request_id": request_id,
+            "method": request.method,
+            "path": request.url.path,
+            "status_code": response.status_code,
+            "latency_ms": latency_ms,
+        },
+    )
+    return response
+
+
 _cors_origins = [
     "http://localhost:5173",
     "http://localhost:3000",
@@ -386,30 +418,14 @@ def create_authoring_job(
     )
 
 
-class InternalTaskPayload(BaseModel):
-    job_id: str
-    idempotency_key: str
-
-
-@app.post("/api/internal/tasks/authoring_step", status_code=200)
-async def process_authoring_job_task(
-    payload: InternalTaskPayload,
-    db: Session = Depends(get_db),
-    x_cloudtasks_taskname: str | None = Header(None),
-) -> dict[str, str]:
-    logger.info("Received Cloud Task execution for job %s | Task: %s", payload.job_id, x_cloudtasks_taskname)
-
-    job = db.scalar(select(AuthoringJob).where(AuthoringJob.id == payload.job_id))
-    if not job:
-        logger.error("Job not found. Discarding task.")
-        raise HTTPException(status_code=404, detail="Job not found")
-
-    if job.status in ["completed", "failed", "processing"]:
-        logger.warning("IDEMPOTENCY TRIGGERED: Job %s is already %s.", job.id, job.status)
-        return {"status": "bypassed", "reason": f"idempotency_barrier: {job.status}"}
-
-    await AuthoringService.run_job(job.id)
-    return {"status": "success", "job_id": job.id}
+# Cloud Tasks internal endpoint — handler lives in shared.internal_tasks
+# to avoid import side effects when worker_app.py mounts the same route.
+app.add_api_route(
+    "/api/internal/tasks/authoring_step",
+    process_authoring_job_task,
+    methods=["POST"],
+    status_code=200,
+)
 
 
 class JobStatusResponse(BaseModel):

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -1,43 +1,59 @@
 from collections.abc import Generator
-import os
 from pathlib import Path
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, Engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+from sqlalchemy.pool import NullPool
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 ENV_FILE = Path(__file__).resolve().parents[2] / ".env"
 
+
 class Settings(BaseSettings):
-    """
-    Configuration settings for the database connection.
+    """Configuration settings for the database connection.
+
     In local/dev environments this may load from a .env file.
-    In production (Cloud Run), these should be injected either by Secret Manager
+    In production (Cloud Run), these should be injected via Secret Manager
     or environment variables mapped to Secret Manager.
     """
-    # Single source of truth for the connection string
+
     database_url: str
-    
-    # Connection Pooling limits to protect Cloud SQL from Serverless horizontal scaling exhaustion
+    # ENVIRONMENT=production switches to NullPool for Supavisor transaction mode
+    environment: str = "development"
+    # Classic pool limits — only used when environment != "production"
     db_pool_size: int = 5
     db_max_overflow: int = 10
     db_pool_timeout: int = 30
-    db_pool_recycle: int = 1800 # Recycle connections after 30 minutes
+    db_pool_recycle: int = 1800
 
     model_config = SettingsConfigDict(env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 
+
+def _make_engine(s: Settings) -> Engine:
+    """Create the SQLAlchemy engine according to the deployment environment.
+
+    Pool selection:
+      environment == "production"  ->  NullPool  (1 conn/request, Supavisor compat.)
+      environment != "production"  ->  QueuePool (persistent pool, local Postgres)
+
+    Supavisor in transaction mode does not support persistent connections.
+    NullPool creates and destroys the connection on each request, which is the
+    correct behaviour for Cloud Run + Supavisor.
+    """
+    if s.environment == "production":
+        return create_engine(s.database_url, poolclass=NullPool)
+    return create_engine(
+        s.database_url,
+        pool_size=s.db_pool_size,
+        max_overflow=s.db_max_overflow,
+        pool_timeout=s.db_pool_timeout,
+        pool_recycle=s.db_pool_recycle,
+        # Verify connection liveness before usage — essential for serverless
+        pool_pre_ping=True,
+    )
+
+
 settings = Settings()
-
-# Create the SQLAlchemy Engine with strict pooling settings for Cloud Run
-engine = create_engine(
-    settings.database_url,
-    pool_size=settings.db_pool_size,
-    max_overflow=settings.db_max_overflow,
-    pool_timeout=settings.db_pool_timeout,
-    pool_recycle=settings.db_pool_recycle,
-    # pool_pre_ping=True verifies connection liveness before usage, essential for serverless
-    pool_pre_ping=True, 
-)
-
+engine = _make_engine(settings)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 class Base(DeclarativeBase):

--- a/backend/src/shared/internal_tasks.py
+++ b/backend/src/shared/internal_tasks.py
@@ -1,0 +1,143 @@
+"""Cloud Tasks internal handler — Issue #9.
+
+Responsibilities:
+- InternalTaskPayload schema
+- _verify_cloud_tasks_oidc(): validate Cloud Tasks OIDC Bearer token
+- process_authoring_job_task(): the internal endpoint handler
+
+Extracted from app.py so both the public API and the authoring-worker
+can import the handler without triggering app.py module-level side effects
+(CORS setup, static SPA mount, load_dotenv, etc.).
+
+OIDC validation flow:
+  SA not configured  ->  SKIP (dev mode, WARNING emitted)
+  SA configured:
+    no Bearer        ->  401 missing_oidc_token
+    invalid JWT      ->  401 invalid_oidc_token
+    JWKS unreachable ->  503 jwks_unavailable  (Cloud Tasks retries automatically)
+    email != SA      ->  401 invalid_service_account
+    OK               ->  handler proceeds
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import Depends, Header, HTTPException
+from jwt import PyJWKClient, PyJWKSetError
+from jwt import decode as jwt_decode
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from case_generator.core.authoring import AuthoringService
+from shared.database import get_db
+from shared.models import AuthoringJob
+
+logger = logging.getLogger(__name__)
+
+ENV_FILE = Path(__file__).resolve().parents[2] / ".env"
+
+
+class _CloudTasksSettings(BaseSettings):
+    """Settings consumed exclusively by the Cloud Tasks handler."""
+
+    cloud_tasks_service_account: str | None = None
+    cloud_tasks_audience: str | None = None
+
+    model_config = SettingsConfigDict(
+        env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore"
+    )
+
+
+_ct_settings = _CloudTasksSettings()
+
+_GOOGLE_OIDC_CERTS_URL = "https://www.googleapis.com/oauth2/v3/certs"
+# Singleton JWKS client with 5-minute cache — Google rotates OIDC keys periodically.
+# lifespan=300 prevents a network fetch on every request while staying fresh.
+_google_jwks_client = PyJWKClient(
+    _GOOGLE_OIDC_CERTS_URL, cache_jwk_set=True, lifespan=300
+)
+
+
+class InternalTaskPayload(BaseModel):
+    """Payload for the Cloud Tasks authoring step endpoint."""
+
+    job_id: str
+    idempotency_key: str
+
+
+def _verify_cloud_tasks_oidc(authorization: str | None) -> None:
+    """Verify the Cloud Tasks OIDC Bearer token.
+
+    Skips validation when CLOUD_TASKS_SERVICE_ACCOUNT is not set (dev/test).
+    Emits a WARNING so misconfigured production deploys are visible in logs.
+
+    Raises:
+        HTTPException 401: token missing, invalid signature, expired, or wrong SA.
+        HTTPException 503: Google JWKS endpoint unreachable (Cloud Tasks will retry).
+    """
+    if not _ct_settings.cloud_tasks_service_account:
+        logger.warning(
+            "oidc_validation_skipped",
+            extra={"reason": "CLOUD_TASKS_SERVICE_ACCOUNT not set — dev mode"},
+        )
+        return
+
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="missing_oidc_token")
+
+    token = authorization.removeprefix("Bearer ")
+    try:
+        signing_key = _google_jwks_client.get_signing_key_from_jwt(token)
+        payload = jwt_decode(
+            token,
+            signing_key,
+            algorithms=["RS256"],
+            audience=_ct_settings.cloud_tasks_audience,
+        )
+    except PyJWKSetError as exc:
+        logger.error("jwks_fetch_failed", extra={"error": str(exc)})
+        raise HTTPException(status_code=503, detail="jwks_unavailable") from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=401, detail="invalid_oidc_token") from exc
+
+    if payload.get("email") != _ct_settings.cloud_tasks_service_account:
+        raise HTTPException(status_code=401, detail="invalid_service_account")
+
+
+async def process_authoring_job_task(
+    payload: InternalTaskPayload,
+    db: Session = Depends(get_db),
+    authorization: str | None = Header(None),
+    x_cloudtasks_taskname: str | None = Header(None),
+) -> dict[str, str]:
+    """Process a single Cloud Tasks authoring step.
+
+    Protected by OIDC validation in production.
+    Idempotency barrier prevents double-processing completed jobs.
+    """
+    _verify_cloud_tasks_oidc(authorization)
+
+    logger.info(
+        "cloud_task_received",
+        extra={"job_id": payload.job_id, "task_name": x_cloudtasks_taskname},
+    )
+
+    job = db.scalar(select(AuthoringJob).where(AuthoringJob.id == payload.job_id))
+    if not job:
+        logger.error("cloud_task_job_not_found", extra={"job_id": payload.job_id})
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    if job.status in ["completed", "failed", "processing"]:
+        logger.warning(
+            "cloud_task_idempotency_barrier",
+            extra={"job_id": job.id, "status": job.status},
+        )
+        return {"status": "bypassed", "reason": f"idempotency_barrier: {job.status}"}
+
+    await AuthoringService.run_job(job.id)
+    return {"status": "success", "job_id": job.id}

--- a/backend/src/shared/worker_app.py
+++ b/backend/src/shared/worker_app.py
@@ -1,0 +1,32 @@
+"""authoring-worker FastAPI entrypoint — Issue #9.
+
+Exposes ONLY /api/internal/tasks/authoring_step and GET /healthz.
+Does NOT mount auth routes, the SPA, or any public user-facing endpoints.
+
+Start with:
+    uvicorn shared.worker_app:worker_app --host 0.0.0.0 --port 8080
+"""
+from fastapi import FastAPI
+
+from shared.internal_tasks import process_authoring_job_task
+
+worker_app = FastAPI(
+    title="ADAM authoring-worker",
+    # Disable interactive docs — this is an internal service
+    docs_url=None,
+    redoc_url=None,
+)
+
+
+@worker_app.get("/healthz")
+def healthz() -> dict[str, str]:
+    """Health check for Cloud Run liveness and readiness probes."""
+    return {"status": "ok"}
+
+
+worker_app.add_api_route(
+    "/api/internal/tasks/authoring_step",
+    process_authoring_job_task,
+    methods=["POST"],
+    status_code=200,
+)

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,37 @@
+"""Tests for database pool selection — Issue #9.
+
+Verifies that _make_engine() selects NullPool in production (for Supavisor
+transaction mode compatibility) and QueuePool in development.
+
+Uses the _make_engine() factory directly — no importlib.reload, no global
+state contamination, no side effects on SessionLocal or other tests.
+"""
+from shared.database import Settings, _make_engine
+
+
+def test_null_pool_when_environment_is_production() -> None:
+    """ENVIRONMENT=production must select NullPool for Supavisor compat."""
+    s = Settings(
+        database_url="postgresql+psycopg://u:p@localhost/db",
+        environment="production",
+    )
+    eng = _make_engine(s)
+    assert eng.pool.__class__.__name__ == "NullPool"
+
+
+def test_classic_pool_when_environment_is_development() -> None:
+    """ENVIRONMENT=development must use QueuePool (persistent local pool)."""
+    s = Settings(
+        database_url="postgresql+psycopg://u:p@localhost/db",
+        environment="development",
+    )
+    eng = _make_engine(s)
+    assert eng.pool.__class__.__name__ != "NullPool"
+
+
+def test_classic_pool_is_default() -> None:
+    """Default environment (no ENVIRONMENT var) must not select NullPool."""
+    s = Settings(database_url="postgresql+psycopg://u:p@localhost/db")
+    eng = _make_engine(s)
+    assert eng.pool.__class__.__name__ != "NullPool"
+    assert s.environment == "development"

--- a/backend/tests/test_internal_tasks.py
+++ b/backend/tests/test_internal_tasks.py
@@ -1,0 +1,167 @@
+"""Tests for OIDC validation and JSON logging middleware — Issue #9.
+
+OIDC validation flow under test:
+  SA not configured   ->  SKIP + WARNING log
+  SA configured:
+    no Bearer         ->  401 missing_oidc_token
+    invalid JWT       ->  401 invalid_oidc_token
+    JWKS unreachable  ->  503 jwks_unavailable
+    email != SA       ->  401 invalid_service_account
+    email == SA       ->  handler proceeds (404 job not found expected)
+
+Logging middleware:
+  Every request emits JSON log with request_id (UUID) and latency_ms (int).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from jwt import PyJWKSetError
+
+import shared.internal_tasks as it_module
+from shared.internal_tasks import _verify_cloud_tasks_oidc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_test_app() -> FastAPI:
+    """Minimal FastAPI that mounts the internal tasks route for testing."""
+    from shared.internal_tasks import process_authoring_job_task
+
+    app = FastAPI()
+    app.add_api_route(
+        "/api/internal/tasks/authoring_step",
+        process_authoring_job_task,
+        methods=["POST"],
+        status_code=200,
+    )
+    return app
+
+
+# ---------------------------------------------------------------------------
+# _verify_cloud_tasks_oidc — unit tests (no HTTP layer needed)
+# ---------------------------------------------------------------------------
+
+class TestVerifyCloudTasksOidc:
+    def test_skip_when_sa_not_configured(self, caplog: pytest.LogCaptureFixture) -> None:
+        """SA not set -> validation skipped, WARNING emitted."""
+        with patch.object(it_module, "_ct_settings") as mock_settings:
+            mock_settings.cloud_tasks_service_account = None
+            with caplog.at_level(logging.WARNING, logger="shared.internal_tasks"):
+                _verify_cloud_tasks_oidc(None)  # must not raise
+        assert "oidc_validation_skipped" in caplog.text
+
+    def test_missing_authorization_header_raises_401(self) -> None:
+        """SA configured + no Authorization header -> 401 missing_oidc_token."""
+        from fastapi import HTTPException
+
+        with patch.object(it_module, "_ct_settings") as mock_settings:
+            mock_settings.cloud_tasks_service_account = "worker@proj.iam.gserviceaccount.com"
+            with pytest.raises(HTTPException) as exc_info:
+                _verify_cloud_tasks_oidc(None)
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "missing_oidc_token"
+
+    def test_invalid_jwt_raises_401(self) -> None:
+        """SA configured + JWT decode failure -> 401 invalid_oidc_token."""
+        from fastapi import HTTPException
+
+        with (
+            patch.object(it_module, "_ct_settings") as mock_settings,
+            patch.object(it_module._google_jwks_client, "get_signing_key_from_jwt", side_effect=Exception("bad token")),
+        ):
+            mock_settings.cloud_tasks_service_account = "worker@proj.iam.gserviceaccount.com"
+            with pytest.raises(HTTPException) as exc_info:
+                _verify_cloud_tasks_oidc("Bearer invalid.token.here")
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "invalid_oidc_token"
+
+    def test_jwks_unavailable_raises_503(self) -> None:
+        """JWKS endpoint unreachable -> 503 jwks_unavailable (Cloud Tasks retries)."""
+        from fastapi import HTTPException
+
+        with (
+            patch.object(it_module, "_ct_settings") as mock_settings,
+            patch.object(
+                it_module._google_jwks_client,
+                "get_signing_key_from_jwt",
+                side_effect=PyJWKSetError("cannot fetch"),
+            ),
+        ):
+            mock_settings.cloud_tasks_service_account = "worker@proj.iam.gserviceaccount.com"
+            with pytest.raises(HTTPException) as exc_info:
+                _verify_cloud_tasks_oidc("Bearer some.token")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "jwks_unavailable"
+
+    def test_wrong_service_account_email_raises_401(self) -> None:
+        """Valid JWT but email claim != configured SA -> 401 invalid_service_account."""
+        from fastapi import HTTPException
+
+        mock_key = MagicMock()
+        with (
+            patch.object(it_module, "_ct_settings") as mock_settings,
+            patch.object(it_module._google_jwks_client, "get_signing_key_from_jwt", return_value=mock_key),
+            patch.object(it_module, "jwt_decode", return_value={"email": "other@proj.iam.gserviceaccount.com"}),
+        ):
+            mock_settings.cloud_tasks_service_account = "worker@proj.iam.gserviceaccount.com"
+            mock_settings.cloud_tasks_audience = "https://api.example.com"
+            with pytest.raises(HTTPException) as exc_info:
+                _verify_cloud_tasks_oidc("Bearer valid.token")
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "invalid_service_account"
+
+    def test_valid_token_passes(self) -> None:
+        """Valid JWT with correct SA email -> no exception raised."""
+        mock_key = MagicMock()
+        sa_email = "worker@proj.iam.gserviceaccount.com"
+        with (
+            patch.object(it_module, "_ct_settings") as mock_settings,
+            patch.object(it_module._google_jwks_client, "get_signing_key_from_jwt", return_value=mock_key),
+            patch.object(it_module, "jwt_decode", return_value={"email": sa_email}),
+        ):
+            mock_settings.cloud_tasks_service_account = sa_email
+            mock_settings.cloud_tasks_audience = "https://api.example.com"
+            _verify_cloud_tasks_oidc("Bearer valid.token")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# JSON logging middleware — integration test via TestClient
+# ---------------------------------------------------------------------------
+
+class TestStructuredLoggingMiddleware:
+    def test_request_log_emits_json_fields(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Every request must emit a log record with request_id, latency_ms, method, path, status_code."""
+        import time
+        import uuid
+        from shared.app import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with caplog.at_level(logging.INFO, logger="shared.app"):
+            client.get("/health")
+
+        # Find the 'request' log record emitted by the middleware
+        request_records = [r for r in caplog.records if r.getMessage() == "request"]
+        assert request_records, "No 'request' log record found — middleware may not be active"
+
+        record = request_records[0]
+        assert hasattr(record, "request_id"), "request_id missing from log"
+        assert hasattr(record, "latency_ms"), "latency_ms missing from log"
+        assert hasattr(record, "method"), "method missing from log"
+        assert hasattr(record, "path"), "path missing from log"
+        assert hasattr(record, "status_code"), "status_code missing from log"
+
+        # Validate types
+        uuid.UUID(record.request_id)  # raises ValueError if not a valid UUID
+        assert isinstance(record.latency_ms, int)
+        assert record.method == "GET"
+        assert record.path == "/health"
+        assert record.status_code == 200

--- a/backend/tests/test_worker_app.py
+++ b/backend/tests/test_worker_app.py
@@ -1,0 +1,49 @@
+"""Smoke tests for the authoring-worker FastAPI entrypoint — Issue #9.
+
+Verifies that:
+- GET /healthz returns 200 {"status": "ok"}
+- POST /api/internal/tasks/authoring_step is mounted and reachable
+  (OIDC skipped in dev — no SA configured — so request reaches the handler)
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from shared.worker_app import worker_app
+
+client = TestClient(worker_app, raise_server_exceptions=False)
+
+
+def test_healthz_returns_200() -> None:
+    """GET /healthz must return 200 with {status: ok}."""
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_internal_tasks_route_is_mounted() -> None:
+    """POST /api/internal/tasks/authoring_step must be reachable.
+
+    With CLOUD_TASKS_SERVICE_ACCOUNT unset (dev mode), OIDC validation is
+    skipped. The handler runs and returns 404 because the job does not exist.
+    404 confirms the endpoint is mounted and the handler executed correctly.
+    """
+    response = client.post(
+        "/api/internal/tasks/authoring_step",
+        json={"job_id": "nonexistent-job-id", "idempotency_key": "k1"},
+    )
+    # 404 means OIDC skipped + handler ran + job not found (expected in tests)
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Job not found"
+
+
+def test_worker_app_does_not_expose_auth_routes() -> None:
+    """worker_app must NOT expose any public auth endpoints."""
+    for path in ["/api/auth/login", "/api/auth/activate", "/api/authoring/jobs"]:
+        response = client.get(path)
+        assert response.status_code == 404, f"Unexpected route exposed: {path}"
+
+
+def test_worker_app_does_not_expose_docs() -> None:
+    """worker_app must NOT expose OpenAPI docs (internal service)."""
+    assert client.get("/docs").status_code == 404
+    assert client.get("/redoc").status_code == 404

--- a/docs/runbooks/cloud-run-deploy.md
+++ b/docs/runbooks/cloud-run-deploy.md
@@ -1,0 +1,176 @@
+# Cloud Run Deploy — ADAM-EDU
+
+> Runbook for deploying and operating the two Cloud Run services introduced in Issue #9.
+
+---
+
+## Services
+
+| Service | Entrypoint | Min instances | Ingress |
+|---|---|---|---|
+| `public-api` | `shared.app:app` | 1 (avoids cold starts for users) | Public |
+| `authoring-worker` | `shared.worker_app:worker_app` | 0 (scale to zero when idle) | Internal |
+
+The `public-api` service handles all user-facing traffic (SPA, auth endpoints, authoring job intake).
+The `authoring-worker` service processes async authoring jobs dispatched by Cloud Tasks — it has no public ingress.
+
+---
+
+## Database connection mode
+
+| Environment | `ENVIRONMENT` value | Pool strategy |
+|---|---|---|
+| Local dev | `development` (default) | QueuePool (persistent, Docker Postgres on 5434) |
+| Cloud Run | `production` | NullPool (1 conn/request, required for Supavisor transaction mode) |
+
+**Why NullPool in production:** Supavisor in transaction mode does not maintain persistent connections.
+A classic connection pool exhausts the allowed concurrent connections when Cloud Run scales horizontally.
+NullPool creates and immediately releases a connection on every request — this is the correct behavior
+for Cloud Run + Supavisor.
+
+---
+
+## Secret Manager → Environment variables
+
+All secrets are stored in Google Secret Manager and mounted as environment variables via Cloud Run
+secret bindings. **Never commit secret values to code, fixtures, or docs.**
+
+| Secret Manager name | Environment variable | Services |
+|---|---|---|
+| `adam-database-url` | `DATABASE_URL` | api + worker |
+| `adam-supabase-url` | `SUPABASE_URL` | api |
+| `adam-supabase-anon-key` | `SUPABASE_ANON_KEY` | api |
+| `adam-supabase-service-role-key` | `SUPABASE_SERVICE_ROLE_KEY` | api + worker |
+| `adam-supabase-jwt-secret` | `SUPABASE_JWT_SECRET` | api (dev fallback only) |
+| `adam-gemini-api-key` | `GEMINI_API_KEY` | worker |
+| `adam-cloud-tasks-sa` | `CLOUD_TASKS_SERVICE_ACCOUNT` | worker |
+| `adam-cloud-tasks-audience` | `CLOUD_TASKS_AUDIENCE` | worker |
+
+Additionally, set these non-secret environment variables directly in the Cloud Run service config:
+
+```
+ENVIRONMENT=production
+CORS_ALLOWED_ORIGIN=https://your-domain.com   # public-api only
+```
+
+---
+
+## OIDC validation for authoring-worker
+
+Cloud Tasks attaches an OIDC Bearer token to every request it dispatches.
+The `authoring-worker` validates this token before executing any job.
+
+**Required configuration (worker service):**
+- `CLOUD_TASKS_SERVICE_ACCOUNT`: the service account email Cloud Tasks uses to sign tokens
+  (e.g. `adam-tasks-invoker@PROJECT_ID.iam.gserviceaccount.com`)
+- `CLOUD_TASKS_AUDIENCE`: the Cloud Run URL of the worker service
+  (e.g. `https://authoring-worker-HASH-uc.a.run.app`)
+
+**If either variable is unset:** OIDC validation is skipped and a WARNING is emitted to logs.
+This is intentional for local development. It must **not** be unset in production.
+
+**Token validation logic:**
+1. Fetch Google OIDC public keys from `https://www.googleapis.com/oauth2/v3/certs` (cached 5 min).
+2. Verify RS256 signature, expiry, and audience claim.
+3. Assert `email` claim equals `CLOUD_TASKS_SERVICE_ACCOUNT`.
+4. If Google's JWKS endpoint is unreachable → 503 (Cloud Tasks retries automatically).
+
+---
+
+## Minimum Cloud Run configuration
+
+### public-api
+
+```yaml
+service: public-api
+image: gcr.io/PROJECT_ID/adam-public-api:TAG
+minInstances: 1
+maxInstances: 10
+concurrency: 80
+memory: 512Mi
+cpu: 1
+ingress: all
+```
+
+### authoring-worker
+
+```yaml
+service: authoring-worker
+image: gcr.io/PROJECT_ID/adam-authoring-worker:TAG
+minInstances: 0
+maxInstances: 5
+concurrency: 10          # LangGraph jobs are CPU-heavy
+memory: 2Gi              # LLM inference buffers
+cpu: 2
+ingress: internal        # Only Cloud Tasks can reach this service
+timeout: 3600            # Long-running authoring jobs
+```
+
+**Cold start notes:**
+- `public-api` min-instances=1 eliminates cold starts for interactive users.
+- `authoring-worker` min-instances=0 is acceptable — Cloud Tasks retries on cold start timeout.
+- Expected worker cold start: 15–30s (LangGraph + Gemini client initialization).
+
+---
+
+## Cloud Monitoring — minimum alert policies
+
+| Alert | Threshold | Rationale |
+|---|---|---|
+| Auth failures | `5xx on /api/auth/*` > 5/min | Detects brute-force or misconfiguration |
+| Global 5xx | > 10/min on public-api | Catches deployment regressions |
+| Latency p95 | > 3s on public-api | Tracks interactive response quality |
+| Cloud Tasks queue depth | > 50 pending tasks | Detects worker backlog |
+| OIDC failures | `detail=invalid_oidc_token` > 3/min in worker logs | Detects unauthorized invocation attempts |
+| JWKS unavailable | `detail=jwks_unavailable` in worker logs | Google OIDC endpoint health |
+
+Log-based alerts should filter on the JSON field `detail` from worker logs.
+
+---
+
+## Rollback procedure
+
+1. **Worker fails after deploy:** `public-api` continues serving users normally.
+   Jobs remain in `pending` state and will be retried by Cloud Tasks once the worker is healthy.
+   No data loss. Rollback the worker image, jobs resume automatically.
+
+2. **public-api fails after deploy:** Roll back to the previous revision via:
+   ```bash
+   gcloud run services update-traffic public-api \
+     --to-revisions=PREVIOUS_REVISION=100 \
+     --region=REGION
+   ```
+
+3. **Database migration rollback:** No migrations in Issue #9. NullPool is a connection strategy
+   change only — reverting `ENVIRONMENT=production` to `development` restores classic pooling.
+
+---
+
+## Local verification commands
+
+```bash
+# Verify NullPool is selected in production mode
+cd backend
+ENVIRONMENT=production uv run python -c \
+  "from shared.database import engine; print(engine.pool.__class__.__name__)"
+# Expected: NullPool
+
+# Verify QueuePool in development mode
+ENVIRONMENT=development uv run python -c \
+  "from shared.database import engine; print(engine.pool.__class__.__name__)"
+# Expected: QueuePool
+
+# Start worker locally (OIDC skipped — no SA configured)
+uv run uvicorn shared.worker_app:worker_app --port 8081 &
+curl http://localhost:8081/healthz
+# Expected: {"status":"ok"}
+
+# Verify OIDC guard fires with SA set
+CLOUD_TASKS_SERVICE_ACCOUNT=test@test.iam.gserviceaccount.com \
+CLOUD_TASKS_AUDIENCE=http://localhost:8081 \
+uv run uvicorn shared.worker_app:worker_app --port 8082 &
+curl -X POST http://localhost:8082/api/internal/tasks/authoring_step \
+  -H "Content-Type: application/json" \
+  -d '{"job_id":"x","idempotency_key":"k"}'
+# Expected: 401 {"detail":"missing_oidc_token"}
+```


### PR DESCRIPTION
## Summary

- **NullPool en producción**: `database.py` selecciona `NullPool` cuando `ENVIRONMENT=production` para compatibilidad con Supavisor transaction mode. Factory `_make_engine(settings)` permite tests sin `importlib.reload`.
- **Validación OIDC Cloud Tasks**: `shared/internal_tasks.py` valida el Bearer OIDC de Cloud Tasks con `PyJWKClient(lifespan=300)` (mismo patrón que `auth.py`). 401 para token inválido, 503 cuando Google JWKS no responde (Cloud Tasks reintenta automáticamente). Skip en dev cuando `CLOUD_TASKS_SERVICE_ACCOUNT` no está configurado.
- **JSON logging estructurado**: `JsonFormatter` de `python-json-logger` + middleware `structured_logging_middleware` que emite por cada request: `{request_id, method, path, status_code, latency_ms}`.
- **Split public-api / authoring-worker**: `shared/worker_app.py` expone solo `/api/internal/tasks/authoring_step` + `GET /healthz`. `Dockerfile.worker` usa `langchain/langgraph-api:3.12` (requerido por LangGraph runtime).
- **Runbook operacional**: `docs/runbooks/cloud-run-deploy.md` documenta min-instances, mapa Secret Manager, alertas Cloud Monitoring y rollback.

Fixes #44. Desbloquea Issue #10 (rate limiting) e Issue #11 (tests/QA gate).

## Cambios respecto al spec original del Issue

El plan-eng-review identificó y corrigió 5 problemas en el spec:
1. `PyJWKClient(lifespan=300)` en lugar de `pyjwt.decode(dict)` (bug en el issue — PyJWT no acepta dict como key)
2. Handler extraído a `shared/internal_tasks.py` (evita side effects al importar `app.py` en worker)
3. `_make_engine(settings)` factory (tests sin `importlib.reload` ni contaminación de estado global)
4. `503 jwks_unavailable` cuando Google JWKS está caído (Cloud Tasks reintenta automáticamente)
5. Warning log cuando OIDC skip aplica (detecta SA no configurada en producción)

## Pre-Landing Review

**1 issue informacional (no bloqueante):**
- `internal_tasks.py:104-112` — TOCTOU en idempotency barrier: patrón read-check-execute pre-existente de `app.py`. Cloud Tasks retry semantics acotan el riesgo. Diferido a post-Fase 1.

## Eval Results

No prompt-related files changed — evals skipped.

## Test plan

- [x] 76 tests pasan, 12 skipped, 0 failed (`uv run pytest -q`)
- [x] 3 tests nuevos: NullPool/QueuePool selection via `_make_engine()`
- [x] 6 tests nuevos: OIDC validation (skip, 401×3, 503, pass)
- [x] 1 test nuevo: JSON logging middleware (campos request_id + latency_ms)
- [x] 4 smoke tests nuevos: worker_app (healthz, route mount, no-auth-routes, no-docs)
- [x] Suite completa: 0 regresiones en tests existentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)