### PR TITLE
feat(security): seguridad operativa de auth y políticas de error (Issue #46)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,8 @@ Si una persona ya tiene una instalacion global personal de `gstack`, puede mante
 - No subas secretos al repositorio.
 - Usa `backend/.env.example` como plantilla.
 - Los valores reales deben vivir en entornos locales o en GitHub Actions Secrets.
+- Para PRs que modifiquen `auth.py`, `app.py` (endpoints auth), `internal_tasks.py` o modelos auth,
+  revisa el checklist de seguridad en [`docs/runbooks/security-pr-checklist.md`](docs/runbooks/security-pr-checklist.md).
 
 ## Criterio de revision
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -65,3 +65,24 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** Identificado en Issue #44 (plan-eng-review TODO item 3, decisión 10A: aceptar bloqueo síncrono hoy). La misma restricción existe en `shared/auth.py` con `JwtVerifier`. Resolver ambos juntos tiene más sentido que resolver solo el worker.
 
 **Depends on / blocked by:** Issue #44 (completado). Solo prioritario si el worker escala a alta concurrencia (>10 req/s simultáneos). Post-Fase 1.
+
+---
+
+## TODO-005: Rate limiting distribuido en endpoints de auth públicos
+
+**What:** Implementar rate limiting en los 5 endpoints de auth públicos con `fastapi-limiter>=0.1.6` + `redis>=5.0` contra Cloud Memorystore:
+- `POST /api/invites/resolve` → 10 req/min por IP
+- `POST /api/invites/redeem` → 5 req/min por IP
+- `POST /api/auth/activate/password` → 5 req/min por IP
+- `POST /api/auth/activate/oauth/complete` → 10 req/min por IP
+- `POST /api/auth/change-password` → 3 req/min por auth_user_id
+
+**Why:** Sin rate limiting, los endpoints de activación e invitación son vulnerables a brute-force y enumeración de tokens. In-memory no protege nada porque `public-api` tiene `max-instances=10` — cada instancia mantiene contadores independientes, permitiendo hasta 10× el límite configurado.
+
+**Pros:** Protección real contra brute-force en tokens de invitación y activación. Cierra el único control de seguridad operativa diferido del Plan Issue #10.
+
+**Cons:** Requiere aprovisionar Cloud Memorystore (Redis) en el proyecto GCP — cambio de infra fuera del alcance de Issue #46. Añade `fastapi-limiter` y `redis` como dependencias de runtime.
+
+**Context:** Identificado en Issue #46 (Plan Issue #10, plan-eng-review decisión 1A). La decisión de diferir fue explícita: no hay Redis disponible en la infra actual, y `slowapi` in-memory da falsa seguridad con max-instances=10. Ver sección "Rate Limiting Strategy" en `docs/runbooks/cloud-run-deploy.md` para los límites target y el contexto de la decisión.
+
+**Depends on / blocked by:** Aprovisionamiento de Cloud Memorystore en el proyecto GCP, o reducción de `maxInstances` a 1 en `public-api`. No bloquea Issue #11.

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -588,6 +588,12 @@ class AuthMeResponse(BaseModel):
 
 @app.get("/api/auth/me", response_model=AuthMeResponse)
 def get_auth_me(actor: CurrentActor = Depends(require_current_actor)) -> AuthMeResponse:
+    audit_log(
+        "session.verified",
+        "success",
+        auth_user_id=actor.auth_user_id,
+        http_status=200,
+    )
     return AuthMeResponse(
         auth_user_id=actor.auth_user_id,
         profile=AuthMeProfileResponse(id=actor.profile.id, full_name=actor.profile.full_name),

--- a/backend/tests/test_issue30_auth_perimeter.py
+++ b/backend/tests/test_issue30_auth_perimeter.py
@@ -216,6 +216,25 @@ def test_auth_me_returns_memberships_and_primary_role(client, auth_headers_facto
     assert first["profile"].full_name == payload["profile"]["full_name"]
 
 
+def test_auth_me_emits_session_verified_audit(client, auth_headers_factory, seed_identity) -> None:
+    """GET /api/auth/me must emit a session.verified audit event on every successful call."""
+    user_id = str(uuid.uuid4())
+    email = "audit@example.edu"
+    seed_identity(user_id=user_id, email=email, role="teacher")
+    headers = auth_headers_factory(sub=user_id, email=email)
+
+    with patch("shared.app.audit_log") as mock_audit:
+        response = client.get("/api/auth/me", headers=headers)
+
+    assert response.status_code == 200
+    mock_audit.assert_called_once_with(
+        "session.verified",
+        "success",
+        auth_user_id=user_id,
+        http_status=200,
+    )
+
+
 def test_authoring_denies_student(client, auth_headers_factory, seed_identity) -> None:
     user_id = str(uuid.uuid4())
     email = "student@example.edu"

--- a/docs/runbooks/cloud-run-deploy.md
+++ b/docs/runbooks/cloud-run-deploy.md
@@ -113,6 +113,31 @@ timeout: 3600            # Long-running authoring jobs
 
 ---
 
+## Rate Limiting Strategy
+
+**Estado actual (Issue #46):** Diferido — ver TODO-005 en `TODOS.md`.
+
+`public-api` usa `maxInstances: 10`. Rate limiting in-memory (`slowapi`) daría contadores
+independientes por instancia — hasta 10× el límite configurado sin protección real.
+
+**Trigger para implementar:**
+- Aprovisionar Cloud Memorystore (Redis) en el proyecto GCP, **o**
+- Reducir `maxInstances` a 1 en `public-api` (permite `slowapi` in-memory)
+
+**Límites target cuando se implemente:**
+
+| Endpoint | Límite | Dimensión |
+|---|---|---|
+| `POST /api/invites/resolve` | 10 req/min | por IP |
+| `POST /api/invites/redeem` | 5 req/min | por IP |
+| `POST /api/auth/activate/password` | 5 req/min | por IP |
+| `POST /api/auth/activate/oauth/complete` | 10 req/min | por IP |
+| `POST /api/auth/change-password` | 3 req/min | por auth_user_id |
+
+**Dependencias de implementación:** `fastapi-limiter>=0.1.6` + `redis>=5.0` en `backend/pyproject.toml`.
+
+---
+
 ## Cloud Monitoring — minimum alert policies
 
 | Alert | Threshold | Rationale |

--- a/docs/runbooks/security-pr-checklist.md
+++ b/docs/runbooks/security-pr-checklist.md
@@ -1,0 +1,58 @@
+# Security PR Checklist — ADAM-EDU
+
+Obligatorio para PRs que toquen: `auth.py`, `app.py` (endpoints auth),
+`internal_tasks.py`, `models.py` (modelos auth).
+
+---
+
+## Auth y tokens
+
+- [ ] No se lee `actor_id`/`role`/`university_id` desde el body como fuente de verdad
+- [ ] JWT verificado con JWKS (no con `SUPABASE_JWT_SECRET` en producción)
+- [ ] `SUPABASE_SERVICE_ROLE_KEY` no aparece en responses, logs ni fixtures de test
+- [ ] Token de invitación scrubbed antes de logs (usar `invite_hash_prefix`, no el token completo)
+
+## Cloud Tasks
+
+- [ ] Cloud Tasks OIDC validado (ya implementado en `shared/internal_tasks.py` — no reimplementar)
+
+## Mensajes de error
+
+- [ ] Mensajes 4xx no revelan: existencia de email, estado de invite (revocado vs inexistente), ni stack traces
+- [ ] `detail` en responses usa códigos cortos sin información de diagnóstico interno
+
+Mensajes de error auditados en Issue #46 (todos conformes):
+
+| Endpoint | Códigos 4xx |
+|---|---|
+| `POST /api/auth/change-password` | `admin_role_required`, `password_rotation_not_required` |
+| `POST /api/invites/resolve` | `invalid_invite` |
+| `POST /api/invites/redeem` | `membership_required`, `invalid_invite` |
+| `POST /api/auth/activate/password` | `password_mismatch`, `invalid_invite`, `full_name_required` |
+| `POST /api/auth/activate/oauth/complete` | `invalid_invite`, `invite_email_mismatch` |
+
+## Auditoría
+
+- [ ] Nuevos flujos de auth cubiertos por `audit_log()` con `outcome` explícito
+- [ ] Eventos de error (`outcome=denied`/`invalid`/`error`) incluyen `reason` descriptivo
+- [ ] `GET /api/auth/me` emite `session.verified` (implementado en Issue #46)
+
+## Rate limiting
+
+- [ ] Rate limiting aplicado en nuevos endpoints de auth públicos
+  - Si `max-instances > 1`: requiere Redis/Memorystore (ver TODO-005 en `TODOS.md`)
+  - Si `max-instances = 1`: puede usar `slowapi` in-memory
+
+## Tests
+
+- [ ] Tests cubren el path de rechazo (401/403) además del happy path
+- [ ] Si se agrega `audit_log()`: unit test que mockea `shared.app.audit_log` y verifica el call
+
+---
+
+## Referencias
+
+- `backend/src/shared/auth.py` — `audit_log()`, `audit_event()`, `mask_email()`
+- `backend/src/shared/internal_tasks.py` — OIDC Cloud Tasks (ya implementado)
+- `docs/runbooks/cloud-run-deploy.md` — Rate Limiting Strategy
+- `TODOS.md` — TODO-005 (rate limiting distribuido)


### PR DESCRIPTION
## Summary

Cierra #46 — Plan Issue #10: controles que evitan que auth "parezca lista" sin estar endurecida.

- **`session.verified` audit**: `GET /api/auth/me` ahora emite `audit_log("session.verified", "success", auth_user_id=..., http_status=200)` en cada sesión verificada — cubre el gap de login_success en el plan maestro
- **Test unitario**: `test_auth_me_emits_session_verified_audit` mockea `shared.app.audit_log` y verifica el call exacto; cubre el critical gap identificado en plan-eng-review
- **Checklist pre-PR**: nuevo `docs/runbooks/security-pr-checklist.md` — checklist reproducible para PRs que toquen auth, con tabla de mensajes auditados
- **Rate limiting deferred**: TODO-005 en `TODOS.md` con trigger explícito (max-instances=10 bloquea in-memory; requiere Redis/Memorystore); documentado en `docs/runbooks/cloud-run-deploy.md`
- **CONTRIBUTING.md**: referencia al security checklist en sección de secretos

## Decisiones de arquitectura

| Decisión | Elección | Razón |
|---|---|---|
| Rate limiting | Diferido (TODO-005) | `max-instances=10` hace in-memory inútil; no hay Redis en infra |
| Mensajes de error | 0 cambios | Los 5 endpoints ya usan códigos opacos sin leakage |
| `invite_email_mismatch` | Mantener | Caller ya tiene JWT válido; valor UX sin revelar email |

## Test plan

- [x] `uv run --directory backend pytest -q` → 77 passed, 12 skipped
- [x] `uv run --directory backend mypy src` → no issues in 24 source files
- [x] `grep SUPABASE_SERVICE_ROLE_KEY backend/src/shared/app.py backend/src/shared/auth.py` → sin matches
- [x] Mensajes 4xx en los 5 endpoints auditados línea a línea → todos conformes

## NOT in scope

- Redis / Cloud Memorystore (infra change → TODO-005)
- Endpoints de emisión/revocación de invites (solo CLI provisioning)
- `session.verify_failed` en `require_current_actor` (failure opaco al endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)