### PR TITLE
test(auth): suites de prueba, concurrencia y QA gate — Issue #11

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -65,3 +65,25 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** Identificado en Issue #44 (plan-eng-review TODO item 3, decisión 10A: aceptar bloqueo síncrono hoy). La misma restricción existe en `shared/auth.py` con `JwtVerifier`. Resolver ambos juntos tiene más sentido que resolver solo el worker.
 
 **Depends on / blocked by:** Issue #44 (completado). Solo prioritario si el worker escala a alta concurrencia (>10 req/s simultáneos). Post-Fase 1.
+
+---
+
+## TODO-005: Rate limiting distribuido (deuda aceptada)
+
+**What:** Reemplazar el rate limiting in-memory (`slowapi` o `limits` con backend local) por un backend distribuido usando Cloud Memorystore (Redis) cuando `max_instances > 1`.
+
+**Why:** El rate limiting in-process vive en cada réplica por separado. Con múltiples instancias de Cloud Run cada réplica tiene su propio contador — un atacante puede hacer N requests por réplica antes de ser bloqueado. Esto hace el rate limiting inefectivo a escala.
+
+**Pros:** Rate limiting efectivo independientemente del número de réplicas. Resistente a ataques distribuidos. Coherente con el modelo de escalado de Cloud Run.
+
+**Cons:** Requiere aprovisionar Cloud Memorystore (Redis) en el mismo proyecto GCP y inyectar `REDIS_URL` como secret. Añade una dependencia de infraestructura nueva. Con `max_instances=1` (configuración actual de Fase 1), el impacto de la deuda es nulo.
+
+**Context:** Identificado en Issue #48 (plan-eng-review, decisión TODO-005). No hay rate limiting implementado todavía en Fase 1 — este TODO documenta la deuda para cuando se implemente en Fase 2. La deuda solo se activa si se escala a múltiples instancias o se incorpora un segundo cliente universitario con tráfico mayor.
+
+**How to implement:**
+1. Aprovisionar Cloud Memorystore (Redis) en el mismo proyecto GCP.
+2. Cambiar el backend de `limits` de `memory://` a `redis://<memorystore-host>`.
+3. Actualizar el Cloud Run service para inyectar `REDIS_URL` desde Secret Manager.
+4. Agregar health check de Redis en `/health`.
+
+**Depends on / blocked by:** Implementación de rate limiting (post-Fase 1) + Cloud Memorystore aprovisionado. Trigger: escala a `max_instances > 1` o segundo cliente universitario.

--- a/backend/tests/test_issue30_auth_perimeter.py
+++ b/backend/tests/test_issue30_auth_perimeter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import concurrent.futures
 from datetime import datetime, timedelta, timezone
+import threading
 import uuid
 from unittest.mock import patch
 
@@ -632,6 +634,69 @@ def test_redeem_success_and_repeat_is_idempotent(
     assert refreshed_invite.status == "consumed"
 
 
+def test_redeem_concurrent_double_redemption_is_idempotent(
+    client, seed_course, seed_identity, seed_invite, auth_headers_factory, db
+) -> None:
+    """Two simultaneous redeem requests for the same invite → exactly one wins.
+
+    DB barrier: UPDATE invite SET status='consumed' WHERE status='pending'
+    RETURNING id is atomic in PostgreSQL. Only one thread gets a row back.
+
+    Thread model:
+        Thread A ──► POST /api/invites/redeem ──► "redeemed"
+        Thread B ──► POST /api/invites/redeem ──► "already_enrolled"
+        threading.Barrier(2) releases both at the same instant.
+    """
+    teacher_seed = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="concurrent-teacher@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000090",
+    )
+    course = seed_course(
+        university_id=teacher_seed["tenant"].id,
+        teacher_membership_id=teacher_seed["membership"].id,
+        title="Concurrent Redeem Course",
+    )
+    student_id = str(uuid.uuid4())
+    student_seed = seed_identity(
+        user_id=student_id,
+        email="concurrent-student@example.edu",
+        role="student",
+        university_id=teacher_seed["tenant"].id,
+    )
+    invite, token = seed_invite(
+        email="concurrent-student@example.edu",
+        university_id=teacher_seed["tenant"].id,
+        role="student",
+        course_id=course.id,
+    )
+    headers = auth_headers_factory(sub=student_id, email="concurrent-student@example.edu")
+
+    barrier = threading.Barrier(2)
+
+    def redeem() -> httpx.Response:
+        barrier.wait()  # release both threads at the same instant
+        return client.post("/api/invites/redeem", json={"invite_token": token}, headers=headers)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(redeem), executor.submit(redeem)]
+        responses = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+    statuses = sorted(r.json()["status"] for r in responses)
+    assert statuses == ["already_enrolled", "redeemed"], f"Unexpected statuses: {statuses}"
+    assert all(r.status_code == 200 for r in responses)
+
+    db.expire_all()
+    course_memberships = db.scalars(
+        select(CourseMembership).where(
+            CourseMembership.course_id == course.id,
+            CourseMembership.membership_id == student_seed["membership"].id,
+        )
+    ).all()
+    assert len(course_memberships) == 1, "Duplicate CourseMembership created under concurrency"
+
+
 def test_activate_oauth_complete_mismatch_does_not_delete_existing_auth_user(client, fake_admin_client, seed_invite, db) -> None:
     tenant = Tenant(id="10000000-0000-0000-0000-000000000070", name="OAuth University")
     db.add(tenant)
@@ -732,3 +797,49 @@ def test_activate_oauth_complete_success(client, seed_invite, auth_headers_facto
         )
     )
     assert membership is not None
+
+
+def test_activate_oauth_full_name_from_user_metadata_key(
+    client, seed_invite, auth_headers_factory, db
+) -> None:
+    """JWT with user_metadata.full_name → Profile uses that name.
+
+    derive_oauth_full_name tries ("full_name", "name") in order.
+    The existing success test covers "name"; this covers the higher-priority "full_name".
+    """
+    tenant = Tenant(id="10000000-0000-0000-0000-000000000073", name="OAuth FullName University")
+    db.add(tenant)
+    db.commit()
+    _, token = seed_invite(email="fullname-teacher@example.edu", university_id=tenant.id, role="teacher")
+    user_id = str(uuid.uuid4())
+    headers = auth_headers_factory(
+        sub=user_id,
+        email="fullname-teacher@example.edu",
+        claims={"user_metadata": {"full_name": "Ana García"}},
+    )
+
+    response = client.post("/api/auth/activate/oauth/complete", json={"invite_token": token}, headers=headers)
+
+    assert response.status_code == 200
+    profile = db.get(Profile, user_id)
+    assert profile is not None
+    assert profile.full_name == "Ana García"
+
+
+def test_activate_oauth_full_name_fallback_to_email_prefix(
+    client, seed_invite, auth_headers_factory, db
+) -> None:
+    """JWT with no user_metadata → Profile.full_name falls back to email prefix."""
+    tenant = Tenant(id="10000000-0000-0000-0000-000000000074", name="OAuth Fallback University")
+    db.add(tenant)
+    db.commit()
+    _, token = seed_invite(email="fallback-teacher@example.edu", university_id=tenant.id, role="teacher")
+    user_id = str(uuid.uuid4())
+    headers = auth_headers_factory(sub=user_id, email="fallback-teacher@example.edu")
+
+    response = client.post("/api/auth/activate/oauth/complete", json={"invite_token": token}, headers=headers)
+
+    assert response.status_code == 200
+    profile = db.get(Profile, user_id)
+    assert profile is not None
+    assert profile.full_name == "fallback-teacher"

--- a/backend/tests/test_student_activation.py
+++ b/backend/tests/test_student_activation.py
@@ -298,3 +298,85 @@ class TestActivatePasswordDomainValidation:
         # Empty allow-list = open (backward-compatible)
         assert resp.status_code == 201
         assert resp.json()["status"] == "activated"
+
+
+class TestActivateOAuthDomainValidation:
+    """B3: _check_student_email_domain is called for students in activate_oauth_complete.
+
+    Production code: shared/app.py
+        if invite.role == "student":
+            _check_student_email_domain(db, invite)
+    """
+
+    def test_oauth_complete_student_email_domain_not_allowed(
+        self, client: TestClient, university, allowed_domain, course, seed_invite, auth_headers_factory
+    ) -> None:
+        """Student with a domain not in allowed_email_domains → 422."""
+        _, token = seed_invite(
+            email="student@foreign.com",
+            university_id=university.id,
+            role="student",
+            course_id=course.id,
+        )
+        user_id = str(uuid.uuid4())
+        headers = auth_headers_factory(sub=user_id, email="student@foreign.com")
+
+        response = client.post(
+            "/api/auth/activate/oauth/complete", json={"invite_token": token}, headers=headers
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == "email_domain_not_allowed"
+
+    def test_oauth_complete_student_email_domain_allowed(
+        self, client: TestClient, university, allowed_domain, course, seed_invite, auth_headers_factory, db
+    ) -> None:
+        """Student with allowed domain → activation succeeds, profile and membership created."""
+        _, token = seed_invite(
+            email="student@universidad.edu",
+            university_id=university.id,
+            role="student",
+            course_id=course.id,
+        )
+        user_id = str(uuid.uuid4())
+        headers = auth_headers_factory(sub=user_id, email="student@universidad.edu")
+
+        response = client.post(
+            "/api/auth/activate/oauth/complete", json={"invite_token": token}, headers=headers
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "activated"
+        profile = db.get(Profile, user_id)
+        assert profile is not None
+        membership = db.scalar(
+            select(Membership).where(
+                Membership.user_id == user_id,
+                Membership.university_id == university.id,
+                Membership.role == "student",
+            )
+        )
+        assert membership is not None
+
+    def test_oauth_complete_teacher_bypasses_domain_check(
+        self, client: TestClient, university, allowed_domain, seed_invite, auth_headers_factory
+    ) -> None:
+        """Teacher role skips domain check even when university has restrictions.
+
+        The condition `if invite.role == 'student'` explicitly excludes teachers.
+        allowed_domain fixture sets up the restriction to prove it exists but is skipped.
+        """
+        _, token = seed_invite(
+            email="teacher@foreign.com",
+            university_id=university.id,
+            role="teacher",
+        )
+        user_id = str(uuid.uuid4())
+        headers = auth_headers_factory(sub=user_id, email="teacher@foreign.com")
+
+        response = client.post(
+            "/api/auth/activate/oauth/complete", json={"invite_token": token}, headers=headers
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "activated"


### PR DESCRIPTION
## Summary

- **Gap 1**: Test de doble redención concurrente (`ThreadPoolExecutor` + `threading.Barrier`) — verifica que solo una solicitud gana y no se crean duplicados en `CourseMembership`
- **Gap 2**: Clase `TestActivateOAuthDomainValidation` en `test_student_activation.py` — cubre B3 (domain check en `activate_oauth_complete`) para estudiante bloqueado, estudiante permitido, y teacher que bypasea el check
- **Gap 3**: Tests de `derive_oauth_full_name` — cubre prioridad de clave `full_name` en `user_metadata` y fallback al prefijo del email
- **TODOS.md**: Agrega TODO-005 (rate limiting distribuido con Cloud Memorystore — deuda aceptada para cuando `max_instances > 1`)

Closes #48

## Test plan

- [x] `uv run --directory backend pytest -q` — 82 passed, 12 skipped
- [x] 0 production code changes
- [x] Gap 1: `test_redeem_concurrent_double_redemption_is_idempotent`
- [x] Gap 2: `TestActivateOAuthDomainValidation` (3 tests)
- [x] Gap 3: `test_activate_oauth_full_name_from_user_metadata_key` + `test_activate_oauth_full_name_fallback_to_email_prefix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)