### PR TITLE
feat(infra): add admin catalog schema substrate

### DIFF
--- a/backend/alembic/versions/a6f6d7ac9c2b_issue52_admin_catalog_infra.py
+++ b/backend/alembic/versions/a6f6d7ac9c2b_issue52_admin_catalog_infra.py
@@ -1,0 +1,171 @@
+"""Issue 52 admin catalog infra
+
+Revision ID: a6f6d7ac9c2b
+Revises: 4c8660e9e4d1
+Create Date: 2026-04-08 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a6f6d7ac9c2b"
+down_revision: Union[str, Sequence[str], None] = "4c8660e9e4d1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+ACADEMIC_LEVELS = ("Pregrado", "Especialización", "Maestría", "MBA", "Doctorado")
+
+
+def _backfill_legacy_courses(connection: sa.Connection) -> None:
+    connection.execute(
+        sa.text(
+            """
+            UPDATE courses
+            SET
+                code = 'LEGACY-' || upper(substr(replace(id, '-', ''), 1, 8)),
+                semester = concat(
+                    extract(year from timezone('UTC', created_at))::int,
+                    '-',
+                    CASE
+                        WHEN extract(month from timezone('UTC', created_at))::int <= 6 THEN 'I'
+                        ELSE 'II'
+                    END
+                ),
+                academic_level = 'Pregrado',
+                max_students = 30,
+                status = 'active',
+                pending_teacher_invite_id = NULL
+            WHERE code IS NULL
+               OR semester IS NULL
+               OR academic_level IS NULL
+               OR max_students IS NULL
+               OR status IS NULL
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    op.add_column("courses", sa.Column("code", sa.Text(), nullable=True))
+    op.add_column("courses", sa.Column("semester", sa.Text(), nullable=True))
+    op.add_column("courses", sa.Column("academic_level", sa.Text(), nullable=True))
+    op.add_column("courses", sa.Column("max_students", sa.Integer(), nullable=True))
+    op.add_column("courses", sa.Column("status", sa.Text(), nullable=True))
+    op.add_column("courses", sa.Column("pending_teacher_invite_id", sa.Text(), nullable=True))
+    op.alter_column("courses", "teacher_membership_id", existing_type=sa.Text(), nullable=True)
+
+    op.add_column("invites", sa.Column("full_name", sa.Text(), nullable=True))
+
+    op.create_table(
+        "course_access_links",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("course_id", sa.Text(), nullable=False),
+        sa.Column("token_hash", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("rotated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint("status IN ('active', 'rotated', 'revoked')", name="ck_course_access_links_status"),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash"),
+    )
+    op.create_index("ix_course_access_links_course_id", "course_access_links", ["course_id"], unique=False)
+    op.create_index(
+        "uix_course_access_links_active_course",
+        "course_access_links",
+        ["course_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'active'"),
+    )
+
+    _backfill_legacy_courses(connection)
+
+    op.create_foreign_key(
+        "fk_courses_pending_teacher_invite_id_invites",
+        "courses",
+        "invites",
+        ["pending_teacher_invite_id"],
+        ["id"],
+    )
+
+    op.alter_column("courses", "code", existing_type=sa.Text(), nullable=False)
+    op.alter_column("courses", "semester", existing_type=sa.Text(), nullable=False)
+    op.alter_column("courses", "academic_level", existing_type=sa.Text(), nullable=False)
+    op.alter_column("courses", "max_students", existing_type=sa.Integer(), nullable=False)
+    op.alter_column("courses", "status", existing_type=sa.Text(), nullable=False)
+
+    op.create_check_constraint("ck_courses_status", "courses", "status IN ('active', 'inactive')")
+    op.create_check_constraint("ck_courses_max_students_positive", "courses", "max_students > 0")
+    op.create_check_constraint(
+        "ck_courses_academic_level",
+        "courses",
+        "academic_level IN ('Pregrado', 'Especialización', 'Maestría', 'MBA', 'Doctorado')",
+    )
+    op.create_check_constraint(
+        "ck_courses_teacher_assignment_xor",
+        "courses",
+        """
+        (
+            teacher_membership_id IS NOT NULL
+            AND pending_teacher_invite_id IS NULL
+        ) OR (
+            teacher_membership_id IS NULL
+            AND pending_teacher_invite_id IS NOT NULL
+        )
+        """,
+    )
+    op.create_unique_constraint(
+        "uix_courses_university_code_semester",
+        "courses",
+        ["university_id", "code", "semester"],
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    pending_teacher_courses = connection.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM courses
+            WHERE teacher_membership_id IS NULL
+               OR pending_teacher_invite_id IS NOT NULL
+            ORDER BY id
+            LIMIT 5
+            """
+        )
+    ).scalars().all()
+    if pending_teacher_courses:
+        raise RuntimeError(
+            "Issue 52 downgrade cannot preserve courses that only exist in the new pending-teacher shape. "
+            f"Resolve or delete these rows before downgrade: {pending_teacher_courses}"
+        )
+
+    op.drop_constraint("uix_courses_university_code_semester", "courses", type_="unique")
+    op.drop_constraint("ck_courses_teacher_assignment_xor", "courses", type_="check")
+    op.drop_constraint("ck_courses_academic_level", "courses", type_="check")
+    op.drop_constraint("ck_courses_max_students_positive", "courses", type_="check")
+    op.drop_constraint("ck_courses_status", "courses", type_="check")
+    op.drop_constraint("fk_courses_pending_teacher_invite_id_invites", "courses", type_="foreignkey")
+
+    op.drop_index("uix_course_access_links_active_course", table_name="course_access_links")
+    op.drop_index("ix_course_access_links_course_id", table_name="course_access_links")
+    op.drop_table("course_access_links")
+
+    op.drop_column("invites", "full_name")
+
+    op.alter_column("courses", "teacher_membership_id", existing_type=sa.Text(), nullable=False)
+    op.drop_column("courses", "pending_teacher_invite_id")
+    op.drop_column("courses", "status")
+    op.drop_column("courses", "max_students")
+    op.drop_column("courses", "academic_level")
+    op.drop_column("courses", "semester")
+    op.drop_column("courses", "code")

--- a/backend/alembic/versions/a6f6d7ac9c2b_issue52_admin_catalog_infra.py
+++ b/backend/alembic/versions/a6f6d7ac9c2b_issue52_admin_catalog_infra.py
@@ -19,9 +19,6 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-ACADEMIC_LEVELS = ("Pregrado", "Especialización", "Maestría", "MBA", "Doctorado")
-
-
 def _backfill_legacy_courses(connection: sa.Connection) -> None:
     connection.execute(
         sa.text(

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -739,6 +739,9 @@ def resolve_invite(req: InviteResolveRequest, db: Session = Depends(get_db)) -> 
                 if membership is not None:
                     profile = db.get(Profile, membership.user_id)
                     teacher_name = profile.full_name if profile is not None else None
+            elif course.pending_teacher_invite_id:
+                pending_invite = db.get(Invite, course.pending_teacher_invite_id)
+                teacher_name = pending_invite.full_name if pending_invite is not None else None
 
     effective_status = invite_effective_status(invite)
     audit_log(

--- a/backend/src/shared/auth.py
+++ b/backend/src/shared/auth.py
@@ -151,6 +151,10 @@ def hash_invite_token(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
+def hash_course_access_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
 def normalize_email(email: str | None) -> str | None:
     if email is None:
         return None

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -11,10 +11,12 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
     UniqueConstraint,
+    text as sql_text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -155,19 +157,58 @@ class Course(Base):
     """Course ownership moves through teacher memberships, not legacy user ids."""
 
     __tablename__ = "courses"
+    __table_args__ = (
+        UniqueConstraint("university_id", "code", "semester", name="uix_courses_university_code_semester"),
+        CheckConstraint("status IN ('active', 'inactive')", name="ck_courses_status"),
+        CheckConstraint("max_students > 0", name="ck_courses_max_students_positive"),
+        CheckConstraint(
+            "academic_level IN ('Pregrado', 'Especialización', 'Maestría', 'MBA', 'Doctorado')",
+            name="ck_courses_academic_level",
+        ),
+        CheckConstraint(
+            """
+            (
+                teacher_membership_id IS NOT NULL
+                AND pending_teacher_invite_id IS NULL
+            ) OR (
+                teacher_membership_id IS NULL
+                AND pending_teacher_invite_id IS NOT NULL
+            )
+            """,
+            name="ck_courses_teacher_assignment_xor",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
     university_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
-    teacher_membership_id: Mapped[str] = mapped_column(Text, ForeignKey("memberships.id"), nullable=False)
+    teacher_membership_id: Mapped[str | None] = mapped_column(Text, ForeignKey("memberships.id"), nullable=True)
+    pending_teacher_invite_id: Mapped[str | None] = mapped_column(
+        Text,
+        ForeignKey("invites.id", name="fk_courses_pending_teacher_invite_id_invites", use_alter=True),
+        nullable=True,
+    )
     title: Mapped[str] = mapped_column(Text, nullable=False)
+    code: Mapped[str] = mapped_column(Text, nullable=False)
+    semester: Mapped[str] = mapped_column(Text, nullable=False)
+    academic_level: Mapped[str] = mapped_column(Text, nullable=False)
+    max_students: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="active")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
     )
 
     university: Mapped["Tenant"] = relationship(back_populates="courses")
-    teacher_membership: Mapped["Membership"] = relationship(back_populates="courses_as_teacher")
-    invites: Mapped[list["Invite"]] = relationship(back_populates="course")
+    teacher_membership: Mapped["Membership | None"] = relationship(
+        back_populates="courses_as_teacher",
+        foreign_keys=[teacher_membership_id],
+    )
+    pending_teacher_invite: Mapped["Invite | None"] = relationship(
+        back_populates="pending_teacher_courses",
+        foreign_keys=[pending_teacher_invite_id],
+    )
+    invites: Mapped[list["Invite"]] = relationship(back_populates="course", foreign_keys="Invite.course_id")
+    access_links: Mapped[list["CourseAccessLink"]] = relationship(back_populates="course")
     course_memberships: Mapped[list["CourseMembership"]] = relationship(back_populates="course")
 
 
@@ -184,6 +225,7 @@ class Invite(Base):
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
     token_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     email: Mapped[str] = mapped_column(Text, nullable=False)
+    full_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     university_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
     course_id: Mapped[str | None] = mapped_column(Text, ForeignKey("courses.id"), nullable=True)
     role: Mapped[str] = mapped_column(Text, nullable=False)
@@ -196,7 +238,38 @@ class Invite(Base):
     )
 
     university: Mapped["Tenant"] = relationship(back_populates="invites")
-    course: Mapped["Course | None"] = relationship(back_populates="invites")
+    course: Mapped["Course | None"] = relationship(back_populates="invites", foreign_keys=[course_id])
+    pending_teacher_courses: Mapped[list["Course"]] = relationship(
+        back_populates="pending_teacher_invite",
+        foreign_keys="Course.pending_teacher_invite_id",
+    )
+
+
+class CourseAccessLink(Base):
+    """Revocable course access link stored as a token hash, never raw token."""
+
+    __tablename__ = "course_access_links"
+    __table_args__ = (
+        CheckConstraint("status IN ('active', 'rotated', 'revoked')", name="ck_course_access_links_status"),
+        Index(
+            "uix_course_access_links_active_course",
+            "course_id",
+            unique=True,
+            postgresql_where=sql_text("status = 'active'"),
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
+    course_id: Mapped[str] = mapped_column(Text, ForeignKey("courses.id"), nullable=False, index=True)
+    token_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="active")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    rotated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    course: Mapped["Course"] = relationship(back_populates="access_links")
 
 
 class CourseMembership(Base):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,18 +10,33 @@ import jwt
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select, text
+from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import close_all_sessions
 
 from shared.app import app
 from shared.auth import get_auth_settings, get_jwt_verifier, get_supabase_admin_auth_client
-from shared.database import SessionLocal, engine
+from shared.database import SessionLocal, engine, settings
 from shared.models import Base, Course, CourseAccessLink, Invite, Membership, Profile, Tenant, User
+
+
+def _assert_local_schema_reset_target() -> None:
+    db_url = make_url(settings.database_url)
+    allowed_hosts = {"localhost", "127.0.0.1"}
+    if settings.environment == "production":
+        raise RuntimeError("Refusing to reset test schema against a production database URL.")
+    if db_url.host not in allowed_hosts or db_url.port != 5434:
+        raise RuntimeError(
+            "Refusing to reset test schema outside the repo-local Postgres target "
+            f"(expected localhost:5434, got {db_url.host}:{db_url.port})."
+        )
 
 
 @pytest.fixture(scope="session", autouse=True)
 def ensure_db_schema() -> None:
     """Recreate the ORM schema once so metadata changes are reflected in the test DB."""
+    _assert_local_schema_reset_target()
+    close_all_sessions()
     with engine.begin() as connection:
         connection.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
         connection.execute(text("CREATE SCHEMA public"))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,12 +16,15 @@ from sqlalchemy.orm import close_all_sessions
 from shared.app import app
 from shared.auth import get_auth_settings, get_jwt_verifier, get_supabase_admin_auth_client
 from shared.database import SessionLocal, engine
-from shared.models import Base, Course, Invite, Membership, Profile, Tenant, User
+from shared.models import Base, Course, CourseAccessLink, Invite, Membership, Profile, Tenant, User
 
 
 @pytest.fixture(scope="session", autouse=True)
 def ensure_db_schema() -> None:
-    """Create the ORM schema once so the suite can run against an empty database."""
+    """Recreate the ORM schema once so metadata changes are reflected in the test DB."""
+    with engine.begin() as connection:
+        connection.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+        connection.execute(text("CREATE SCHEMA public"))
     Base.metadata.create_all(bind=engine)
 
 
@@ -221,8 +224,32 @@ def seed_identity(db) -> Callable[..., dict[str, object]]:
 
 @pytest.fixture
 def seed_course(db):
-    def _factory(*, university_id: str, teacher_membership_id: str, title: str = "Test Course") -> Course:
-        course = Course(university_id=university_id, teacher_membership_id=teacher_membership_id, title=title)
+    def _factory(
+        *,
+        university_id: str,
+        teacher_membership_id: str | None = None,
+        pending_teacher_invite_id: str | None = None,
+        title: str = "Test Course",
+        code: str | None = None,
+        semester: str = "2026-I",
+        academic_level: str = "Pregrado",
+        max_students: int = 30,
+        status: str = "active",
+    ) -> Course:
+        if (teacher_membership_id is None) == (pending_teacher_invite_id is None):
+            raise ValueError("seed_course requires exactly one teacher assignment")
+
+        course = Course(
+            university_id=university_id,
+            teacher_membership_id=teacher_membership_id,
+            pending_teacher_invite_id=pending_teacher_invite_id,
+            title=title,
+            code=code or f"TEST-{uuid.uuid4().hex[:8].upper()}",
+            semester=semester,
+            academic_level=academic_level,
+            max_students=max_students,
+            status=status,
+        )
         db.add(course)
         db.commit()
         db.refresh(course)
@@ -239,6 +266,7 @@ def seed_invite(db):
         university_id: str,
         role: str,
         course_id: str | None = None,
+        full_name: str | None = None,
         status: str = "pending",
         expires_at: datetime | None = None,
         raw_token: str | None = None,
@@ -249,6 +277,7 @@ def seed_invite(db):
         invite = Invite(
             token_hash=hash_invite_token(token),
             email=email,
+            full_name=full_name,
             university_id=university_id,
             course_id=course_id,
             role=role,
@@ -259,6 +288,32 @@ def seed_invite(db):
         db.commit()
         db.refresh(invite)
         return invite, token
+
+    return _factory
+
+
+@pytest.fixture
+def seed_course_access_link(db):
+    def _factory(
+        *,
+        course_id: str,
+        raw_token: str | None = None,
+        status: str = "active",
+        rotated_at: datetime | None = None,
+    ) -> tuple[CourseAccessLink, str]:
+        from shared.auth import hash_course_access_token
+
+        token = raw_token or f"course-access-{uuid.uuid4()}"
+        access_link = CourseAccessLink(
+            course_id=course_id,
+            token_hash=hash_course_access_token(token),
+            status=status,
+            rotated_at=rotated_at,
+        )
+        db.add(access_link)
+        db.commit()
+        db.refresh(access_link)
+        return access_link, token
 
     return _factory
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,10 +25,19 @@ def _assert_local_schema_reset_target() -> None:
     allowed_hosts = {"localhost", "127.0.0.1"}
     if settings.environment == "production":
         raise RuntimeError("Refusing to reset test schema against a production database URL.")
-    if db_url.host not in allowed_hosts or db_url.port != 5434:
+    is_repo_local_postgres = db_url.host in allowed_hosts and db_url.port == 5434
+    is_github_actions_postgres = (
+        os.getenv("GITHUB_ACTIONS") == "true"
+        and db_url.host in allowed_hosts
+        and db_url.port == 5432
+        and db_url.database == "postgres"
+        and db_url.username == "postgres"
+    )
+    if not (is_repo_local_postgres or is_github_actions_postgres):
         raise RuntimeError(
-            "Refusing to reset test schema outside the repo-local Postgres target "
-            f"(expected localhost:5434, got {db_url.host}:{db_url.port})."
+            "Refusing to reset test schema outside approved local test targets "
+            "(repo-local localhost:5434 or GitHub Actions 127.0.0.1:5432/postgres, "
+            f"got {db_url.host}:{db_url.port}/{db_url.database})."
         )
 
 

--- a/backend/tests/test_issue23_identity_schema.py
+++ b/backend/tests/test_issue23_identity_schema.py
@@ -134,6 +134,7 @@ def test_issue23_alembic_upgrade_and_downgrade() -> None:
             "courses",
             "course_memberships",
             "university_sso_configs",
+            "course_access_links",
         }.issubset(tables)
 
         with engine.begin() as conn:
@@ -186,8 +187,31 @@ def test_issue23_alembic_upgrade_and_downgrade() -> None:
             conn.execute(
                 text(
                     """
-                    INSERT INTO courses (id, university_id, teacher_membership_id, title, created_at)
-                    VALUES (:id, :university_id, :teacher_membership_id, :title, NOW())
+                    INSERT INTO courses (
+                        id,
+                        university_id,
+                        teacher_membership_id,
+                        pending_teacher_invite_id,
+                        title,
+                        code,
+                        semester,
+                        academic_level,
+                        max_students,
+                        status,
+                        created_at
+                    ) VALUES (
+                        :id,
+                        :university_id,
+                        :teacher_membership_id,
+                        NULL,
+                        :title,
+                        :code,
+                        :semester,
+                        :academic_level,
+                        :max_students,
+                        :status,
+                        NOW()
+                    )
                     """
                 ),
                 {
@@ -195,6 +219,11 @@ def test_issue23_alembic_upgrade_and_downgrade() -> None:
                     "university_id": "10000000-0000-0000-0000-000000000001",
                     "teacher_membership_id": "30000000-0000-0000-0000-000000000001",
                     "title": "Course A",
+                    "code": "ISSUE23-COURSE-001",
+                    "semester": "2026-I",
+                    "academic_level": "Pregrado",
+                    "max_students": 30,
+                    "status": "active",
                 },
             )
 
@@ -202,9 +231,9 @@ def test_issue23_alembic_upgrade_and_downgrade() -> None:
                 text(
                     """
                     INSERT INTO invites (
-                        id, token_hash, email, university_id, course_id, role, status, expires_at, consumed_at, created_at
+                        id, token_hash, email, full_name, university_id, course_id, role, status, expires_at, consumed_at, created_at
                     ) VALUES (
-                        :id, :token_hash, :email, :university_id, :course_id, :role, :status, NOW() + INTERVAL '1 day', NULL, NOW()
+                        :id, :token_hash, :email, :full_name, :university_id, :course_id, :role, :status, NOW() + INTERVAL '1 day', NULL, NOW()
                     )
                     """
                 ),
@@ -212,6 +241,7 @@ def test_issue23_alembic_upgrade_and_downgrade() -> None:
                     "id": "50000000-0000-0000-0000-000000000001",
                     "token_hash": "teacher-token-hash",
                     "email": "teacher-invite@example.edu",
+                    "full_name": None,
                     "university_id": "10000000-0000-0000-0000-000000000001",
                     "course_id": None,
                     "role": "teacher",
@@ -225,9 +255,9 @@ def test_issue23_alembic_upgrade_and_downgrade() -> None:
                     text(
                         """
                         INSERT INTO invites (
-                            id, token_hash, email, university_id, course_id, role, status, expires_at, consumed_at, created_at
+                            id, token_hash, email, full_name, university_id, course_id, role, status, expires_at, consumed_at, created_at
                         ) VALUES (
-                            :id, :token_hash, :email, :university_id, :course_id, :role, :status, NOW() + INTERVAL '1 day', NULL, NOW()
+                            :id, :token_hash, :email, :full_name, :university_id, :course_id, :role, :status, NOW() + INTERVAL '1 day', NULL, NOW()
                         )
                         """
                     ),
@@ -235,6 +265,7 @@ def test_issue23_alembic_upgrade_and_downgrade() -> None:
                         "id": "50000000-0000-0000-0000-000000000002",
                         "token_hash": "student-token-hash",
                         "email": "student-invite@example.edu",
+                        "full_name": None,
                         "university_id": "10000000-0000-0000-0000-000000000001",
                         "course_id": None,
                         "role": "student",

--- a/backend/tests/test_issue52_admin_catalog_infra.py
+++ b/backend/tests/test_issue52_admin_catalog_infra.py
@@ -1,0 +1,529 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+import uuid
+
+from alembic import command
+from alembic.config import Config
+import pytest
+from sqlalchemy import create_engine, inspect, select, text
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.exc import IntegrityError
+
+from shared.auth import hash_course_access_token
+from shared.database import settings
+from shared.models import Course, CourseAccessLink, Invite, Membership, Tenant
+
+
+ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
+PRE_ISSUE52_REVISION = "4c8660e9e4d1"
+
+
+def _make_temp_database_urls() -> tuple[str, URL, URL]:
+    base_url = make_url(settings.database_url)
+    temp_name = f"issue52_{uuid.uuid4().hex[:10]}"
+    temp_url = base_url.set(database=temp_name)
+    admin_url = base_url.set(database="postgres")
+    return temp_name, temp_url, admin_url
+
+
+@contextmanager
+def temporary_database() -> str:
+    db_name, temp_url, admin_url = _make_temp_database_urls()
+    admin_engine = create_engine(admin_url.render_as_string(hide_password=False), isolation_level="AUTOCOMMIT")
+    temp_engine = None
+    try:
+        with admin_engine.connect() as conn:
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+        temp_engine = create_engine(temp_url.render_as_string(hide_password=False))
+        yield temp_url.render_as_string(hide_password=False)
+    finally:
+        if temp_engine is not None:
+            temp_engine.dispose()
+        with admin_engine.connect() as conn:
+            conn.execute(
+                text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :db_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"db_name": db_name},
+            )
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        admin_engine.dispose()
+
+
+def _alembic_config(db_url: str) -> Config:
+    config = Config(str(ALEMBIC_INI))
+    config.set_main_option("sqlalchemy.url", db_url)
+    return config
+
+
+def _seed_issue52_legacy_course(engine) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO tenants (id, name, created_at)
+                VALUES (:id, :name, NOW())
+                ON CONFLICT (id) DO NOTHING
+                """
+            ),
+            {"id": "10000000-0000-0000-0000-000000000201", "name": "Issue 52 Tenant"},
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO profiles (id, full_name, created_at, updated_at)
+                VALUES (:id, :full_name, NOW(), NOW())
+                """
+            ),
+            {"id": "20000000-0000-0000-0000-000000000201", "full_name": "Legacy Teacher"},
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO memberships (
+                    id, user_id, university_id, role, status, must_rotate_password, created_at, updated_at
+                ) VALUES (
+                    :id, :user_id, :university_id, :role, :status, :must_rotate_password, NOW(), NOW()
+                )
+                """
+            ),
+            {
+                "id": "30000000-0000-0000-0000-000000000201",
+                "user_id": "20000000-0000-0000-0000-000000000201",
+                "university_id": "10000000-0000-0000-0000-000000000201",
+                "role": "teacher",
+                "status": "active",
+                "must_rotate_password": False,
+            },
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO courses (id, university_id, teacher_membership_id, title, created_at)
+                VALUES (:id, :university_id, :teacher_membership_id, :title, :created_at)
+                """
+            ),
+            {
+                "id": "40000000-0000-0000-0000-000000000201",
+                "university_id": "10000000-0000-0000-0000-000000000201",
+                "teacher_membership_id": "30000000-0000-0000-0000-000000000201",
+                "title": "Legacy Course",
+                "created_at": "2025-08-15T10:00:00+00:00",
+            },
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO invites (
+                    id, token_hash, email, university_id, course_id, role, status, expires_at, consumed_at, created_at
+                ) VALUES (
+                    :id, :token_hash, :email, :university_id, NULL, :role, :status, NOW() + INTERVAL '1 day', NULL, NOW()
+                )
+                """
+            ),
+            {
+                "id": "50000000-0000-0000-0000-000000000201",
+                "token_hash": "legacy-teacher-token-hash",
+                "email": "legacy-teacher@example.edu",
+                "university_id": "10000000-0000-0000-0000-000000000201",
+                "role": "teacher",
+                "status": "pending",
+            },
+        )
+
+
+def test_issue52_alembic_upgrade_backfill_and_downgrade() -> None:
+    with temporary_database() as db_url:
+        config = _alembic_config(db_url)
+        command.upgrade(config, PRE_ISSUE52_REVISION)
+
+        engine = create_engine(db_url)
+        _seed_issue52_legacy_course(engine)
+
+        command.upgrade(config, "head")
+
+        inspector = inspect(engine)
+        assert "course_access_links" in inspector.get_table_names()
+        course_columns = {column["name"] for column in inspector.get_columns("courses")}
+        assert {"code", "semester", "academic_level", "max_students", "status", "pending_teacher_invite_id"}.issubset(
+            course_columns
+        )
+        invite_columns = {column["name"] for column in inspector.get_columns("invites")}
+        assert "full_name" in invite_columns
+
+        with engine.begin() as conn:
+            course = conn.execute(
+                text(
+                    """
+                    SELECT
+                        code,
+                        semester,
+                        academic_level,
+                        max_students,
+                        status,
+                        pending_teacher_invite_id,
+                        teacher_membership_id
+                    FROM courses
+                    WHERE id = :course_id
+                    """
+                ),
+                {"course_id": "40000000-0000-0000-0000-000000000201"},
+            ).mappings().one()
+            assert course["code"] == "LEGACY-40000000"
+            assert course["semester"] == "2025-II"
+            assert course["academic_level"] == "Pregrado"
+            assert course["max_students"] == 30
+            assert course["status"] == "active"
+            assert course["pending_teacher_invite_id"] is None
+            assert course["teacher_membership_id"] == "30000000-0000-0000-0000-000000000201"
+
+            legacy_invite = conn.execute(
+                text("SELECT full_name FROM invites WHERE id = :invite_id"),
+                {"invite_id": "50000000-0000-0000-0000-000000000201"},
+            ).scalar_one()
+            assert legacy_invite is None
+
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO course_access_links (id, course_id, token_hash, status, created_at, rotated_at)
+                    VALUES (:id, :course_id, :token_hash, 'active', NOW(), NULL)
+                    """
+                ),
+                {
+                    "id": "60000000-0000-0000-0000-000000000201",
+                    "course_id": "40000000-0000-0000-0000-000000000201",
+                    "token_hash": "course-link-token-hash-1",
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO course_access_links (id, course_id, token_hash, status, created_at, rotated_at)
+                    VALUES (:id, :course_id, :token_hash, 'rotated', NOW(), NOW())
+                    """
+                ),
+                {
+                    "id": "60000000-0000-0000-0000-000000000202",
+                    "course_id": "40000000-0000-0000-0000-000000000201",
+                    "token_hash": "course-link-token-hash-2",
+                },
+            )
+
+            with pytest.raises(IntegrityError):
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO course_access_links (id, course_id, token_hash, status, created_at, rotated_at)
+                        VALUES (:id, :course_id, :token_hash, 'active', NOW(), NULL)
+                        """
+                    ),
+                    {
+                        "id": "60000000-0000-0000-0000-000000000203",
+                        "course_id": "40000000-0000-0000-0000-000000000201",
+                        "token_hash": "course-link-token-hash-3",
+                    },
+                )
+
+        command.downgrade(config, PRE_ISSUE52_REVISION)
+        inspector = inspect(engine)
+        assert "course_access_links" not in inspector.get_table_names()
+        downgraded_course_columns = {column["name"] for column in inspector.get_columns("courses")}
+        assert "code" not in downgraded_course_columns
+        assert "pending_teacher_invite_id" not in downgraded_course_columns
+        engine.dispose()
+
+
+def test_issue52_downgrade_rejects_pending_teacher_only_courses() -> None:
+    with temporary_database() as db_url:
+        config = _alembic_config(db_url)
+        command.upgrade(config, "head")
+
+        engine = create_engine(db_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO tenants (id, name, created_at)
+                    VALUES (:id, :name, NOW())
+                    """
+                ),
+                {"id": "10000000-0000-0000-0000-000000000218", "name": "Downgrade Guard University"},
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO invites (
+                        id, token_hash, email, full_name, university_id, course_id, role, status, expires_at, consumed_at, created_at
+                    ) VALUES (
+                        :id, :token_hash, :email, :full_name, :university_id, NULL, 'teacher', 'pending', NOW() + INTERVAL '1 day', NULL, NOW()
+                    )
+                    """
+                ),
+                {
+                    "id": "50000000-0000-0000-0000-000000000218",
+                    "token_hash": "downgrade-guard-token",
+                    "email": "pending-downgrade@example.edu",
+                    "full_name": "Pending Downgrade",
+                    "university_id": "10000000-0000-0000-0000-000000000218",
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO courses (
+                        id, university_id, teacher_membership_id, pending_teacher_invite_id, title, code, semester, academic_level, max_students, status, created_at
+                    ) VALUES (
+                        :id, :university_id, NULL, :pending_teacher_invite_id, :title, :code, :semester, :academic_level, :max_students, :status, NOW()
+                    )
+                    """
+                ),
+                {
+                    "id": "40000000-0000-0000-0000-000000000218",
+                    "university_id": "10000000-0000-0000-0000-000000000218",
+                    "pending_teacher_invite_id": "50000000-0000-0000-0000-000000000218",
+                    "title": "Pending Teacher Only Course",
+                    "code": "ISSUE52-DOWNGRADE-001",
+                    "semester": "2026-I",
+                    "academic_level": "Pregrado",
+                    "max_students": 30,
+                    "status": "active",
+                },
+            )
+
+        with pytest.raises(RuntimeError, match="pending-teacher shape"):
+            command.downgrade(config, PRE_ISSUE52_REVISION)
+
+        engine.dispose()
+
+
+def test_issue52_course_constraints_allow_teacher_membership_assignment(db, seed_identity) -> None:
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-membership@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000211",
+    )
+    course = Course(
+        university_id=teacher["tenant"].id,
+        teacher_membership_id=teacher["membership"].id,
+        pending_teacher_invite_id=None,
+        title="Teacher Assigned Course",
+        code="ISSUE52-ACTIVE-001",
+        semester="2026-I",
+        academic_level="Pregrado",
+        max_students=30,
+        status="active",
+    )
+    db.add(course)
+    db.commit()
+
+    assert course.id is not None
+
+
+def test_issue52_course_constraints_allow_pending_teacher_assignment(db, seed_invite) -> None:
+    tenant = Tenant(id="10000000-0000-0000-0000-000000000212", name="Pending Invite University")
+    db.add(tenant)
+    db.commit()
+    invite, _ = seed_invite(
+        email="pending.teacher@example.edu",
+        university_id=tenant.id,
+        role="teacher",
+        full_name="Pending Teacher",
+    )
+    course = Course(
+        university_id=tenant.id,
+        teacher_membership_id=None,
+        pending_teacher_invite_id=invite.id,
+        title="Pending Teacher Course",
+        code="ISSUE52-PENDING-001",
+        semester="2026-I",
+        academic_level="Pregrado",
+        max_students=30,
+        status="active",
+    )
+    db.add(course)
+    db.commit()
+
+    assert course.pending_teacher_invite_id == invite.id
+
+
+def test_issue52_course_rejects_invalid_teacher_assignment_xor(db, seed_identity, seed_invite) -> None:
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-xor@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000213",
+    )
+    invite, _ = seed_invite(
+        email="pending-xor@example.edu",
+        university_id=teacher["tenant"].id,
+        role="teacher",
+    )
+
+    both_set = Course(
+        university_id=teacher["tenant"].id,
+        teacher_membership_id=teacher["membership"].id,
+        pending_teacher_invite_id=invite.id,
+        title="Invalid Both Set",
+        code="ISSUE52-XOR-001",
+        semester="2026-I",
+        academic_level="Pregrado",
+        max_students=30,
+        status="active",
+    )
+    db.add(both_set)
+    with pytest.raises(IntegrityError):
+        db.commit()
+    db.rollback()
+
+    both_null = Course(
+        university_id=teacher["tenant"].id,
+        teacher_membership_id=None,
+        pending_teacher_invite_id=None,
+        title="Invalid Both Null",
+        code="ISSUE52-XOR-002",
+        semester="2026-I",
+        academic_level="Pregrado",
+        max_students=30,
+        status="active",
+    )
+    db.add(both_null)
+    with pytest.raises(IntegrityError):
+        db.commit()
+
+
+def test_issue52_course_rejects_duplicate_code_per_university_and_semester(db, seed_identity) -> None:
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-dup-a@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000214",
+    )
+    other_teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-dup-b@example.edu",
+        role="teacher",
+        university_id=teacher["tenant"].id,
+    )
+    db.add(
+        Course(
+            university_id=teacher["tenant"].id,
+            teacher_membership_id=teacher["membership"].id,
+            pending_teacher_invite_id=None,
+            title="Duplicate A",
+            code="ISSUE52-DUP-001",
+            semester="2026-I",
+            academic_level="Pregrado",
+            max_students=30,
+            status="active",
+        )
+    )
+    db.commit()
+
+    db.add(
+        Course(
+            university_id=teacher["tenant"].id,
+            teacher_membership_id=other_teacher["membership"].id,
+            pending_teacher_invite_id=None,
+            title="Duplicate B",
+            code="ISSUE52-DUP-001",
+            semester="2026-I",
+            academic_level="Pregrado",
+            max_students=30,
+            status="active",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db.commit()
+
+
+def test_issue52_course_rejects_non_positive_max_students(db, seed_identity) -> None:
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-capacity@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000215",
+    )
+    db.add(
+        Course(
+            university_id=teacher["tenant"].id,
+            teacher_membership_id=teacher["membership"].id,
+            pending_teacher_invite_id=None,
+            title="Invalid Capacity",
+            code="ISSUE52-CAPACITY-001",
+            semester="2026-I",
+            academic_level="Pregrado",
+            max_students=0,
+            status="active",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db.commit()
+
+
+def test_issue52_course_access_links_enforce_single_active_and_unique_token_hash(
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+) -> None:
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-links@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000216",
+    )
+    course = seed_course(university_id=teacher["tenant"].id, teacher_membership_id=teacher["membership"].id)
+    active_link, raw_active_token = seed_course_access_link(course_id=course.id, status="active")
+
+    rotated_link = CourseAccessLink(
+        course_id=course.id,
+        token_hash=hash_course_access_token("rotated-token"),
+        status="rotated",
+        rotated_at=active_link.created_at,
+    )
+    db.add(rotated_link)
+    db.commit()
+
+    second_active = CourseAccessLink(
+        course_id=course.id,
+        token_hash=hash_course_access_token("second-active-token"),
+        status="active",
+    )
+    db.add(second_active)
+    with pytest.raises(IntegrityError):
+        db.commit()
+    db.rollback()
+
+    duplicate_hash = CourseAccessLink(
+        course_id=course.id,
+        token_hash=hash_course_access_token(raw_active_token),
+        status="revoked",
+    )
+    db.add(duplicate_hash)
+    with pytest.raises(IntegrityError):
+        db.commit()
+
+
+def test_issue52_invites_allow_null_full_name(db, seed_invite) -> None:
+    tenant = Tenant(id="10000000-0000-0000-0000-000000000217", name="Invite Null Full Name University")
+    db.add(tenant)
+    db.commit()
+    invite, _ = seed_invite(
+        email="legacy-null-fullname@example.edu",
+        university_id=tenant.id,
+        role="teacher",
+        full_name=None,
+    )
+
+    refreshed = db.scalar(select(Invite).where(Invite.id == invite.id))
+    assert refreshed is not None
+    assert refreshed.full_name is None

--- a/backend/tests/test_student_activation.py
+++ b/backend/tests/test_student_activation.py
@@ -70,6 +70,11 @@ def course(db, university):
         university_id=UNIVERSITY_ID,
         teacher_membership_id=teacher_membership.id,
         title="Curso de Prueba",
+        code="TEST-STUDENT-ACT-001",
+        semester="2026-I",
+        academic_level="Pregrado",
+        max_students=30,
+        status="active",
     )
     db.add(c)
     db.commit()
@@ -106,6 +111,11 @@ class TestResolveInviteTeacherName:
             university_id=UNIVERSITY_ID,
             teacher_membership_id=membership.id,
             title="Análisis de Datos",
+            code="TEST-STUDENT-ACT-002",
+            semester="2026-I",
+            academic_level="Pregrado",
+            max_students=30,
+            status="active",
         )
         db.add(course)
         db.commit()


### PR DESCRIPTION
## Summary
- add the Issue 52 Alembic migration for admin catalog schema, pending teacher assignment, and course access links
- align shared ORM/auth helpers and harden invite teacher-name compatibility for pending invites
- extend backend fixtures and migration/schema tests so Alembic and ORM stay in sync

## Validation
- uv run --directory backend pytest -q
- uv run --directory backend mypy src

Refs #52