### PR TITLE
feat: add admin dashboard read endpoints

### DIFF
--- a/backend/src/shared/admin_context.py
+++ b/backend/src/shared/admin_context.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import Depends, HTTPException, status
+
+from shared.auth import CurrentActor, require_current_actor
+
+
+@dataclass(slots=True)
+class AdminContext:
+    """Tenant-scoped admin context resolved from the authenticated actor."""
+
+    auth_user_id: str
+    admin_membership_id: str
+    university_id: str
+
+
+def resolve_admin_context(actor: CurrentActor) -> AdminContext:
+    """Resolve the single active university_admin membership required by admin APIs."""
+    active_admin_memberships = [
+        membership
+        for membership in actor.active_memberships
+        if membership.role == "university_admin"
+    ]
+
+    if not active_admin_memberships:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="admin_role_required",
+        )
+
+    if len(active_admin_memberships) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="admin_membership_context_required",
+        )
+
+    membership = active_admin_memberships[0]
+    return AdminContext(
+        auth_user_id=actor.auth_user_id,
+        admin_membership_id=membership.id,
+        university_id=membership.university_id,
+    )
+
+
+def require_admin_context(
+    actor: CurrentActor = Depends(require_current_actor),
+) -> AdminContext:
+    """FastAPI dependency that enforces a single active admin membership."""
+    return resolve_admin_context(actor)

--- a/backend/src/shared/admin_reads.py
+++ b/backend/src/shared/admin_reads.py
@@ -1,0 +1,549 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from math import ceil
+import threading
+from typing import Any, Literal
+
+from cachetools import TTLCache
+from fastapi import HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import Select, and_, func, or_, select
+from sqlalchemy.orm import Session, aliased
+
+from shared.admin_context import AdminContext
+from shared.auth import get_supabase_admin_auth_client
+from shared.models import Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, User
+
+
+TeacherState = Literal["active", "pending", "stale_pending_invite"]
+AccessLinkStatus = Literal["active", "missing"]
+_MISSING_TEACHER_EMAIL = "__missing_teacher_email__"
+_teacher_email_cache: TTLCache[str, str] = TTLCache(maxsize=500, ttl=300)
+_teacher_email_cache_lock = threading.Lock()
+
+
+class DashboardSummaryResponse(BaseModel):
+    active_courses: int
+    active_teachers: int
+    enrolled_students: int
+    average_occupancy: int
+
+
+class TeacherMembershipAssignmentResponse(BaseModel):
+    kind: Literal["membership"]
+    membership_id: str
+
+
+class TeacherPendingInviteAssignmentResponse(BaseModel):
+    kind: Literal["pending_invite"]
+    invite_id: str
+
+
+class CourseListItemResponse(BaseModel):
+    id: str
+    title: str
+    code: str
+    semester: str
+    academic_level: str
+    status: str
+    teacher_display_name: str
+    teacher_state: TeacherState
+    teacher_assignment: TeacherMembershipAssignmentResponse | TeacherPendingInviteAssignmentResponse
+    students_count: int
+    max_students: int
+    occupancy_percent: int
+    access_link: None = None
+    access_link_status: AccessLinkStatus
+
+
+class AdminCoursesResponse(BaseModel):
+    items: list[CourseListItemResponse]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+
+
+class ActiveTeacherOptionResponse(BaseModel):
+    membership_id: str
+    full_name: str
+    email: str
+
+
+class PendingInviteOptionResponse(BaseModel):
+    invite_id: str
+    full_name: str
+    email: str
+    status: Literal["pending"]
+
+
+class TeacherOptionsResponse(BaseModel):
+    active_teachers: list[ActiveTeacherOptionResponse]
+    pending_invites: list[PendingInviteOptionResponse]
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _effective_invite_status(invite_status: str, expires_at: datetime | None) -> str:
+    if invite_status == "pending" and expires_at is not None and expires_at <= utc_now():
+        return "expired"
+    return invite_status
+
+
+def _clamp_percent(value: int) -> int:
+    return max(0, min(100, value))
+
+
+def _calculate_percent(students_count: int, max_students: int) -> int:
+    if max_students <= 0:
+        return 0
+    return _clamp_percent(round((students_count / max_students) * 100))
+
+
+def _calculate_total_pages(total: int, page_size: int) -> int:
+    if total == 0:
+        return 0
+    return ceil(total / page_size)
+
+
+def get_dashboard_summary(db: Session, context: AdminContext) -> DashboardSummaryResponse:
+    """Return tenant-scoped dashboard KPIs for the admin home screen."""
+    active_courses = int(
+        db.scalar(
+            select(func.count())
+            .select_from(Course)
+            .where(
+                Course.university_id == context.university_id,
+                Course.status == "active",
+            )
+        )
+        or 0
+    )
+
+    active_teachers = int(
+        db.scalar(
+            select(func.count(func.distinct(Course.teacher_membership_id)))
+            .select_from(Course)
+            .join(
+                Membership,
+                and_(
+                    Course.teacher_membership_id == Membership.id,
+                    Membership.university_id == context.university_id,
+                    Membership.role == "teacher",
+                    Membership.status == "active",
+                ),
+            )
+            .where(
+                Course.university_id == context.university_id,
+                Course.status == "active",
+            )
+        )
+        or 0
+    )
+
+    enrolled_students = int(
+        db.scalar(
+            select(func.count())
+            .select_from(CourseMembership)
+            .join(
+                Course,
+                and_(
+                    CourseMembership.course_id == Course.id,
+                    Course.university_id == context.university_id,
+                    Course.status == "active",
+                ),
+            )
+            .join(
+                Membership,
+                and_(
+                    CourseMembership.membership_id == Membership.id,
+                    Membership.university_id == context.university_id,
+                    Membership.role == "student",
+                    Membership.status == "active",
+                ),
+            )
+        )
+        or 0
+    )
+
+    total_capacity = int(
+        db.scalar(
+            select(func.coalesce(func.sum(Course.max_students), 0)).where(
+                Course.university_id == context.university_id,
+                Course.status == "active",
+            )
+        )
+        or 0
+    )
+
+    average_occupancy = (
+        _clamp_percent(round((enrolled_students / total_capacity) * 100))
+        if total_capacity > 0
+        else 0
+    )
+
+    return DashboardSummaryResponse(
+        active_courses=active_courses,
+        active_teachers=active_teachers,
+        enrolled_students=enrolled_students,
+        average_occupancy=average_occupancy,
+    )
+
+
+def _build_courses_query(
+    *,
+    context: AdminContext,
+    search: str | None,
+    semester: str | None,
+    course_status: str | None,
+    academic_level: str | None,
+) -> Select[Any]:
+    teacher_membership = aliased(Membership)
+    teacher_profile = aliased(Profile)
+    teacher_user = aliased(User)
+    pending_invite = aliased(Invite)
+    active_link = aliased(CourseAccessLink)
+
+    student_counts = (
+        select(
+            CourseMembership.course_id.label("course_id"),
+            func.count().label("students_count"),
+        )
+        .select_from(CourseMembership)
+        .join(
+            Membership,
+            and_(
+                CourseMembership.membership_id == Membership.id,
+                Membership.university_id == context.university_id,
+                Membership.role == "student",
+                Membership.status == "active",
+            ),
+        )
+        .group_by(CourseMembership.course_id)
+        .subquery()
+    )
+
+    stmt = (
+        select(
+            Course.id.label("id"),
+            Course.title.label("title"),
+            Course.code.label("code"),
+            Course.semester.label("semester"),
+            Course.academic_level.label("academic_level"),
+            Course.status.label("status"),
+            Course.max_students.label("max_students"),
+            Course.created_at.label("created_at"),
+            Course.teacher_membership_id.label("course_teacher_membership_id"),
+            Course.pending_teacher_invite_id.label("course_pending_teacher_invite_id"),
+            func.coalesce(student_counts.c.students_count, 0).label("students_count"),
+            teacher_membership.id.label("teacher_membership_id"),
+            teacher_profile.full_name.label("teacher_profile_full_name"),
+            teacher_user.email.label("teacher_user_email"),
+            pending_invite.id.label("pending_invite_id"),
+            pending_invite.full_name.label("pending_invite_full_name"),
+            pending_invite.email.label("pending_invite_email"),
+            pending_invite.status.label("pending_invite_status"),
+            pending_invite.expires_at.label("pending_invite_expires_at"),
+            active_link.status.label("active_link_status"),
+        )
+        .select_from(Course)
+        .outerjoin(
+            teacher_membership,
+            and_(
+                Course.teacher_membership_id == teacher_membership.id,
+                teacher_membership.university_id == context.university_id,
+                teacher_membership.role == "teacher",
+            ),
+        )
+        .outerjoin(teacher_profile, teacher_membership.user_id == teacher_profile.id)
+        .outerjoin(
+            teacher_user,
+            and_(
+                teacher_membership.user_id == teacher_user.id,
+                teacher_user.tenant_id == context.university_id,
+                teacher_user.role == "teacher",
+            ),
+        )
+        .outerjoin(
+            pending_invite,
+            and_(
+                Course.pending_teacher_invite_id == pending_invite.id,
+                pending_invite.university_id == context.university_id,
+                pending_invite.role == "teacher",
+            ),
+        )
+        .outerjoin(student_counts, student_counts.c.course_id == Course.id)
+        .outerjoin(
+            active_link,
+            and_(
+                active_link.course_id == Course.id,
+                active_link.status == "active",
+            ),
+        )
+        .where(Course.university_id == context.university_id)
+    )
+
+    if search:
+        pattern = f"%{search.strip()}%"
+        stmt = stmt.where(
+            or_(
+                Course.title.ilike(pattern),
+                Course.code.ilike(pattern),
+                teacher_profile.full_name.ilike(pattern),
+                teacher_user.email.ilike(pattern),
+                pending_invite.full_name.ilike(pattern),
+                pending_invite.email.ilike(pattern),
+            )
+        )
+
+    if semester:
+        stmt = stmt.where(Course.semester == semester)
+    if course_status:
+        stmt = stmt.where(Course.status == course_status)
+    if academic_level:
+        stmt = stmt.where(Course.academic_level == academic_level)
+
+    return stmt
+
+
+def _serialize_course_item(row: dict[str, Any]) -> CourseListItemResponse:
+    course_teacher_membership_id = row["course_teacher_membership_id"]
+    course_pending_teacher_invite_id = row["course_pending_teacher_invite_id"]
+    students_count = int(row["students_count"])
+    max_students = int(row["max_students"])
+
+    if course_teacher_membership_id is not None:
+        if row["teacher_membership_id"] is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="invalid_teacher_assignment",
+            )
+        teacher_display_name = row["teacher_profile_full_name"] or row["teacher_user_email"]
+        if not teacher_display_name:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="teacher_display_name_unavailable",
+            )
+        return CourseListItemResponse(
+            id=row["id"],
+            title=row["title"],
+            code=row["code"],
+            semester=row["semester"],
+            academic_level=row["academic_level"],
+            status=row["status"],
+            teacher_display_name=teacher_display_name,
+            teacher_state="active",
+            teacher_assignment=TeacherMembershipAssignmentResponse(
+                kind="membership",
+                membership_id=course_teacher_membership_id,
+            ),
+            students_count=students_count,
+            max_students=max_students,
+            occupancy_percent=_calculate_percent(students_count, max_students),
+            access_link=None,
+            access_link_status="active" if row["active_link_status"] == "active" else "missing",
+        )
+
+    if course_pending_teacher_invite_id is None or row["pending_invite_id"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="invalid_teacher_assignment",
+        )
+
+    invite_display_name = row["pending_invite_full_name"] or row["pending_invite_email"]
+    if not invite_display_name:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="teacher_display_name_unavailable",
+        )
+
+    effective_invite_status = _effective_invite_status(
+        row["pending_invite_status"],
+        row["pending_invite_expires_at"],
+    )
+    teacher_state: TeacherState = "pending" if effective_invite_status == "pending" else "stale_pending_invite"
+
+    return CourseListItemResponse(
+        id=row["id"],
+        title=row["title"],
+        code=row["code"],
+        semester=row["semester"],
+        academic_level=row["academic_level"],
+        status=row["status"],
+        teacher_display_name=invite_display_name,
+        teacher_state=teacher_state,
+        teacher_assignment=TeacherPendingInviteAssignmentResponse(
+            kind="pending_invite",
+            invite_id=course_pending_teacher_invite_id,
+        ),
+        students_count=students_count,
+        max_students=max_students,
+        occupancy_percent=_calculate_percent(students_count, max_students),
+        access_link=None,
+        access_link_status="active" if row["active_link_status"] == "active" else "missing",
+    )
+
+
+def list_admin_courses(
+    db: Session,
+    context: AdminContext,
+    *,
+    search: str | None,
+    semester: str | None,
+    course_status: str | None,
+    academic_level: str | None,
+    page: int,
+    page_size: int,
+) -> AdminCoursesResponse:
+    """Return the paginated, tenant-scoped course directory for the dashboard."""
+    base_stmt = _build_courses_query(
+        context=context,
+        search=search,
+        semester=semester,
+        course_status=course_status,
+        academic_level=academic_level,
+    )
+
+    total = int(
+        db.scalar(select(func.count()).select_from(base_stmt.order_by(None).subquery()))
+        or 0
+    )
+
+    rows = (
+        db.execute(
+            base_stmt.order_by(Course.created_at.desc(), Course.id.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        .mappings()
+        .all()
+    )
+
+    return AdminCoursesResponse(
+        items=[_serialize_course_item(dict(row)) for row in rows],
+        page=page,
+        page_size=page_size,
+        total=total,
+        total_pages=_calculate_total_pages(total, page_size),
+    )
+
+
+def _resolve_teacher_email(user_id: str, legacy_email: str | None) -> str:
+    if legacy_email:
+        return legacy_email
+
+    with _teacher_email_cache_lock:
+        if user_id in _teacher_email_cache:
+            cached_email = _teacher_email_cache[user_id]
+            if cached_email == _MISSING_TEACHER_EMAIL:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="teacher_email_unavailable",
+                )
+            return cached_email
+
+    try:
+        auth_user = get_supabase_admin_auth_client().get_user_by_id(user_id)
+    except Exception as exc:
+        with _teacher_email_cache_lock:
+            _teacher_email_cache[user_id] = _MISSING_TEACHER_EMAIL
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="teacher_email_unavailable",
+        ) from exc
+
+    if auth_user is not None and auth_user.email:
+        with _teacher_email_cache_lock:
+            _teacher_email_cache[user_id] = auth_user.email
+        return auth_user.email
+
+    with _teacher_email_cache_lock:
+        _teacher_email_cache[user_id] = _MISSING_TEACHER_EMAIL
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="teacher_email_unavailable",
+    )
+
+
+def list_teacher_options(db: Session, context: AdminContext) -> TeacherOptionsResponse:
+    """Return active teachers and pending teacher invites for the admin tenant."""
+    teacher_rows = (
+        db.execute(
+            select(
+                Membership.id.label("membership_id"),
+                Membership.user_id.label("user_id"),
+                Profile.full_name.label("full_name"),
+                User.email.label("legacy_email"),
+            )
+            .select_from(Membership)
+            .join(Profile, Membership.user_id == Profile.id)
+            .outerjoin(
+                User,
+                and_(
+                    User.id == Membership.user_id,
+                    User.tenant_id == context.university_id,
+                    User.role == "teacher",
+                ),
+            )
+            .where(
+                Membership.university_id == context.university_id,
+                Membership.role == "teacher",
+                Membership.status == "active",
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    active_teachers = [
+        ActiveTeacherOptionResponse(
+            membership_id=row["membership_id"],
+            full_name=row["full_name"],
+            email=_resolve_teacher_email(row["user_id"], row["legacy_email"]),
+        )
+        for row in teacher_rows
+    ]
+    active_teachers.sort(
+        key=lambda teacher: ((teacher.full_name or teacher.email).lower(), teacher.membership_id)
+    )
+
+    pending_rows = (
+        db.execute(
+            select(
+                Invite.id.label("invite_id"),
+                Invite.full_name.label("full_name"),
+                Invite.email.label("email"),
+                Invite.status.label("status"),
+            )
+            .select_from(Invite)
+            .where(
+                Invite.university_id == context.university_id,
+                Invite.role == "teacher",
+                Invite.status == "pending",
+                Invite.expires_at > utc_now(),
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    pending_invites = [
+        PendingInviteOptionResponse(
+            invite_id=row["invite_id"],
+            full_name=row["full_name"] or row["email"],
+            email=row["email"],
+            status="pending",
+        )
+        for row in pending_rows
+    ]
+    pending_invites.sort(
+        key=lambda invite: ((invite.full_name or invite.email).lower(), invite.invite_id)
+    )
+
+    return TeacherOptionsResponse(
+        active_teachers=active_teachers,
+        pending_invites=pending_invites,
+    )

--- a/backend/src/shared/admin_reads.py
+++ b/backend/src/shared/admin_reads.py
@@ -286,8 +286,9 @@ def _build_courses_query(
         .where(Course.university_id == context.university_id)
     )
 
-    if search:
-        pattern = f"%{search.strip()}%"
+    normalized_search = (search or "").strip()
+    if normalized_search:
+        pattern = f"%{normalized_search}%"
         stmt = stmt.where(
             or_(
                 Course.title.ilike(pattern),
@@ -448,8 +449,6 @@ def _resolve_teacher_email(user_id: str, legacy_email: str | None) -> str:
     try:
         auth_user = get_supabase_admin_auth_client().get_user_by_id(user_id)
     except Exception as exc:
-        with _teacher_email_cache_lock:
-            _teacher_email_cache[user_id] = _MISSING_TEACHER_EMAIL
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="teacher_email_unavailable",

--- a/backend/src/shared/admin_router.py
+++ b/backend/src/shared/admin_router.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from shared.admin_context import AdminContext, require_admin_context
+from shared.admin_reads import (
+    AdminCoursesResponse,
+    DashboardSummaryResponse,
+    TeacherOptionsResponse,
+    get_dashboard_summary,
+    list_admin_courses,
+    list_teacher_options,
+)
+from shared.database import get_db
+
+router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+
+@router.get("/dashboard/summary", response_model=DashboardSummaryResponse)
+def get_admin_dashboard_summary(
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+) -> DashboardSummaryResponse:
+    return get_dashboard_summary(db, context)
+
+
+@router.get("/courses", response_model=AdminCoursesResponse)
+def get_admin_courses(
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+    search: str | None = Query(default=None),
+    semester: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    academic_level: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=8, ge=1, le=50),
+) -> AdminCoursesResponse:
+    return list_admin_courses(
+        db,
+        context,
+        search=search,
+        semester=semester,
+        course_status=status,
+        academic_level=academic_level,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/teacher-options", response_model=TeacherOptionsResponse)
+def get_admin_teacher_options(
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+) -> TeacherOptionsResponse:
+    return list_teacher_options(db, context)

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -31,6 +31,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from case_generator.core.authoring import AuthoringService
 from case_generator.suggest_service import SuggestRequest, SuggestResponse, generate_suggestion
+from shared.admin_router import router as admin_router
 from shared.auth import (
     AuthError,
     CurrentActor,
@@ -286,6 +287,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(title="adam-v8.0 - Case Generation API", lifespan=lifespan)
+app.include_router(admin_router)
 
 
 @app.middleware("http")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import close_all_sessions
 from shared.app import app
 from shared.auth import get_auth_settings, get_jwt_verifier, get_supabase_admin_auth_client
 from shared.database import SessionLocal, engine, settings
-from shared.models import Base, Course, CourseAccessLink, Invite, Membership, Profile, Tenant, User
+from shared.models import Base, Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, Tenant, User
 
 
 def _assert_local_schema_reset_target() -> None:
@@ -342,6 +342,21 @@ def seed_course_access_link(db):
     return _factory
 
 
+@pytest.fixture
+def seed_course_membership(db):
+    def _factory(*, course_id: str, membership_id: str) -> CourseMembership:
+        course_membership = CourseMembership(
+            course_id=course_id,
+            membership_id=membership_id,
+        )
+        db.add(course_membership)
+        db.commit()
+        db.refresh(course_membership)
+        return course_membership
+
+    return _factory
+
+
 @dataclass
 class FakeAdminUser:
     id: str
@@ -361,6 +376,7 @@ class FakeAdminClient:
     fail_delete: bool = False
     fail_update_password: bool = False
     updated_passwords: dict[str, str] = field(default_factory=dict)
+    get_user_by_id_calls: dict[str, int] = field(default_factory=dict)
 
     def find_user_by_email(self, email: str) -> FakeAdminUser | None:
         return self.users_by_email.get(email.lower())
@@ -379,6 +395,7 @@ class FakeAdminClient:
         return self.get_or_create_user_by_email(email, password).user
 
     def get_user_by_id(self, user_id: str) -> FakeAdminUser | None:
+        self.get_user_by_id_calls[user_id] = self.get_user_by_id_calls.get(user_id, 0) + 1
         return self.users_by_id.get(user_id)
 
     def delete_user(self, user_id: str) -> None:
@@ -398,4 +415,5 @@ class FakeAdminClient:
 def fake_admin_client(monkeypatch: pytest.MonkeyPatch) -> FakeAdminClient:
     client = FakeAdminClient()
     monkeypatch.setattr("shared.app.get_supabase_admin_auth_client", lambda: client)
+    monkeypatch.setattr("shared.admin_reads.get_supabase_admin_auth_client", lambda: client)
     return client

--- a/backend/tests/test_issue55_admin_reads.py
+++ b/backend/tests/test_issue55_admin_reads.py
@@ -333,6 +333,43 @@ def test_issue55_courses_support_pending_invite_search_and_stale_pending_state(
     assert items_by_id[stale_course.id]["teacher_state"] == "stale_pending_invite"
 
 
+def test_issue55_courses_ignore_whitespace_only_search(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000567"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-whitespace@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    first_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Whitespace One",
+        code="WS-001",
+    )
+    second_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Whitespace Two",
+        code="WS-002",
+    )
+
+    response = client.get(
+        "/api/admin/courses",
+        params={"search": "   "},
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    assert {item["id"] for item in response.json()["items"]} == {first_course.id, second_course.id}
+
+
 def test_issue55_courses_return_access_link_status_without_raw_token(
     client,
     seed_identity,
@@ -555,6 +592,58 @@ def test_issue55_teacher_options_caches_supabase_fallback_between_requests(
     assert first_response.status_code == 200
     assert second_response.status_code == 200
     assert fake_admin_client.get_user_by_id_calls[teacher_user_id] == 1
+
+
+def test_issue55_teacher_options_does_not_cache_transient_supabase_failure(
+    client,
+    fake_admin_client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000568"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher_user_id = str(uuid.uuid4())
+    seed_identity(
+        user_id=teacher_user_id,
+        email="ignored-transient@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Transient Teacher",
+        create_legacy_user=False,
+    )
+
+    original_get_user_by_id = fake_admin_client.get_user_by_id
+    state = {"fail_once": True}
+
+    def flaky_get_user_by_id(user_id: str):
+        fake_admin_client.get_user_by_id_calls[user_id] = fake_admin_client.get_user_by_id_calls.get(user_id, 0) + 1
+        if state["fail_once"]:
+            state["fail_once"] = False
+            raise RuntimeError("temporary outage")
+        return fake_admin_client.users_by_id.get(user_id)
+
+    fake_admin_client.get_user_by_id = flaky_get_user_by_id  # type: ignore[method-assign]
+    fake_admin_client.users_by_id[teacher_user_id] = type(
+        "User",
+        (),
+        {"id": teacher_user_id, "email": "transient.teacher@example.edu"},
+    )()
+
+    first_response = client.get(
+        "/api/admin/teacher-options",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+    second_response = client.get(
+        "/api/admin/teacher-options",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert first_response.status_code == 500
+    assert first_response.json()["detail"] == "teacher_email_unavailable"
+    assert second_response.status_code == 200
+    assert second_response.json()["active_teachers"][0]["email"] == "transient.teacher@example.edu"
+    assert fake_admin_client.get_user_by_id_calls[teacher_user_id] == 2
+    fake_admin_client.get_user_by_id = original_get_user_by_id  # type: ignore[method-assign]
 
 
 def test_issue55_teacher_options_fail_explicitly_if_email_is_unavailable(

--- a/backend/tests/test_issue55_admin_reads.py
+++ b/backend/tests/test_issue55_admin_reads.py
@@ -1,0 +1,582 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import uuid
+
+from sqlalchemy import select
+
+from shared.models import Course, Membership, Tenant
+
+
+def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
+    return auth_headers_factory(sub=user_id, email=email)
+
+
+def _seed_admin(seed_identity, *, university_id: str) -> tuple[str, str]:
+    user_id = str(uuid.uuid4())
+    email = f"admin-{uuid.uuid4().hex[:8]}@example.edu"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="university_admin",
+        university_id=university_id,
+        create_legacy_user=False,
+        full_name="Admin User",
+    )
+    return user_id, email
+
+
+def test_issue55_admin_endpoints_require_bearer_token(client) -> None:
+    response = client.get("/api/admin/dashboard/summary")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "invalid_token"
+
+
+def test_issue55_admin_context_requires_university_admin_role(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    user_id = str(uuid.uuid4())
+    email = "teacher-no-admin@example.edu"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000551",
+    )
+
+    response = client.get(
+        "/api/admin/dashboard/summary",
+        headers=_auth_headers(auth_headers_factory, user_id=user_id, email=email),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "admin_role_required"
+
+
+def test_issue55_admin_context_requires_single_admin_membership(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    user_id = str(uuid.uuid4())
+    email = "multi-admin@example.edu"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="university_admin",
+        university_id="10000000-0000-0000-0000-000000000552",
+        create_legacy_user=False,
+    )
+    tenant = Tenant(id="10000000-0000-0000-0000-000000000553", name="Second Admin Tenant")
+    db.add(tenant)
+    db.flush()
+    db.add(
+        Membership(
+            user_id=user_id,
+            university_id=tenant.id,
+            role="university_admin",
+            status="active",
+            must_rotate_password=False,
+        )
+    )
+    db.commit()
+
+    response = client.get(
+        "/api/admin/dashboard/summary",
+        headers=_auth_headers(auth_headers_factory, user_id=user_id, email=email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "admin_membership_context_required"
+
+
+def test_issue55_summary_is_tenant_scoped_and_clamps_average_occupancy(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000554"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-a@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    other_tenant_teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-b@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000555",
+    )
+
+    active_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Active Course",
+        max_students=1,
+    )
+    seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Inactive Course",
+        status="inactive",
+    )
+    foreign_course = seed_course(
+        university_id=other_tenant_teacher["tenant"].id,
+        teacher_membership_id=other_tenant_teacher["membership"].id,
+        title="Foreign Active Course",
+    )
+
+    student_one = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-one@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    student_two = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-two@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    foreign_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-three@example.edu",
+        role="student",
+        university_id=other_tenant_teacher["tenant"].id,
+    )
+    seed_course_membership(course_id=active_course.id, membership_id=student_one["membership"].id)
+    seed_course_membership(course_id=active_course.id, membership_id=student_two["membership"].id)
+    seed_course_membership(course_id=foreign_course.id, membership_id=foreign_student["membership"].id)
+
+    response = client.get(
+        "/api/admin/dashboard/summary",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "active_courses": 1,
+        "active_teachers": 1,
+        "enrolled_students": 2,
+        "average_occupancy": 100,
+    }
+
+
+def test_issue55_summary_returns_zero_average_without_active_courses(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000556"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+
+    response = client.get(
+        "/api/admin/dashboard/summary",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["average_occupancy"] == 0
+
+
+def test_issue55_courses_support_filters_search_pagination_and_stable_order(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000557"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="julio.paz@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Julio Paz",
+    )
+    other_teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="other.teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Other Teacher",
+    )
+
+    first = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Gerencia Estrategica",
+        code="GTD-GEME-01",
+        semester="2026-I",
+        academic_level="Especialización",
+        status="active",
+    )
+    second = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Gobernanza de Datos",
+        code="GTD-GODA-01",
+        semester="2026-I",
+        academic_level="Especialización",
+        status="active",
+    )
+    seed_course(
+        university_id=university_id,
+        teacher_membership_id=other_teacher["membership"].id,
+        title="Inactive Course",
+        code="OTHER-001",
+        semester="2025-II",
+        academic_level="Pregrado",
+        status="inactive",
+    )
+
+    same_created_at = datetime(2026, 1, 10, tzinfo=timezone.utc)
+    first_db = db.scalar(select(Course).where(Course.id == first.id))
+    second_db = db.scalar(select(Course).where(Course.id == second.id))
+    assert first_db is not None
+    assert second_db is not None
+    first_db.created_at = same_created_at
+    second_db.created_at = same_created_at
+    db.commit()
+
+    response = client.get(
+        "/api/admin/courses",
+        params={
+            "search": "Julio",
+            "semester": "2026-I",
+            "status": "active",
+            "academic_level": "Especialización",
+            "page": 1,
+            "page_size": 1,
+        },
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    expected_first_id = sorted([first.id, second.id], reverse=True)[0]
+    assert payload["total"] == 2
+    assert payload["total_pages"] == 2
+    assert payload["items"][0]["id"] == expected_first_id
+    assert payload["items"][0]["teacher_state"] == "active"
+    assert payload["items"][0]["teacher_assignment"]["kind"] == "membership"
+
+
+def test_issue55_courses_support_pending_invite_search_and_stale_pending_state(
+    client,
+    seed_identity,
+    seed_course,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000558"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+
+    valid_invite, _ = seed_invite(
+        email="pending.teacher@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Pending Teacher",
+        status="pending",
+    )
+    stale_invite, _ = seed_invite(
+        email="stale.teacher@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Stale Teacher",
+        status="consumed",
+    )
+
+    valid_course = seed_course(
+        university_id=university_id,
+        pending_teacher_invite_id=valid_invite.id,
+        title="Course With Pending Invite",
+        code="PENDING-001",
+    )
+    stale_course = seed_course(
+        university_id=university_id,
+        pending_teacher_invite_id=stale_invite.id,
+        title="Course With Stale Invite",
+        code="STALE-001",
+    )
+
+    search_response = client.get(
+        "/api/admin/courses",
+        params={"search": "pending.teacher@example.edu"},
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+    assert search_response.status_code == 200
+    assert [item["id"] for item in search_response.json()["items"]] == [valid_course.id]
+
+    response = client.get(
+        "/api/admin/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    items_by_id = {item["id"]: item for item in response.json()["items"]}
+    assert items_by_id[valid_course.id]["teacher_state"] == "pending"
+    assert items_by_id[valid_course.id]["teacher_assignment"] == {
+        "kind": "pending_invite",
+        "invite_id": valid_invite.id,
+    }
+    assert items_by_id[stale_course.id]["teacher_state"] == "stale_pending_invite"
+
+
+def test_issue55_courses_return_access_link_status_without_raw_token(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000559"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-links@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    active_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Course With Link",
+    )
+    no_link_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Course Without Link",
+    )
+    _, raw_token = seed_course_access_link(course_id=active_course.id, status="active")
+
+    response = client.get(
+        "/api/admin/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    items_by_id = {item["id"]: item for item in payload["items"]}
+    assert items_by_id[active_course.id]["access_link"] is None
+    assert items_by_id[active_course.id]["access_link_status"] == "active"
+    assert items_by_id[no_link_course.id]["access_link_status"] == "missing"
+    assert raw_token not in response.text
+
+
+def test_issue55_courses_fail_closed_on_cross_tenant_teacher_assignment(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    admin_university_id = "10000000-0000-0000-0000-000000000560"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=admin_university_id)
+    foreign_teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="foreign-teacher@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000561",
+    )
+
+    broken_course = Course(
+        university_id=admin_university_id,
+        teacher_membership_id=foreign_teacher["membership"].id,
+        pending_teacher_invite_id=None,
+        title="Broken Cross Tenant Course",
+        code="BROKEN-001",
+        semester="2026-I",
+        academic_level="Pregrado",
+        max_students=20,
+        status="active",
+    )
+    db.add(broken_course)
+    db.commit()
+
+    response = client.get(
+        "/api/admin/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "invalid_teacher_assignment"
+
+
+def test_issue55_teacher_options_exclude_stale_invites_and_foreign_tenant_data(
+    client,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000562"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+
+    active_teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="b.teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="B Teacher",
+    )
+    seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="foreign.teacher@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000563",
+        full_name="A Teacher",
+    )
+
+    valid_pending, _ = seed_invite(
+        email="diana@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Diana Lopez",
+    )
+    seed_invite(
+        email="expired@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Expired Teacher",
+        expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    seed_invite(
+        email="consumed@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Consumed Teacher",
+        status="consumed",
+    )
+    seed_invite(
+        email="foreign@example.edu",
+        university_id="10000000-0000-0000-0000-000000000563",
+        role="teacher",
+        full_name="Foreign Invite",
+    )
+
+    response = client.get(
+        "/api/admin/teacher-options",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["active_teachers"] == [
+        {
+            "membership_id": active_teacher["membership"].id,
+            "full_name": "B Teacher",
+            "email": "b.teacher@example.edu",
+        }
+    ]
+    assert payload["pending_invites"] == [
+        {
+            "invite_id": valid_pending.id,
+            "full_name": "Diana Lopez",
+            "email": "diana@example.edu",
+            "status": "pending",
+        }
+    ]
+
+
+def test_issue55_teacher_options_uses_supabase_fallback_for_missing_legacy_email(
+    client,
+    fake_admin_client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000564"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher_user_id = str(uuid.uuid4())
+    seed_identity(
+        user_id=teacher_user_id,
+        email="ignored@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Fallback Teacher",
+        create_legacy_user=False,
+    )
+    fake_admin_client.users_by_id[teacher_user_id] = type(
+        "User",
+        (),
+        {"id": teacher_user_id, "email": "fallback.teacher@example.edu"},
+    )()
+
+    response = client.get(
+        "/api/admin/teacher-options",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["active_teachers"][0]["email"] == "fallback.teacher@example.edu"
+    assert fake_admin_client.get_user_by_id_calls[teacher_user_id] == 1
+
+
+def test_issue55_teacher_options_caches_supabase_fallback_between_requests(
+    client,
+    fake_admin_client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000566"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher_user_id = str(uuid.uuid4())
+    seed_identity(
+        user_id=teacher_user_id,
+        email="ignored-cache@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Cached Teacher",
+        create_legacy_user=False,
+    )
+    fake_admin_client.users_by_id[teacher_user_id] = type(
+        "User",
+        (),
+        {"id": teacher_user_id, "email": "cached.teacher@example.edu"},
+    )()
+
+    first_response = client.get(
+        "/api/admin/teacher-options",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+    second_response = client.get(
+        "/api/admin/teacher-options",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert fake_admin_client.get_user_by_id_calls[teacher_user_id] == 1
+
+
+def test_issue55_teacher_options_fail_explicitly_if_email_is_unavailable(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000565"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-no-email@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="No Email Teacher",
+        create_legacy_user=False,
+    )
+
+    response = client.get(
+        "/api/admin/teacher-options",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "teacher_email_unavailable"


### PR DESCRIPTION
## Summary
- add reusable admin context resolution for tenant-scoped university admin APIs
- add `GET /api/admin/dashboard/summary`, `GET /api/admin/courses`, and `GET /api/admin/teacher-options`
- keep `shared.app` thin by mounting a dedicated admin router and moving query/serialization logic into `shared.admin_reads`
- return structured teacher assignment state, pagination metadata, and safe `access_link_status` without reconstructing raw tokens
- add backend fixtures and regression coverage for admin auth, tenant isolation, stale pending invites, pagination, and cached Supabase fallback for teacher emails

## Test Coverage
- Added dedicated backend coverage in `backend/tests/test_issue55_admin_reads.py`
- Verified new admin read paths for auth/context, KPIs, filters, pagination, stale pending invites, tenant isolation, access-link safety, and teacher email fallback caching

## Pre-Landing Review
- Reviewed before PR. No blocking issues found.
- Residual latency risk on teacher email fallback was reduced with a TTL cache around Supabase lookups.

## Design Review
- No frontend files changed, design review skipped.

## Eval Results
- No prompt-related files changed, evals skipped.

## Plan Completion
- Completed the Issue 55 backend scope from `docs/planPlataforma/PlanesFases/fase2_dashboardAdmin.md`.
- Deferred nothing. This PR is backend-only by design.

## Verification Results
- `uv run --directory backend pytest -q`
- `uv run --directory backend mypy src`
- Result: `107 passed, 12 skipped`
- Result: `Success: no issues found in 27 source files`

## Test Plan
- [x] Backend pytest passes
- [x] Backend mypy passes

Generated with Codex
