### PR TITLE
feat(admin): implement admin write-path and link rotation

### DIFF
--- a/backend/src/shared/admin_reads.py
+++ b/backend/src/shared/admin_reads.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session, aliased
 
 from shared.admin_context import AdminContext
 from shared.auth import get_supabase_admin_auth_client
+from shared.invite_status import invite_effective_status_from_fields
 from shared.models import Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, User
 
 
@@ -53,7 +54,7 @@ class CourseListItemResponse(BaseModel):
     students_count: int
     max_students: int
     occupancy_percent: int
-    access_link: None = None
+    access_link: str | None = None
     access_link_status: AccessLinkStatus
 
 
@@ -85,12 +86,6 @@ class TeacherOptionsResponse(BaseModel):
 
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
-
-
-def _effective_invite_status(invite_status: str, expires_at: datetime | None) -> str:
-    if invite_status == "pending" and expires_at is not None and expires_at <= utc_now():
-        return "expired"
-    return invite_status
 
 
 def _clamp_percent(value: int) -> int:
@@ -310,7 +305,7 @@ def _build_courses_query(
     return stmt
 
 
-def _serialize_course_item(row: dict[str, Any]) -> CourseListItemResponse:
+def _serialize_course_item(row: dict[str, Any], *, access_link: str | None = None) -> CourseListItemResponse:
     course_teacher_membership_id = row["course_teacher_membership_id"]
     course_pending_teacher_invite_id = row["course_pending_teacher_invite_id"]
     students_count = int(row["students_count"])
@@ -344,7 +339,7 @@ def _serialize_course_item(row: dict[str, Any]) -> CourseListItemResponse:
             students_count=students_count,
             max_students=max_students,
             occupancy_percent=_calculate_percent(students_count, max_students),
-            access_link=None,
+            access_link=access_link,
             access_link_status="active" if row["active_link_status"] == "active" else "missing",
         )
 
@@ -361,7 +356,7 @@ def _serialize_course_item(row: dict[str, Any]) -> CourseListItemResponse:
             detail="teacher_display_name_unavailable",
         )
 
-    effective_invite_status = _effective_invite_status(
+    effective_invite_status = invite_effective_status_from_fields(
         row["pending_invite_status"],
         row["pending_invite_expires_at"],
     )
@@ -383,9 +378,41 @@ def _serialize_course_item(row: dict[str, Any]) -> CourseListItemResponse:
         students_count=students_count,
         max_students=max_students,
         occupancy_percent=_calculate_percent(students_count, max_students),
-        access_link=None,
+        access_link=access_link,
         access_link_status="active" if row["active_link_status"] == "active" else "missing",
     )
+
+
+def get_admin_course_item(
+    db: Session,
+    context: AdminContext,
+    course_id: str,
+    *,
+    access_link: str | None = None,
+) -> CourseListItemResponse:
+    row = (
+        db.execute(
+            _build_courses_query(
+                context=context,
+                search=None,
+                semester=None,
+                course_status=None,
+                academic_level=None,
+            )
+            .where(Course.id == course_id)
+            .limit(1)
+        )
+        .mappings()
+        .first()
+    )
+
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="course_not_found",
+        )
+
+    return _serialize_course_item(dict(row), access_link=access_link)
 
 
 def list_admin_courses(

--- a/backend/src/shared/admin_router.py
+++ b/backend/src/shared/admin_router.py
@@ -8,11 +8,22 @@ from sqlalchemy.orm import Session
 from shared.admin_context import AdminContext, require_admin_context
 from shared.admin_reads import (
     AdminCoursesResponse,
+    CourseListItemResponse,
     DashboardSummaryResponse,
     TeacherOptionsResponse,
     get_dashboard_summary,
     list_admin_courses,
     list_teacher_options,
+)
+from shared.admin_writes import (
+    AdminCourseMutationRequest,
+    CourseAccessLinkRegenerateResponse,
+    CreateTeacherInviteRequest,
+    TeacherInviteResponse,
+    create_admin_course,
+    create_teacher_invite,
+    regenerate_admin_course_access_link,
+    update_admin_course,
 )
 from shared.database import get_db
 
@@ -56,3 +67,43 @@ def get_admin_teacher_options(
     db: Session = Depends(get_db),
 ) -> TeacherOptionsResponse:
     return list_teacher_options(db, context)
+
+
+@router.post("/courses", response_model=CourseListItemResponse, status_code=201)
+def post_admin_course(
+    request: AdminCourseMutationRequest,
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+) -> CourseListItemResponse:
+    return create_admin_course(db, context, request)
+
+
+@router.patch("/courses/{course_id}", response_model=CourseListItemResponse)
+def patch_admin_course(
+    course_id: str,
+    request: AdminCourseMutationRequest,
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+) -> CourseListItemResponse:
+    return update_admin_course(db, context, course_id, request)
+
+
+@router.post("/teacher-invites", response_model=TeacherInviteResponse, status_code=201)
+def post_teacher_invite(
+    request: CreateTeacherInviteRequest,
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+) -> TeacherInviteResponse:
+    return create_teacher_invite(db, context, request)
+
+
+@router.post(
+    "/courses/{course_id}/access-link/regenerate",
+    response_model=CourseAccessLinkRegenerateResponse,
+)
+def post_regenerate_course_access_link(
+    course_id: str,
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+) -> CourseAccessLinkRegenerateResponse:
+    return regenerate_admin_course_access_link(db, context, course_id)

--- a/backend/src/shared/admin_writes.py
+++ b/backend/src/shared/admin_writes.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+import secrets
+import re
+from typing import Any, Literal, NoReturn
+
+from fastapi import HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from shared.admin_context import AdminContext
+from shared.admin_reads import CourseListItemResponse, get_admin_course_item
+from shared.auth import audit_log, hash_invite_token, normalize_email
+from shared.course_access_links import (
+    GeneratedCourseAccessLink,
+    create_course_access_link,
+    regenerate_course_access_link,
+    try_acquire_course_regeneration_lock,
+)
+from shared.invite_status import invite_effective_status, utc_now
+from shared.models import Course, Invite, Membership
+
+
+ACADEMIC_LEVELS = frozenset({"Pregrado", "Especialización", "Maestría", "MBA", "Doctorado"})
+SEMESTER_PATTERN = re.compile(r"^\d{4}-(I|II)$")
+TEACHER_INVITE_TTL = timedelta(days=7)
+_DUPLICATE_COURSE_CONSTRAINT = "uix_courses_university_code_semester"
+
+
+class AdminCourseMutationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    code: str
+    semester: str
+    academic_level: str
+    max_students: int = Field(gt=0)
+    status: Literal["active", "inactive"]
+    teacher_assignment: dict[str, Any]
+
+    @field_validator("title", "code", "semester", "academic_level", mode="before")
+    @classmethod
+    def _strip_text_fields(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator("title", "code")
+    @classmethod
+    def _validate_non_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+    @field_validator("semester")
+    @classmethod
+    def _validate_semester(cls, value: str) -> str:
+        if not SEMESTER_PATTERN.fullmatch(value):
+            raise ValueError("semester must use YYYY-I or YYYY-II")
+        return value
+
+    @field_validator("academic_level")
+    @classmethod
+    def _validate_academic_level(cls, value: str) -> str:
+        if value not in ACADEMIC_LEVELS:
+            raise ValueError("academic_level is invalid")
+        return value
+
+
+class CreateTeacherInviteRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    full_name: str
+    email: str
+
+    @field_validator("full_name", "email", mode="before")
+    @classmethod
+    def _strip_fields(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator("full_name")
+    @classmethod
+    def _validate_full_name(cls, value: str) -> str:
+        if not value:
+            raise ValueError("full_name is required")
+        return value
+
+    @field_validator("email")
+    @classmethod
+    def _validate_email(cls, value: str) -> str:
+        if not value:
+            raise ValueError("email is required")
+        return value
+
+
+class TeacherInviteResponse(BaseModel):
+    invite_id: str
+    full_name: str
+    email: str
+    status: Literal["pending"]
+    activation_link: str
+
+
+class CourseAccessLinkRegenerateResponse(BaseModel):
+    course_id: str
+    access_link: str
+    access_link_status: Literal["active"]
+
+
+@dataclass(slots=True)
+class ResolvedTeacherAssignment:
+    teacher_membership_id: str | None
+    pending_teacher_invite_id: str | None
+    membership_id: str | None = None
+    invite_id: str | None = None
+
+
+def _constraint_name_from_integrity_error(exc: IntegrityError) -> str | None:
+    diag = getattr(getattr(exc, "orig", None), "diag", None)
+    return getattr(diag, "constraint_name", None)
+
+
+def _raise_invalid_teacher_assignment() -> NoReturn:
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail="invalid_teacher_assignment",
+    )
+
+
+def _parse_teacher_assignment(payload: dict[str, Any]) -> tuple[str, str]:
+    if not isinstance(payload, dict):
+        _raise_invalid_teacher_assignment()
+
+    kind = payload.get("kind")
+    if kind == "membership":
+        if set(payload.keys()) != {"kind", "membership_id"}:
+            _raise_invalid_teacher_assignment()
+        membership_id = payload.get("membership_id")
+        if not isinstance(membership_id, str):
+            _raise_invalid_teacher_assignment()
+        stripped_membership_id = membership_id.strip()
+        if not stripped_membership_id:
+            _raise_invalid_teacher_assignment()
+        return kind, stripped_membership_id
+
+    if kind == "pending_invite":
+        if set(payload.keys()) != {"kind", "invite_id"}:
+            _raise_invalid_teacher_assignment()
+        invite_id = payload.get("invite_id")
+        if not isinstance(invite_id, str):
+            _raise_invalid_teacher_assignment()
+        stripped_invite_id = invite_id.strip()
+        if not stripped_invite_id:
+            _raise_invalid_teacher_assignment()
+        return kind, stripped_invite_id
+
+    _raise_invalid_teacher_assignment()
+    raise AssertionError("unreachable")
+
+
+def _resolve_teacher_assignment(
+    db: Session,
+    context: AdminContext,
+    payload: dict[str, Any],
+) -> ResolvedTeacherAssignment:
+    kind, reference_id = _parse_teacher_assignment(payload)
+
+    if kind == "membership":
+        membership = db.scalar(
+            select(Membership).where(
+                Membership.id == reference_id,
+                Membership.university_id == context.university_id,
+                Membership.role == "teacher",
+                Membership.status == "active",
+            )
+        )
+        if membership is None:
+            _raise_invalid_teacher_assignment()
+        assert membership is not None
+
+        return ResolvedTeacherAssignment(
+            teacher_membership_id=membership.id,
+            pending_teacher_invite_id=None,
+            membership_id=membership.id,
+        )
+
+    invite = db.scalar(
+        select(Invite).where(
+            Invite.id == reference_id,
+            Invite.university_id == context.university_id,
+            Invite.role == "teacher",
+        )
+    )
+    if invite is None or invite_effective_status(invite) != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="stale_pending_teacher_invite",
+        )
+
+    return ResolvedTeacherAssignment(
+        teacher_membership_id=None,
+        pending_teacher_invite_id=invite.id,
+        invite_id=invite.id,
+    )
+
+
+def _get_course_for_admin_or_404(db: Session, context: AdminContext, course_id: str) -> Course:
+    course = db.scalar(
+        select(Course).where(
+            Course.id == course_id,
+            Course.university_id == context.university_id,
+        )
+    )
+    if course is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="course_not_found",
+        )
+    return course
+
+
+def _map_course_integrity_error(exc: IntegrityError) -> HTTPException:
+    if _constraint_name_from_integrity_error(exc) == _DUPLICATE_COURSE_CONSTRAINT:
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="duplicate_course_code_in_semester",
+        )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="admin_course_write_failed",
+    )
+
+
+def _build_teacher_activation_link(raw_token: str) -> str:
+    return f"/app/teacher/activate#invite_token={raw_token}"
+
+
+def _emit_course_audit_event(
+    *,
+    event: str,
+    context: AdminContext,
+    course: Course,
+    assignment: ResolvedTeacherAssignment,
+) -> None:
+    audit_log(
+        event,
+        "success",
+        auth_user_id=context.auth_user_id,
+        university_id=context.university_id,
+        course_id=course.id,
+        membership_id=assignment.membership_id,
+        invite_id=assignment.invite_id,
+        http_status=status.HTTP_200_OK,
+    )
+
+
+def create_admin_course(
+    db: Session,
+    context: AdminContext,
+    request: AdminCourseMutationRequest,
+) -> CourseListItemResponse:
+    assignment = _resolve_teacher_assignment(db, context, request.teacher_assignment)
+    generated_link: GeneratedCourseAccessLink | None = None
+
+    try:
+        course = Course(
+            university_id=context.university_id,
+            teacher_membership_id=assignment.teacher_membership_id,
+            pending_teacher_invite_id=assignment.pending_teacher_invite_id,
+            title=request.title,
+            code=request.code,
+            semester=request.semester,
+            academic_level=request.academic_level,
+            max_students=request.max_students,
+            status=request.status,
+        )
+        db.add(course)
+        db.flush()
+        generated_link = create_course_access_link(db, course.id)
+        db.commit()
+    except HTTPException:
+        db.rollback()
+        raise
+    except IntegrityError as exc:
+        db.rollback()
+        raise _map_course_integrity_error(exc) from exc
+
+    item = get_admin_course_item(
+        db,
+        context,
+        course.id,
+        access_link=generated_link.access_link if generated_link is not None else None,
+    )
+    audit_log(
+        "admin.course.created",
+        "success",
+        auth_user_id=context.auth_user_id,
+        university_id=context.university_id,
+        course_id=course.id,
+        link_id=generated_link.link_id if generated_link is not None else None,
+        membership_id=assignment.membership_id,
+        invite_id=assignment.invite_id,
+        http_status=status.HTTP_201_CREATED,
+    )
+    return item
+
+
+def update_admin_course(
+    db: Session,
+    context: AdminContext,
+    course_id: str,
+    request: AdminCourseMutationRequest,
+) -> CourseListItemResponse:
+    course = _get_course_for_admin_or_404(db, context, course_id)
+    assignment = _resolve_teacher_assignment(db, context, request.teacher_assignment)
+    previous_status = course.status
+
+    try:
+        course.title = request.title
+        course.code = request.code
+        course.semester = request.semester
+        course.academic_level = request.academic_level
+        course.max_students = request.max_students
+        course.status = request.status
+        course.teacher_membership_id = assignment.teacher_membership_id
+        course.pending_teacher_invite_id = assignment.pending_teacher_invite_id
+        db.flush()
+        db.commit()
+    except HTTPException:
+        db.rollback()
+        raise
+    except IntegrityError as exc:
+        db.rollback()
+        raise _map_course_integrity_error(exc) from exc
+
+    item = get_admin_course_item(db, context, course.id)
+    event_name = "admin.course.archived" if previous_status != "inactive" and request.status == "inactive" else "admin.course.updated"
+    _emit_course_audit_event(
+        event=event_name,
+        context=context,
+        course=course,
+        assignment=assignment,
+    )
+    return item
+
+
+def create_teacher_invite(
+    db: Session,
+    context: AdminContext,
+    request: CreateTeacherInviteRequest,
+) -> TeacherInviteResponse:
+    normalized_email = normalize_email(request.email)
+    if normalized_email is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="email_required",
+        )
+
+    raw_token = secrets.token_urlsafe(32)
+    try:
+        invite = Invite(
+            token_hash=hash_invite_token(raw_token),
+            email=normalized_email,
+            full_name=request.full_name,
+            university_id=context.university_id,
+            course_id=None,
+            role="teacher",
+            status="pending",
+            expires_at=utc_now() + TEACHER_INVITE_TTL,
+        )
+        db.add(invite)
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="teacher_invite_create_failed",
+        ) from exc
+
+    audit_log(
+        "admin.teacher.invited",
+        "success",
+        auth_user_id=context.auth_user_id,
+        university_id=context.university_id,
+        invite_id=invite.id,
+        http_status=status.HTTP_201_CREATED,
+    )
+    return TeacherInviteResponse(
+        invite_id=invite.id,
+        full_name=request.full_name,
+        email=normalized_email,
+        status="pending",
+        activation_link=_build_teacher_activation_link(raw_token),
+    )
+
+
+def regenerate_admin_course_access_link(
+    db: Session,
+    context: AdminContext,
+    course_id: str,
+) -> CourseAccessLinkRegenerateResponse:
+    course = _get_course_for_admin_or_404(db, context, course_id)
+    if course.status != "active":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="course_inactive",
+        )
+
+    try:
+        if not try_acquire_course_regeneration_lock(db, course.id):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="course_link_regeneration_in_progress",
+            )
+        generated_link = regenerate_course_access_link(db, course.id)
+        db.commit()
+    except HTTPException:
+        db.rollback()
+        raise
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="course_link_regeneration_failed",
+        ) from exc
+
+    audit_log(
+        "admin.course_link.regenerated",
+        "success",
+        auth_user_id=context.auth_user_id,
+        university_id=context.university_id,
+        course_id=course.id,
+        link_id=generated_link.link_id,
+        http_status=status.HTTP_200_OK,
+    )
+    return CourseAccessLinkRegenerateResponse(
+        course_id=course.id,
+        access_link=generated_link.access_link,
+        access_link_status="active",
+    )

--- a/backend/src/shared/admin_writes.py
+++ b/backend/src/shared/admin_writes.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
-import secrets
 import re
+import secrets
 from typing import Any, Literal, NoReturn
 
 from fastapi import HTTPException, status

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -47,6 +47,7 @@ from shared.auth import (
     require_verified_identity,
 )
 from shared.database import SessionLocal, get_db
+from shared.invite_status import invite_effective_status
 from shared.models import (
     AllowedEmailDomain,
     Assignment,
@@ -72,12 +73,6 @@ logger = logging.getLogger(__name__)
 
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
-
-
-def invite_effective_status(invite: Invite) -> str:
-    if invite.status == "pending" and invite.expires_at <= utc_now():
-        return "expired"
-    return invite.status
 
 
 def get_legacy_teacher_or_500(db: Session, actor: CurrentActor) -> User:

--- a/backend/src/shared/auth.py
+++ b/backend/src/shared/auth.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session, joinedload
 from supabase import Client, create_client
 
 from shared.database import get_db
+from shared.invite_status import invite_effective_status
 from shared.models import CourseMembership, Invite, Membership, Profile, User
 
 ENV_FILE = Path(__file__).resolve().parents[2] / ".env"
@@ -190,6 +191,10 @@ def audit_event(
     invite_hash_prefix: str | None = None,
     job_id: str | None = None,
     assignment_id: str | None = None,
+    university_id: str | None = None,
+    course_id: str | None = None,
+    link_id: str | None = None,
+    membership_id: str | None = None,
     http_status: int | None = None,
     reason: str | None = None,
 ) -> None:
@@ -201,6 +206,10 @@ def audit_event(
         "invite_hash_prefix": invite_hash_prefix,
         "job_id": job_id,
         "assignment_id": assignment_id,
+        "university_id": university_id,
+        "course_id": course_id,
+        "link_id": link_id,
+        "membership_id": membership_id,
         "http_status": http_status,
         "reason": reason,
     }
@@ -216,6 +225,10 @@ def audit_log(event: str, outcome: str, **fields: Any) -> None:
         invite_hash_prefix=fields.get("invite_hash_prefix"),
         job_id=fields.get("job_id"),
         assignment_id=fields.get("assignment_id"),
+        university_id=fields.get("university_id"),
+        course_id=fields.get("course_id"),
+        link_id=fields.get("link_id"),
+        membership_id=fields.get("membership_id"),
         http_status=fields.get("http_status"),
         reason=fields.get("reason"),
     )
@@ -544,13 +557,11 @@ def resolve_invite_by_token(db: Session, invite_token: str) -> InviteResolution:
 
 
 def validate_pending_invite(invite: Invite) -> None:
-    expires_at = _coerce_datetime(invite.expires_at)
-    if invite.status != "pending":
-        if invite.status == "expired" or expires_at <= datetime.now(timezone.utc):
-            raise AuthError(410, "invite_expired")
-        raise AuthError(404, "invite_invalid")
-    if expires_at <= datetime.now(timezone.utc):
+    effective_status = invite_effective_status(invite)
+    if effective_status == "expired":
         raise AuthError(410, "invite_expired")
+    if effective_status != "pending":
+        raise AuthError(404, "invite_invalid")
 
 
 def consume_invite(db: Session, invite: Invite) -> bool:

--- a/backend/src/shared/course_access_links.py
+++ b/backend/src/shared/course_access_links.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import secrets
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from shared.auth import hash_course_access_token
+from shared.models import CourseAccessLink
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def generate_course_access_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def serialize_course_access_link(raw_token: str) -> str:
+    return f"/app/join#course_access_token={raw_token}"
+
+
+def course_regeneration_lock_key(course_id: str) -> int:
+    digest = hashlib.sha256(course_id.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=True)
+
+
+def try_acquire_course_regeneration_lock(db: Session, course_id: str) -> bool:
+    lock_key = course_regeneration_lock_key(course_id)
+    return bool(db.scalar(select(func.pg_try_advisory_xact_lock(lock_key))))
+
+
+@dataclass(slots=True)
+class GeneratedCourseAccessLink:
+    link_id: str
+    raw_token: str
+    access_link: str
+    access_link_status: str
+
+
+def create_course_access_link(db: Session, course_id: str) -> GeneratedCourseAccessLink:
+    raw_token = generate_course_access_token()
+    access_link = CourseAccessLink(
+        course_id=course_id,
+        token_hash=hash_course_access_token(raw_token),
+        status="active",
+    )
+    db.add(access_link)
+    db.flush()
+    return GeneratedCourseAccessLink(
+        link_id=access_link.id,
+        raw_token=raw_token,
+        access_link=serialize_course_access_link(raw_token),
+        access_link_status="active",
+    )
+
+
+def regenerate_course_access_link(db: Session, course_id: str) -> GeneratedCourseAccessLink:
+    active_links = db.scalars(
+        select(CourseAccessLink)
+        .where(
+            CourseAccessLink.course_id == course_id,
+            CourseAccessLink.status == "active",
+        )
+        .with_for_update()
+    ).all()
+
+    rotated_at = utc_now()
+    for active_link in active_links:
+        active_link.status = "rotated"
+        active_link.rotated_at = rotated_at
+
+    return create_course_access_link(db, course_id)

--- a/backend/src/shared/invite_status.py
+++ b/backend/src/shared/invite_status.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Protocol
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class InviteStatusCarrier(Protocol):
+    status: str
+    expires_at: datetime
+
+
+def invite_effective_status_from_fields(invite_status: str, expires_at: datetime | None) -> str:
+    if invite_status == "pending" and expires_at is not None and expires_at <= utc_now():
+        return "expired"
+    return invite_status
+
+
+def invite_effective_status(invite: InviteStatusCarrier) -> str:
+    return invite_effective_status_from_fields(invite.status, invite.expires_at)

--- a/backend/tests/test_issue56_admin_writes.py
+++ b/backend/tests/test_issue56_admin_writes.py
@@ -1,0 +1,720 @@
+from __future__ import annotations
+
+from datetime import timedelta
+import uuid
+
+from sqlalchemy import func, select
+
+from shared.course_access_links import course_regeneration_lock_key
+from shared.database import SessionLocal
+from shared.invite_status import utc_now
+from shared.models import Course, CourseAccessLink, Invite
+
+
+def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
+    return auth_headers_factory(sub=user_id, email=email)
+
+
+def _seed_admin(seed_identity, *, university_id: str) -> tuple[str, str]:
+    user_id = str(uuid.uuid4())
+    email = f"admin-{uuid.uuid4().hex[:8]}@example.edu"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="university_admin",
+        university_id=university_id,
+        create_legacy_user=False,
+        full_name="Admin User",
+    )
+    return user_id, email
+
+
+def _course_payload(*, teacher_assignment: dict[str, str], **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "title": "Gerencia Estratégica y Modelos de Negocio",
+        "code": "GTD-GEME-01",
+        "semester": "2026-I",
+        "academic_level": "Especialización",
+        "max_students": 30,
+        "status": "active",
+        "teacher_assignment": teacher_assignment,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _flatten_audit_payload(calls: list[tuple[str, str, dict[str, object]]]) -> str:
+    return " ".join(f"{event} {outcome} {fields}" for event, outcome, fields in calls)
+
+
+def test_issue56_create_course_with_teacher_membership_creates_initial_access_link(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000601"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-membership-create@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Membership",
+    )
+
+    response = client.post(
+        "/api/admin/courses",
+        json=_course_payload(teacher_assignment={"kind": "membership", "membership_id": teacher["membership"].id}),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["teacher_assignment"] == {
+        "kind": "membership",
+        "membership_id": teacher["membership"].id,
+    }
+    assert payload["teacher_state"] == "active"
+    assert payload["access_link_status"] == "active"
+    assert payload["access_link"].startswith("/app/join#course_access_token=")
+
+    raw_token = payload["access_link"].split("=", maxsplit=1)[1]
+    stored_link = db.scalar(select(CourseAccessLink).where(CourseAccessLink.course_id == payload["id"]))
+    assert stored_link is not None
+    assert stored_link.status == "active"
+    assert raw_token not in stored_link.token_hash
+
+
+def test_issue56_create_course_with_pending_teacher_invite(
+    client,
+    db,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000602"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    invite, _ = seed_invite(
+        email="pending-teacher-create@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Pending Teacher Create",
+    )
+
+    response = client.post(
+        "/api/admin/courses",
+        json=_course_payload(teacher_assignment={"kind": "pending_invite", "invite_id": invite.id}),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["teacher_assignment"] == {
+        "kind": "pending_invite",
+        "invite_id": invite.id,
+    }
+    assert payload["teacher_state"] == "pending"
+    created_course = db.get(Course, payload["id"])
+    assert created_course is not None
+    assert created_course.pending_teacher_invite_id == invite.id
+    assert created_course.teacher_membership_id is None
+
+
+def test_issue56_create_course_rejects_malformed_teacher_assignment(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000603"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+
+    response = client.post(
+        "/api/admin/courses",
+        json=_course_payload(teacher_assignment={"kind": "membership"}),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "invalid_teacher_assignment"
+
+
+def test_issue56_create_course_rejects_invalid_teacher_membership_selection(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000604"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    foreign_teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="foreign-membership@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000605",
+    )
+
+    response = client.post(
+        "/api/admin/courses",
+        json=_course_payload(
+            teacher_assignment={"kind": "membership", "membership_id": foreign_teacher["membership"].id}
+        ),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "invalid_teacher_assignment"
+
+
+def test_issue56_create_course_rejects_stale_pending_teacher_invite(
+    client,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000606"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    invite, _ = seed_invite(
+        email="stale-pending-create@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Stale Pending",
+        status="consumed",
+    )
+
+    response = client.post(
+        "/api/admin/courses",
+        json=_course_payload(teacher_assignment={"kind": "pending_invite", "invite_id": invite.id}),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "stale_pending_teacher_invite"
+
+
+def test_issue56_create_course_translates_duplicate_code_and_semester_conflict(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000607"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="duplicate-code-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        code="GTD-GEME-01",
+        semester="2026-I",
+    )
+
+    response = client.post(
+        "/api/admin/courses",
+        json=_course_payload(teacher_assignment={"kind": "membership", "membership_id": teacher["membership"].id}),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "duplicate_course_code_in_semester"
+
+
+def test_issue56_patch_course_updates_visible_fields_and_switches_to_pending_invite(
+    client,
+    seed_identity,
+    seed_course,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000608"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="patch-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Patch Teacher",
+    )
+    invite, _ = seed_invite(
+        email="patch-pending@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Patch Pending",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Original Title",
+        code="PATCH-001",
+        max_students=25,
+    )
+
+    response = client.patch(
+        f"/api/admin/courses/{course.id}",
+        json=_course_payload(
+            teacher_assignment={"kind": "pending_invite", "invite_id": invite.id},
+            title="Updated Title",
+            code="PATCH-002",
+            max_students=35,
+        ),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["title"] == "Updated Title"
+    assert payload["code"] == "PATCH-002"
+    assert payload["max_students"] == 35
+    assert payload["teacher_assignment"] == {"kind": "pending_invite", "invite_id": invite.id}
+    assert payload["teacher_state"] == "pending"
+    assert payload["access_link"] is None
+
+
+def test_issue56_patch_course_switches_from_pending_invite_to_membership(
+    client,
+    seed_identity,
+    seed_course,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000609"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="switch-membership@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Switch Membership",
+    )
+    invite, _ = seed_invite(
+        email="switch-invite@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Switch Invite",
+    )
+    course = seed_course(
+        university_id=university_id,
+        pending_teacher_invite_id=invite.id,
+        title="Pending Course",
+        code="PENDING-TO-MEMBERSHIP",
+    )
+
+    response = client.patch(
+        f"/api/admin/courses/{course.id}",
+        json=_course_payload(
+            teacher_assignment={"kind": "membership", "membership_id": teacher["membership"].id},
+            title="Membership Course",
+            code="MEMBERSHIP-COURSE",
+        ),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["teacher_assignment"] == {
+        "kind": "membership",
+        "membership_id": teacher["membership"].id,
+    }
+    assert payload["teacher_state"] == "active"
+
+
+def test_issue56_patch_course_archives_via_inactive_status(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000610"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="archive-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Archive Me",
+        code="ARCHIVE-001",
+    )
+
+    response = client.patch(
+        f"/api/admin/courses/{course.id}",
+        json=_course_payload(
+            teacher_assignment={"kind": "membership", "membership_id": teacher["membership"].id},
+            status="inactive",
+        ),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "inactive"
+    db.expire_all()
+    refreshed = db.get(Course, course.id)
+    assert refreshed is not None
+    assert refreshed.status == "inactive"
+
+
+def test_issue56_patch_course_rejects_cross_tenant_course(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    admin_university_id = "10000000-0000-0000-0000-000000000611"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=admin_university_id)
+    foreign_teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="foreign-course-teacher@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000612",
+    )
+    course = seed_course(
+        university_id=foreign_teacher["tenant"].id,
+        teacher_membership_id=foreign_teacher["membership"].id,
+        title="Foreign Course",
+        code="FOREIGN-001",
+    )
+
+    response = client.patch(
+        f"/api/admin/courses/{course.id}",
+        json=_course_payload(
+            teacher_assignment={"kind": "membership", "membership_id": foreign_teacher["membership"].id}
+        ),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "course_not_found"
+
+
+def test_issue56_patch_course_rejects_stale_pending_teacher_invite(
+    client,
+    seed_identity,
+    seed_course,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000613"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="stale-patch-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    stale_invite, _ = seed_invite(
+        email="stale-patch@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Stale Patch",
+        expires_at=utc_now() - timedelta(minutes=1),
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Stale Invite Course",
+        code="STALE-PATCH-001",
+    )
+
+    response = client.patch(
+        f"/api/admin/courses/{course.id}",
+        json=_course_payload(
+            teacher_assignment={"kind": "pending_invite", "invite_id": stale_invite.id}
+        ),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "stale_pending_teacher_invite"
+
+
+def test_issue56_teacher_invite_persists_full_name_returns_activation_link_and_keeps_course_links_untouched(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000614"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+
+    response = client.post(
+        "/api/admin/teacher-invites",
+        json={"full_name": "  Diana Lopez  ", "email": "  DIANA.LOPEZ@UNIV.EDU "},
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["full_name"] == "Diana Lopez"
+    assert payload["email"] == "diana.lopez@univ.edu"
+    assert payload["status"] == "pending"
+    assert payload["activation_link"].startswith("/app/teacher/activate#invite_token=")
+
+    invite = db.get(Invite, payload["invite_id"])
+    assert invite is not None
+    assert invite.full_name == "Diana Lopez"
+    assert invite.email == "diana.lopez@univ.edu"
+    assert invite.course_id is None
+    assert db.scalar(select(func.count()).select_from(CourseAccessLink)) == 0
+
+
+def test_issue56_regenerate_course_access_link_rotates_previous_link_and_keeps_one_active(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000615"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="regenerate-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Rotate Link Course",
+        code="ROTATE-001",
+    )
+    original_link, original_raw = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        f"/api/admin/courses/{course.id}/access-link/regenerate",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["course_id"] == course.id
+    assert payload["access_link"].startswith("/app/join#course_access_token=")
+    assert original_raw not in payload["access_link"]
+
+    db.expire_all()
+    links = db.scalars(
+        select(CourseAccessLink)
+        .where(CourseAccessLink.course_id == course.id)
+        .order_by(CourseAccessLink.created_at.asc(), CourseAccessLink.id.asc())
+    ).all()
+    assert len([link for link in links if link.status == "active"]) == 1
+    rotated = next(link for link in links if link.id == original_link.id)
+    assert rotated.status == "rotated"
+    assert rotated.rotated_at is not None
+
+
+def test_issue56_regenerate_course_access_link_rejects_inactive_course(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000616"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="inactive-regenerate@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        status="inactive",
+        title="Inactive Rotate Course",
+        code="ROTATE-INACTIVE-001",
+    )
+
+    response = client.post(
+        f"/api/admin/courses/{course.id}/access-link/regenerate",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "course_inactive"
+
+
+def test_issue56_regenerate_course_access_link_returns_conflict_when_lock_is_held(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000617"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="concurrent-regenerate@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Concurrent Rotate Course",
+        code="ROTATE-CONCURRENT-001",
+    )
+    seed_course_access_link(course_id=course.id, status="active")
+
+    blocking_session = SessionLocal()
+    try:
+        blocking_session.execute(select(func.pg_advisory_xact_lock(course_regeneration_lock_key(course.id))))
+
+        response = client.post(
+            f"/api/admin/courses/{course.id}/access-link/regenerate",
+            headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+        )
+    finally:
+        blocking_session.rollback()
+        blocking_session.close()
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "course_link_regeneration_in_progress"
+
+
+def test_issue56_create_course_emits_audit_event_without_raw_token(
+    client,
+    monkeypatch,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000618"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="audit-create-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    captured: list[tuple[str, str, dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        "shared.admin_writes.audit_log",
+        lambda event, outcome, **fields: captured.append((event, outcome, fields)),
+    )
+
+    response = client.post(
+        "/api/admin/courses",
+        json=_course_payload(teacher_assignment={"kind": "membership", "membership_id": teacher["membership"].id}),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 201
+    assert captured[0][0] == "admin.course.created"
+    assert captured[0][1] == "success"
+    assert "course_access_token" not in _flatten_audit_payload(captured)
+
+
+def test_issue56_archive_course_emits_archived_audit_event(
+    client,
+    monkeypatch,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000619"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="audit-archive-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Audit Archive",
+        code="AUDIT-ARCHIVE-001",
+    )
+    captured: list[tuple[str, str, dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        "shared.admin_writes.audit_log",
+        lambda event, outcome, **fields: captured.append((event, outcome, fields)),
+    )
+
+    response = client.patch(
+        f"/api/admin/courses/{course.id}",
+        json=_course_payload(
+            teacher_assignment={"kind": "membership", "membership_id": teacher["membership"].id},
+            status="inactive",
+        ),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    assert captured[0][0] == "admin.course.archived"
+
+
+def test_issue56_teacher_invite_emits_audit_event(
+    client,
+    monkeypatch,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000620"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    captured: list[tuple[str, str, dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        "shared.admin_writes.audit_log",
+        lambda event, outcome, **fields: captured.append((event, outcome, fields)),
+    )
+
+    response = client.post(
+        "/api/admin/teacher-invites",
+        json={"full_name": "Audit Invite", "email": "audit.invite@example.edu"},
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 201
+    assert captured[0][0] == "admin.teacher.invited"
+
+
+def test_issue56_regenerate_course_access_link_emits_audit_event_without_raw_token(
+    client,
+    monkeypatch,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000621"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="audit-regenerate-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Audit Regenerate",
+        code="AUDIT-REGENERATE-001",
+    )
+    seed_course_access_link(course_id=course.id, status="active")
+    captured: list[tuple[str, str, dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        "shared.admin_writes.audit_log",
+        lambda event, outcome, **fields: captured.append((event, outcome, fields)),
+    )
+
+    response = client.post(
+        f"/api/admin/courses/{course.id}/access-link/regenerate",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    assert captured[0][0] == "admin.course_link.regenerated"
+    assert "course_access_token" not in _flatten_audit_payload(captured)


### PR DESCRIPTION
## Summary
- implementa el write-path admin para cursos e invitaciones docentes bajo `/api/admin`
- agrega un servicio canonico para `course_access_links`, con generacion segura de token, hashing y rotacion serializada por curso
- reutiliza el shape de `GET /api/admin/courses` para `POST /api/admin/courses` y `PATCH /api/admin/courses/{id}` para evitar drift con Issue #55
- extrae la semantica efectiva de invites a un helper compartido reutilizable por reads, writes y el futuro Issue #4
- cubre contratos de error, auditoria y concurrencia con tests backend dedicados

## Key Behavior
- `GET /api/admin/courses` sigue devolviendo `access_link: null`
- el dashboard solo recibe links copiables en:
  - `POST /api/admin/courses`
  - `POST /api/admin/courses/{course_id}/access-link/regenerate`
- `POST /api/admin/courses/{course_id}/access-link/regenerate` usa `pg_try_advisory_xact_lock` y responde `409 course_link_regeneration_in_progress` si pierde el lock
- `PATCH /api/admin/courses/{id}` archiva via `status = inactive`, no borra cursos
- `POST /api/admin/teacher-invites` persiste `full_name` y devuelve `activation_link` con `#invite_token=`

## Test Coverage
- `uv run --directory backend pytest -q`
- `uv run --directory backend mypy src`
- nueva suite: `backend/tests/test_issue56_admin_writes.py`

## Pre-Landing Review
- no hice merge ni deploy
- el diff fue revisado localmente antes del PR y la rama quedo con tests backend y tipado en verde

## Test Plan
- [x] backend test suite green
- [x] backend mypy green

🤖 Generated with Codex