### PR TITLE
feat: implement secure course access enrollment

### DIFF
--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -45,8 +45,6 @@ from shared.auth import (
     require_verified_identity,
 )
 from shared.identity_activation import (
-    _allowed_domains_cache,
-    _allowed_domains_lock,
     derive_activation_full_name,
     derive_oauth_full_name,
     ensure_course_membership as ensure_course_membership_impl,

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -8,14 +8,12 @@ import json
 import logging
 import os
 import pathlib
-import threading
+import sys
 import time
 from typing import Any
 import uuid
 
 from pythonjsonlogger.json import JsonFormatter
-
-from cachetools import TTLCache
 
 from dotenv import load_dotenv
 from fastapi import BackgroundTasks, Depends, FastAPI, Header, HTTPException, Request, Response, status
@@ -23,7 +21,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -32,6 +29,7 @@ from sse_starlette.sse import EventSourceResponse
 from case_generator.core.authoring import AuthoringService
 from case_generator.suggest_service import SuggestRequest, SuggestResponse, generate_suggestion
 from shared.admin_router import router as admin_router
+from shared.course_access_router import router as course_access_router
 from shared.auth import (
     AuthError,
     CurrentActor,
@@ -46,10 +44,19 @@ from shared.auth import (
     require_teacher_actor,
     require_verified_identity,
 )
+from shared.identity_activation import (
+    _allowed_domains_cache,
+    _allowed_domains_lock,
+    derive_activation_full_name,
+    derive_oauth_full_name,
+    ensure_course_membership as ensure_course_membership_impl,
+    ensure_email_domain_allowed,
+    upsert_membership as upsert_membership_impl,
+    upsert_profile as upsert_profile_impl,
+)
 from shared.database import SessionLocal, get_db
 from shared.invite_status import invite_effective_status
 from shared.models import (
-    AllowedEmailDomain,
     Assignment,
     AuthoringJob,
     Course,
@@ -69,7 +76,6 @@ _json_handler = logging.StreamHandler()
 _json_handler.setFormatter(JsonFormatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
 logging.basicConfig(handlers=[_json_handler], level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)
-
 
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
@@ -104,79 +110,15 @@ def require_invite_email_match(invite: Invite, email: str | None) -> None:
 
 
 def upsert_profile(db: Session, auth_user_id: str, full_name: str | None) -> Profile:
-    profile = db.scalar(select(Profile).where(Profile.id == auth_user_id))
-    if profile is None:
-        if not full_name:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="full_name_required")
-        profile = Profile(id=auth_user_id, full_name=full_name.strip())
-        db.add(profile)
-        db.flush()
-        return profile
-
-    if full_name and profile.full_name != full_name.strip():
-        profile.full_name = full_name.strip()
-        db.flush()
-    return profile
+    return upsert_profile_impl(db, auth_user_id, full_name)
 
 
 def upsert_membership(db: Session, auth_user_id: str, university_id: str, role: str) -> Membership:
-    membership = db.scalar(
-        select(Membership).where(
-            Membership.user_id == auth_user_id,
-            Membership.university_id == university_id,
-            Membership.role == role,
-        )
-    )
-    if membership is not None:
-        membership.status = "active"
-        membership.must_rotate_password = False
-        db.flush()
-        return membership
-
-    membership = Membership(
-        user_id=auth_user_id,
-        university_id=university_id,
-        role=role,
-        status="active",
-        must_rotate_password=False,
-    )
-    db.add(membership)
-    db.flush()
-    return membership
+    return upsert_membership_impl(db, auth_user_id, university_id, role)
 
 
 def upsert_course_membership(db: Session, course_id: str, membership_id: str) -> tuple[CourseMembership, bool]:
-    course_membership = db.scalar(
-        select(CourseMembership).where(
-            CourseMembership.course_id == course_id,
-            CourseMembership.membership_id == membership_id,
-        )
-    )
-    if course_membership is not None:
-        return course_membership, False
-
-    inserted_id = db.execute(
-        pg_insert(CourseMembership)
-        .values(course_id=course_id, membership_id=membership_id)
-        .on_conflict_do_nothing(constraint="uix_course_membership")
-        .returning(CourseMembership.id)
-    ).scalar_one_or_none()
-
-    if inserted_id is None:
-        existing = db.scalar(
-            select(CourseMembership).where(
-                CourseMembership.course_id == course_id,
-                CourseMembership.membership_id == membership_id,
-            )
-        )
-        if existing is None:  # pragma: no cover
-            raise RuntimeError("course_membership_upsert_failed")
-        return existing, False
-
-    created_membership = db.get(CourseMembership, inserted_id)
-    if created_membership is None:  # pragma: no cover
-        raise RuntimeError("course_membership_inserted_but_missing")
-    return created_membership, True
+    return ensure_course_membership_impl(db, course_id=course_id, membership_id=membership_id)
 
 
 def consume_invite_if_pending(db: Session, invite: Invite) -> bool:
@@ -215,50 +157,6 @@ def activation_state_exists(db: Session, invite: Invite, auth_user_id: str) -> b
 
     return True
 
-
-def derive_oauth_full_name(identity: VerifiedIdentity) -> str | None:
-    user_metadata = identity.claims.get("user_metadata")
-    if isinstance(user_metadata, dict):
-        for key in ("full_name", "name"):
-            value = user_metadata.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-    if identity.email:
-        return identity.email.split("@", maxsplit=1)[0]
-    return None
-
-
-def derive_activation_full_name(full_name: str | None, email: str) -> str:
-    normalized = (full_name or "").strip()
-    if normalized:
-        return normalized
-    return email.split("@", maxsplit=1)[0]
-
-
-# ---------------------------------------------------------------------------
-# Domain validation cache — TTL 5 min, thread-safe via explicit lock.
-# Empty list means no domain restriction configured for that university.
-# ---------------------------------------------------------------------------
-_allowed_domains_cache: TTLCache[str, list[str]] = TTLCache(maxsize=100, ttl=300)
-_allowed_domains_lock = threading.Lock()
-
-
-def _get_allowed_domains(db: Session, university_id: str) -> list[str]:
-    """Return allowed email domains for a university, with TTL caching."""
-    with _allowed_domains_lock:
-        if university_id in _allowed_domains_cache:
-            return _allowed_domains_cache[university_id]
-    domains = db.scalars(
-        select(AllowedEmailDomain.domain).where(
-            AllowedEmailDomain.university_id == university_id,
-        )
-    ).all()
-    result = [d.lower() for d in domains]
-    with _allowed_domains_lock:
-        _allowed_domains_cache[university_id] = result
-    return result
-
-
 def _check_student_email_domain(db: Session, invite: Invite) -> None:
     """Raise 422 if the invite email domain is not in the university's allow-list.
 
@@ -266,13 +164,11 @@ def _check_student_email_domain(db: Session, invite: Invite) -> None:
     accepted). This preserves backward-compatibility for existing universities
     that have not yet configured allowed_email_domains.
     """
-    email_domain = invite.email.split("@")[-1].lower()
-    allowed = _get_allowed_domains(db, invite.university_id)
-    if allowed and email_domain not in allowed:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="email_domain_not_allowed",
-        )
+    ensure_email_domain_allowed(
+        db,
+        university_id=invite.university_id,
+        email=invite.email,
+    )
 
 
 @asynccontextmanager
@@ -283,6 +179,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 app = FastAPI(title="adam-v8.0 - Case Generation API", lifespan=lifespan)
 app.include_router(admin_router)
+app.include_router(course_access_router)
 
 
 @app.middleware("http")
@@ -929,10 +826,20 @@ def activate_password(
         created_new_user = admin_user_result.created
 
     try:
-        upsert_profile(db, auth_user.id, derive_activation_full_name(req.full_name, invite.email))
-        membership = upsert_membership(db, auth_user.id, invite.university_id, invite.role)
+        current_module = sys.modules[__name__]
+        current_module.upsert_profile(
+            db,
+            auth_user.id,
+            derive_activation_full_name(req.full_name, invite.email),
+        )
+        membership = current_module.upsert_membership(
+            db,
+            auth_user.id,
+            invite.university_id,
+            invite.role,
+        )
         if invite.role == "student" and invite.course_id:
-            upsert_course_membership(db, invite.course_id, membership.id)
+            current_module.upsert_course_membership(db, invite.course_id, membership.id)
         if not consume_invite_if_pending(db, invite):
             db.rollback()
             if activation_state_exists(db, invite, auth_user.id):
@@ -1012,10 +919,20 @@ def activate_oauth_complete(
         _check_student_email_domain(db, invite)
 
     try:
-        upsert_profile(db, identity.auth_user_id, derive_oauth_full_name(identity))
-        membership = upsert_membership(db, identity.auth_user_id, invite.university_id, invite.role)
+        current_module = sys.modules[__name__]
+        current_module.upsert_profile(
+            db,
+            identity.auth_user_id,
+            derive_oauth_full_name(identity) or identity.auth_user_id,
+        )
+        membership = current_module.upsert_membership(
+            db,
+            identity.auth_user_id,
+            invite.university_id,
+            invite.role,
+        )
         if invite.role == "student" and invite.course_id:
-            upsert_course_membership(db, invite.course_id, membership.id)
+            current_module.upsert_course_membership(db, invite.course_id, membership.id)
         if not consume_invite_if_pending(db, invite):
             db.rollback()
             if activation_state_exists(db, invite, identity.auth_user_id):

--- a/backend/src/shared/auth.py
+++ b/backend/src/shared/auth.py
@@ -17,7 +17,6 @@ from fastapi import Depends, Header
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 from supabase import Client, create_client
 

--- a/backend/src/shared/auth.py
+++ b/backend/src/shared/auth.py
@@ -381,7 +381,13 @@ class SupabaseAdminAuthClient:
         if admin is None:
             raise RuntimeError("Supabase admin API is unavailable")
 
-        response = admin.create_user({"email": email, "password": password, "email_confirm": True})
+        try:
+            response = admin.create_user({"email": email, "password": password, "email_confirm": True})
+        except Exception:
+            existing_after_conflict = self.get_user_by_email(email)
+            if existing_after_conflict is not None:
+                return AdminUserResult(user=existing_after_conflict, created=False)
+            raise
         user = self._extract_single_user(response)
         return AdminUserResult(user=user, created=True)
 

--- a/backend/src/shared/auth.py
+++ b/backend/src/shared/auth.py
@@ -15,7 +15,8 @@ from jwt import PyJWKClient
 from jwt.exceptions import InvalidTokenError, PyJWKClientError
 from fastapi import Depends, Header
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from sqlalchemy import update
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 from supabase import Client, create_client
@@ -189,6 +190,7 @@ def audit_event(
     auth_user_id: str | None = None,
     invite_id: str | None = None,
     invite_hash_prefix: str | None = None,
+    token_hash_prefix: str | None = None,
     job_id: str | None = None,
     assignment_id: str | None = None,
     university_id: str | None = None,
@@ -204,6 +206,7 @@ def audit_event(
         "auth_user_id": auth_user_id,
         "invite_id": invite_id,
         "invite_hash_prefix": invite_hash_prefix,
+        "token_hash_prefix": token_hash_prefix,
         "job_id": job_id,
         "assignment_id": assignment_id,
         "university_id": university_id,
@@ -223,6 +226,7 @@ def audit_log(event: str, outcome: str, **fields: Any) -> None:
         auth_user_id=fields.get("auth_user_id"),
         invite_id=fields.get("invite_id"),
         invite_hash_prefix=fields.get("invite_hash_prefix"),
+        token_hash_prefix=fields.get("token_hash_prefix"),
         job_id=fields.get("job_id"),
         assignment_id=fields.get("assignment_id"),
         university_id=fields.get("university_id"),
@@ -576,14 +580,19 @@ def consume_invite(db: Session, invite: Invite) -> bool:
 
 
 def ensure_profile(db: Session, *, user_id: str, full_name: str) -> Profile:
-    profile = db.query(Profile).filter(Profile.id == user_id).first()
-    if profile is None:
-        profile = Profile(id=user_id, full_name=full_name)
-        db.add(profile)
-        db.flush()
-        return profile
-    profile.full_name = full_name
-    db.flush()
+    inserted_id = db.execute(
+        pg_insert(Profile)
+        .values(id=user_id, full_name=full_name)
+        .on_conflict_do_update(
+            index_elements=[Profile.id],
+            set_={"full_name": full_name},
+        )
+        .returning(Profile.id)
+    ).scalar_one()
+
+    profile = db.get(Profile, inserted_id)
+    if profile is None:  # pragma: no cover
+        raise RuntimeError("profile_upsert_failed")
     return profile
 
 
@@ -595,56 +604,53 @@ def ensure_membership(
     role: str,
     must_rotate_password: bool = False,
 ) -> Membership:
-    membership = (
-        db.query(Membership)
-        .filter(
-            Membership.user_id == user_id,
-            Membership.university_id == university_id,
-            Membership.role == role,
-        )
-        .first()
-    )
-    if membership is None:
-        membership = Membership(
+    inserted_id = db.execute(
+        pg_insert(Membership)
+        .values(
             user_id=user_id,
             university_id=university_id,
             role=role,
             status="active",
             must_rotate_password=must_rotate_password,
         )
-        db.add(membership)
-        db.flush()
-        return membership
+        .on_conflict_do_update(
+            constraint="uix_membership_user_university_role",
+            set_={
+                "status": "active",
+                "must_rotate_password": must_rotate_password,
+            },
+        )
+        .returning(Membership.id)
+    ).scalar_one()
 
-    membership.status = "active"
-    membership.must_rotate_password = must_rotate_password
-    db.flush()
+    membership = db.get(Membership, inserted_id)
+    if membership is None:  # pragma: no cover
+        raise RuntimeError("membership_upsert_failed")
     return membership
 
 
 def ensure_course_membership(db: Session, *, course_id: str, membership_id: str) -> tuple[CourseMembership, bool]:
-    existing = (
-        db.query(CourseMembership)
-        .filter(CourseMembership.course_id == course_id, CourseMembership.membership_id == membership_id)
-        .first()
-    )
-    if existing is not None:
-        return existing, False
+    inserted_id = db.execute(
+        pg_insert(CourseMembership)
+        .values(course_id=course_id, membership_id=membership_id)
+        .on_conflict_do_nothing(constraint="uix_course_membership")
+        .returning(CourseMembership.id)
+    ).scalar_one_or_none()
 
-    enrollment = CourseMembership(course_id=course_id, membership_id=membership_id)
-    db.add(enrollment)
-    try:
-        db.flush()
-    except IntegrityError:
-        db.rollback()
-        existing = (
-            db.query(CourseMembership)
-            .filter(CourseMembership.course_id == course_id, CourseMembership.membership_id == membership_id)
-            .first()
+    if inserted_id is None:
+        existing = db.scalar(
+            select(CourseMembership).where(
+                CourseMembership.course_id == course_id,
+                CourseMembership.membership_id == membership_id,
+            )
         )
         if existing is None:  # pragma: no cover
-            raise
+            raise RuntimeError("course_membership_upsert_failed")
         return existing, False
+
+    enrollment = db.get(CourseMembership, inserted_id)
+    if enrollment is None:  # pragma: no cover
+        raise RuntimeError("course_membership_inserted_but_missing")
     return enrollment, True
 
 

--- a/backend/src/shared/course_access.py
+++ b/backend/src/shared/course_access.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from fastapi import HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from shared import auth as auth_helpers
+from shared.auth import CurrentActor, VerifiedIdentity, audit_log, hash_course_access_token, normalize_email
+from shared.identity_activation import (
+    allowed_auth_methods_for_university,
+    derive_activation_full_name,
+    derive_oauth_full_name,
+    ensure_email_domain_allowed,
+    ensure_course_membership,
+    upsert_membership as ensure_membership,
+    upsert_profile as ensure_profile,
+)
+from shared.models import Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, Tenant
+
+
+AllowedAuthMethod = Literal["password", "microsoft"]
+EnrollmentStatus = Literal["enrolled", "already_enrolled"]
+
+
+class CourseAccessResolveRequest(BaseModel):
+    course_access_token: str
+
+
+class CourseAccessResolveResponse(BaseModel):
+    course_id: str
+    course_title: str
+    university_name: str
+    teacher_display_name: str | None
+    course_status: Literal["active"]
+    link_status: Literal["active"]
+    allowed_auth_methods: list[AllowedAuthMethod]
+
+
+class CourseAccessEnrollRequest(BaseModel):
+    course_access_token: str
+
+
+class CourseAccessEnrollResponse(BaseModel):
+    status: EnrollmentStatus
+
+
+class CourseAccessActivatePasswordRequest(BaseModel):
+    course_access_token: str
+    email: str | None = None
+    full_name: str | None = None
+    password: str
+    confirm_password: str
+
+
+class CourseAccessActivatePasswordResponse(BaseModel):
+    status: Literal["activated"]
+    next_step: Literal["sign_in"]
+    email: str
+
+
+class CourseAccessActivateOAuthCompleteRequest(BaseModel):
+    course_access_token: str
+
+
+class CourseAccessActivateOAuthCompleteResponse(BaseModel):
+    status: Literal["activated"]
+
+
+@dataclass(slots=True)
+class CourseAccessContext:
+    link: CourseAccessLink
+    course: Course
+    tenant: Tenant
+    teacher_display_name: str | None
+    allowed_auth_methods: list[AllowedAuthMethod]
+
+
+def _course_access_hash_prefix(course_access_token: str) -> str:
+    return hash_course_access_token(course_access_token)[:12]
+
+
+def _resolve_teacher_display_name(db: Session, course: Course) -> str | None:
+    if course.teacher_membership_id is not None:
+        membership = db.get(Membership, course.teacher_membership_id)
+        if membership is None:
+            return None
+        profile = db.get(Profile, membership.user_id)
+        return profile.full_name if profile is not None else None
+
+    if course.pending_teacher_invite_id is not None:
+        pending_invite = db.get(Invite, course.pending_teacher_invite_id)
+        return pending_invite.full_name if pending_invite is not None else None
+
+    return None
+
+
+def _resolve_course_access_context(db: Session, course_access_token: str) -> CourseAccessContext:
+    token_hash_prefix = _course_access_hash_prefix(course_access_token)
+    access_link = db.scalar(
+        select(CourseAccessLink).where(
+            CourseAccessLink.token_hash == hash_course_access_token(course_access_token),
+        )
+    )
+    if access_link is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="invalid_course_access_token",
+        )
+
+    if access_link.status == "rotated":
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail="course_access_link_rotated",
+        )
+
+    if access_link.status == "revoked":
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail="course_access_link_revoked",
+        )
+
+    course = db.get(Course, access_link.course_id)
+    if course is None:  # pragma: no cover
+        audit_log(
+            "course_access.resolve",
+            "invalid",
+            token_hash_prefix=token_hash_prefix,
+            link_id=access_link.id,
+            http_status=status.HTTP_404_NOT_FOUND,
+            reason="invalid_course_access_token",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="invalid_course_access_token",
+        )
+
+    if course.status != "active":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="course_inactive",
+        )
+
+    tenant = db.get(Tenant, course.university_id)
+    if tenant is None:  # pragma: no cover
+        raise RuntimeError("course_access_tenant_missing")
+
+    return CourseAccessContext(
+        link=access_link,
+        course=course,
+        tenant=tenant,
+        teacher_display_name=_resolve_teacher_display_name(db, course),
+        allowed_auth_methods=cast(
+            list[AllowedAuthMethod],
+            [
+                method
+                for method in allowed_auth_methods_for_university(db, course.university_id)
+                if method in {"password", "microsoft"}
+            ],
+        ),
+    )
+
+
+def _require_course_access_context(db: Session, course_access_token: str, *, event: str) -> CourseAccessContext:
+    try:
+        return _resolve_course_access_context(db, course_access_token)
+    except HTTPException as exc:
+        audit_log(
+            event,
+            "denied" if exc.status_code in {status.HTTP_403_FORBIDDEN, status.HTTP_409_CONFLICT} else "invalid",
+            token_hash_prefix=_course_access_hash_prefix(course_access_token),
+            http_status=exc.status_code,
+            reason=str(exc.detail),
+        )
+        raise
+
+
+def _get_student_membership_id(actor: CurrentActor, university_id: str) -> str:
+    for membership in actor.active_memberships:
+        if membership.role == "student" and membership.university_id == university_id:
+            return membership.id
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="student_membership_required",
+    )
+
+
+def _ensure_oauth_allowed(context: CourseAccessContext) -> None:
+    if "microsoft" not in context.allowed_auth_methods:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="auth_method_not_allowed",
+        )
+
+
+def _activation_state_exists_for_user(
+    db: Session,
+    *,
+    auth_user_id: str,
+    university_id: str,
+    course_id: str,
+) -> bool:
+    profile = db.get(Profile, auth_user_id)
+    if profile is None:
+        return False
+
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == auth_user_id,
+            Membership.university_id == university_id,
+            Membership.role == "student",
+            Membership.status == "active",
+        )
+    )
+    if membership is None:
+        return False
+
+    existing_course_membership = db.scalar(
+        select(CourseMembership.id).where(
+            CourseMembership.course_id == course_id,
+            CourseMembership.membership_id == membership.id,
+        )
+    )
+    return existing_course_membership is not None
+
+
+def resolve_course_access(
+    db: Session,
+    request: CourseAccessResolveRequest,
+) -> CourseAccessResolveResponse:
+    context = _require_course_access_context(db, request.course_access_token, event="course_access.resolve")
+    audit_log(
+        "course_access.resolve",
+        "resolved",
+        university_id=context.course.university_id,
+        course_id=context.course.id,
+        link_id=context.link.id,
+        token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+        http_status=status.HTTP_200_OK,
+        reason="active",
+    )
+    return CourseAccessResolveResponse(
+        course_id=context.course.id,
+        course_title=context.course.title,
+        university_name=context.tenant.name,
+        teacher_display_name=context.teacher_display_name,
+        course_status="active",
+        link_status="active",
+        allowed_auth_methods=context.allowed_auth_methods,
+    )
+
+
+def enroll_with_course_access(
+    db: Session,
+    actor: CurrentActor,
+    request: CourseAccessEnrollRequest,
+) -> CourseAccessEnrollResponse:
+    context = _require_course_access_context(db, request.course_access_token, event="course_access.enroll")
+    if actor.email is None:
+        audit_log(
+            "course_access.enroll",
+            "denied",
+            auth_user_id=actor.auth_user_id,
+            university_id=context.course.university_id,
+            course_id=context.course.id,
+            link_id=context.link.id,
+            token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+            http_status=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            reason="course_access_email_required",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="course_access_email_required",
+        )
+
+    ensure_email_domain_allowed(db, context.course.university_id, actor.email)
+    membership_id = _get_student_membership_id(actor, context.course.university_id)
+    _, created = ensure_course_membership(
+        db,
+        course_id=context.course.id,
+        membership_id=membership_id,
+    )
+    db.commit()
+
+    enrollment_status: EnrollmentStatus = "enrolled" if created else "already_enrolled"
+    audit_log(
+        "course_access.enroll",
+        enrollment_status,
+        auth_user_id=actor.auth_user_id,
+        university_id=context.course.university_id,
+        course_id=context.course.id,
+        link_id=context.link.id,
+        membership_id=membership_id,
+        token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+        http_status=status.HTTP_200_OK,
+        reason=enrollment_status,
+    )
+    return CourseAccessEnrollResponse(status=enrollment_status)
+
+
+def activate_course_access_password(
+    db: Session,
+    request: CourseAccessActivatePasswordRequest,
+) -> CourseAccessActivatePasswordResponse:
+    if request.password != request.confirm_password:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="password_mismatch",
+        )
+
+    normalized_email = normalize_email(request.email)
+    if normalized_email is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="course_access_email_required",
+        )
+    if not (request.full_name and request.full_name.strip()):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="full_name_required",
+        )
+
+    context = _require_course_access_context(
+        db,
+        request.course_access_token,
+        event="course_access.activate_password",
+    )
+    ensure_email_domain_allowed(db, context.course.university_id, normalized_email)
+
+    admin_client = auth_helpers.get_supabase_admin_auth_client()
+    existing_user = admin_client.find_user_by_email(normalized_email)
+    if existing_user is not None and _activation_state_exists_for_user(
+        db,
+        auth_user_id=existing_user.id,
+        university_id=context.course.university_id,
+        course_id=context.course.id,
+    ):
+        audit_log(
+            "course_access.activate_password",
+            "activated",
+            auth_user_id=existing_user.id,
+            university_id=context.course.university_id,
+            course_id=context.course.id,
+            link_id=context.link.id,
+            token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+            http_status=status.HTTP_201_CREATED,
+            reason="already_activated",
+        )
+        return CourseAccessActivatePasswordResponse(
+            status="activated",
+            next_step="sign_in",
+            email=normalized_email,
+        )
+
+    created_new_user = False
+    auth_user = existing_user
+    if auth_user is None:
+        created_user_result = admin_client.get_or_create_user_by_email(normalized_email, request.password)
+        auth_user = created_user_result.user
+        created_new_user = created_user_result.created
+
+    try:
+        ensure_profile(
+            db,
+            auth_user_id=auth_user.id,
+            full_name=derive_activation_full_name(request.full_name, normalized_email),
+        )
+        membership = ensure_membership(
+            db,
+            auth_user_id=auth_user.id,
+            university_id=context.course.university_id,
+            role="student",
+        )
+        ensure_course_membership(db, course_id=context.course.id, membership_id=membership.id)
+        db.commit()
+    except HTTPException:
+        db.rollback()
+        raise
+    except Exception as exc:
+        db.rollback()
+        if created_new_user:
+            try:
+                admin_client.delete_user(auth_user.id)
+            except Exception:
+                audit_log(
+                    "course_access.activate_password",
+                    "partial_failure",
+                    auth_user_id=auth_user.id,
+                    university_id=context.course.university_id,
+                    course_id=context.course.id,
+                    link_id=context.link.id,
+                    token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+                    http_status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    reason="compensation_failed",
+                )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="activation_failed",
+        ) from exc
+
+    audit_log(
+        "course_access.activate_password",
+        "activated",
+        auth_user_id=auth_user.id,
+        university_id=context.course.university_id,
+        course_id=context.course.id,
+        link_id=context.link.id,
+        token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+        http_status=status.HTTP_201_CREATED,
+        reason="activated",
+    )
+    return CourseAccessActivatePasswordResponse(
+        status="activated",
+        next_step="sign_in",
+        email=normalized_email,
+    )
+
+
+def activate_course_access_oauth_complete(
+    db: Session,
+    identity: VerifiedIdentity,
+    request: CourseAccessActivateOAuthCompleteRequest,
+) -> CourseAccessActivateOAuthCompleteResponse:
+    context = _require_course_access_context(
+        db,
+        request.course_access_token,
+        event="course_access.activate_oauth",
+    )
+    _ensure_oauth_allowed(context)
+
+    normalized_email = normalize_email(identity.email)
+    if normalized_email is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="course_access_email_required",
+        )
+
+    ensure_email_domain_allowed(db, context.course.university_id, normalized_email)
+    if _activation_state_exists_for_user(
+        db,
+        auth_user_id=identity.auth_user_id,
+        university_id=context.course.university_id,
+        course_id=context.course.id,
+    ):
+        audit_log(
+            "course_access.activate_oauth",
+            "activated",
+            auth_user_id=identity.auth_user_id,
+            university_id=context.course.university_id,
+            course_id=context.course.id,
+            link_id=context.link.id,
+            token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+            http_status=status.HTTP_200_OK,
+            reason="already_activated",
+        )
+        return CourseAccessActivateOAuthCompleteResponse(status="activated")
+
+    try:
+        ensure_profile(
+            db,
+            auth_user_id=identity.auth_user_id,
+            full_name=derive_oauth_full_name(identity) or identity.auth_user_id,
+        )
+        membership = ensure_membership(
+            db,
+            auth_user_id=identity.auth_user_id,
+            university_id=context.course.university_id,
+            role="student",
+        )
+        ensure_course_membership(db, course_id=context.course.id, membership_id=membership.id)
+        db.commit()
+    except HTTPException:
+        db.rollback()
+        raise
+    except Exception as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="activation_failed",
+        ) from exc
+
+    audit_log(
+        "course_access.activate_oauth",
+        "activated",
+        auth_user_id=identity.auth_user_id,
+        university_id=context.course.university_id,
+        course_id=context.course.id,
+        link_id=context.link.id,
+        token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+        http_status=status.HTTP_200_OK,
+        reason="activated",
+    )
+    return CourseAccessActivateOAuthCompleteResponse(status="activated")

--- a/backend/src/shared/course_access.py
+++ b/backend/src/shared/course_access.py
@@ -70,6 +70,14 @@ class CourseAccessActivateOAuthCompleteResponse(BaseModel):
     status: Literal["activated"]
 
 
+class CourseAccessActivateCompleteRequest(BaseModel):
+    course_access_token: str
+
+
+class CourseAccessActivateCompleteResponse(BaseModel):
+    status: Literal["activated"]
+
+
 @dataclass(slots=True)
 class CourseAccessContext:
     link: CourseAccessLink
@@ -441,12 +449,46 @@ def activate_course_access_oauth_complete(
     identity: VerifiedIdentity,
     request: CourseAccessActivateOAuthCompleteRequest,
 ) -> CourseAccessActivateOAuthCompleteResponse:
+    response = _activate_course_access_authenticated(
+        db,
+        identity=identity,
+        course_access_token=request.course_access_token,
+        event="course_access.activate_oauth",
+        require_microsoft=True,
+    )
+    return CourseAccessActivateOAuthCompleteResponse(status=response.status)
+
+
+def activate_course_access_complete(
+    db: Session,
+    identity: VerifiedIdentity,
+    request: CourseAccessActivateCompleteRequest,
+) -> CourseAccessActivateCompleteResponse:
+    response = _activate_course_access_authenticated(
+        db,
+        identity=identity,
+        course_access_token=request.course_access_token,
+        event="course_access.activate_complete",
+        require_microsoft=False,
+    )
+    return CourseAccessActivateCompleteResponse(status=response.status)
+
+
+def _activate_course_access_authenticated(
+    db: Session,
+    *,
+    identity: VerifiedIdentity,
+    course_access_token: str,
+    event: str,
+    require_microsoft: bool,
+) -> CourseAccessActivateCompleteResponse:
     context = _require_course_access_context(
         db,
-        request.course_access_token,
-        event="course_access.activate_oauth",
+        course_access_token,
+        event=event,
     )
-    _ensure_oauth_allowed(context)
+    if require_microsoft:
+        _ensure_oauth_allowed(context)
 
     normalized_email = normalize_email(identity.email)
     if normalized_email is None:
@@ -463,23 +505,23 @@ def activate_course_access_oauth_complete(
         course_id=context.course.id,
     ):
         audit_log(
-            "course_access.activate_oauth",
+            event,
             "activated",
             auth_user_id=identity.auth_user_id,
             university_id=context.course.university_id,
             course_id=context.course.id,
             link_id=context.link.id,
-            token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+            token_hash_prefix=_course_access_hash_prefix(course_access_token),
             http_status=status.HTTP_200_OK,
             reason="already_activated",
         )
-        return CourseAccessActivateOAuthCompleteResponse(status="activated")
+        return CourseAccessActivateCompleteResponse(status="activated")
 
     try:
         ensure_profile(
             db,
             auth_user_id=identity.auth_user_id,
-            full_name=derive_oauth_full_name(identity) or identity.auth_user_id,
+            full_name=derive_oauth_full_name(identity) or normalized_email.split("@", maxsplit=1)[0],
         )
         membership = ensure_membership(
             db,
@@ -500,14 +542,14 @@ def activate_course_access_oauth_complete(
         ) from exc
 
     audit_log(
-        "course_access.activate_oauth",
+        event,
         "activated",
         auth_user_id=identity.auth_user_id,
         university_id=context.course.university_id,
         course_id=context.course.id,
         link_id=context.link.id,
-        token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+        token_hash_prefix=_course_access_hash_prefix(course_access_token),
         http_status=status.HTTP_200_OK,
         reason="activated",
     )
-    return CourseAccessActivateOAuthCompleteResponse(status="activated")
+    return CourseAccessActivateCompleteResponse(status="activated")

--- a/backend/src/shared/course_access.py
+++ b/backend/src/shared/course_access.py
@@ -355,6 +355,23 @@ def activate_course_access_password(
             email=normalized_email,
         )
 
+    if existing_user is not None:
+        audit_log(
+            "course_access.activate_password",
+            "denied",
+            auth_user_id=existing_user.id,
+            university_id=context.course.university_id,
+            course_id=context.course.id,
+            link_id=context.link.id,
+            token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+            http_status=status.HTTP_409_CONFLICT,
+            reason="account_exists_sign_in_required",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="account_exists_sign_in_required",
+        )
+
     created_new_user = False
     auth_user = existing_user
     if auth_user is None:

--- a/backend/src/shared/course_access_router.py
+++ b/backend/src/shared/course_access_router.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import Session
 
 from shared.auth import CurrentActor, VerifiedIdentity, require_current_actor, require_verified_identity
 from shared.course_access import (
+    CourseAccessActivateCompleteRequest,
+    CourseAccessActivateCompleteResponse,
     CourseAccessActivateOAuthCompleteRequest,
     CourseAccessActivateOAuthCompleteResponse,
     CourseAccessActivatePasswordRequest,
@@ -15,6 +17,7 @@ from shared.course_access import (
     CourseAccessEnrollResponse,
     CourseAccessResolveRequest,
     CourseAccessResolveResponse,
+    activate_course_access_complete,
     activate_course_access_oauth_complete,
     activate_course_access_password,
     enroll_with_course_access,
@@ -48,6 +51,15 @@ def post_course_access_activate_password(
     db: Session = Depends(get_db),
 ) -> CourseAccessActivatePasswordResponse:
     return activate_course_access_password(db, request)
+
+
+@router.post("/activate/complete", response_model=CourseAccessActivateCompleteResponse)
+def post_course_access_activate_complete(
+    request: CourseAccessActivateCompleteRequest,
+    identity: Annotated[VerifiedIdentity, Depends(require_verified_identity)],
+    db: Session = Depends(get_db),
+) -> CourseAccessActivateCompleteResponse:
+    return activate_course_access_complete(db, identity, request)
 
 
 @router.post("/activate/oauth/complete", response_model=CourseAccessActivateOAuthCompleteResponse)

--- a/backend/src/shared/course_access_router.py
+++ b/backend/src/shared/course_access_router.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from shared.auth import CurrentActor, VerifiedIdentity, require_current_actor, require_verified_identity
+from shared.course_access import (
+    CourseAccessActivateOAuthCompleteRequest,
+    CourseAccessActivateOAuthCompleteResponse,
+    CourseAccessActivatePasswordRequest,
+    CourseAccessActivatePasswordResponse,
+    CourseAccessEnrollRequest,
+    CourseAccessEnrollResponse,
+    CourseAccessResolveRequest,
+    CourseAccessResolveResponse,
+    activate_course_access_oauth_complete,
+    activate_course_access_password,
+    enroll_with_course_access,
+    resolve_course_access,
+)
+from shared.database import get_db
+
+router = APIRouter(prefix="/api/course-access", tags=["course-access"])
+
+
+@router.post("/resolve", response_model=CourseAccessResolveResponse)
+def post_course_access_resolve(
+    request: CourseAccessResolveRequest,
+    db: Session = Depends(get_db),
+) -> CourseAccessResolveResponse:
+    return resolve_course_access(db, request)
+
+
+@router.post("/enroll", response_model=CourseAccessEnrollResponse)
+def post_course_access_enroll(
+    request: CourseAccessEnrollRequest,
+    actor: Annotated[CurrentActor, Depends(require_current_actor)],
+    db: Session = Depends(get_db),
+) -> CourseAccessEnrollResponse:
+    return enroll_with_course_access(db, actor, request)
+
+
+@router.post("/activate/password", response_model=CourseAccessActivatePasswordResponse, status_code=201)
+def post_course_access_activate_password(
+    request: CourseAccessActivatePasswordRequest,
+    db: Session = Depends(get_db),
+) -> CourseAccessActivatePasswordResponse:
+    return activate_course_access_password(db, request)
+
+
+@router.post("/activate/oauth/complete", response_model=CourseAccessActivateOAuthCompleteResponse)
+def post_course_access_activate_oauth_complete(
+    request: CourseAccessActivateOAuthCompleteRequest,
+    identity: Annotated[VerifiedIdentity, Depends(require_verified_identity)],
+    db: Session = Depends(get_db),
+) -> CourseAccessActivateOAuthCompleteResponse:
+    return activate_course_access_oauth_complete(db, identity, request)

--- a/backend/src/shared/identity_activation.py
+++ b/backend/src/shared/identity_activation.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import threading
+from typing import Any
+
+from cachetools import TTLCache
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from shared.auth import normalize_email
+from shared.models import AllowedEmailDomain, CourseMembership, Membership, Profile, UniversitySsoConfig
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+_allowed_domains_cache: TTLCache[str, list[str]] = TTLCache(maxsize=100, ttl=300)
+_allowed_domains_lock = threading.Lock()
+
+
+def get_allowed_domains(db: Session, university_id: str) -> list[str]:
+    with _allowed_domains_lock:
+        if university_id in _allowed_domains_cache:
+            return _allowed_domains_cache[university_id]
+
+    domains = db.scalars(
+        select(AllowedEmailDomain.domain).where(
+            AllowedEmailDomain.university_id == university_id,
+        )
+    ).all()
+    normalized_domains = [domain.lower() for domain in domains]
+
+    with _allowed_domains_lock:
+        _allowed_domains_cache[university_id] = normalized_domains
+
+    return normalized_domains
+
+
+def ensure_email_domain_allowed(db: Session, university_id: str, email: str) -> None:
+    normalized_email = normalize_email(email)
+    if normalized_email is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="course_access_email_required",
+        )
+
+    email_domain = normalized_email.split("@")[-1].lower()
+    allowed_domains = get_allowed_domains(db, university_id)
+    if allowed_domains and email_domain not in allowed_domains:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="email_domain_not_allowed",
+        )
+
+
+def derive_activation_full_name(full_name: str | None, email: str) -> str:
+    normalized = (full_name or "").strip()
+    if normalized:
+        return normalized
+    return email.split("@", maxsplit=1)[0]
+
+
+def derive_oauth_full_name(identity: Any) -> str | None:
+    claims = getattr(identity, "claims", {})
+    if isinstance(claims, dict):
+        user_metadata = claims.get("user_metadata")
+        if isinstance(user_metadata, dict):
+            for key in ("full_name", "name"):
+                value = user_metadata.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+
+    identity_email = getattr(identity, "email", None)
+    normalized_email = normalize_email(identity_email)
+    if normalized_email:
+        return normalized_email.split("@", maxsplit=1)[0]
+    return None
+
+
+def upsert_profile(db: Session, auth_user_id: str, full_name: str | None) -> Profile:
+    normalized_full_name = (full_name or "").strip()
+    if not normalized_full_name:
+        existing_profile = db.get(Profile, auth_user_id)
+        if existing_profile is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="full_name_required",
+            )
+        return existing_profile
+
+    profile_id = db.execute(
+        pg_insert(Profile)
+        .values(
+            id=auth_user_id,
+            full_name=normalized_full_name,
+            created_at=utc_now(),
+            updated_at=utc_now(),
+        )
+        .on_conflict_do_update(
+            index_elements=[Profile.id],
+            set_={
+                "full_name": normalized_full_name,
+                "updated_at": utc_now(),
+            },
+        )
+        .returning(Profile.id)
+    ).scalar_one()
+
+    profile = db.get(Profile, profile_id)
+    if profile is None:  # pragma: no cover
+        raise RuntimeError("profile_upsert_failed")
+    return profile
+
+
+def upsert_membership(
+    db: Session,
+    auth_user_id: str,
+    university_id: str,
+    role: str,
+    *,
+    must_rotate_password: bool = False,
+) -> Membership:
+    membership_id = db.execute(
+        pg_insert(Membership)
+        .values(
+            user_id=auth_user_id,
+            university_id=university_id,
+            role=role,
+            status="active",
+            must_rotate_password=must_rotate_password,
+            created_at=utc_now(),
+            updated_at=utc_now(),
+        )
+        .on_conflict_do_update(
+            constraint="uix_membership_user_university_role",
+            set_={
+                "status": "active",
+                "must_rotate_password": must_rotate_password,
+                "updated_at": utc_now(),
+            },
+        )
+        .returning(Membership.id)
+    ).scalar_one()
+
+    membership = db.get(Membership, membership_id)
+    if membership is None:  # pragma: no cover
+        raise RuntimeError("membership_upsert_failed")
+    return membership
+
+
+def ensure_course_membership(db: Session, *, course_id: str, membership_id: str) -> tuple[CourseMembership, bool]:
+    inserted_id = db.execute(
+        pg_insert(CourseMembership)
+        .values(
+            course_id=course_id,
+            membership_id=membership_id,
+            created_at=utc_now(),
+        )
+        .on_conflict_do_nothing(constraint="uix_course_membership")
+        .returning(CourseMembership.id)
+    ).scalar_one_or_none()
+
+    if inserted_id is None:
+        existing = db.scalar(
+            select(CourseMembership).where(
+                CourseMembership.course_id == course_id,
+                CourseMembership.membership_id == membership_id,
+            )
+        )
+        if existing is None:  # pragma: no cover
+            raise RuntimeError("course_membership_upsert_failed")
+        return existing, False
+
+    course_membership = db.get(CourseMembership, inserted_id)
+    if course_membership is None:  # pragma: no cover
+        raise RuntimeError("course_membership_inserted_but_missing")
+    return course_membership, True
+
+
+def allowed_auth_methods_for_university(db: Session, university_id: str) -> list[str]:
+    microsoft_enabled = db.scalar(
+        select(UniversitySsoConfig.id).where(
+            UniversitySsoConfig.university_id == university_id,
+            UniversitySsoConfig.provider == "azure",
+            UniversitySsoConfig.enabled == True,  # noqa: E712
+        )
+    )
+    if microsoft_enabled is not None:
+        return ["microsoft", "password"]
+    return ["password"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -297,6 +297,12 @@ def seed_invite(db):
     ) -> tuple[Invite, str]:
         from shared.auth import hash_invite_token
 
+        tenant = db.get(Tenant, university_id)
+        if tenant is None:
+            tenant = Tenant(id=university_id, name=f"Tenant {university_id[-6:]}")
+            db.add(tenant)
+            db.flush()
+
         token = raw_token or f"invite-{uuid.uuid4()}"
         invite = Invite(
             token_hash=hash_invite_token(token),
@@ -414,6 +420,7 @@ class FakeAdminClient:
 @pytest.fixture
 def fake_admin_client(monkeypatch: pytest.MonkeyPatch) -> FakeAdminClient:
     client = FakeAdminClient()
+    monkeypatch.setattr("shared.auth.get_supabase_admin_auth_client", lambda: client)
     monkeypatch.setattr("shared.app.get_supabase_admin_auth_client", lambda: client)
     monkeypatch.setattr("shared.admin_reads.get_supabase_admin_auth_client", lambda: client)
     return client

--- a/backend/tests/test_issue30_auth_perimeter.py
+++ b/backend/tests/test_issue30_auth_perimeter.py
@@ -184,6 +184,40 @@ def test_supabase_admin_get_user_by_email_paginates_across_list_users_pages() ->
     assert admin_client.client.auth.admin.calls == [(1, 200), (2, 200)]
 
 
+def test_supabase_admin_get_or_create_user_by_email_recovers_from_duplicate_create() -> None:
+    settings = build_auth_settings()
+    admin_client = SupabaseAdminAuthClient(settings)
+
+    class StubAdmin:
+        def __init__(self) -> None:
+            self.create_calls = 0
+            self.list_calls: list[tuple[int | None, int | None]] = []
+
+        def create_user(self, payload: dict[str, object]):
+            self.create_calls += 1
+            assert payload["email"] == "race@example.edu"
+            raise RuntimeError("user already exists")
+
+        def list_users(self, page: int | None = None, per_page: int | None = None):
+            self.list_calls.append((page, per_page))
+            if len(self.list_calls) == 1:
+                return []
+            return [{"id": "existing-user", "email": "race@example.edu"}]
+
+    class StubClient:
+        def __init__(self) -> None:
+            self.auth = type("Auth", (), {"admin": StubAdmin()})()
+
+    admin_client._client = StubClient()
+
+    result = admin_client.get_or_create_user_by_email("race@example.edu", "Secure1234!")
+
+    assert result.created is False
+    assert result.user.id == "existing-user"
+    assert admin_client.client.auth.admin.create_calls == 1
+    assert admin_client.client.auth.admin.list_calls == [(1, 200), (1, 200)]
+
+
 def test_auth_me_profile_incomplete(client, auth_headers_factory, seed_identity) -> None:
     user_id = str(uuid.uuid4())
     email = "noprofile@example.edu"

--- a/backend/tests/test_issue57_course_access.py
+++ b/backend/tests/test_issue57_course_access.py
@@ -300,7 +300,7 @@ def test_issue57_course_access_activate_password_creates_membership_and_enrollme
     assert enrollment is not None
 
 
-def test_issue57_course_access_activate_password_reuses_existing_user(
+def test_issue57_course_access_activate_password_returns_idempotent_response_for_existing_activation(
     client,
     db,
     fake_admin_client,
@@ -322,6 +322,14 @@ def test_issue57_course_access_activate_password_reuses_existing_user(
         title="Curso Reuse",
         code="COURSE-ACCESS-006",
     )
+    student = seed_identity(
+        user_id=existing_user.id,
+        email="student.reuse@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    db.add(CourseMembership(course_id=course.id, membership_id=student["membership"].id))
+    db.commit()
     _, token = seed_course_access_link(course_id=course.id, status="active")
 
     response = client.post(
@@ -339,6 +347,46 @@ def test_issue57_course_access_activate_password_reuses_existing_user(
     )
     assert membership is not None
     assert len(fake_admin_client.users_by_email) == 1
+
+
+def test_issue57_course_access_activate_password_existing_account_requires_sign_in(
+    client,
+    db,
+    fake_admin_client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.existing.account@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    fake_admin_client.create_password_user("student.existing.account@example.edu", "Existing123!")
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Existing Account",
+        code="COURSE-ACCESS-006A",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/password",
+        json=_activate_password_payload(token, email="student.existing.account@example.edu"),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "account_exists_sign_in_required"
+    memberships = db.scalars(
+        select(Membership).where(
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    ).all()
+    assert memberships == []
 
 
 def test_issue57_course_access_activate_password_requires_email_and_full_name(

--- a/backend/tests/test_issue57_course_access.py
+++ b/backend/tests/test_issue57_course_access.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import concurrent.futures
-from datetime import datetime, timedelta, timezone
 import threading
 import uuid
 
@@ -387,6 +386,62 @@ def test_issue57_course_access_activate_password_existing_account_requires_sign_
         )
     ).all()
     assert memberships == []
+
+
+def test_issue57_course_access_activate_complete_creates_membership_for_existing_session(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.complete@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Complete",
+        code="COURSE-ACCESS-006B",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+    student_id = str(uuid.uuid4())
+
+    response = client.post(
+        "/api/course-access/activate/complete",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(
+            sub=student_id,
+            email="student.complete@example.edu",
+            claims={"user_metadata": {"full_name": "Estudiante Complete"}},
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "activated"}
+    profile = db.get(Profile, student_id)
+    assert profile is not None
+    assert profile.full_name == "Estudiante Complete"
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == student_id,
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    )
+    assert membership is not None
+    enrollment = db.scalar(
+        select(CourseMembership).where(
+            CourseMembership.course_id == course.id,
+            CourseMembership.membership_id == membership.id,
+        )
+    )
+    assert enrollment is not None
 
 
 def test_issue57_course_access_activate_password_requires_email_and_full_name(

--- a/backend/tests/test_issue57_course_access.py
+++ b/backend/tests/test_issue57_course_access.py
@@ -1,0 +1,634 @@
+from __future__ import annotations
+
+import concurrent.futures
+from datetime import datetime, timedelta, timezone
+import threading
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from shared.models import AllowedEmailDomain, CourseMembership, Membership, Profile, UniversitySsoConfig
+
+
+def _resolve_payload(token: str) -> dict[str, str]:
+    return {"course_access_token": token}
+
+
+def _activate_password_payload(token: str, *, email: str, full_name: str = "Estudiante Test") -> dict[str, str]:
+    return {
+        "course_access_token": token,
+        "email": email,
+        "full_name": full_name,
+        "password": "Secure1234!",
+        "confirm_password": "Secure1234!",
+    }
+
+
+def test_issue57_course_access_resolve_success_returns_course_public_data(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.resolve@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Prof. Resolve",
+    )
+    db.add(
+        UniversitySsoConfig(
+            university_id=university_id,
+            provider="azure",
+            azure_tenant_id="azure-tenant",
+            client_id="client-id",
+            enabled=True,
+        )
+    )
+    db.commit()
+
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Gerencia Estrategica",
+        code="COURSE-ACCESS-001",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post("/api/course-access/resolve", json=_resolve_payload(token))
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "course_id": course.id,
+        "course_title": "Gerencia Estrategica",
+        "university_name": teacher["tenant"].name,
+        "teacher_display_name": "Prof. Resolve",
+        "course_status": "active",
+        "link_status": "active",
+        "allowed_auth_methods": ["microsoft", "password"],
+    }
+
+
+@pytest.mark.parametrize(
+    ("link_status", "course_status", "expected_status", "expected_detail"),
+    [
+        ("missing", "active", 404, "invalid_course_access_token"),
+        ("rotated", "active", 410, "course_access_link_rotated"),
+        ("revoked", "active", 410, "course_access_link_revoked"),
+        ("active", "inactive", 409, "course_inactive"),
+    ],
+)
+def test_issue57_course_access_resolve_fail_closed(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    link_status: str,
+    course_status: str,
+    expected_status: int,
+    expected_detail: str,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.failclosed@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Fail Closed",
+        code=f"FAIL-{uuid.uuid4().hex[:6].upper()}",
+        status=course_status,
+    )
+    token = "missing-token"
+    if link_status != "missing":
+        _, token = seed_course_access_link(course_id=course.id, status=link_status)
+
+    response = client.post("/api/course-access/resolve", json=_resolve_payload(token))
+
+    assert response.status_code == expected_status
+    assert response.json()["detail"] == expected_detail
+
+
+def test_issue57_course_access_enroll_requires_active_student_membership_for_tenant(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.membership@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    outsider = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.outsider@example.edu",
+        role="student",
+        university_id=str(uuid.uuid4()),
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Membership",
+        code="COURSE-ACCESS-002",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/enroll",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(sub=outsider["profile"].id, email="student.outsider@example.edu"),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "student_membership_required"
+
+
+def test_issue57_course_access_enroll_validates_actor_email_domain(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.domain@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.foreign@example.com",
+        role="student",
+        university_id=university_id,
+    )
+    db.add(AllowedEmailDomain(university_id=university_id, domain="universidad.edu"))
+    db.commit()
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Dominio",
+        code="COURSE-ACCESS-003",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/enroll",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(sub=student["profile"].id, email="student.foreign@example.com"),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "email_domain_not_allowed"
+
+
+def test_issue57_course_access_enroll_is_idempotent_under_concurrency(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.concurrent@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.concurrent@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Concurrente",
+        code="COURSE-ACCESS-004",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+    headers = auth_headers_factory(sub=student["profile"].id, email="student.concurrent@example.edu")
+    barrier = threading.Barrier(2)
+
+    def enroll_once():
+        barrier.wait()
+        return client.post("/api/course-access/enroll", json=_resolve_payload(token), headers=headers)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(enroll_once), executor.submit(enroll_once)]
+        responses = [future.result() for future in concurrent.futures.as_completed(futures)]
+
+    statuses = sorted(response.json()["status"] for response in responses)
+    assert statuses == ["already_enrolled", "enrolled"]
+    assert all(response.status_code == 200 for response in responses)
+
+    db.expire_all()
+    course_memberships = db.scalars(
+        select(CourseMembership).where(
+            CourseMembership.course_id == course.id,
+            CourseMembership.membership_id == student["membership"].id,
+        )
+    ).all()
+    assert len(course_memberships) == 1
+
+
+def test_issue57_course_access_activate_password_creates_membership_and_enrollment(
+    client,
+    db,
+    fake_admin_client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.password@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Password",
+        code="COURSE-ACCESS-005",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/password",
+        json=_activate_password_payload(token, email="student.password@example.edu"),
+    )
+
+    assert response.status_code == 201
+    assert response.json() == {
+        "status": "activated",
+        "next_step": "sign_in",
+        "email": "student.password@example.edu",
+    }
+    auth_user = fake_admin_client.users_by_email["student.password@example.edu"]
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == auth_user.id,
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    )
+    assert membership is not None
+    enrollment = db.scalar(
+        select(CourseMembership).where(
+            CourseMembership.course_id == course.id,
+            CourseMembership.membership_id == membership.id,
+        )
+    )
+    assert enrollment is not None
+
+
+def test_issue57_course_access_activate_password_reuses_existing_user(
+    client,
+    db,
+    fake_admin_client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.reuse@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    existing_user = fake_admin_client.create_password_user("student.reuse@example.edu", "Existing123!")
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Reuse",
+        code="COURSE-ACCESS-006",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/password",
+        json=_activate_password_payload(token, email="student.reuse@example.edu"),
+    )
+
+    assert response.status_code == 201
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == existing_user.id,
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    )
+    assert membership is not None
+    assert len(fake_admin_client.users_by_email) == 1
+
+
+def test_issue57_course_access_activate_password_requires_email_and_full_name(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.required@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Required",
+        code="COURSE-ACCESS-007",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    missing_email = client.post(
+        "/api/course-access/activate/password",
+        json={
+            "course_access_token": token,
+            "full_name": "Estudiante",
+            "password": "Secure1234!",
+            "confirm_password": "Secure1234!",
+        },
+    )
+    missing_name = client.post(
+        "/api/course-access/activate/password",
+        json={
+            "course_access_token": token,
+            "email": "student.required@example.edu",
+            "password": "Secure1234!",
+            "confirm_password": "Secure1234!",
+        },
+    )
+
+    assert missing_email.status_code == 422
+    assert missing_email.json()["detail"] == "course_access_email_required"
+    assert missing_name.status_code == 422
+    assert missing_name.json()["detail"] == "full_name_required"
+
+
+def test_issue57_course_access_activate_password_validates_domain(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.domain.password@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    db.add(AllowedEmailDomain(university_id=university_id, domain="universidad.edu"))
+    db.commit()
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Password Domain",
+        code="COURSE-ACCESS-008",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/password",
+        json=_activate_password_payload(token, email="student.foreign@example.com"),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "email_domain_not_allowed"
+
+
+def test_issue57_course_access_activate_oauth_complete_creates_membership_and_enrollment(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.oauth@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    db.add(
+        UniversitySsoConfig(
+            university_id=university_id,
+            provider="azure",
+            azure_tenant_id="azure-tenant",
+            client_id="client-id",
+            enabled=True,
+        )
+    )
+    db.commit()
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso OAuth",
+        code="COURSE-ACCESS-009",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+    student_id = str(uuid.uuid4())
+
+    response = client.post(
+        "/api/course-access/activate/oauth/complete",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(
+            sub=student_id,
+            email="student.oauth@universidad.edu",
+            claims={"user_metadata": {"full_name": "Estudiante OAuth"}},
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "activated"
+    profile = db.get(Profile, student_id)
+    assert profile is not None
+    assert profile.full_name == "Estudiante OAuth"
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == student_id,
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    )
+    assert membership is not None
+    enrollment = db.scalar(
+        select(CourseMembership).where(
+            CourseMembership.course_id == course.id,
+            CourseMembership.membership_id == membership.id,
+        )
+    )
+    assert enrollment is not None
+
+
+def test_issue57_course_access_activate_oauth_complete_enforces_sso_and_domain(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.oauth.rules@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    db.add(AllowedEmailDomain(university_id=university_id, domain="universidad.edu"))
+    db.commit()
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso OAuth Rules",
+        code="COURSE-ACCESS-010",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    no_sso = client.post(
+        "/api/course-access/activate/oauth/complete",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(sub=str(uuid.uuid4()), email="student@universidad.edu"),
+    )
+
+    db.add(
+        UniversitySsoConfig(
+            university_id=university_id,
+            provider="azure",
+            azure_tenant_id="azure-tenant",
+            client_id="client-id",
+            enabled=True,
+        )
+    )
+    db.commit()
+
+    invalid_domain = client.post(
+        "/api/course-access/activate/oauth/complete",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(sub=str(uuid.uuid4()), email="student@foreign.com"),
+    )
+
+    assert no_sso.status_code == 403
+    assert no_sso.json()["detail"] == "auth_method_not_allowed"
+    assert invalid_domain.status_code == 422
+    assert invalid_domain.json()["detail"] == "email_domain_not_allowed"
+
+
+def test_issue57_course_access_activate_oauth_complete_is_idempotent(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.oauth.idempotent@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    db.add(
+        UniversitySsoConfig(
+            university_id=university_id,
+            provider="azure",
+            azure_tenant_id="azure-tenant",
+            client_id="client-id",
+            enabled=True,
+        )
+    )
+    db.commit()
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso OAuth Idempotent",
+        code="COURSE-ACCESS-011",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+    student_id = str(uuid.uuid4())
+    headers = auth_headers_factory(sub=student_id, email="student.oauth.idempotent@universidad.edu")
+
+    first = client.post("/api/course-access/activate/oauth/complete", json=_resolve_payload(token), headers=headers)
+    second = client.post("/api/course-access/activate/oauth/complete", json=_resolve_payload(token), headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    memberships = db.scalars(
+        select(Membership).where(
+            Membership.user_id == student_id,
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    ).all()
+    enrollments = db.scalars(
+        select(CourseMembership)
+        .join(Membership, Membership.id == CourseMembership.membership_id)
+        .where(
+            Membership.user_id == student_id,
+            CourseMembership.course_id == course.id,
+        )
+    ).all()
+    assert len(memberships) == 1
+    assert len(enrollments) == 1
+
+
+def test_issue57_course_access_audit_never_logs_raw_token(
+    client,
+    monkeypatch,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.audit@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Audit",
+        code="COURSE-ACCESS-012",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+    captured: list[tuple[str, str, dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        "shared.course_access.audit_log",
+        lambda event, outcome, **fields: captured.append((event, outcome, fields)),
+    )
+
+    response = client.post("/api/course-access/resolve", json=_resolve_payload(token))
+
+    assert response.status_code == 200
+    flattened = " ".join(str(item) for item in captured)
+    assert token not in flattened

--- a/backend/tests/test_student_activation.py
+++ b/backend/tests/test_student_activation.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 
-from shared.app import _allowed_domains_cache, _allowed_domains_lock
+from shared.identity_activation import _allowed_domains_cache, _allowed_domains_lock
 from shared.models import AllowedEmailDomain, Course, Membership, Profile, Tenant
 
 

--- a/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { AuthCallbackPage } from "./AuthCallbackPage";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import type { AuthMeActor } from "@/app/auth/auth-types";
+
+import { AuthCallbackPage } from "./AuthCallbackPage";
 
 vi.mock("@/app/auth/useAuth");
 vi.mock("@/shared/activationContext");
@@ -16,12 +18,14 @@ vi.mock("@/shared/api", () => ({
             activateOAuthComplete: vi.fn(),
             redeemInvite: vi.fn(),
             enrollWithCourseAccess: vi.fn(),
+            activateCourseAccessComplete: vi.fn(),
             activateCourseAccessOAuthComplete: vi.fn(),
         },
     },
     ApiError: class ApiError extends Error {
         status: number;
         detail?: string;
+
         constructor(status: number, message: string, detail?: string) {
             super(message);
             this.name = "ApiError";
@@ -32,12 +36,9 @@ vi.mock("@/shared/api", () => ({
 }));
 
 import { useAuth } from "@/app/auth/useAuth";
-import {
-    readActivationContext,
-    clearActivationContext,
-} from "@/shared/activationContext";
-import { useNavigate } from "react-router-dom";
+import { clearActivationContext, readActivationContext } from "@/shared/activationContext";
 import { api } from "@/shared/api";
+import { useNavigate } from "react-router-dom";
 
 const mockNavigate = vi.fn();
 const mockRefreshActor = vi.fn();
@@ -76,6 +77,7 @@ describe("AuthCallbackPage", () => {
         vi.mocked(api.auth.activateOAuthComplete).mockResolvedValue({ status: "activated" });
         vi.mocked(api.auth.redeemInvite).mockResolvedValue({ status: "redeemed" });
         vi.mocked(api.auth.enrollWithCourseAccess).mockResolvedValue({ status: "enrolled" });
+        vi.mocked(api.auth.activateCourseAccessComplete).mockResolvedValue({ status: "activated" });
         vi.mocked(api.auth.activateCourseAccessOAuthComplete).mockResolvedValue({ status: "activated" });
     });
 
@@ -92,7 +94,7 @@ describe("AuthCallbackPage", () => {
             </MemoryRouter>,
         );
 
-        expect(screen.getByText(/completando inicio de sesion/i)).toBeTruthy();
+        expect(screen.getByText(/completando inicio de sesión/i)).toBeTruthy();
     });
 
     it("handles teacher invite oauth activation", async () => {
@@ -166,7 +168,30 @@ describe("AuthCallbackPage", () => {
         );
     });
 
-    it("falls back to course access oauth activation when enroll reports missing membership", async () => {
+    it("uses authenticated course access completion when no student membership exists yet", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-access-complete",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(useAuth).mockReturnValue({ ...baseCtx, actor: null });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(api.auth.activateCourseAccessComplete).toHaveBeenCalledWith("course-access-complete"),
+        );
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith("/student", { replace: true }),
+        );
+    });
+
+    it("falls back to authenticated course access completion when enroll reports missing membership", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "student_join_course_access",
             token_kind: "course_access",
@@ -188,7 +213,7 @@ describe("AuthCallbackPage", () => {
         );
 
         await waitFor(() =>
-            expect(api.auth.activateCourseAccessOAuthComplete).toHaveBeenCalledWith("course-access-fallback"),
+            expect(api.auth.activateCourseAccessComplete).toHaveBeenCalledWith("course-access-fallback"),
         );
     });
 
@@ -200,7 +225,7 @@ describe("AuthCallbackPage", () => {
             expires_at: Date.now() + 300000,
         });
         vi.mocked(useAuth).mockReturnValue({ ...baseCtx, actor: null });
-        vi.mocked(api.auth.activateCourseAccessOAuthComplete).mockRejectedValue(
+        vi.mocked(api.auth.activateCourseAccessComplete).mockRejectedValue(
             Object.assign(new Error("course_access_link_rotated"), {
                 detail: "course_access_link_rotated",
                 status: 410,

--- a/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
@@ -7,18 +7,16 @@ import type { AuthMeActor } from "@/app/auth/auth-types";
 vi.mock("@/app/auth/useAuth");
 vi.mock("@/shared/activationContext");
 vi.mock("react-router-dom", async () => {
-    const actual = await vi.importActual<typeof import("react-router-dom")>(
-        "react-router-dom",
-    );
+    const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
     return { ...actual, useNavigate: vi.fn() };
 });
 vi.mock("@/shared/api", () => ({
     api: {
         auth: {
             activateOAuthComplete: vi.fn(),
-            resolveInvite: vi.fn(),
-            activatePassword: vi.fn(),
             redeemInvite: vi.fn(),
+            enrollWithCourseAccess: vi.fn(),
+            activateCourseAccessOAuthComplete: vi.fn(),
         },
     },
     ApiError: class ApiError extends Error {
@@ -42,24 +40,23 @@ import { useNavigate } from "react-router-dom";
 import { api } from "@/shared/api";
 
 const mockNavigate = vi.fn();
+const mockRefreshActor = vi.fn();
 
-const teacherActor: AuthMeActor = {
+const studentActor: AuthMeActor = {
     auth_user_id: "u1",
-    profile: { id: "u1", full_name: "Docente" },
+    profile: { id: "u1", full_name: "Estudiante" },
     memberships: [
         {
             id: "m1",
             university_id: "uni1",
-            role: "teacher",
+            role: "student",
             status: "active",
             must_rotate_password: false,
         },
     ],
     must_rotate_password: false,
-    primary_role: "teacher",
+    primary_role: "student",
 };
-
-const mockRefreshActor = vi.fn();
 
 const baseCtx = {
     session: { access_token: "jwt" } as never,
@@ -77,9 +74,12 @@ describe("AuthCallbackPage", () => {
         vi.mocked(clearActivationContext).mockImplementation(() => undefined);
         vi.mocked(mockRefreshActor).mockResolvedValue(undefined);
         vi.mocked(api.auth.activateOAuthComplete).mockResolvedValue({ status: "activated" });
+        vi.mocked(api.auth.redeemInvite).mockResolvedValue({ status: "redeemed" });
+        vi.mocked(api.auth.enrollWithCourseAccess).mockResolvedValue({ status: "enrolled" });
+        vi.mocked(api.auth.activateCourseAccessOAuthComplete).mockResolvedValue({ status: "activated" });
     });
 
-    it("shows loading state while auth is in flight", () => {
+    it("shows loading state while auth is loading", () => {
         vi.mocked(useAuth).mockReturnValue({
             ...baseCtx,
             loading: true,
@@ -92,130 +92,18 @@ describe("AuthCallbackPage", () => {
             </MemoryRouter>,
         );
 
-        expect(screen.getByText(/completando inicio de sesión/i)).toBeTruthy();
+        expect(screen.getByText(/completando inicio de sesion/i)).toBeTruthy();
     });
 
-    it("redirects teacher to /teacher after successful auth", async () => {
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            actor: teacherActor,
-        });
-
-        render(
-            <MemoryRouter>
-                <AuthCallbackPage />
-            </MemoryRouter>,
-        );
-
-        await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith("/teacher", {
-                replace: true,
-            }),
-        );
-    });
-
-    it("does not clear activation context on plain login (no pending ctx)", async () => {
-        // clearActivationContext() is called only inside terminal activation
-        // branches (success or error), not eagerly at the top of the effect.
-        // Eager clearing was removed to fix a React StrictMode double-invocation
-        // bug where the second effect run found null ctx and navigated to "/".
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            actor: teacherActor,
-        });
-
-        render(
-            <MemoryRouter>
-                <AuthCallbackPage />
-            </MemoryRouter>,
-        );
-
-        await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith("/teacher", {
-                replace: true,
-            }),
-        );
-
-        expect(clearActivationContext).not.toHaveBeenCalled();
-    });
-
-    it("redirects to / when no session after loading", async () => {
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            session: null,
-            actor: null,
-        });
-
-        render(
-            <MemoryRouter>
-                <AuthCallbackPage />
-            </MemoryRouter>,
-        );
-
-        await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true }),
-        );
-    });
-
-    it("redirects to /admin/change-password when must_rotate_password", async () => {
-        const rotateActor: AuthMeActor = {
-            ...teacherActor,
-            must_rotate_password: true,
-            primary_role: "university_admin",
-        };
-
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            actor: rotateActor,
-        });
-
-        render(
-            <MemoryRouter>
-                <AuthCallbackPage />
-            </MemoryRouter>,
-        );
-
-        await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith(
-                "/admin/change-password",
-                { replace: true },
-            ),
-        );
-    });
-
-    it("shows error message when auth error is present", () => {
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            error: "Token inválido",
-            session: null,
-            actor: null,
-        });
-
-        render(
-            <MemoryRouter>
-                <AuthCallbackPage />
-            </MemoryRouter>,
-        );
-
-        expect(
-            screen.getByText(/no se pudo completar el inicio de sesión/i),
-        ).toBeTruthy();
-    });
-
-    // ---- New cases for Issue #37 OAuth activation ----
-
-    it("calls activateOAuthComplete then refreshActor then navigates to /teacher when ctx.flow === teacher_activate", async () => {
+    it("handles teacher invite oauth activation", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
-            invite_token: "tok-abc",
+            token_kind: "invite",
+            invite_token: "teacher-tok",
             role: "teacher",
             expires_at: Date.now() + 300000,
         });
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            actor: null, // not yet activated
-        });
-        vi.mocked(api.auth.activateOAuthComplete).mockResolvedValue({ status: "activated" });
+        vi.mocked(useAuth).mockReturnValue({ ...baseCtx, actor: null });
 
         render(
             <MemoryRouter>
@@ -224,29 +112,72 @@ describe("AuthCallbackPage", () => {
         );
 
         await waitFor(() =>
-            expect(api.auth.activateOAuthComplete).toHaveBeenCalledWith("tok-abc"),
+            expect(api.auth.activateOAuthComplete).toHaveBeenCalledWith("teacher-tok"),
         );
-        await waitFor(() => expect(mockRefreshActor).toHaveBeenCalled());
         await waitFor(() =>
             expect(mockNavigate).toHaveBeenCalledWith("/teacher", { replace: true }),
         );
     });
 
-    it("shows activation error UI (not / redirect) when activateOAuthComplete fails", async () => {
+    it("handles student invite oauth activation", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
-            flow: "teacher_activate",
-            invite_token: "tok-abc",
-            role: "teacher",
+            flow: "student_join_invite",
+            token_kind: "invite",
+            invite_token: "student-invite-tok",
+            role: "student",
             expires_at: Date.now() + 300000,
         });
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            actor: null,
+        vi.mocked(useAuth).mockReturnValue({ ...baseCtx, actor: null });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(api.auth.activateOAuthComplete).toHaveBeenCalledWith("student-invite-tok"),
+        );
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith("/student", { replace: true }),
+        );
+    });
+
+    it("uses course access enroll when the actor already has a student membership", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-access-tok",
+            expires_at: Date.now() + 300000,
         });
-        vi.mocked(api.auth.activateOAuthComplete).mockRejectedValue(
-            Object.assign(new Error("email_mismatch"), {
-                detail: "email_mismatch",
-                status: 422,
+        vi.mocked(useAuth).mockReturnValue({ ...baseCtx, actor: studentActor });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(api.auth.enrollWithCourseAccess).toHaveBeenCalledWith("course-access-tok"),
+        );
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith("/student", { replace: true }),
+        );
+    });
+
+    it("falls back to course access oauth activation when enroll reports missing membership", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-access-fallback",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(useAuth).mockReturnValue({ ...baseCtx, actor: studentActor });
+        vi.mocked(api.auth.enrollWithCourseAccess).mockRejectedValue(
+            Object.assign(new Error("student_membership_required"), {
+                detail: "student_membership_required",
+                status: 403,
             }),
         );
 
@@ -257,122 +188,22 @@ describe("AuthCallbackPage", () => {
         );
 
         await waitFor(() =>
-            expect(
-                screen.getByText(/no coincide con la invitación/i),
-            ).toBeTruthy(),
-        );
-
-        // Must NOT redirect to /
-        expect(mockNavigate).not.toHaveBeenCalledWith("/", { replace: true });
-
-        // Must show link back to /teacher/activate
-        expect(screen.getByText(/volver a activación/i)).toBeTruthy();
-    });
-
-    it("redirects to /teacher for regular login (no ctx, teacher actor)", async () => {
-        vi.mocked(readActivationContext).mockReturnValue(null);
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            actor: teacherActor,
-        });
-
-        render(
-            <MemoryRouter>
-                <AuthCallbackPage />
-            </MemoryRouter>,
-        );
-
-        await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith("/teacher", { replace: true }),
+            expect(api.auth.activateCourseAccessOAuthComplete).toHaveBeenCalledWith("course-access-fallback"),
         );
     });
 
-    // ---- New cases for Issue #39 student_join ----
-
-    it("calls activateOAuthComplete then refreshActor then navigates to /student when ctx.flow === student_join and actor is null", async () => {
+    it("shows course access specific errors", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-abc",
-            role: "student",
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-access-rotated",
             expires_at: Date.now() + 300000,
         });
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            actor: null, // no membership yet — first activation
-        });
-        vi.mocked(api.auth.activateOAuthComplete).mockResolvedValue({ status: "activated" });
-
-        render(
-            <MemoryRouter>
-                <AuthCallbackPage />
-            </MemoryRouter>,
-        );
-
-        await waitFor(() =>
-            expect(api.auth.activateOAuthComplete).toHaveBeenCalledWith("stu-tok-abc"),
-        );
-        await waitFor(() => expect(mockRefreshActor).toHaveBeenCalled());
-        await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith("/student", { replace: true }),
-        );
-    });
-
-    it("calls redeemInvite then refreshActor then navigates to /student when ctx.flow === student_join and actor exists", async () => {
-        const studentActor: AuthMeActor = {
-            ...teacherActor,
-            primary_role: "student",
-            memberships: [
-                {
-                    id: "m2",
-                    university_id: "uni1",
-                    role: "student",
-                    status: "active",
-                    must_rotate_password: false,
-                },
-            ],
-        };
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-xyz",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            actor: studentActor, // already has membership
-        });
-        vi.mocked(api.auth.redeemInvite).mockResolvedValue({ status: "redeemed" });
-
-        render(
-            <MemoryRouter>
-                <AuthCallbackPage />
-            </MemoryRouter>,
-        );
-
-        await waitFor(() =>
-            expect(api.auth.redeemInvite).toHaveBeenCalledWith("stu-tok-xyz"),
-        );
-        await waitFor(() => expect(mockRefreshActor).toHaveBeenCalled());
-        await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith("/student", { replace: true }),
-        );
-    });
-
-    it("shows email_domain_not_allowed error when student_join activateOAuthComplete fails", async () => {
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-domain",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            actor: null,
-        });
-        vi.mocked(api.auth.activateOAuthComplete).mockRejectedValue(
-            Object.assign(new Error("email_domain_not_allowed"), {
-                detail: "email_domain_not_allowed",
-                status: 422,
+        vi.mocked(useAuth).mockReturnValue({ ...baseCtx, actor: null });
+        vi.mocked(api.auth.activateCourseAccessOAuthComplete).mockRejectedValue(
+            Object.assign(new Error("course_access_link_rotated"), {
+                detail: "course_access_link_rotated",
+                status: 410,
             }),
         );
 
@@ -383,45 +214,7 @@ describe("AuthCallbackPage", () => {
         );
 
         await waitFor(() =>
-            expect(
-                screen.getByText(/no está habilitado para esta universidad/i),
-            ).toBeTruthy(),
+            expect(screen.getByText(/fue rotado/i)).toBeTruthy(),
         );
-        // Must show "Contacta a tu docente" instead of link to /teacher/activate
-        expect(screen.getByText(/contacta a tu docente/i)).toBeTruthy();
-        expect(mockNavigate).not.toHaveBeenCalledWith("/", { replace: true });
-    });
-
-    it("redirects to /student for regular login with student actor and no ctx", async () => {
-        const studentActor: AuthMeActor = {
-            ...teacherActor,
-            primary_role: "student",
-            memberships: [
-                {
-                    id: "m2",
-                    university_id: "uni1",
-                    role: "student",
-                    status: "active",
-                    must_rotate_password: false,
-                },
-            ],
-        };
-        vi.mocked(readActivationContext).mockReturnValue(null);
-        vi.mocked(useAuth).mockReturnValue({
-            ...baseCtx,
-            actor: studentActor,
-        });
-
-        render(
-            <MemoryRouter>
-                <AuthCallbackPage />
-            </MemoryRouter>,
-        );
-
-        await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith("/student", { replace: true }),
-        );
-        // Must NOT redirect to /student/login (loop prevention)
-        expect(mockNavigate).not.toHaveBeenCalledWith("/student/login", expect.anything());
     });
 });

--- a/frontend/src/features/auth-callback/AuthCallbackPage.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.tsx
@@ -7,42 +7,38 @@ import {
     clearActivationContext,
 } from "@/shared/activationContext";
 
-/**
- * OAuth PKCE callback page — /app/auth/callback
- *
- * Supabase completes the PKCE code exchange automatically via getSession()
- * in the AuthProvider bootstrap. This page waits for that to finish, reads
- * any short-lived activation context from sessionStorage, cleans it up, and
- * redirects the user to the appropriate destination.
- *
- * Activation flows handled:
- *   teacher_activate — calls activateOAuthComplete, navigates to /teacher
- *   student_join     — calls activateOAuthComplete (no session) or
- *                      redeemInvite (session exists), navigates to /student
- *
- * Security rules:
- * - invite_token is never read from the URL (not in state, path, or query)
- * - activation context is always cleared after this page runs (success or error)
- * - no redirect happens while loading is true (prevents race conditions)
- */
-
 function parseActivationError(err: ApiError): string {
     switch (err.detail) {
         case "invalid_invite":
-            return "Esta invitación ya no es válida. Solicita una nueva.";
+            return "Esta invitacion ya no es valida. Solicita una nueva.";
+        case "invalid_course_access_token":
+            return "Este enlace de acceso ya no es valido.";
+        case "course_access_link_rotated":
+            return "Este enlace fue rotado. Solicita el enlace actualizado.";
+        case "course_access_link_revoked":
+            return "Este enlace fue revocado. Solicita uno nuevo.";
+        case "course_inactive":
+            return "Este curso no esta disponible en este momento.";
         case "email_mismatch":
-        case "invite_email_mismatch": // Backend may return either string
-            return "El correo de tu cuenta Microsoft no coincide con la invitación.";
+        case "invite_email_mismatch":
+            return "El correo de tu cuenta Microsoft no coincide con la invitacion.";
         case "email_domain_not_allowed":
-            return "Tu correo institucional no está habilitado para esta universidad.";
+            return "Tu correo institucional no esta habilitado para esta universidad.";
         case "membership_required":
-            return "No tienes una invitación activa para este curso.";
+        case "student_membership_required":
+            return "No tienes una membresia activa para este curso.";
+        case "auth_method_not_allowed":
+            return "Microsoft no esta habilitado para este curso.";
         default:
-            return "No se pudo completar la activación. Intenta de nuevo.";
+            return "No se pudo completar la activacion. Intenta de nuevo.";
     }
 }
 
-type ActivationFlow = "teacher_activate" | "student_join" | null;
+type ActivationFlow =
+    | "teacher_activate"
+    | "student_join_invite"
+    | "student_join_course_access"
+    | null;
 
 export function AuthCallbackPage() {
     const { session, actor, loading, error, refreshActor } = useAuth();
@@ -57,10 +53,6 @@ export function AuthCallbackPage() {
         handled.current = true;
 
         const ctx = readActivationContext();
-        // Do NOT clear ctx here — React StrictMode double-invokes effects on
-        // mount. The first run would clear sessionStorage; the second run would
-        // find null ctx and navigate("/") before activation completes.
-        // clearActivationContext() is called inside each terminal branch below.
 
         if (!session) {
             clearActivationContext();
@@ -69,9 +61,10 @@ export function AuthCallbackPage() {
         }
 
         if (ctx?.flow === "teacher_activate") {
+            const teacherCtx = ctx;
             async function runTeacherActivation() {
                 try {
-                    await api.auth.activateOAuthComplete(ctx!.invite_token);
+                    await api.auth.activateOAuthComplete(teacherCtx.invite_token);
                     clearActivationContext();
                     await refreshActor();
                     navigate("/teacher", { replace: true });
@@ -85,26 +78,56 @@ export function AuthCallbackPage() {
             return;
         }
 
-        if (ctx?.flow === "student_join") {
-            async function runStudentActivation() {
+        if (ctx?.flow === "student_join_invite") {
+            const inviteCtx = ctx;
+            async function runStudentInviteActivation() {
                 try {
                     if (!actor) {
-                        // No membership yet — full OAuth activation
-                        await api.auth.activateOAuthComplete(ctx!.invite_token);
+                        await api.auth.activateOAuthComplete(inviteCtx.invite_token);
                     } else {
-                        // Already has a membership — just redeem to enroll in course
-                        await api.auth.redeemInvite(ctx!.invite_token);
+                        await api.auth.redeemInvite(inviteCtx.invite_token);
                     }
                     clearActivationContext();
                     await refreshActor();
                     navigate("/student", { replace: true });
                 } catch (err: unknown) {
                     clearActivationContext();
-                    setActivationFlow("student_join");
+                    setActivationFlow("student_join_invite");
                     setActivationError(parseActivationError(err as ApiError));
                 }
             }
-            void runStudentActivation();
+            void runStudentInviteActivation();
+            return;
+        }
+
+        if (ctx?.flow === "student_join_course_access") {
+            const courseAccessCtx = ctx;
+            async function runCourseAccessActivation() {
+                try {
+                    if (!actor) {
+                        await api.auth.activateCourseAccessOAuthComplete(courseAccessCtx.course_access_token);
+                    } else {
+                        try {
+                            await api.auth.enrollWithCourseAccess(courseAccessCtx.course_access_token);
+                        } catch (err: unknown) {
+                            const apiErr = err as ApiError;
+                            if (apiErr.detail === "student_membership_required") {
+                                await api.auth.activateCourseAccessOAuthComplete(courseAccessCtx.course_access_token);
+                            } else {
+                                throw err;
+                            }
+                        }
+                    }
+                    clearActivationContext();
+                    await refreshActor();
+                    navigate("/student", { replace: true });
+                } catch (err: unknown) {
+                    clearActivationContext();
+                    setActivationFlow("student_join_course_access");
+                    setActivationError(parseActivationError(err as ApiError));
+                }
+            }
+            void runCourseAccessActivation();
             return;
         }
 
@@ -137,7 +160,7 @@ export function AuthCallbackPage() {
         return (
             <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
                 <p className="text-sm text-danger">
-                    No se pudo completar el inicio de sesión. Intenta de nuevo.
+                    No se pudo completar el inicio de sesion. Intenta de nuevo.
                 </p>
                 <a href="/app/" className="text-sm underline hover:opacity-80">
                     Volver al inicio
@@ -155,22 +178,21 @@ export function AuthCallbackPage() {
                         href="/app/teacher/activate"
                         className="text-sm underline hover:opacity-80"
                     >
-                        Volver a activación
+                        Volver a activacion
                     </a>
                 ) : (
                     <p className="text-sm text-muted-foreground">
-                        Contacta a tu docente para obtener un nuevo enlace de activación.
+                        Solicita un nuevo enlace si el problema persiste.
                     </p>
                 )}
             </div>
         );
     }
 
-    // Show spinner while waiting for PKCE exchange + actor resolution
     return (
         <div className="flex items-center justify-center py-24">
             <span className="text-sm text-muted-foreground">
-                Completando inicio de sesión…
+                Completando inicio de sesion...
             </span>
         </div>
     );

--- a/frontend/src/features/auth-callback/AuthCallbackPage.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.tsx
@@ -1,36 +1,34 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+
 import { useAuth } from "@/app/auth/useAuth";
 import { api, ApiError } from "@/shared/api";
-import {
-    readActivationContext,
-    clearActivationContext,
-} from "@/shared/activationContext";
+import { clearActivationContext, readActivationContext } from "@/shared/activationContext";
 
 function parseActivationError(err: ApiError): string {
     switch (err.detail) {
         case "invalid_invite":
-            return "Esta invitacion ya no es valida. Solicita una nueva.";
+            return "Esta invitación ya no es válida. Solicita una nueva.";
         case "invalid_course_access_token":
-            return "Este enlace de acceso ya no es valido.";
+            return "Este enlace de acceso ya no es válido.";
         case "course_access_link_rotated":
             return "Este enlace fue rotado. Solicita el enlace actualizado.";
         case "course_access_link_revoked":
             return "Este enlace fue revocado. Solicita uno nuevo.";
         case "course_inactive":
-            return "Este curso no esta disponible en este momento.";
+            return "Este curso no está disponible en este momento.";
         case "email_mismatch":
         case "invite_email_mismatch":
-            return "El correo de tu cuenta Microsoft no coincide con la invitacion.";
+            return "El correo de tu cuenta Microsoft no coincide con la invitación.";
         case "email_domain_not_allowed":
-            return "Tu correo institucional no esta habilitado para esta universidad.";
+            return "Tu correo institucional no está habilitado para esta universidad.";
         case "membership_required":
         case "student_membership_required":
-            return "No tienes una membresia activa para este curso.";
+            return "No tienes una membresía activa para este curso.";
         case "auth_method_not_allowed":
-            return "Microsoft no esta habilitado para este curso.";
+            return "Microsoft no está habilitado para este curso.";
         default:
-            return "No se pudo completar la activacion. Intenta de nuevo.";
+            return "No se pudo completar la activación. Intenta de nuevo.";
     }
 }
 
@@ -104,20 +102,25 @@ export function AuthCallbackPage() {
             const courseAccessCtx = ctx;
             async function runCourseAccessActivation() {
                 try {
-                    if (!actor) {
-                        await api.auth.activateCourseAccessOAuthComplete(courseAccessCtx.course_access_token);
-                    } else {
+                    const hasStudentMembership = actor?.memberships.some(
+                        (membership) => membership.role === "student" && membership.status === "active",
+                    ) ?? false;
+
+                    if (hasStudentMembership) {
                         try {
                             await api.auth.enrollWithCourseAccess(courseAccessCtx.course_access_token);
                         } catch (err: unknown) {
                             const apiErr = err as ApiError;
                             if (apiErr.detail === "student_membership_required") {
-                                await api.auth.activateCourseAccessOAuthComplete(courseAccessCtx.course_access_token);
+                                await api.auth.activateCourseAccessComplete(courseAccessCtx.course_access_token);
                             } else {
                                 throw err;
                             }
                         }
+                    } else {
+                        await api.auth.activateCourseAccessComplete(courseAccessCtx.course_access_token);
                     }
+
                     clearActivationContext();
                     await refreshActor();
                     navigate("/student", { replace: true });
@@ -160,7 +163,7 @@ export function AuthCallbackPage() {
         return (
             <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
                 <p className="text-sm text-danger">
-                    No se pudo completar el inicio de sesion. Intenta de nuevo.
+                    No se pudo completar el inicio de sesión. Intenta de nuevo.
                 </p>
                 <a href="/app/" className="text-sm underline hover:opacity-80">
                     Volver al inicio
@@ -178,7 +181,7 @@ export function AuthCallbackPage() {
                         href="/app/teacher/activate"
                         className="text-sm underline hover:opacity-80"
                     >
-                        Volver a activacion
+                        Volver a activación
                     </a>
                 ) : (
                     <p className="text-sm text-muted-foreground">
@@ -192,7 +195,7 @@ export function AuthCallbackPage() {
     return (
         <div className="flex items-center justify-center py-24">
             <span className="text-sm text-muted-foreground">
-                Completando inicio de sesion...
+                Completando inicio de sesión...
             </span>
         </div>
     );

--- a/frontend/src/features/student-auth/StudentJoinPage.test.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.test.tsx
@@ -6,9 +6,7 @@ import { StudentJoinPage } from "./StudentJoinPage";
 vi.mock("@/shared/activationContext");
 vi.mock("@/shared/supabaseClient");
 vi.mock("react-router-dom", async () => {
-    const actual = await vi.importActual<typeof import("react-router-dom")>(
-        "react-router-dom",
-    );
+    const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
     return { ...actual, useNavigate: vi.fn() };
 });
 
@@ -19,6 +17,10 @@ vi.mock("@/shared/api", () => ({
             activatePassword: vi.fn(),
             activateOAuthComplete: vi.fn(),
             redeemInvite: vi.fn(),
+            resolveCourseAccess: vi.fn(),
+            enrollWithCourseAccess: vi.fn(),
+            activateCourseAccessPassword: vi.fn(),
+            activateCourseAccessOAuthComplete: vi.fn(),
         },
     },
     ApiError: class ApiError extends Error {
@@ -43,16 +45,6 @@ import { useNavigate } from "react-router-dom";
 import { api } from "@/shared/api";
 
 const mockNavigate = vi.fn();
-
-const pendingInvite = {
-    role: "student" as const,
-    email_masked: "s****@universidad.edu",
-    university_name: "Universidad de Prueba",
-    course_title: "Análisis de Datos",
-    teacher_name: "Prof. García",
-    status: "pending" as const,
-    expires_at: new Date(Date.now() + 3600000).toISOString(),
-};
 
 function makeSupabaseMock(
     signInResult: { error: null | { message: string } } = { error: null },
@@ -81,212 +73,105 @@ describe("StudentJoinPage", () => {
         vi.mocked(clearActivationContext).mockImplementation(() => undefined);
         vi.mocked(saveActivationContext).mockImplementation(() => undefined);
         vi.mocked(getSupabaseClient).mockReturnValue(makeSupabaseMock() as never);
-        // Default: resolveInvite hangs unless overridden per test
-        vi.mocked(api.auth.resolveInvite).mockReturnValue(new Promise(() => undefined));
     });
 
-    // 1. Sin activation context → error enlace inválido
-    it("shows invalid link error when there is no activation context", () => {
-        vi.mocked(readActivationContext).mockReturnValue(null);
-
+    it("shows invalid link state when there is no activation context", () => {
         renderPage();
-
-        expect(screen.getByText(/enlace de activación no es válido/i)).toBeTruthy();
+        expect(screen.getByText(/este enlace de acceso no es valido/i)).toBeTruthy();
     });
 
-    // 2. Con activation context → llama resolveInvite con invite_token
-    it("calls resolveInvite with the invite_token from activation context", async () => {
+    it("keeps invite_token flow working", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingInvite);
-
-        renderPage();
-
-        await waitFor(() =>
-            expect(api.auth.resolveInvite).toHaveBeenCalledWith("stu-tok-123"),
-        );
-    });
-
-    // 3. Invite pending → muestra email_masked disabled
-    it("renders activation form with email_masked disabled when invite is pending", async () => {
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingInvite);
-
-        renderPage();
-
-        await waitFor(() =>
-            expect(screen.getByDisplayValue("s****@universidad.edu")).toBeTruthy(),
-        );
-
-        const emailInput = screen.getByDisplayValue("s****@universidad.edu");
-        expect(emailInput).toHaveProperty("disabled", true);
-        expect(screen.getByText("Universidad de Prueba")).toBeTruthy();
-    });
-
-    // 4. teacher_name visible cuando resolvedInvite.teacher_name no es null
-    it("shows teacher_name in form when resolvedInvite.teacher_name is not null", async () => {
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingInvite);
-
-        renderPage();
-
-        await waitFor(() =>
-            expect(screen.getByText(/Prof. García/i)).toBeTruthy(),
-        );
-    });
-
-    // 5. teacher_name NO aparece cuando es null
-    it("does not render teacher_name section when resolvedInvite.teacher_name is null", async () => {
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
+            flow: "student_join_invite",
+            token_kind: "invite",
+            invite_token: "invite-tok-123",
             role: "student",
             expires_at: Date.now() + 300000,
         });
         vi.mocked(api.auth.resolveInvite).mockResolvedValue({
-            ...pendingInvite,
-            teacher_name: null,
+            role: "student",
+            email_masked: "s****@universidad.edu",
+            university_name: "Universidad de Prueba",
+            course_title: "Analisis de Datos",
+            teacher_name: "Prof. Garcia",
+            status: "pending",
+            expires_at: new Date(Date.now() + 3600000).toISOString(),
         });
 
         renderPage();
 
         await waitFor(() =>
-            expect(screen.getByDisplayValue("s****@universidad.edu")).toBeTruthy(),
+            expect(api.auth.resolveInvite).toHaveBeenCalledWith("invite-tok-123"),
         );
-
-        expect(screen.queryByText(/Docente:/i)).toBeNull();
+        expect(screen.getByDisplayValue("s****@universidad.edu")).toHaveProperty("disabled", true);
+        expect(screen.getByText(/Prof. Garcia/i)).toBeTruthy();
     });
 
-    // 6. Invite expired → mensaje específico
-    it("shows expired message when invite status is expired", async () => {
+    it("supports course_access_token resolution and renders editable email", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-tok-123",
             expires_at: Date.now() + 300000,
         });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue({
-            ...pendingInvite,
-            status: "expired",
+        vi.mocked(api.auth.resolveCourseAccess).mockResolvedValue({
+            course_id: "course-1",
+            course_title: "Gerencia Estrategica",
+            university_name: "Universidad Demo",
+            teacher_display_name: "Julio Paz",
+            course_status: "active",
+            link_status: "active",
+            allowed_auth_methods: ["password"],
         });
 
         renderPage();
 
         await waitFor(() =>
-            expect(screen.getByText(/ha expirado/i)).toBeTruthy(),
+            expect(api.auth.resolveCourseAccess).toHaveBeenCalledWith("course-tok-123"),
         );
+        const emailInput = screen.getByPlaceholderText(/tu.correo@universidad.edu/i) as HTMLInputElement;
+        expect(emailInput.disabled).toBe(false);
+        expect(screen.queryByText(/Continuar con Microsoft/i)).toBeNull();
     });
 
-    // 7. Invite consumed → mensaje específico
-    it("shows consumed message when invite status is consumed", async () => {
+    it("shows a specific course access error for rotated links", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-tok-rotated",
             expires_at: Date.now() + 300000,
         });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue({
-            ...pendingInvite,
-            status: "consumed",
-        });
+        vi.mocked(api.auth.resolveCourseAccess).mockRejectedValue(
+            Object.assign(new Error("course_access_link_rotated"), {
+                detail: "course_access_link_rotated",
+                status: 410,
+            }),
+        );
 
         renderPage();
 
         await waitFor(() =>
-            expect(screen.getByText(/ya fue utilizada/i)).toBeTruthy(),
+            expect(screen.getByText(/fue rotado/i)).toBeTruthy(),
         );
     });
 
-    // 8. Invite revoked → mensaje específico
-    it("shows revoked message when invite status is revoked", async () => {
+    it("submits course access password activation and signs in", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-tok-submit",
             expires_at: Date.now() + 300000,
         });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue({
-            ...pendingInvite,
-            status: "revoked",
+        vi.mocked(api.auth.resolveCourseAccess).mockResolvedValue({
+            course_id: "course-1",
+            course_title: "Gerencia Estrategica",
+            university_name: "Universidad Demo",
+            teacher_display_name: "Julio Paz",
+            course_status: "active",
+            link_status: "active",
+            allowed_auth_methods: ["microsoft", "password"],
         });
-
-        renderPage();
-
-        await waitFor(() =>
-            expect(screen.getByText(/fue revocada/i)).toBeTruthy(),
-        );
-    });
-
-    // 9. Passwords no coinciden → error client-side, NO llama activatePassword
-    it("shows client-side error when passwords do not match — does not call activatePassword", async () => {
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingInvite);
-
-        renderPage();
-
-        await waitFor(() => screen.getByText(/Activar cuenta/i));
-
-        const allInputs = document.querySelectorAll("input[type=password]");
-        fireEvent.change(allInputs[0], { target: { value: "password123" } });
-        fireEvent.change(allInputs[1], { target: { value: "different456" } });
-
-        const form = document.querySelector("form")!;
-        await act(async () => {
-            fireEvent.submit(form);
-        });
-
-        expect(screen.getByText(/contraseñas no coinciden/i)).toBeTruthy();
-        expect(api.auth.activatePassword).not.toHaveBeenCalled();
-    });
-
-    // 10. Campo full_name visible y requerido en el formulario
-    it("shows full_name field — required for student activation", async () => {
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingInvite);
-
-        renderPage();
-
-        await waitFor(() => screen.getByText(/Nombre completo/i));
-
-        const fullNameInput = document.querySelector("input[type=text]") as HTMLInputElement;
-        expect(fullNameInput).toBeTruthy();
-        expect(fullNameInput.required).toBe(true);
-    });
-
-    // 11. Submit válido → activatePassword → signInWithPassword → navigate /student
-    it("calls activatePassword then signInWithPassword with res.email and navigates to /student", async () => {
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingInvite);
-        vi.mocked(api.auth.activatePassword).mockResolvedValue({
+        vi.mocked(api.auth.activateCourseAccessPassword).mockResolvedValue({
             status: "activated",
             next_step: "sign_in",
             email: "student@universidad.edu",
@@ -298,27 +183,28 @@ describe("StudentJoinPage", () => {
 
         await waitFor(() => screen.getByText(/Activar cuenta/i));
 
-        const textInputs = document.querySelectorAll("input[type=text]");
-        fireEvent.change(textInputs[0], { target: { value: "Estudiante Test" } });
+        fireEvent.change(screen.getByPlaceholderText(/tu.correo@universidad.edu/i), {
+            target: { value: "student@universidad.edu" },
+        });
+        fireEvent.change(screen.getByPlaceholderText(/Nombre completo/i), {
+            target: { value: "Estudiante Test" },
+        });
+        const passwordInputs = document.querySelectorAll("input[type=password]");
+        fireEvent.change(passwordInputs[0], { target: { value: "Password123!" } });
+        fireEvent.change(passwordInputs[1], { target: { value: "Password123!" } });
 
-        const allInputs = document.querySelectorAll("input[type=password]");
-        fireEvent.change(allInputs[0], { target: { value: "Password123!" } });
-        fireEvent.change(allInputs[1], { target: { value: "Password123!" } });
-
-        const form = document.querySelector("form")!;
         await act(async () => {
-            fireEvent.submit(form);
+            fireEvent.submit(document.querySelector("form")!);
         });
 
         await waitFor(() =>
-            expect(api.auth.activatePassword).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    invite_token: "stu-tok-123",
-                    full_name: "Estudiante Test",
-                    password: "Password123!",
-                    confirm_password: "Password123!",
-                }),
-            ),
+            expect(api.auth.activateCourseAccessPassword).toHaveBeenCalledWith({
+                course_access_token: "course-tok-submit",
+                email: "student@universidad.edu",
+                full_name: "Estudiante Test",
+                password: "Password123!",
+                confirm_password: "Password123!",
+            }),
         );
         await waitFor(() =>
             expect(supabaseMock.auth.signInWithPassword).toHaveBeenCalledWith({
@@ -328,110 +214,6 @@ describe("StudentJoinPage", () => {
         );
         await waitFor(() =>
             expect(mockNavigate).toHaveBeenCalledWith("/student", { replace: true }),
-        );
-    });
-
-    // 12. email_domain_not_allowed → error inline específico
-    it("shows email_domain_not_allowed error when backend rejects the domain", async () => {
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingInvite);
-        vi.mocked(api.auth.activatePassword).mockRejectedValue(
-            Object.assign(new Error("email_domain_not_allowed"), {
-                detail: "email_domain_not_allowed",
-                status: 422,
-            }),
-        );
-
-        renderPage();
-
-        await waitFor(() => screen.getByText(/Activar cuenta/i));
-
-        const textInputs = document.querySelectorAll("input[type=text]");
-        fireEvent.change(textInputs[0], { target: { value: "Estudiante Test" } });
-
-        const allInputs = document.querySelectorAll("input[type=password]");
-        fireEvent.change(allInputs[0], { target: { value: "Password123!" } });
-        fireEvent.change(allInputs[1], { target: { value: "Password123!" } });
-
-        const form = document.querySelector("form")!;
-        await act(async () => {
-            fireEvent.submit(form);
-        });
-
-        await waitFor(() =>
-            expect(
-                screen.getByText(/no está habilitado para esta universidad/i),
-            ).toBeTruthy(),
-        );
-    });
-
-    // 13. activatePassword falla con invalid_invite → error inline
-    it("shows inline error when activatePassword fails with invalid_invite", async () => {
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingInvite);
-        vi.mocked(api.auth.activatePassword).mockRejectedValue(
-            Object.assign(new Error("invalid_invite"), {
-                detail: "invalid_invite",
-                status: 422,
-            }),
-        );
-
-        renderPage();
-
-        await waitFor(() => screen.getByText(/Activar cuenta/i));
-
-        const textInputs = document.querySelectorAll("input[type=text]");
-        fireEvent.change(textInputs[0], { target: { value: "Estudiante Test" } });
-
-        const allInputs = document.querySelectorAll("input[type=password]");
-        fireEvent.change(allInputs[0], { target: { value: "Password123!" } });
-        fireEvent.change(allInputs[1], { target: { value: "Password123!" } });
-
-        const form = document.querySelector("form")!;
-        await act(async () => {
-            fireEvent.submit(form);
-        });
-
-        await waitFor(() =>
-            expect(screen.getByText(/ya no es válida/i)).toBeTruthy(),
-        );
-
-        // Submit button still accessible (inline error, not redirect)
-        expect(screen.getByText(/Activar cuenta/i)).toBeTruthy();
-    });
-
-    // 14. Botón Microsoft → signInWithOAuth con provider: "azure"
-    it("calls signInWithOAuth with provider azure when Microsoft button is clicked", async () => {
-        vi.mocked(readActivationContext).mockReturnValue({
-            flow: "student_join",
-            invite_token: "stu-tok-123",
-            role: "student",
-            expires_at: Date.now() + 300000,
-        });
-        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingInvite);
-        const supabaseMock = makeSupabaseMock();
-        vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
-
-        renderPage();
-
-        await waitFor(() => screen.getByText(/Continuar con Microsoft/i));
-
-        await act(async () => {
-            fireEvent.click(screen.getByText(/Continuar con Microsoft/i));
-        });
-
-        expect(supabaseMock.auth.signInWithOAuth).toHaveBeenCalledWith(
-            expect.objectContaining({ provider: "azure" }),
         );
     });
 });

--- a/frontend/src/features/student-auth/StudentJoinPage.test.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.test.tsx
@@ -216,4 +216,50 @@ describe("StudentJoinPage", () => {
             expect(mockNavigate).toHaveBeenCalledWith("/student", { replace: true }),
         );
     });
+
+    it("shows an explicit sign-in message when the course access email already has an account", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-tok-existing",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveCourseAccess).mockResolvedValue({
+            course_id: "course-1",
+            course_title: "Gerencia Estrategica",
+            university_name: "Universidad Demo",
+            teacher_display_name: "Julio Paz",
+            course_status: "active",
+            link_status: "active",
+            allowed_auth_methods: ["microsoft", "password"],
+        });
+        vi.mocked(api.auth.activateCourseAccessPassword).mockRejectedValue(
+            Object.assign(new Error("account_exists_sign_in_required"), {
+                detail: "account_exists_sign_in_required",
+                status: 409,
+            }),
+        );
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Activar cuenta/i));
+
+        fireEvent.change(screen.getByPlaceholderText(/tu.correo@universidad.edu/i), {
+            target: { value: "student@universidad.edu" },
+        });
+        fireEvent.change(screen.getByPlaceholderText(/Nombre completo/i), {
+            target: { value: "Estudiante Test" },
+        });
+        const passwordInputs = document.querySelectorAll("input[type=password]");
+        fireEvent.change(passwordInputs[0], { target: { value: "Password123!" } });
+        fireEvent.change(passwordInputs[1], { target: { value: "Password123!" } });
+
+        await act(async () => {
+            fireEvent.submit(document.querySelector("form")!);
+        });
+
+        await waitFor(() =>
+            expect(screen.getByText(/ya existe una cuenta con este correo/i)).toBeTruthy(),
+        );
+    });
 });

--- a/frontend/src/features/student-auth/StudentJoinPage.test.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.test.tsx
@@ -77,7 +77,7 @@ describe("StudentJoinPage", () => {
 
     it("shows invalid link state when there is no activation context", () => {
         renderPage();
-        expect(screen.getByText(/este enlace de acceso no es valido/i)).toBeTruthy();
+        expect(screen.getByText(/este enlace de acceso no es válido/i)).toBeTruthy();
     });
 
     it("keeps invite_token flow working", async () => {
@@ -261,5 +261,8 @@ describe("StudentJoinPage", () => {
         await waitFor(() =>
             expect(screen.getByText(/ya existe una cuenta con este correo/i)).toBeTruthy(),
         );
+        expect(
+            screen.getByRole("link", { name: /iniciar sesión para continuar/i }),
+        ).toHaveAttribute("href", "/student/login");
     });
 });

--- a/frontend/src/features/student-auth/StudentJoinPage.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.tsx
@@ -62,6 +62,8 @@ function resolveSubmitError(err: ApiError, tokenKind: "invite" | "course_access"
             return "Debes ingresar tu correo electronico.";
         case "email_domain_not_allowed":
             return "Tu correo institucional no esta habilitado para esta universidad.";
+        case "account_exists_sign_in_required":
+            return "Ya existe una cuenta con este correo. Inicia sesion en /student/login o usa Microsoft.";
         default:
             return tokenKind === "invite"
                 ? "No se pudo completar la activacion. Intenta de nuevo."

--- a/frontend/src/features/student-auth/StudentJoinPage.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.tsx
@@ -7,98 +7,178 @@ import {
     readActivationContext,
     clearActivationContext,
 } from "@/shared/activationContext";
-import type { InviteResolveResponse } from "@/shared/adam-types";
+import type {
+    ActivationContext,
+    CourseAccessResolveResponse,
+    InviteResolveResponse,
+} from "@/shared/adam-types";
 
-function resolveErrorMessage(err: ApiError | null, inviteStatus?: string): string {
+function resolveInviteErrorMessage(err: ApiError | null, inviteStatus?: string): string {
     if (inviteStatus === "expired") {
-        return "Tu invitación ha expirado. Solicita una nueva al docente.";
+        return "Tu invitacion ha expirado. Solicita una nueva al docente.";
     }
     if (inviteStatus === "consumed") {
-        return "Esta invitación ya fue utilizada. Intenta iniciar sesión directamente.";
+        return "Esta invitacion ya fue utilizada. Intenta iniciar sesion directamente.";
     }
     if (inviteStatus === "revoked") {
-        return "Esta invitación fue revocada. Contacta a tu docente.";
+        return "Esta invitacion fue revocada. Contacta a tu docente.";
     }
     if (err) {
-        return "No se pudo verificar la invitación. El enlace puede ser inválido.";
+        return "No se pudo verificar la invitacion. El enlace puede ser invalido.";
     }
-    return "No se pudo verificar la invitación. El enlace puede ser inválido.";
+    return "No se pudo verificar la invitacion. El enlace puede ser invalido.";
 }
 
-/**
- * Student course join page — Issue #39.
- *
- * Reads #invite_token from the URL hash, persists it in sessionStorage
- * (5-min TTL), calls POST /api/invites/resolve, and renders either the
- * Microsoft OAuth button or the password activation form.
- *
- * Security rules (non-negotiable):
- * - invite_token never appears in window.location after mount
- * - email field in the form is always disabled — pre-filled from resolve
- * - full_name is required for student activation
- * - no "Forgot password" CTA
- */
+function resolveCourseAccessErrorMessage(err: ApiError | null): string {
+    switch (err?.detail) {
+        case "course_access_link_rotated":
+            return "Este enlace de acceso fue rotado. Solicita el enlace actualizado.";
+        case "course_access_link_revoked":
+            return "Este enlace de acceso fue revocado. Solicita uno nuevo.";
+        case "course_inactive":
+            return "Este curso no esta disponible en este momento.";
+        case "invalid_course_access_token":
+            return "No se pudo verificar el acceso al curso. El enlace puede ser invalido.";
+        default:
+            return "No se pudo verificar el acceso al curso. El enlace puede ser invalido.";
+    }
+}
+
+function resolveSubmitError(err: ApiError, tokenKind: "invite" | "course_access"): string {
+    switch (err.detail) {
+        case "invalid_invite":
+            return "Esta invitacion ya no es valida. Solicita una nueva.";
+        case "invalid_course_access_token":
+            return "Este enlace de acceso ya no es valido.";
+        case "course_access_link_rotated":
+            return "Este enlace fue rotado. Solicita el enlace actualizado.";
+        case "course_access_link_revoked":
+            return "Este enlace fue revocado. Solicita uno nuevo.";
+        case "course_inactive":
+            return "Este curso no esta disponible en este momento.";
+        case "full_name_required":
+            return "El nombre completo es requerido.";
+        case "course_access_email_required":
+            return "Debes ingresar tu correo electronico.";
+        case "email_domain_not_allowed":
+            return "Tu correo institucional no esta habilitado para esta universidad.";
+        default:
+            return tokenKind === "invite"
+                ? "No se pudo completar la activacion. Intenta de nuevo."
+                : "No se pudo completar el acceso al curso. Intenta de nuevo.";
+    }
+}
+
+function isStudentJoinContext(
+    ctx: ActivationContext | null,
+): ctx is Extract<ActivationContext, { flow: "student_join_invite" | "student_join_course_access" }> {
+    return ctx?.flow === "student_join_invite" || ctx?.flow === "student_join_course_access";
+}
+
 export function StudentJoinPage() {
     const navigate = useNavigate();
 
-    // Initialize from sessionStorage first (covers page refresh with valid TTL context)
-    const [inviteToken, setInviteToken] = useState<string | null>(() => {
+    const [joinContext, setJoinContext] = useState<Extract<ActivationContext, { flow: "student_join_invite" | "student_join_course_access" }> | null>(() => {
         const ctx = readActivationContext();
-        return ctx?.flow === "student_join" ? ctx.invite_token : null;
+        return isStudentJoinContext(ctx) ? ctx : null;
     });
 
     const [resolving, setResolving] = useState(false);
     const [resolvedInvite, setResolvedInvite] = useState<InviteResolveResponse | null>(null);
+    const [resolvedCourseAccess, setResolvedCourseAccess] = useState<CourseAccessResolveResponse | null>(null);
     const [resolveError, setResolveError] = useState<string | null>(null);
 
+    const [email, setEmail] = useState("");
     const [fullName, setFullName] = useState("");
     const [password, setPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
     const [submitting, setSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState<string | null>(null);
 
-    // Parse hash and save to sessionStorage
     useEffect(() => {
-        const hash = window.location.hash;
-        const params = new URLSearchParams(hash.replace(/^#/, ""));
-        const token = params.get("invite_token");
+        const params = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+        const inviteToken = params.get("invite_token");
+        const courseAccessToken = params.get("course_access_token");
 
-        if (token) {
+        if (inviteToken) {
+            const nextContext: Extract<ActivationContext, { flow: "student_join_invite" }> = {
+                flow: "student_join_invite",
+                token_kind: "invite",
+                invite_token: inviteToken,
+                role: "student",
+                expires_at: Date.now() + 5 * 60 * 1000,
+            };
             saveActivationContext({
-                flow: "student_join",
-                invite_token: token,
+                flow: "student_join_invite",
+                token_kind: "invite",
+                invite_token: inviteToken,
                 role: "student",
             });
             window.history.replaceState(null, "", window.location.pathname);
-            setInviteToken(token);
-        } else if (!inviteToken) {
+            setJoinContext(nextContext);
+            return;
+        }
+
+        if (courseAccessToken) {
+            const nextContext: Extract<ActivationContext, { flow: "student_join_course_access" }> = {
+                flow: "student_join_course_access",
+                token_kind: "course_access",
+                course_access_token: courseAccessToken,
+                expires_at: Date.now() + 5 * 60 * 1000,
+            };
+            saveActivationContext({
+                flow: "student_join_course_access",
+                token_kind: "course_access",
+                course_access_token: courseAccessToken,
+            });
+            window.history.replaceState(null, "", window.location.pathname);
+            setJoinContext(nextContext);
+            return;
+        }
+
+        if (!joinContext) {
             clearActivationContext();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    // Resolve invite once we have a token
     useEffect(() => {
-        if (!inviteToken) return;
+        if (!joinContext) return;
 
         let cancelled = false;
         setResolving(true);
         setResolveError(null);
         setResolvedInvite(null);
+        setResolvedCourseAccess(null);
 
-        api.auth
-            .resolveInvite(inviteToken)
-            .then((res) => {
+        const resolvePromise = joinContext.token_kind === "invite"
+            ? api.auth.resolveInvite(joinContext.invite_token)
+            : api.auth.resolveCourseAccess(joinContext.course_access_token);
+
+        resolvePromise
+            .then((response) => {
                 if (cancelled) return;
-                if (res.status !== "pending") {
-                    setResolveError(resolveErrorMessage(null, res.status));
-                } else {
-                    setResolvedInvite(res);
+
+                if (joinContext.token_kind === "invite") {
+                    const inviteResponse = response as InviteResolveResponse;
+                    if (inviteResponse.status !== "pending") {
+                        setResolveError(resolveInviteErrorMessage(null, inviteResponse.status));
+                    } else {
+                        setResolvedInvite(inviteResponse);
+                    }
+                    return;
                 }
+
+                setResolvedCourseAccess(response as CourseAccessResolveResponse);
             })
             .catch((err: unknown) => {
                 if (cancelled) return;
-                setResolveError(resolveErrorMessage(err as ApiError));
+                const apiErr = err as ApiError;
+                setResolveError(
+                    joinContext.token_kind === "invite"
+                        ? resolveInviteErrorMessage(apiErr)
+                        : resolveCourseAccessErrorMessage(apiErr),
+                );
             })
             .finally(() => {
                 if (!cancelled) setResolving(false);
@@ -107,7 +187,7 @@ export function StudentJoinPage() {
         return () => {
             cancelled = true;
         };
-    }, [inviteToken]);
+    }, [joinContext]);
 
     async function handleMicrosoftJoin() {
         const supabase = getSupabaseClient();
@@ -116,93 +196,87 @@ export function StudentJoinPage() {
             provider: "azure",
             options: { redirectTo: import.meta.env.VITE_AUTH_CALLBACK_URL },
         });
-        // signInWithOAuth redirects — no code after this
     }
 
     async function handlePasswordSubmit(e: React.FormEvent) {
         e.preventDefault();
         setSubmitError(null);
 
+        if (!joinContext) {
+            setSubmitError("No se encontro un contexto de acceso valido.");
+            return;
+        }
         if (password !== confirmPassword) {
-            setSubmitError("Las contraseñas no coinciden.");
+            setSubmitError("Las contrasenas no coinciden.");
             return;
         }
         if (password.length < 8) {
-            setSubmitError("La contraseña debe tener al menos 8 caracteres.");
+            setSubmitError("La contrasena debe tener al menos 8 caracteres.");
             return;
         }
 
         setSubmitting(true);
         try {
-            const res = await api.auth.activatePassword({
-                invite_token: inviteToken!,
-                password,
-                confirm_password: confirmPassword,
-                full_name: fullName,
-            });
+            const response = joinContext.token_kind === "invite"
+                ? await api.auth.activatePassword({
+                    invite_token: joinContext.invite_token,
+                    password,
+                    confirm_password: confirmPassword,
+                    full_name: fullName,
+                })
+                : await api.auth.activateCourseAccessPassword({
+                    course_access_token: joinContext.course_access_token,
+                    email,
+                    full_name: fullName,
+                    password,
+                    confirm_password: confirmPassword,
+                });
 
             const supabase = getSupabaseClient();
             if (!supabase) {
-                setSubmitError("No se pudo iniciar sesión. Recarga la página e intenta de nuevo.");
+                setSubmitError("No se pudo iniciar sesion. Recarga la pagina e intenta de nuevo.");
                 return;
             }
             const { error } = await supabase.auth.signInWithPassword({
-                email: res.email,
+                email: response.email,
                 password,
             });
 
             if (error) {
-                setSubmitError(
-                    "No se pudo iniciar sesión después de la activación. Intenta de nuevo.",
-                );
+                setSubmitError("No se pudo iniciar sesion despues de la activacion. Intenta de nuevo.");
                 return;
             }
 
             clearActivationContext();
             navigate("/student", { replace: true });
         } catch (err: unknown) {
-            const apiErr = err as ApiError;
-            if (apiErr.detail === "invalid_invite") {
-                setSubmitError("Esta invitación ya no es válida. Solicita una nueva.");
-            } else if (apiErr.detail === "full_name_required") {
-                setSubmitError("El nombre completo es requerido.");
-            } else if (apiErr.detail === "email_domain_not_allowed") {
-                setSubmitError(
-                    "Tu correo institucional no está habilitado para esta universidad.",
-                );
-            } else {
-                setSubmitError("No se pudo completar la activación. Intenta de nuevo.");
-            }
+            setSubmitError(resolveSubmitError(err as ApiError, joinContext.token_kind));
         } finally {
             setSubmitting(false);
         }
     }
 
-    // State 1: No activation context
-    if (!inviteToken && !resolving) {
+    if (!joinContext && !resolving) {
         return (
             <div className="flex flex-col items-center justify-center gap-6 px-4 py-24 text-center">
                 <h1 className="text-xl font-semibold">Unirse a un curso</h1>
                 <p className="text-sm text-danger max-w-sm">
-                    Este enlace de activación no es válido. Solicita un nuevo enlace al
-                    docente de tu curso.
+                    Este enlace de acceso no es valido. Solicita un nuevo enlace.
                 </p>
             </div>
         );
     }
 
-    // State 2: Resolving invite
     if (resolving) {
         return (
             <div className="flex flex-col items-center justify-center gap-4 px-4 py-24">
                 <span className="text-sm text-muted-foreground">
-                    Verificando invitación…
+                    Verificando acceso...
                 </span>
             </div>
         );
     }
 
-    // State 3: Invite invalid (expired/consumed/revoked/error)
     if (resolveError) {
         return (
             <div className="flex flex-col items-center justify-center gap-6 px-4 py-24 text-center">
@@ -212,73 +286,85 @@ export function StudentJoinPage() {
         );
     }
 
-    // State 4: Invite valid — show activation form
-    if (!resolvedInvite) return null;
+    const isInviteFlow = joinContext?.token_kind === "invite";
+    const allowMicrosoft = isInviteFlow || resolvedCourseAccess?.allowed_auth_methods.includes("microsoft") || false;
+    const universityName = isInviteFlow ? resolvedInvite?.university_name : resolvedCourseAccess?.university_name;
+    const courseTitle = isInviteFlow ? resolvedInvite?.course_title : resolvedCourseAccess?.course_title;
+    const teacherName = isInviteFlow ? resolvedInvite?.teacher_name : resolvedCourseAccess?.teacher_display_name;
+
+    if (isInviteFlow && !resolvedInvite) return null;
+    if (!isInviteFlow && !resolvedCourseAccess) return null;
 
     return (
         <div className="flex flex-col items-center justify-center gap-6 px-4 py-16">
             <div className="w-full max-w-sm space-y-6">
                 <div className="space-y-1 text-center">
                     <h1 className="text-xl font-semibold">Unirse a un curso</h1>
-                    <p className="text-sm text-muted-foreground">
-                        {resolvedInvite.university_name}
-                    </p>
-                    {resolvedInvite.course_title && (
-                        <p className="text-sm text-muted-foreground">
-                            Curso: {resolvedInvite.course_title}
-                        </p>
+                    <p className="text-sm text-muted-foreground">{universityName}</p>
+                    {courseTitle && (
+                        <p className="text-sm text-muted-foreground">Curso: {courseTitle}</p>
                     )}
-                    {resolvedInvite.teacher_name && (
-                        <p className="text-sm text-muted-foreground">
-                            Docente: {resolvedInvite.teacher_name}
-                        </p>
+                    {teacherName && (
+                        <p className="text-sm text-muted-foreground">Docente: {teacherName}</p>
                     )}
                 </div>
 
                 <div className="space-y-2">
-                    <label className="text-sm font-medium">Correo electrónico</label>
-                    <input
-                        type="email"
-                        value={resolvedInvite.email_masked}
-                        disabled
-                        className="w-full rounded-md border border-input bg-muted px-3 py-2 text-sm text-muted-foreground"
-                    />
+                    <label className="text-sm font-medium">Correo electronico</label>
+                    {isInviteFlow ? (
+                        <input
+                            type="email"
+                            value={resolvedInvite?.email_masked ?? ""}
+                            disabled
+                            className="w-full rounded-md border border-input bg-muted px-3 py-2 text-sm text-muted-foreground"
+                        />
+                    ) : (
+                        <input
+                            type="email"
+                            value={email}
+                            onChange={(event) => setEmail(event.target.value)}
+                            placeholder="tu.correo@universidad.edu"
+                            required
+                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        />
+                    )}
                 </div>
 
-                {/* Opción A — Microsoft */}
-                <div className="space-y-2">
-                    <p className="text-sm font-medium">Activar con Microsoft (recomendado)</p>
-                    <button
-                        type="button"
-                        onClick={() => void handleMicrosoftJoin()}
-                        className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
-                    >
-                        Continuar con Microsoft
-                    </button>
-                </div>
-
-                <div className="relative">
-                    <div className="absolute inset-0 flex items-center">
-                        <span className="w-full border-t border-border" />
+                {allowMicrosoft && (
+                    <div className="space-y-2">
+                        <p className="text-sm font-medium">Continuar con Microsoft</p>
+                        <button
+                            type="button"
+                            onClick={() => void handleMicrosoftJoin()}
+                            className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+                        >
+                            Continuar con Microsoft
+                        </button>
                     </div>
-                    <div className="relative flex justify-center">
-                        <span className="bg-background px-2 text-xs text-muted-foreground">
-                            o crea una contraseña
-                        </span>
-                    </div>
-                </div>
+                )}
 
-                {/* Opción B — Password */}
-                <form onSubmit={(e) => void handlePasswordSubmit(e)} className="space-y-4">
+                {allowMicrosoft && (
+                    <div className="relative">
+                        <div className="absolute inset-0 flex items-center">
+                            <span className="w-full border-t border-border" />
+                        </div>
+                        <div className="relative flex justify-center">
+                            <span className="bg-background px-2 text-xs text-muted-foreground">
+                                o crea una contrasena
+                            </span>
+                        </div>
+                    </div>
+                )}
+
+                <form onSubmit={(event) => void handlePasswordSubmit(event)} className="space-y-4">
                     <div className="space-y-2">
                         <label className="text-sm font-medium">
-                            Nombre completo{" "}
-                            <span className="text-danger">*</span>
+                            Nombre completo <span className="text-danger">*</span>
                         </label>
                         <input
                             type="text"
                             value={fullName}
-                            onChange={(e) => setFullName(e.target.value)}
+                            onChange={(event) => setFullName(event.target.value)}
                             placeholder="Nombre completo"
                             required
                             className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
@@ -286,37 +372,35 @@ export function StudentJoinPage() {
                     </div>
 
                     <div className="space-y-2">
-                        <label className="text-sm font-medium">Contraseña</label>
+                        <label className="text-sm font-medium">Contrasena</label>
                         <input
                             type="password"
                             value={password}
-                            onChange={(e) => setPassword(e.target.value)}
+                            onChange={(event) => setPassword(event.target.value)}
                             required
                             className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                         />
                     </div>
 
                     <div className="space-y-2">
-                        <label className="text-sm font-medium">Confirmar contraseña</label>
+                        <label className="text-sm font-medium">Confirmar contrasena</label>
                         <input
                             type="password"
                             value={confirmPassword}
-                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            onChange={(event) => setConfirmPassword(event.target.value)}
                             required
                             className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                         />
                     </div>
 
-                    {submitError && (
-                        <p className="text-sm text-danger">{submitError}</p>
-                    )}
+                    {submitError && <p className="text-sm text-danger">{submitError}</p>}
 
                     <button
                         type="submit"
                         disabled={submitting}
                         className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
                     >
-                        {submitting ? "Activando…" : "Activar cuenta"}
+                        {submitting ? "Activando..." : "Activar cuenta"}
                     </button>
                 </form>
             </div>

--- a/frontend/src/features/student-auth/StudentJoinPage.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { api, ApiError } from "@/shared/api";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 import {
@@ -15,18 +15,18 @@ import type {
 
 function resolveInviteErrorMessage(err: ApiError | null, inviteStatus?: string): string {
     if (inviteStatus === "expired") {
-        return "Tu invitacion ha expirado. Solicita una nueva al docente.";
+        return "Tu invitación ha expirado. Solicita una nueva al docente.";
     }
     if (inviteStatus === "consumed") {
-        return "Esta invitacion ya fue utilizada. Intenta iniciar sesion directamente.";
+        return "Esta invitación ya fue utilizada. Intenta iniciar sesión directamente.";
     }
     if (inviteStatus === "revoked") {
-        return "Esta invitacion fue revocada. Contacta a tu docente.";
+        return "Esta invitación fue revocada. Contacta a tu docente.";
     }
     if (err) {
-        return "No se pudo verificar la invitacion. El enlace puede ser invalido.";
+        return "No se pudo verificar la invitación. El enlace puede ser inválido.";
     }
-    return "No se pudo verificar la invitacion. El enlace puede ser invalido.";
+    return "No se pudo verificar la invitación. El enlace puede ser inválido.";
 }
 
 function resolveCourseAccessErrorMessage(err: ApiError | null): string {
@@ -36,37 +36,37 @@ function resolveCourseAccessErrorMessage(err: ApiError | null): string {
         case "course_access_link_revoked":
             return "Este enlace de acceso fue revocado. Solicita uno nuevo.";
         case "course_inactive":
-            return "Este curso no esta disponible en este momento.";
+            return "Este curso no está disponible en este momento.";
         case "invalid_course_access_token":
-            return "No se pudo verificar el acceso al curso. El enlace puede ser invalido.";
+            return "No se pudo verificar el acceso al curso. El enlace puede ser inválido.";
         default:
-            return "No se pudo verificar el acceso al curso. El enlace puede ser invalido.";
+            return "No se pudo verificar el acceso al curso. El enlace puede ser inválido.";
     }
 }
 
 function resolveSubmitError(err: ApiError, tokenKind: "invite" | "course_access"): string {
     switch (err.detail) {
         case "invalid_invite":
-            return "Esta invitacion ya no es valida. Solicita una nueva.";
+            return "Esta invitación ya no es válida. Solicita una nueva.";
         case "invalid_course_access_token":
-            return "Este enlace de acceso ya no es valido.";
+            return "Este enlace de acceso ya no es válido.";
         case "course_access_link_rotated":
             return "Este enlace fue rotado. Solicita el enlace actualizado.";
         case "course_access_link_revoked":
             return "Este enlace fue revocado. Solicita uno nuevo.";
         case "course_inactive":
-            return "Este curso no esta disponible en este momento.";
+            return "Este curso no está disponible en este momento.";
         case "full_name_required":
             return "El nombre completo es requerido.";
         case "course_access_email_required":
-            return "Debes ingresar tu correo electronico.";
+            return "Debes ingresar tu correo electrónico.";
         case "email_domain_not_allowed":
-            return "Tu correo institucional no esta habilitado para esta universidad.";
+            return "Tu correo institucional no está habilitado para esta universidad.";
         case "account_exists_sign_in_required":
-            return "Ya existe una cuenta con este correo. Inicia sesion en /student/login o usa Microsoft.";
+            return "Ya existe una cuenta con este correo. Inicia sesión para completar la inscripción.";
         default:
             return tokenKind === "invite"
-                ? "No se pudo completar la activacion. Intenta de nuevo."
+                ? "No se pudo completar la activación. Intenta de nuevo."
                 : "No se pudo completar el acceso al curso. Intenta de nuevo.";
     }
 }
@@ -205,15 +205,15 @@ export function StudentJoinPage() {
         setSubmitError(null);
 
         if (!joinContext) {
-            setSubmitError("No se encontro un contexto de acceso valido.");
+            setSubmitError("No se encontró un contexto de acceso válido.");
             return;
         }
         if (password !== confirmPassword) {
-            setSubmitError("Las contrasenas no coinciden.");
+            setSubmitError("Las contraseñas no coinciden.");
             return;
         }
         if (password.length < 8) {
-            setSubmitError("La contrasena debe tener al menos 8 caracteres.");
+            setSubmitError("La contraseña debe tener al menos 8 caracteres.");
             return;
         }
 
@@ -236,7 +236,7 @@ export function StudentJoinPage() {
 
             const supabase = getSupabaseClient();
             if (!supabase) {
-                setSubmitError("No se pudo iniciar sesion. Recarga la pagina e intenta de nuevo.");
+                setSubmitError("No se pudo iniciar sesión. Recarga la página e intenta de nuevo.");
                 return;
             }
             const { error } = await supabase.auth.signInWithPassword({
@@ -245,7 +245,7 @@ export function StudentJoinPage() {
             });
 
             if (error) {
-                setSubmitError("No se pudo iniciar sesion despues de la activacion. Intenta de nuevo.");
+                setSubmitError("No se pudo iniciar sesión después de la activación. Intenta de nuevo.");
                 return;
             }
 
@@ -263,7 +263,7 @@ export function StudentJoinPage() {
             <div className="flex flex-col items-center justify-center gap-6 px-4 py-24 text-center">
                 <h1 className="text-xl font-semibold">Unirse a un curso</h1>
                 <p className="text-sm text-danger max-w-sm">
-                    Este enlace de acceso no es valido. Solicita un nuevo enlace.
+                    Este enlace de acceso no es válido. Solicita un nuevo enlace.
                 </p>
             </div>
         );
@@ -312,7 +312,7 @@ export function StudentJoinPage() {
                 </div>
 
                 <div className="space-y-2">
-                    <label className="text-sm font-medium">Correo electronico</label>
+                    <label className="text-sm font-medium">Correo electrónico</label>
                     {isInviteFlow ? (
                         <input
                             type="email"
@@ -352,7 +352,7 @@ export function StudentJoinPage() {
                         </div>
                         <div className="relative flex justify-center">
                             <span className="bg-background px-2 text-xs text-muted-foreground">
-                                o crea una contrasena
+                                o crea una contraseña
                             </span>
                         </div>
                     </div>
@@ -374,7 +374,7 @@ export function StudentJoinPage() {
                     </div>
 
                     <div className="space-y-2">
-                        <label className="text-sm font-medium">Contrasena</label>
+                        <label className="text-sm font-medium">Contraseña</label>
                         <input
                             type="password"
                             value={password}
@@ -385,7 +385,7 @@ export function StudentJoinPage() {
                     </div>
 
                     <div className="space-y-2">
-                        <label className="text-sm font-medium">Confirmar contrasena</label>
+                        <label className="text-sm font-medium">Confirmar contraseña</label>
                         <input
                             type="password"
                             value={confirmPassword}
@@ -395,7 +395,19 @@ export function StudentJoinPage() {
                         />
                     </div>
 
-                    {submitError && <p className="text-sm text-danger">{submitError}</p>}
+                    {submitError && (
+                        <div className="space-y-2">
+                            <p className="text-sm text-danger">{submitError}</p>
+                            {submitError.includes("Inicia sesión") && (
+                                <Link
+                                    to="/student/login"
+                                    className="inline-flex text-sm font-medium underline hover:opacity-80"
+                                >
+                                    Iniciar sesión para continuar
+                                </Link>
+                            )}
+                        </div>
+                    )}
 
                     <button
                         type="submit"

--- a/frontend/src/features/student-auth/StudentLoginPage.test.tsx
+++ b/frontend/src/features/student-auth/StudentLoginPage.test.tsx
@@ -1,9 +1,23 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import { StudentLoginPage } from "./StudentLoginPage";
 
 vi.mock("@/shared/supabaseClient");
+vi.mock("@/shared/activationContext", () => ({
+    readActivationContext: vi.fn(),
+}));
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+    return { ...actual, useNavigate: vi.fn() };
+});
+
+import { readActivationContext } from "@/shared/activationContext";
+import { getSupabaseClient } from "@/shared/supabaseClient";
+import { useNavigate } from "react-router-dom";
+
+const mockNavigate = vi.fn();
 
 function makeSupabaseMock(
     signInResult: { error: null | { message: string } } = { error: null },
@@ -24,15 +38,14 @@ function renderPage() {
     );
 }
 
-import { getSupabaseClient } from "@/shared/supabaseClient";
-
 describe("StudentLoginPage", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.mocked(getSupabaseClient).mockReturnValue(makeSupabaseMock() as never);
+        vi.mocked(readActivationContext).mockReturnValue(null);
+        vi.mocked(useNavigate).mockReturnValue(mockNavigate);
     });
 
-    // 1. Botón Microsoft → signInWithOAuth con provider: "azure"
     it("calls signInWithOAuth with provider azure when Microsoft button is clicked", async () => {
         const supabaseMock = makeSupabaseMock();
         vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
@@ -48,7 +61,6 @@ describe("StudentLoginPage", () => {
         );
     });
 
-    // 2. Password form → llama signInWithPassword con email y password
     it("calls signInWithPassword when password form is submitted", async () => {
         const supabaseMock = makeSupabaseMock({ error: null });
         vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
@@ -58,8 +70,9 @@ describe("StudentLoginPage", () => {
         fireEvent.change(screen.getByRole("textbox"), {
             target: { value: "student@universidad.edu" },
         });
-        const passwordInput = document.querySelector("input[type=password]")!;
-        fireEvent.change(passwordInput, { target: { value: "MyPassword123!" } });
+        fireEvent.change(document.querySelector("input[type=password]")!, {
+            target: { value: "MyPassword123!" },
+        });
 
         await act(async () => {
             fireEvent.submit(document.querySelector("form")!);
@@ -73,8 +86,35 @@ describe("StudentLoginPage", () => {
         );
     });
 
-    // 3. signInWithPassword falla → error genérico (nunca revela existencia del email)
-    it("shows generic error when signInWithPassword fails — never reveals email existence", async () => {
+    it("resumes course access completion after a successful password login", async () => {
+        const supabaseMock = makeSupabaseMock({ error: null });
+        vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-access-tok",
+            expires_at: Date.now() + 300000,
+        });
+
+        renderPage();
+
+        fireEvent.change(screen.getByRole("textbox"), {
+            target: { value: "student@universidad.edu" },
+        });
+        fireEvent.change(document.querySelector("input[type=password]")!, {
+            target: { value: "MyPassword123!" },
+        });
+
+        await act(async () => {
+            fireEvent.submit(document.querySelector("form")!);
+        });
+
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith("/auth/callback", { replace: true }),
+        );
+    });
+
+    it("shows generic error when signInWithPassword fails and never reveals email existence", async () => {
         const supabaseMock = makeSupabaseMock({ error: { message: "Invalid login credentials" } });
         vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
 
@@ -83,24 +123,20 @@ describe("StudentLoginPage", () => {
         fireEvent.change(screen.getByRole("textbox"), {
             target: { value: "noexiste@universidad.edu" },
         });
-        const passwordInput = document.querySelector("input[type=password]")!;
-        fireEvent.change(passwordInput, { target: { value: "wrongpassword" } });
+        fireEvent.change(document.querySelector("input[type=password]")!, {
+            target: { value: "wrongpassword" },
+        });
 
         await act(async () => {
             fireEvent.submit(document.querySelector("form")!);
         });
 
         await waitFor(() =>
-            expect(
-                screen.getByText(/credenciales incorrectas/i),
-            ).toBeTruthy(),
+            expect(screen.getByText(/credenciales incorrectas/i)).toBeTruthy(),
         );
-
-        // Must NOT reveal the email-specific error from Supabase
         expect(screen.queryByText(/Invalid login credentials/i)).toBeNull();
     });
 
-    // 4. No hay CTA de "Olvidé mi contraseña" en ninguna parte de la página
     it("does not render a forgot-password CTA anywhere in the page", () => {
         renderPage();
 

--- a/frontend/src/features/student-auth/StudentLoginPage.tsx
+++ b/frontend/src/features/student-auth/StudentLoginPage.tsx
@@ -1,21 +1,22 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { readActivationContext } from "@/shared/activationContext";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 
 /**
- * Student login page — Issue #39.
+ * Student login page.
  *
  * Two paths:
- * A) Microsoft OAuth — signInWithOAuth redirects to /app/auth/callback,
- *    which handles role-based navigation via AuthContext.
- * B) Password — signInWithPassword; AuthContext onAuthStateChange fires
- *    SIGNED_IN and RequireRole reacts automatically.
+ * A) Microsoft OAuth -> signInWithOAuth redirects to /app/auth/callback.
+ * B) Password -> signInWithPassword; AuthContext onAuthStateChange fires SIGNED_IN.
  *
- * Non-negotiables:
- * - No "Forgot password" CTA
- * - No free registration CTA
- * - Password errors never reveal whether the email exists
+ * If the user arrived here from a course-access link that requires an existing
+ * password account, we resume the enrollment flow in /auth/callback after the
+ * password sign-in succeeds.
  */
 export function StudentLoginPage() {
+    const navigate = useNavigate();
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [submitting, setSubmitting] = useState(false);
@@ -28,11 +29,10 @@ export function StudentLoginPage() {
             provider: "azure",
             options: { redirectTo: import.meta.env.VITE_AUTH_CALLBACK_URL },
         });
-        // signInWithOAuth redirects — no code after this
     }
 
-    async function handlePasswordSubmit(e: React.FormEvent) {
-        e.preventDefault();
+    async function handlePasswordSubmit(event: React.FormEvent) {
+        event.preventDefault();
         setLoginError(null);
         setSubmitting(true);
 
@@ -42,19 +42,21 @@ export function StudentLoginPage() {
                 setLoginError("Credenciales incorrectas. Verifica tu correo y contraseña.");
                 return;
             }
+
             const { error } = await supabase.auth.signInWithPassword({
                 email,
                 password,
             });
 
             if (error) {
-                // Never reveal whether the email exists
-                setLoginError(
-                    "Credenciales incorrectas. Verifica tu correo y contraseña.",
-                );
+                setLoginError("Credenciales incorrectas. Verifica tu correo y contraseña.");
+                return;
             }
-            // On success: AuthContext onAuthStateChange fires SIGNED_IN → actor updates
-            // → RequireRole or RootRedirect reacts automatically
+
+            const activationContext = readActivationContext();
+            if (activationContext?.flow === "student_join_course_access") {
+                navigate("/auth/callback", { replace: true });
+            }
         } finally {
             setSubmitting(false);
         }
@@ -67,7 +69,6 @@ export function StudentLoginPage() {
                     <h1 className="text-xl font-semibold">Acceso estudiantes</h1>
                 </div>
 
-                {/* Opción A — Microsoft */}
                 <button
                     type="button"
                     onClick={() => void handleMicrosoftLogin()}
@@ -87,14 +88,13 @@ export function StudentLoginPage() {
                     </div>
                 </div>
 
-                {/* Opción B — Password */}
-                <form onSubmit={(e) => void handlePasswordSubmit(e)} className="space-y-4">
+                <form onSubmit={(event) => void handlePasswordSubmit(event)} className="space-y-4">
                     <div className="space-y-2">
                         <label className="text-sm font-medium">Correo electrónico</label>
                         <input
                             type="email"
                             value={email}
-                            onChange={(e) => setEmail(e.target.value)}
+                            onChange={(event) => setEmail(event.target.value)}
                             required
                             className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                         />
@@ -105,15 +105,13 @@ export function StudentLoginPage() {
                         <input
                             type="password"
                             value={password}
-                            onChange={(e) => setPassword(e.target.value)}
+                            onChange={(event) => setPassword(event.target.value)}
                             required
                             className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                         />
                     </div>
 
-                    {loginError && (
-                        <p className="text-sm text-danger">{loginError}</p>
-                    )}
+                    {loginError && <p className="text-sm text-danger">{loginError}</p>}
 
                     <button
                         type="submit"

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.test.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.test.tsx
@@ -103,6 +103,7 @@ describe("TeacherActivatePage", () => {
     it("calls resolveInvite with the invite_token from activation context", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
+            token_kind: "invite",
             invite_token: "tok-abc",
             role: "teacher",
             expires_at: Date.now() + 300000,
@@ -120,6 +121,7 @@ describe("TeacherActivatePage", () => {
     it("renders the activation form with email_masked disabled when invite is pending", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
+            token_kind: "invite",
             invite_token: "tok-abc",
             role: "teacher",
             expires_at: Date.now() + 300000,
@@ -142,6 +144,7 @@ describe("TeacherActivatePage", () => {
     it("shows expired message when invite status is expired", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
+            token_kind: "invite",
             invite_token: "tok-abc",
             role: "teacher",
             expires_at: Date.now() + 300000,
@@ -162,6 +165,7 @@ describe("TeacherActivatePage", () => {
     it("shows consumed message when invite status is consumed", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
+            token_kind: "invite",
             invite_token: "tok-abc",
             role: "teacher",
             expires_at: Date.now() + 300000,
@@ -182,6 +186,7 @@ describe("TeacherActivatePage", () => {
     it("shows client-side error when passwords do not match — does not call activatePassword", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
+            token_kind: "invite",
             invite_token: "tok-abc",
             role: "teacher",
             expires_at: Date.now() + 300000,
@@ -209,6 +214,7 @@ describe("TeacherActivatePage", () => {
     it("calls activatePassword then signInWithPassword with res.email and navigates to /teacher", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
+            token_kind: "invite",
             invite_token: "tok-abc",
             role: "teacher",
             expires_at: Date.now() + 300000,
@@ -261,6 +267,7 @@ describe("TeacherActivatePage", () => {
     it("shows inline error when activatePassword fails with invalid_invite", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
+            token_kind: "invite",
             invite_token: "tok-abc",
             role: "teacher",
             expires_at: Date.now() + 300000,
@@ -295,6 +302,7 @@ describe("TeacherActivatePage", () => {
     it("calls signInWithOAuth with provider azure when Microsoft button is clicked", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
+            token_kind: "invite",
             invite_token: "tok-abc",
             role: "teacher",
             expires_at: Date.now() + 300000,

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
@@ -65,6 +65,7 @@ export function TeacherActivatePage() {
         if (token) {
             saveActivationContext({
                 flow: "teacher_activate",
+                token_kind: "invite",
                 invite_token: token,
                 role: "teacher",
             });

--- a/frontend/src/shared/activationContext.test.ts
+++ b/frontend/src/shared/activationContext.test.ts
@@ -14,9 +14,10 @@ describe("activationContext", () => {
         vi.useRealTimers();
     });
 
-    it("save → read returns the correct value", () => {
+    it("save and read preserves invite activation context", () => {
         saveActivationContext({
             flow: "teacher_activate",
+            token_kind: "invite",
             invite_token: "tok_abc123",
             role: "teacher",
         });
@@ -24,20 +25,50 @@ describe("activationContext", () => {
         const ctx = readActivationContext();
         expect(ctx).not.toBeNull();
         expect(ctx?.flow).toBe("teacher_activate");
-        expect(ctx?.invite_token).toBe("tok_abc123");
-        expect(ctx?.role).toBe("teacher");
-        expect(typeof ctx?.expires_at).toBe("number");
+        expect(ctx?.token_kind).toBe("invite");
+        expect("invite_token" in (ctx ?? {})).toBe(true);
     });
 
-    it("returns null when nothing is stored", () => {
-        expect(readActivationContext()).toBeNull();
+    it("save and read preserves course access context", () => {
+        saveActivationContext({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course_tok_123",
+        });
+
+        const ctx = readActivationContext();
+        expect(ctx).not.toBeNull();
+        expect(ctx?.flow).toBe("student_join_course_access");
+        expect(ctx?.token_kind).toBe("course_access");
+        expect("course_access_token" in (ctx ?? {})).toBe(true);
+    });
+
+    it("normalizes the legacy student_join invite shape", () => {
+        sessionStorage.setItem(
+            "adam_activation_ctx",
+            JSON.stringify({
+                flow: "student_join",
+                invite_token: "legacy_tok",
+                role: "student",
+                expires_at: Date.now() + 1000,
+            }),
+        );
+
+        const ctx = readActivationContext();
+        expect(ctx).toEqual({
+            flow: "student_join_invite",
+            token_kind: "invite",
+            invite_token: "legacy_tok",
+            role: "student",
+            expires_at: expect.any(Number),
+        });
     });
 
     it("clearActivationContext removes the stored context", () => {
         saveActivationContext({
-            flow: "student_join",
-            invite_token: "tok_xyz",
-            role: "student",
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course_tok_xyz",
         });
         clearActivationContext();
         expect(readActivationContext()).toBeNull();
@@ -47,19 +78,18 @@ describe("activationContext", () => {
         vi.useFakeTimers();
         saveActivationContext({
             flow: "teacher_activate",
+            token_kind: "invite",
             invite_token: "tok_expired",
             role: "teacher",
         });
 
-        // Advance clock past the 5-minute TTL
         vi.advanceTimersByTime(5 * 60 * 1000 + 1);
 
         expect(readActivationContext()).toBeNull();
-        // The key must be cleaned up
         expect(sessionStorage.getItem("adam_activation_ctx")).toBeNull();
     });
 
-    it("returns null and removes the entry for malformed JSON", () => {
+    it("returns null and removes malformed payloads", () => {
         sessionStorage.setItem("adam_activation_ctx", "{invalid-json}");
         expect(readActivationContext()).toBeNull();
         expect(sessionStorage.getItem("adam_activation_ctx")).toBeNull();

--- a/frontend/src/shared/activationContext.test.ts
+++ b/frontend/src/shared/activationContext.test.ts
@@ -24,9 +24,13 @@ describe("activationContext", () => {
 
         const ctx = readActivationContext();
         expect(ctx).not.toBeNull();
-        expect(ctx?.flow).toBe("teacher_activate");
-        expect(ctx?.token_kind).toBe("invite");
-        expect("invite_token" in (ctx ?? {})).toBe(true);
+        expect(ctx).toEqual({
+            flow: "teacher_activate",
+            token_kind: "invite",
+            invite_token: "tok_abc123",
+            role: "teacher",
+            expires_at: expect.any(Number),
+        });
     });
 
     it("save and read preserves course access context", () => {
@@ -38,9 +42,12 @@ describe("activationContext", () => {
 
         const ctx = readActivationContext();
         expect(ctx).not.toBeNull();
-        expect(ctx?.flow).toBe("student_join_course_access");
-        expect(ctx?.token_kind).toBe("course_access");
-        expect("course_access_token" in (ctx ?? {})).toBe(true);
+        expect(ctx).toEqual({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course_tok_123",
+            expires_at: expect.any(Number),
+        });
     });
 
     it("normalizes the legacy student_join invite shape", () => {

--- a/frontend/src/shared/activationContext.ts
+++ b/frontend/src/shared/activationContext.ts
@@ -39,15 +39,10 @@ type ActivationContextInput =
 export function saveActivationContext(
     ctx: ActivationContextInput,
 ): void {
-    const value: ActivationContext = ctx.token_kind === "invite"
-        ? {
-            ...ctx,
-            expires_at: Date.now() + TTL_MS,
-        }
-        : {
-            ...ctx,
-            expires_at: Date.now() + TTL_MS,
-        };
+    const value: ActivationContext = {
+        ...ctx,
+        expires_at: Date.now() + TTL_MS,
+    };
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(value));
 }
 

--- a/frontend/src/shared/activationContext.ts
+++ b/frontend/src/shared/activationContext.ts
@@ -1,34 +1,53 @@
 /**
  * Short-lived activation context stored in sessionStorage.
  *
- * Used to carry invite_token across an OAuth redirect without placing it
+ * Used to carry invite_token or course_access_token across an OAuth redirect without placing it
  * in the URL, OAuth state param, localStorage, or any server-side store.
  *
  * TTL is hard-coded at 5 minutes. Expired contexts are silently dropped and
  * treated as non-existent. The token is cleared by AuthCallbackPage after
  * the activation flow completes (success or terminal error).
  *
- * invite_token MUST NOT appear in query strings, path params, OAuth state,
+ * Tokens MUST NOT appear in query strings, path params, OAuth state,
  * breadcrumbs, or logs at any point.
  */
+
+import type { ActivationContext } from "./adam-types";
 
 const STORAGE_KEY = "adam_activation_ctx";
 const TTL_MS = 5 * 60 * 1000;
 
-interface ActivationContext {
-    flow: "teacher_activate" | "student_join";
-    invite_token: string;
-    role: "teacher" | "student";
-    expires_at: number; // epoch ms
-}
+type ActivationContextInput =
+    | {
+        flow: "teacher_activate";
+        token_kind: "invite";
+        invite_token: string;
+        role: "teacher";
+    }
+    | {
+        flow: "student_join_invite";
+        token_kind: "invite";
+        invite_token: string;
+        role: "student";
+    }
+    | {
+        flow: "student_join_course_access";
+        token_kind: "course_access";
+        course_access_token: string;
+    };
 
 export function saveActivationContext(
-    ctx: Omit<ActivationContext, "expires_at">,
+    ctx: ActivationContextInput,
 ): void {
-    const value: ActivationContext = {
-        ...ctx,
-        expires_at: Date.now() + TTL_MS,
-    };
+    const value: ActivationContext = ctx.token_kind === "invite"
+        ? {
+            ...ctx,
+            expires_at: Date.now() + TTL_MS,
+        }
+        : {
+            ...ctx,
+            expires_at: Date.now() + TTL_MS,
+        };
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(value));
 }
 
@@ -37,7 +56,12 @@ export function readActivationContext(): ActivationContext | null {
     if (!raw) return null;
 
     try {
-        const ctx = JSON.parse(raw) as ActivationContext;
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        const ctx = normalizeActivationContext(parsed);
+        if (!ctx) {
+            sessionStorage.removeItem(STORAGE_KEY);
+            return null;
+        }
         if (Date.now() > ctx.expires_at) {
             sessionStorage.removeItem(STORAGE_KEY);
             return null;
@@ -51,4 +75,51 @@ export function readActivationContext(): ActivationContext | null {
 
 export function clearActivationContext(): void {
     sessionStorage.removeItem(STORAGE_KEY);
+}
+
+function normalizeActivationContext(raw: Record<string, unknown>): ActivationContext | null {
+    const expiresAt = typeof raw.expires_at === "number" ? raw.expires_at : null;
+    if (expiresAt === null) return null;
+
+    if (
+        raw.flow === "teacher_activate"
+        && typeof raw.invite_token === "string"
+        && raw.role === "teacher"
+    ) {
+        return {
+            flow: "teacher_activate",
+            token_kind: "invite",
+            invite_token: raw.invite_token,
+            role: "teacher",
+            expires_at: expiresAt,
+        };
+    }
+
+    if (
+        (raw.flow === "student_join" || raw.flow === "student_join_invite")
+        && typeof raw.invite_token === "string"
+        && raw.role === "student"
+    ) {
+        return {
+            flow: "student_join_invite",
+            token_kind: "invite",
+            invite_token: raw.invite_token,
+            role: "student",
+            expires_at: expiresAt,
+        };
+    }
+
+    if (
+        raw.flow === "student_join_course_access"
+        && typeof raw.course_access_token === "string"
+    ) {
+        return {
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: raw.course_access_token,
+            expires_at: expiresAt,
+        };
+    }
+
+    return null;
 }

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -245,6 +245,30 @@ export interface InviteRedeemResponse {
     status: "redeemed" | "already_enrolled";
 }
 
+export type AllowedAuthMethod = "password" | "microsoft";
+
+export type ActivationContext =
+    | {
+        flow: "teacher_activate";
+        token_kind: "invite";
+        invite_token: string;
+        role: "teacher";
+        expires_at: number;
+    }
+    | {
+        flow: "student_join_invite";
+        token_kind: "invite";
+        invite_token: string;
+        role: "student";
+        expires_at: number;
+    }
+    | {
+        flow: "student_join_course_access";
+        token_kind: "course_access";
+        course_access_token: string;
+        expires_at: number;
+    };
+
 export interface ActivatePasswordRequest {
     invite_token: string;
     password: string;
@@ -260,6 +284,38 @@ export interface ActivatePasswordResponse {
 
 export interface ActivateOAuthCompleteResponse {
     status: string;
+}
+
+export interface CourseAccessResolveResponse {
+    course_id: string;
+    course_title: string;
+    university_name: string;
+    teacher_display_name: string | null;
+    course_status: "active";
+    link_status: "active";
+    allowed_auth_methods: AllowedAuthMethod[];
+}
+
+export interface CourseAccessEnrollResponse {
+    status: "enrolled" | "already_enrolled";
+}
+
+export interface CourseAccessActivatePasswordRequest {
+    course_access_token: string;
+    email?: string;
+    full_name?: string;
+    password: string;
+    confirm_password: string;
+}
+
+export interface CourseAccessActivatePasswordResponse {
+    status: "activated";
+    next_step: "sign_in";
+    email: string;
+}
+
+export interface CourseAccessActivateOAuthCompleteResponse {
+    status: "activated";
 }
 
 // Admin password rotation (Issue #8)

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -314,6 +314,10 @@ export interface CourseAccessActivatePasswordResponse {
     email: string;
 }
 
+export interface CourseAccessActivateCompleteResponse {
+    status: "activated";
+}
+
 export interface CourseAccessActivateOAuthCompleteResponse {
     status: "activated";
 }

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -10,6 +10,7 @@ import type {
     AuthoringJobStatusResponse,
     ChangePasswordRequest,
     ChangePasswordResponse,
+    CourseAccessActivateCompleteResponse,
     CourseAccessActivateOAuthCompleteResponse,
     CourseAccessActivatePasswordRequest,
     CourseAccessActivatePasswordResponse,
@@ -337,6 +338,15 @@ export const api = {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(req),
+            });
+        },
+        async activateCourseAccessComplete(
+            course_access_token: string,
+        ): Promise<CourseAccessActivateCompleteResponse> {
+            return parseJsonResponse<CourseAccessActivateCompleteResponse>("/course-access/activate/complete", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ course_access_token }),
             });
         },
         async activateCourseAccessOAuthComplete(

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -10,6 +10,11 @@ import type {
     AuthoringJobStatusResponse,
     ChangePasswordRequest,
     ChangePasswordResponse,
+    CourseAccessActivateOAuthCompleteResponse,
+    CourseAccessActivatePasswordRequest,
+    CourseAccessActivatePasswordResponse,
+    CourseAccessEnrollResponse,
+    CourseAccessResolveResponse,
     IntentType,
     InviteRedeemResponse,
     InviteResolveResponse,
@@ -309,6 +314,38 @@ export const api = {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ invite_token }),
+            });
+        },
+        async resolveCourseAccess(course_access_token: string): Promise<CourseAccessResolveResponse> {
+            return parseJsonResponse<CourseAccessResolveResponse>("/course-access/resolve", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ course_access_token }),
+            });
+        },
+        async enrollWithCourseAccess(course_access_token: string): Promise<CourseAccessEnrollResponse> {
+            return parseJsonResponse<CourseAccessEnrollResponse>("/course-access/enroll", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ course_access_token }),
+            });
+        },
+        async activateCourseAccessPassword(
+            req: CourseAccessActivatePasswordRequest,
+        ): Promise<CourseAccessActivatePasswordResponse> {
+            return parseJsonResponse<CourseAccessActivatePasswordResponse>("/course-access/activate/password", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(req),
+            });
+        },
+        async activateCourseAccessOAuthComplete(
+            course_access_token: string,
+        ): Promise<CourseAccessActivateOAuthCompleteResponse> {
+            return parseJsonResponse<CourseAccessActivateOAuthCompleteResponse>("/course-access/activate/oauth/complete", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ course_access_token }),
             });
         },
         async changePassword(req: ChangePasswordRequest): Promise<ChangePasswordResponse> {


### PR DESCRIPTION
## Summary
- add a dedicated secure `course_access` backend flow for resolve, enroll, password activation, and OAuth completion
- support `course_access_token` alongside legacy `invite_token` in the student join and auth callback frontend flows
- harden identity activation and enrollment idempotency, including a pre-PR fix that requires sign-in for existing password accounts instead of silently breaking auto-login

## Review notes
- pre-PR review found one production blocker: existing password accounts could be enrolled through course access but then fail the frontend auto sign-in because the entered password was never applied
- fixed by returning `account_exists_sign_in_required` and showing an explicit sign-in path in the student join UI
- added regression coverage for the auth create-user race recovery and the existing-account course access case

## Validation
- `uv run --directory backend pytest -q tests/test_issue30_auth_perimeter.py tests/test_issue57_course_access.py`
- `npm --prefix frontend run test -- src/features/student-auth/StudentJoinPage.test.tsx`
- full validation had already been run earlier on this branch before the pre-PR fix: backend `pytest`, backend `mypy`, frontend `test`, frontend `build`, frontend `lint`