### PR TITLE
feat(admin-dashboard): harden backend and end-to-end coverage for phase 2 follow-up

### DIFF
--- a/backend/src/shared/admin_reads.py
+++ b/backend/src/shared/admin_reads.py
@@ -258,8 +258,6 @@ def _build_courses_query(
             teacher_user,
             and_(
                 teacher_membership.user_id == teacher_user.id,
-                teacher_user.tenant_id == context.university_id,
-                teacher_user.role == "teacher",
             ),
         )
         .outerjoin(
@@ -508,11 +506,7 @@ def list_teacher_options(db: Session, context: AdminContext) -> TeacherOptionsRe
             .join(Profile, Membership.user_id == Profile.id)
             .outerjoin(
                 User,
-                and_(
-                    User.id == Membership.user_id,
-                    User.tenant_id == context.university_id,
-                    User.role == "teacher",
-                ),
+                User.id == Membership.user_id,
             )
             .where(
                 Membership.university_id == context.university_id,

--- a/backend/src/shared/admin_writes.py
+++ b/backend/src/shared/admin_writes.py
@@ -9,7 +9,7 @@ from typing import Any, Literal, NoReturn
 from fastapi import HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Session
 
 from shared.admin_context import AdminContext
@@ -195,13 +195,21 @@ def _resolve_teacher_assignment(
             membership_id=membership.id,
         )
 
-    invite = db.scalar(
-        select(Invite).where(
-            Invite.id == reference_id,
-            Invite.university_id == context.university_id,
-            Invite.role == "teacher",
+    try:
+        invite = db.scalar(
+            select(Invite)
+            .where(
+                Invite.id == reference_id,
+                Invite.university_id == context.university_id,
+                Invite.role == "teacher",
+            )
+            .with_for_update(nowait=True)
         )
-    )
+    except OperationalError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="stale_pending_teacher_invite",
+        ) from exc
     if invite is None or invite_effective_status(invite) != "pending":
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os
 import pathlib
-import sys
 import time
 from typing import Any
 import uuid
@@ -49,6 +48,7 @@ from shared.identity_activation import (
     derive_oauth_full_name,
     ensure_course_membership as ensure_course_membership_impl,
     ensure_email_domain_allowed,
+    promote_pending_teacher_courses as promote_pending_teacher_courses_impl,
     upsert_membership as upsert_membership_impl,
     upsert_profile as upsert_profile_impl,
 )
@@ -115,17 +115,33 @@ def upsert_membership(db: Session, auth_user_id: str, university_id: str, role: 
     return upsert_membership_impl(db, auth_user_id, university_id, role)
 
 
-def promote_pending_teacher_courses(db: Session, invite_id: str, membership_id: str, university_id: str) -> None:
-    courses = db.scalars(
-        select(Course).where(
-            Course.university_id == university_id,
-            Course.pending_teacher_invite_id == invite_id,
+def upsert_legacy_teacher_user(db: Session, *, auth_user_id: str, university_id: str, email: str) -> User:
+    legacy_user = db.get(User, auth_user_id)
+    if legacy_user is None:
+        legacy_user = User(
+            id=auth_user_id,
+            tenant_id=university_id,
+            email=email,
+            role="teacher",
         )
-    ).all()
-    for course in courses:
-        course.teacher_membership_id = membership_id
-        course.pending_teacher_invite_id = None
+        db.add(legacy_user)
+        db.flush()
+        return legacy_user
+
+    legacy_user.tenant_id = university_id
+    legacy_user.email = email
+    legacy_user.role = "teacher"
     db.flush()
+    return legacy_user
+
+
+def promote_pending_teacher_courses(db: Session, invite_id: str, membership_id: str, university_id: str) -> None:
+    promote_pending_teacher_courses_impl(
+        db,
+        invite_id=invite_id,
+        membership_id=membership_id,
+        university_id=university_id,
+    )
 
 
 def upsert_course_membership(db: Session, course_id: str, membership_id: str) -> tuple[CourseMembership, bool]:
@@ -837,22 +853,27 @@ def activate_password(
         created_new_user = admin_user_result.created
 
     try:
-        current_module = sys.modules[__name__]
-        current_module.upsert_profile(
+        upsert_profile(
             db,
             auth_user.id,
             derive_activation_full_name(req.full_name, invite.email),
         )
-        membership = current_module.upsert_membership(
+        membership = upsert_membership(
             db,
             auth_user.id,
             invite.university_id,
             invite.role,
         )
         if invite.role == "teacher":
+            upsert_legacy_teacher_user(
+                db,
+                auth_user_id=auth_user.id,
+                university_id=invite.university_id,
+                email=invite.email,
+            )
             promote_pending_teacher_courses(db, invite.id, membership.id, invite.university_id)
         if invite.role == "student" and invite.course_id:
-            current_module.upsert_course_membership(db, invite.course_id, membership.id)
+            upsert_course_membership(db, invite.course_id, membership.id)
         if not consume_invite_if_pending(db, invite):
             db.rollback()
             if activation_state_exists(db, invite, auth_user.id):
@@ -932,22 +953,27 @@ def activate_oauth_complete(
         _check_student_email_domain(db, invite)
 
     try:
-        current_module = sys.modules[__name__]
-        current_module.upsert_profile(
+        upsert_profile(
             db,
             identity.auth_user_id,
-            derive_oauth_full_name(identity) or identity.auth_user_id,
+            derive_oauth_full_name(identity) or invite.email.split("@", maxsplit=1)[0],
         )
-        membership = current_module.upsert_membership(
+        membership = upsert_membership(
             db,
             identity.auth_user_id,
             invite.university_id,
             invite.role,
         )
         if invite.role == "teacher":
+            upsert_legacy_teacher_user(
+                db,
+                auth_user_id=identity.auth_user_id,
+                university_id=invite.university_id,
+                email=invite.email,
+            )
             promote_pending_teacher_courses(db, invite.id, membership.id, invite.university_id)
         if invite.role == "student" and invite.course_id:
-            current_module.upsert_course_membership(db, invite.course_id, membership.id)
+            upsert_course_membership(db, invite.course_id, membership.id)
         if not consume_invite_if_pending(db, invite):
             db.rollback()
             if activation_state_exists(db, invite, identity.auth_user_id):

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -102,6 +102,14 @@ def get_invite_by_token(db: Session, invite_token: str) -> Invite | None:
     return db.scalar(select(Invite).where(Invite.token_hash == hash_invite_token(invite_token)))
 
 
+def get_invite_by_token_for_update(db: Session, invite_token: str) -> Invite | None:
+    return db.scalar(
+        select(Invite)
+        .where(Invite.token_hash == hash_invite_token(invite_token))
+        .with_for_update()
+    )
+
+
 def require_invite_email_match(invite: Invite, email: str | None) -> None:
     if normalize_email(invite.email) != normalize_email(email):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="invalid_invite_actor")
@@ -128,7 +136,6 @@ def upsert_legacy_teacher_user(db: Session, *, auth_user_id: str, university_id:
         db.flush()
         return legacy_user
 
-    legacy_user.tenant_id = university_id
     legacy_user.email = email
     legacy_user.role = "teacher"
     db.flush()
@@ -183,6 +190,37 @@ def activation_state_exists(db: Session, invite: Invite, auth_user_id: str) -> b
         return course_membership is not None
 
     return True
+
+
+def _get_activation_membership(db: Session, invite: Invite, auth_user_id: str) -> Membership | None:
+    return db.scalar(
+        select(Membership).where(
+            Membership.user_id == auth_user_id,
+            Membership.university_id == invite.university_id,
+            Membership.role == invite.role,
+        )
+    )
+
+
+def repair_consumed_activation_state(
+    db: Session,
+    *,
+    invite: Invite,
+    auth_user_id: str,
+    email: str,
+) -> None:
+    membership = _get_activation_membership(db, invite, auth_user_id)
+    if membership is None:
+        raise RuntimeError("activation_membership_missing_during_repair")
+
+    if invite.role == "teacher":
+        upsert_legacy_teacher_user(
+            db,
+            auth_user_id=auth_user_id,
+            university_id=invite.university_id,
+            email=email,
+        )
+        promote_pending_teacher_courses(db, invite.id, membership.id, invite.university_id)
 
 def _check_student_email_domain(db: Session, invite: Invite) -> None:
     """Raise 422 if the invite email domain is not in the university's allow-list.
@@ -825,7 +863,7 @@ def activate_password(
     if req.password != req.confirm_password:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="password_mismatch")
 
-    invite = get_invite_by_token(db, req.invite_token)
+    invite = get_invite_by_token_for_update(db, req.invite_token)
     if invite is None:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_invite")
 
@@ -833,6 +871,20 @@ def activate_password(
     existing_user = admin_client.find_user_by_email(invite.email)
     effective_status = invite_effective_status(invite)
     if effective_status == "consumed" and existing_user and activation_state_exists(db, invite, existing_user.id):
+        try:
+            repair_consumed_activation_state(
+                db,
+                invite=invite,
+                auth_user_id=existing_user.id,
+                email=invite.email,
+            )
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="activation_failed",
+            ) from exc
         return ActivatePasswordResponse(status="activated", next_step="sign_in", email=invite.email)
     if effective_status != "pending":
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_invite")
@@ -856,7 +908,7 @@ def activate_password(
         upsert_profile(
             db,
             auth_user.id,
-            derive_activation_full_name(req.full_name, invite.email),
+            derive_activation_full_name(req.full_name or invite.full_name, invite.email),
         )
         membership = upsert_membership(
             db,
@@ -875,9 +927,16 @@ def activate_password(
         if invite.role == "student" and invite.course_id:
             upsert_course_membership(db, invite.course_id, membership.id)
         if not consume_invite_if_pending(db, invite):
-            db.rollback()
             if activation_state_exists(db, invite, auth_user.id):
+                repair_consumed_activation_state(
+                    db,
+                    invite=invite,
+                    auth_user_id=auth_user.id,
+                    email=invite.email,
+                )
+                db.commit()
                 return ActivatePasswordResponse(status="activated", next_step="sign_in", email=invite.email)
+            db.rollback()
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_invite")
         db.commit()
     except HTTPException:
@@ -926,12 +985,26 @@ def activate_oauth_complete(
     identity: VerifiedIdentity = Depends(require_verified_identity),
     db: Session = Depends(get_db),
 ) -> ActivateOAuthCompleteResponse:
-    invite = get_invite_by_token(db, req.invite_token)
+    invite = get_invite_by_token_for_update(db, req.invite_token)
     if invite is None:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_invite")
 
     effective_status = invite_effective_status(invite)
     if effective_status == "consumed" and activation_state_exists(db, invite, identity.auth_user_id):
+        try:
+            repair_consumed_activation_state(
+                db,
+                invite=invite,
+                auth_user_id=identity.auth_user_id,
+                email=invite.email,
+            )
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="activation_failed",
+            ) from exc
         return ActivateOAuthCompleteResponse(status="activated")
     if effective_status != "pending":
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_invite")
@@ -956,7 +1029,7 @@ def activate_oauth_complete(
         upsert_profile(
             db,
             identity.auth_user_id,
-            derive_oauth_full_name(identity) or invite.email.split("@", maxsplit=1)[0],
+            derive_oauth_full_name(identity) or invite.full_name or invite.email.split("@", maxsplit=1)[0],
         )
         membership = upsert_membership(
             db,
@@ -975,9 +1048,16 @@ def activate_oauth_complete(
         if invite.role == "student" and invite.course_id:
             upsert_course_membership(db, invite.course_id, membership.id)
         if not consume_invite_if_pending(db, invite):
-            db.rollback()
             if activation_state_exists(db, invite, identity.auth_user_id):
+                repair_consumed_activation_state(
+                    db,
+                    invite=invite,
+                    auth_user_id=identity.auth_user_id,
+                    email=invite.email,
+                )
+                db.commit()
                 return ActivateOAuthCompleteResponse(status="activated")
+            db.rollback()
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_invite")
         db.commit()
     except HTTPException:

--- a/backend/src/shared/identity_activation.py
+++ b/backend/src/shared/identity_activation.py
@@ -73,11 +73,6 @@ def derive_oauth_full_name(identity: Any) -> str | None:
                 value = user_metadata.get(key)
                 if isinstance(value, str) and value.strip():
                     return value.strip()
-
-    identity_email = getattr(identity, "email", None)
-    normalized_email = normalize_email(identity_email)
-    if normalized_email:
-        return normalized_email.split("@", maxsplit=1)[0]
     return None
 
 

--- a/backend/src/shared/identity_activation.py
+++ b/backend/src/shared/identity_activation.py
@@ -6,12 +6,12 @@ from typing import Any
 
 from cachetools import TTLCache
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from shared.auth import normalize_email
-from shared.models import AllowedEmailDomain, CourseMembership, Membership, Profile, UniversitySsoConfig
+from shared.models import AllowedEmailDomain, Course, CourseMembership, Membership, Profile, UniversitySsoConfig
 
 
 def utc_now() -> datetime:
@@ -179,6 +179,41 @@ def ensure_course_membership(db: Session, *, course_id: str, membership_id: str)
     if course_membership is None:  # pragma: no cover
         raise RuntimeError("course_membership_inserted_but_missing")
     return course_membership, True
+
+
+def promote_pending_teacher_courses(
+    db: Session,
+    *,
+    invite_id: str,
+    membership_id: str,
+    university_id: str,
+) -> int:
+    promoted_courses = db.execute(
+        update(Course)
+        .where(
+            Course.university_id == university_id,
+            Course.pending_teacher_invite_id == invite_id,
+            Course.teacher_membership_id.is_(None),
+        )
+        .values(
+            teacher_membership_id=membership_id,
+            pending_teacher_invite_id=None,
+        )
+        .returning(Course.id)
+    ).scalars().all()
+
+    remaining_pending_courses = db.scalar(
+        select(Course.id)
+        .where(
+            Course.university_id == university_id,
+            Course.pending_teacher_invite_id == invite_id,
+        )
+        .limit(1)
+    )
+    if remaining_pending_courses is not None:  # pragma: no cover
+        raise RuntimeError("pending_teacher_course_promotion_incomplete")
+
+    return len(promoted_courses)
 
 
 def allowed_auth_methods_for_university(db: Session, university_id: str) -> list[str]:

--- a/backend/tests/test_issue30_auth_perimeter.py
+++ b/backend/tests/test_issue30_auth_perimeter.py
@@ -25,6 +25,20 @@ def build_auth_settings(*, environment: str = "development", jwt_secret: str = "
     )
 
 
+def _seed_admin(seed_identity, *, university_id: str) -> tuple[str, str]:
+    user_id = str(uuid.uuid4())
+    email = f"admin-{uuid.uuid4().hex[:8]}@example.edu"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="university_admin",
+        university_id=university_id,
+        create_legacy_user=False,
+        full_name="Admin Reviewer",
+    )
+    return user_id, email
+
+
 def test_health_returns_ok(client) -> None:
     response = client.get("/health")
 
@@ -882,11 +896,13 @@ def test_activate_password_promotes_pending_teacher_courses(
     seed_course,
     seed_identity,
     seed_invite,
+    auth_headers_factory,
 ) -> None:
     teacher_university = "10000000-0000-0000-0000-000000000073"
     tenant = Tenant(id=teacher_university, name="Teacher Promotion University")
     db.add(tenant)
     db.commit()
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=teacher_university)
     invite, token = seed_invite(
         email="teacher.promote@example.edu",
         university_id=teacher_university,
@@ -937,6 +953,37 @@ def test_activate_password_promotes_pending_teacher_courses(
     assert refreshed_first.pending_teacher_invite_id is None
     assert refreshed_second.pending_teacher_invite_id is None
 
+    admin_headers = auth_headers_factory(sub=admin_id, email=admin_email)
+    courses_response = client.get("/api/admin/courses", headers=admin_headers)
+    assert courses_response.status_code == 200, courses_response.text
+    courses_payload = courses_response.json()
+    promoted_courses = sorted(courses_payload["items"], key=lambda item: item["code"])
+    assert [item["code"] for item in promoted_courses] == ["PROMOTE-001", "PROMOTE-002"]
+    assert all(item["teacher_state"] == "active" for item in promoted_courses)
+    assert all(item["teacher_assignment"] == {"kind": "membership", "membership_id": membership.id} for item in promoted_courses)
+    assert all(item["teacher_display_name"] == "teacher.promote" for item in promoted_courses)
+
+    summary_response = client.get("/api/admin/dashboard/summary", headers=admin_headers)
+    assert summary_response.status_code == 200, summary_response.text
+    assert summary_response.json() == {
+        "active_courses": 2,
+        "active_teachers": 1,
+        "enrolled_students": 0,
+        "average_occupancy": 0,
+    }
+
+    teacher_options_response = client.get("/api/admin/teacher-options", headers=admin_headers)
+    assert teacher_options_response.status_code == 200, teacher_options_response.text
+    teacher_options_payload = teacher_options_response.json()
+    assert teacher_options_payload["pending_invites"] == []
+    assert teacher_options_payload["active_teachers"] == [
+        {
+            "membership_id": membership.id,
+            "full_name": "teacher.promote",
+            "email": "teacher.promote@example.edu",
+        }
+    ]
+
 
 def test_activate_oauth_complete_promotes_pending_teacher_courses(
     client,
@@ -944,11 +991,13 @@ def test_activate_oauth_complete_promotes_pending_teacher_courses(
     seed_course,
     seed_invite,
     auth_headers_factory,
+    seed_identity,
 ) -> None:
     teacher_university = "10000000-0000-0000-0000-000000000074"
     tenant = Tenant(id=teacher_university, name="Teacher OAuth Promotion University")
     db.add(tenant)
     db.commit()
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=teacher_university)
     invite, token = seed_invite(
         email="teacher.oauth.promote@example.edu",
         university_id=teacher_university,
@@ -988,6 +1037,53 @@ def test_activate_oauth_complete_promotes_pending_teacher_courses(
     assert refreshed_course is not None
     assert refreshed_course.teacher_membership_id == membership.id
     assert refreshed_course.pending_teacher_invite_id is None
+
+    admin_headers = auth_headers_factory(sub=admin_id, email=admin_email)
+    courses_response = client.get("/api/admin/courses", headers=admin_headers)
+    assert courses_response.status_code == 200, courses_response.text
+    assert courses_response.json()["items"] == [
+        {
+            "id": course.id,
+            "title": "Pending OAuth Promotion",
+            "code": "PROMOTE-OAUTH-001",
+            "semester": "2026-I",
+            "academic_level": "Pregrado",
+            "status": "active",
+            "teacher_display_name": "Teacher OAuth Promote",
+            "teacher_state": "active",
+            "teacher_assignment": {
+                "kind": "membership",
+                "membership_id": membership.id,
+            },
+            "students_count": 0,
+            "max_students": 30,
+            "occupancy_percent": 0,
+            "access_link": None,
+            "access_link_status": "missing",
+        }
+    ]
+
+    summary_response = client.get("/api/admin/dashboard/summary", headers=admin_headers)
+    assert summary_response.status_code == 200, summary_response.text
+    assert summary_response.json() == {
+        "active_courses": 1,
+        "active_teachers": 1,
+        "enrolled_students": 0,
+        "average_occupancy": 0,
+    }
+
+    teacher_options_response = client.get("/api/admin/teacher-options", headers=admin_headers)
+    assert teacher_options_response.status_code == 200, teacher_options_response.text
+    assert teacher_options_response.json() == {
+        "active_teachers": [
+            {
+                "membership_id": membership.id,
+                "full_name": "Teacher OAuth Promote",
+                "email": "teacher.oauth.promote@example.edu",
+            }
+        ],
+        "pending_invites": [],
+    }
 
 
 def test_activate_oauth_full_name_from_user_metadata_key(

--- a/backend/tests/test_issue30_auth_perimeter.py
+++ b/backend/tests/test_issue30_auth_perimeter.py
@@ -13,7 +13,7 @@ from jwt.exceptions import PyJWKClientError
 from sqlalchemy import select
 
 from shared.auth import AuthError, AuthSettings, JwtVerifier, SupabaseAdminAuthClient
-from shared.models import Assignment, AuthoringJob, CourseMembership, Membership, Profile, Tenant
+from shared.models import Assignment, AuthoringJob, Course, CourseMembership, Membership, Profile, Tenant, User
 
 
 def build_auth_settings(*, environment: str = "development", jwt_secret: str = "test-jwt-secret-with-sufficient-length-123") -> AuthSettings:
@@ -961,7 +961,7 @@ def test_activate_password_promotes_pending_teacher_courses(
     assert [item["code"] for item in promoted_courses] == ["PROMOTE-001", "PROMOTE-002"]
     assert all(item["teacher_state"] == "active" for item in promoted_courses)
     assert all(item["teacher_assignment"] == {"kind": "membership", "membership_id": membership.id} for item in promoted_courses)
-    assert all(item["teacher_display_name"] == "teacher.promote" for item in promoted_courses)
+    assert all(item["teacher_display_name"] == "Teacher Promote" for item in promoted_courses)
 
     summary_response = client.get("/api/admin/dashboard/summary", headers=admin_headers)
     assert summary_response.status_code == 200, summary_response.text
@@ -979,7 +979,7 @@ def test_activate_password_promotes_pending_teacher_courses(
     assert teacher_options_payload["active_teachers"] == [
         {
             "membership_id": membership.id,
-            "full_name": "teacher.promote",
+            "full_name": "Teacher Promote",
             "email": "teacher.promote@example.edu",
         }
     ]
@@ -1091,7 +1091,7 @@ def test_activate_oauth_full_name_from_user_metadata_key(
 ) -> None:
     """JWT with user_metadata.full_name → Profile uses that name.
 
-    derive_oauth_full_name tries ("full_name", "name") in order.
+    derive_oauth_full_name tries metadata keys ("full_name", "name") in order.
     The existing success test covers "name"; this covers the higher-priority "full_name".
     """
     tenant = Tenant(id=str(uuid.uuid4()), name="OAuth FullName University")
@@ -1113,14 +1113,19 @@ def test_activate_oauth_full_name_from_user_metadata_key(
     assert profile.full_name == "Ana García"
 
 
-def test_activate_oauth_full_name_fallback_to_email_prefix(
+def test_activate_oauth_full_name_fallback_to_invite_full_name(
     client, seed_invite, auth_headers_factory, db
 ) -> None:
     """JWT with no user_metadata → Profile.full_name falls back to email prefix."""
     tenant = Tenant(id=str(uuid.uuid4()), name="OAuth Fallback University")
     db.add(tenant)
     db.commit()
-    _, token = seed_invite(email="fallback-teacher@example.edu", university_id=tenant.id, role="teacher")
+    _, token = seed_invite(
+        email="fallback-teacher@example.edu",
+        university_id=tenant.id,
+        role="teacher",
+        full_name="Fallback Invite Teacher",
+    )
     user_id = str(uuid.uuid4())
     headers = auth_headers_factory(sub=user_id, email="fallback-teacher@example.edu")
 
@@ -1129,4 +1134,294 @@ def test_activate_oauth_full_name_fallback_to_email_prefix(
     assert response.status_code == 200
     profile = db.get(Profile, user_id)
     assert profile is not None
-    assert profile.full_name == "fallback-teacher"
+    assert profile.full_name == "Fallback Invite Teacher"
+
+
+def test_activate_password_repairs_consumed_teacher_invite_without_legacy_bridge(
+    client,
+    db,
+    fake_admin_client,
+    seed_identity,
+    seed_invite,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000075"
+    db.add(Tenant(id=university_id, name="Consumed Repair Password University"))
+    db.commit()
+    auth_user = fake_admin_client.create_password_user("repair.password.teacher@example.edu", "unused-password")
+    seed_identity(
+        user_id=auth_user.id,
+        email="repair.password.teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Repair Password Teacher",
+        create_legacy_user=False,
+    )
+    invite, token = seed_invite(
+        email="repair.password.teacher@example.edu",
+        university_id=university_id,
+        role="teacher",
+        status="consumed",
+        full_name="Repair Password Teacher",
+    )
+
+    response = client.post(
+        "/api/auth/activate/password",
+        json={
+            "invite_token": token,
+            "password": "super-secret",
+            "confirm_password": "super-secret",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    repaired_legacy_user = db.get(User, auth_user.id)
+    assert repaired_legacy_user is not None
+    assert repaired_legacy_user.tenant_id == university_id
+    assert repaired_legacy_user.email == invite.email
+    assert repaired_legacy_user.role == "teacher"
+
+
+def test_activate_oauth_complete_repairs_consumed_teacher_invite_without_legacy_bridge(
+    client,
+    db,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000076"
+    db.add(Tenant(id=university_id, name="Consumed Repair OAuth University"))
+    db.commit()
+    auth_user_id = str(uuid.uuid4())
+    seed_identity(
+        user_id=auth_user_id,
+        email="repair.oauth.teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Repair OAuth Teacher",
+        create_legacy_user=False,
+    )
+    _, token = seed_invite(
+        email="repair.oauth.teacher@example.edu",
+        university_id=university_id,
+        role="teacher",
+        status="consumed",
+        full_name="Repair OAuth Teacher",
+    )
+
+    response = client.post(
+        "/api/auth/activate/oauth/complete",
+        json={"invite_token": token},
+        headers=auth_headers_factory(
+            sub=auth_user_id,
+            email="repair.oauth.teacher@example.edu",
+            claims={"user_metadata": {}},
+        ),
+    )
+
+    assert response.status_code == 200, response.text
+    repaired_legacy_user = db.get(User, auth_user_id)
+    assert repaired_legacy_user is not None
+    assert repaired_legacy_user.tenant_id == university_id
+    assert repaired_legacy_user.email == "repair.oauth.teacher@example.edu"
+    assert repaired_legacy_user.role == "teacher"
+
+
+def test_activate_password_repairs_consumed_teacher_courses_left_pending(
+    client,
+    db,
+    fake_admin_client,
+    seed_identity,
+    seed_invite,
+    seed_course,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000077"
+    db.add(Tenant(id=university_id, name="Consumed Course Repair University"))
+    db.commit()
+    auth_user = fake_admin_client.create_password_user("repair.course.teacher@example.edu", "unused-password")
+    teacher_seed = seed_identity(
+        user_id=auth_user.id,
+        email="repair.course.teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Repair Course Teacher",
+        create_legacy_user=False,
+    )
+    invite, token = seed_invite(
+        email="repair.course.teacher@example.edu",
+        university_id=university_id,
+        role="teacher",
+        status="consumed",
+        full_name="Repair Course Teacher",
+    )
+    course = seed_course(
+        university_id=university_id,
+        pending_teacher_invite_id=invite.id,
+        title="Repair Pending Course",
+        code="REPAIR-PENDING-001",
+    )
+
+    response = client.post(
+        "/api/auth/activate/password",
+        json={
+            "invite_token": token,
+            "password": "super-secret",
+            "confirm_password": "super-secret",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    db.expire_all()
+    refreshed_course = db.get(Course, course.id)
+    assert refreshed_course is not None
+    assert refreshed_course.teacher_membership_id == teacher_seed["membership"].id
+    assert refreshed_course.pending_teacher_invite_id is None
+
+
+def test_activate_oauth_complete_keeps_first_tenant_bridge_and_admin_reads_work_across_universities(
+    client,
+    db,
+    seed_identity,
+    seed_invite,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    first_university_id = "10000000-0000-0000-0000-000000000078"
+    second_university_id = "10000000-0000-0000-0000-000000000079"
+    db.add_all(
+        [
+            Tenant(id=first_university_id, name="First Teacher University"),
+            Tenant(id=second_university_id, name="Second Teacher University"),
+        ]
+    )
+    db.commit()
+    first_admin_id, first_admin_email = _seed_admin(seed_identity, university_id=first_university_id)
+    second_admin_id, second_admin_email = _seed_admin(seed_identity, university_id=second_university_id)
+    teacher_user_id = str(uuid.uuid4())
+    first_teacher = seed_identity(
+        user_id=teacher_user_id,
+        email="multi.university.teacher@example.edu",
+        role="teacher",
+        university_id=first_university_id,
+        full_name="Multi University Teacher",
+    )
+    first_course = seed_course(
+        university_id=first_university_id,
+        teacher_membership_id=first_teacher["membership"].id,
+        title="First University Course",
+        code="MULTI-UNI-001",
+    )
+    invite, token = seed_invite(
+        email="multi.university.teacher@example.edu",
+        university_id=second_university_id,
+        role="teacher",
+        full_name="Multi University Teacher",
+    )
+    second_course = seed_course(
+        university_id=second_university_id,
+        pending_teacher_invite_id=invite.id,
+        title="Second University Course",
+        code="MULTI-UNI-002",
+    )
+
+    response = client.post(
+        "/api/auth/activate/oauth/complete",
+        json={"invite_token": token},
+        headers=auth_headers_factory(
+            sub=teacher_user_id,
+            email="multi.university.teacher@example.edu",
+            claims={"user_metadata": {}},
+        ),
+    )
+
+    assert response.status_code == 200, response.text
+    second_membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == teacher_user_id,
+            Membership.university_id == second_university_id,
+            Membership.role == "teacher",
+        )
+    )
+    assert second_membership is not None
+    legacy_user = db.get(User, teacher_user_id)
+    assert legacy_user is not None
+    assert legacy_user.tenant_id == first_university_id
+
+    first_courses_response = client.get(
+        "/api/admin/courses",
+        headers=auth_headers_factory(sub=first_admin_id, email=first_admin_email),
+    )
+    assert first_courses_response.status_code == 200, first_courses_response.text
+    assert first_courses_response.json()["items"] == [
+        {
+            "id": first_course.id,
+            "title": "First University Course",
+            "code": "MULTI-UNI-001",
+            "semester": "2026-I",
+            "academic_level": "Pregrado",
+            "status": "active",
+            "teacher_display_name": "Multi University Teacher",
+            "teacher_state": "active",
+            "teacher_assignment": {
+                "kind": "membership",
+                "membership_id": first_teacher["membership"].id,
+            },
+            "students_count": 0,
+            "max_students": 30,
+            "occupancy_percent": 0,
+            "access_link": None,
+            "access_link_status": "missing",
+        }
+    ]
+
+    second_courses_response = client.get(
+        "/api/admin/courses",
+        headers=auth_headers_factory(sub=second_admin_id, email=second_admin_email),
+    )
+    assert second_courses_response.status_code == 200, second_courses_response.text
+    assert second_courses_response.json()["items"] == [
+        {
+            "id": second_course.id,
+            "title": "Second University Course",
+            "code": "MULTI-UNI-002",
+            "semester": "2026-I",
+            "academic_level": "Pregrado",
+            "status": "active",
+            "teacher_display_name": "Multi University Teacher",
+            "teacher_state": "active",
+            "teacher_assignment": {
+                "kind": "membership",
+                "membership_id": second_membership.id,
+            },
+            "students_count": 0,
+            "max_students": 30,
+            "occupancy_percent": 0,
+            "access_link": None,
+            "access_link_status": "missing",
+        }
+    ]
+
+    first_options_response = client.get(
+        "/api/admin/teacher-options",
+        headers=auth_headers_factory(sub=first_admin_id, email=first_admin_email),
+    )
+    assert first_options_response.status_code == 200, first_options_response.text
+    assert first_options_response.json()["active_teachers"] == [
+        {
+            "membership_id": first_teacher["membership"].id,
+            "full_name": "Multi University Teacher",
+            "email": "multi.university.teacher@example.edu",
+        }
+    ]
+
+    second_options_response = client.get(
+        "/api/admin/teacher-options",
+        headers=auth_headers_factory(sub=second_admin_id, email=second_admin_email),
+    )
+    assert second_options_response.status_code == 200, second_options_response.text
+    assert second_options_response.json()["active_teachers"] == [
+        {
+            "membership_id": second_membership.id,
+            "full_name": "Multi University Teacher",
+            "email": "multi.university.teacher@example.edu",
+        }
+    ]

--- a/backend/tests/test_issue55_admin_reads.py
+++ b/backend/tests/test_issue55_admin_reads.py
@@ -5,7 +5,7 @@ import uuid
 
 from sqlalchemy import select
 
-from shared.models import Course, Membership, Tenant
+from shared.models import Course, Membership, Tenant, User
 
 
 def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
@@ -669,3 +669,93 @@ def test_issue55_teacher_options_fail_explicitly_if_email_is_unavailable(
 
     assert response.status_code == 500
     assert response.json()["detail"] == "teacher_email_unavailable"
+
+
+def test_issue55_teacher_options_and_courses_ignore_legacy_tenant_mismatch_for_teacher_email(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    first_university_id = "10000000-0000-0000-0000-000000000566"
+    second_university_id = "10000000-0000-0000-0000-000000000567"
+    _seed_admin(seed_identity, university_id=first_university_id)
+    second_admin_id, second_admin_email = _seed_admin(seed_identity, university_id=second_university_id)
+    teacher_user_id = str(uuid.uuid4())
+    seed_identity(
+        user_id=teacher_user_id,
+        email="shared.teacher@example.edu",
+        role="teacher",
+        university_id=first_university_id,
+        full_name="Shared Teacher",
+    )
+    db.add(
+        Membership(
+            user_id=teacher_user_id,
+            university_id=second_university_id,
+            role="teacher",
+            status="active",
+            must_rotate_password=False,
+        )
+    )
+    db.commit()
+    second_membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == teacher_user_id,
+            Membership.university_id == second_university_id,
+            Membership.role == "teacher",
+        )
+    )
+    assert second_membership is not None
+    legacy_user = db.get(User, teacher_user_id)
+    assert legacy_user is not None
+    assert legacy_user.tenant_id == first_university_id
+    second_course = seed_course(
+        university_id=second_university_id,
+        teacher_membership_id=second_membership.id,
+        title="Second Tenant Shared Teacher",
+        code="SHARED-TEACHER-001",
+    )
+
+    teacher_options_response = client.get(
+        "/api/admin/teacher-options",
+        headers=_auth_headers(auth_headers_factory, user_id=second_admin_id, email=second_admin_email),
+    )
+
+    assert teacher_options_response.status_code == 200, teacher_options_response.text
+    assert teacher_options_response.json()["active_teachers"] == [
+        {
+            "membership_id": second_membership.id,
+            "full_name": "Shared Teacher",
+            "email": "shared.teacher@example.edu",
+        }
+    ]
+
+    courses_response = client.get(
+        "/api/admin/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=second_admin_id, email=second_admin_email),
+    )
+
+    assert courses_response.status_code == 200, courses_response.text
+    assert courses_response.json()["items"] == [
+        {
+            "id": second_course.id,
+            "title": "Second Tenant Shared Teacher",
+            "code": "SHARED-TEACHER-001",
+            "semester": "2026-I",
+            "academic_level": "Pregrado",
+            "status": "active",
+            "teacher_display_name": "Shared Teacher",
+            "teacher_state": "active",
+            "teacher_assignment": {
+                "kind": "membership",
+                "membership_id": second_membership.id,
+            },
+            "students_count": 0,
+            "max_students": 30,
+            "occupancy_percent": 0,
+            "access_link": None,
+            "access_link_status": "missing",
+        }
+    ]

--- a/backend/tests/test_issue56_admin_writes.py
+++ b/backend/tests/test_issue56_admin_writes.py
@@ -191,6 +191,41 @@ def test_issue56_create_course_rejects_stale_pending_teacher_invite(
     assert response.json()["detail"] == "stale_pending_teacher_invite"
 
 
+def test_issue56_create_course_rejects_pending_teacher_invite_locked_by_activation(
+    client,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000624"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    invite, _ = seed_invite(
+        email="locked-create@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Locked Create",
+    )
+
+    blocking_session = SessionLocal()
+    try:
+        locked_invite = blocking_session.scalar(
+            select(Invite).where(Invite.id == invite.id).with_for_update()
+        )
+        assert locked_invite is not None
+
+        response = client.post(
+            "/api/admin/courses",
+            json=_course_payload(teacher_assignment={"kind": "pending_invite", "invite_id": invite.id}),
+            headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+        )
+    finally:
+        blocking_session.rollback()
+        blocking_session.close()
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "stale_pending_teacher_invite"
+
+
 def test_issue56_create_course_translates_duplicate_code_and_semester_conflict(
     client,
     seed_identity,
@@ -534,6 +569,56 @@ def test_issue56_patch_course_rejects_stale_pending_teacher_invite(
         ),
         headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
     )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "stale_pending_teacher_invite"
+
+
+def test_issue56_patch_course_rejects_pending_teacher_invite_locked_by_activation(
+    client,
+    seed_identity,
+    seed_course,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000625"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="locked-patch-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    invite, _ = seed_invite(
+        email="locked-patch@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Locked Patch",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Locked Patch Course",
+        code="LOCKED-PATCH-001",
+    )
+
+    blocking_session = SessionLocal()
+    try:
+        locked_invite = blocking_session.scalar(
+            select(Invite).where(Invite.id == invite.id).with_for_update()
+        )
+        assert locked_invite is not None
+
+        response = client.patch(
+            f"/api/admin/courses/{course.id}",
+            json=_course_payload(
+                teacher_assignment={"kind": "pending_invite", "invite_id": invite.id}
+            ),
+            headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+        )
+    finally:
+        blocking_session.rollback()
+        blocking_session.close()
 
     assert response.status_code == 409
     assert response.json()["detail"] == "stale_pending_teacher_invite"

--- a/backend/tests/test_issue56_admin_writes.py
+++ b/backend/tests/test_issue56_admin_writes.py
@@ -8,7 +8,7 @@ from sqlalchemy import func, select
 from shared.course_access_links import course_regeneration_lock_key
 from shared.database import SessionLocal
 from shared.invite_status import utc_now
-from shared.models import Course, CourseAccessLink, Invite
+from shared.models import Course, CourseAccessLink, CourseMembership, Invite, Membership, UniversitySsoConfig
 
 
 def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
@@ -321,6 +321,69 @@ def test_issue56_patch_course_switches_from_pending_invite_to_membership(
     assert payload["teacher_state"] == "active"
 
 
+def test_issue56_create_course_accepts_legacy_ascii_academic_level_alias(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000630"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="create-alias-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Create Alias Teacher",
+    )
+
+    response = client.post(
+        "/api/admin/courses",
+        json=_course_payload(
+            teacher_assignment={"kind": "membership", "membership_id": teacher["membership"].id},
+            title="Legacy Alias Create",
+            code="ALIAS-CREATE-001",
+            academic_level="Especializacion",
+        ),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 201
+    assert response.json()["academic_level"] == "Especialización"
+    db.expire_all()
+    created = db.get(Course, response.json()["id"])
+    assert created is not None
+    assert created.academic_level == "Especialización"
+
+
+def test_issue56_create_course_rejects_invalid_academic_level(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000632"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="invalid-level-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+
+    response = client.post(
+        "/api/admin/courses",
+        json=_course_payload(
+            teacher_assignment={"kind": "membership", "membership_id": teacher["membership"].id},
+            academic_level="Posdoctorado",
+        ),
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 422
+    assert "academic_level" in response.text
+    assert "invalid" in response.text
+
+
 def test_issue56_patch_course_accepts_legacy_ascii_academic_level_alias(
     client,
     db,
@@ -551,6 +614,155 @@ def test_issue56_regenerate_course_access_link_rotates_previous_link_and_keeps_o
     rotated = next(link for link in links if link.id == original_link.id)
     assert rotated.status == "rotated"
     assert rotated.rotated_at is not None
+
+
+def test_issue56_regenerate_course_access_link_supports_password_runtime_end_to_end(
+    client,
+    db,
+    fake_admin_client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000622"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="regenerate-password@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Password Regenerate",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Rotate Runtime Password",
+        code="ROTATE-RUNTIME-PASSWORD-001",
+    )
+    _, original_raw = seed_course_access_link(course_id=course.id, status="active")
+
+    regenerate_response = client.post(
+        f"/api/admin/courses/{course.id}/access-link/regenerate",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert regenerate_response.status_code == 200, regenerate_response.text
+    new_link = regenerate_response.json()["access_link"]
+    new_raw = new_link.split("=", maxsplit=1)[1]
+
+    old_resolve = client.post("/api/course-access/resolve", json={"course_access_token": original_raw})
+    assert old_resolve.status_code == 410
+    assert old_resolve.json()["detail"] == "course_access_link_rotated"
+
+    new_resolve = client.post("/api/course-access/resolve", json={"course_access_token": new_raw})
+    assert new_resolve.status_code == 200
+    assert new_resolve.json()["course_id"] == course.id
+
+    activate_response = client.post(
+        "/api/course-access/activate/password",
+        json={
+            "course_access_token": new_raw,
+            "email": "student.rotated.password@example.edu",
+            "full_name": "Student Rotated Password",
+            "password": "Secure1234!",
+            "confirm_password": "Secure1234!",
+        },
+    )
+    assert activate_response.status_code == 201, activate_response.text
+
+    auth_user = fake_admin_client.find_user_by_email("student.rotated.password@example.edu")
+    assert auth_user is not None
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == auth_user.id,
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    )
+    assert membership is not None
+    enrollment = db.scalar(
+        select(CourseMembership).where(
+            CourseMembership.course_id == course.id,
+            CourseMembership.membership_id == membership.id,
+        )
+    )
+    assert enrollment is not None
+
+
+def test_issue56_regenerate_course_access_link_supports_oauth_runtime_end_to_end(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000623"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="regenerate-oauth@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher OAuth Regenerate",
+    )
+    db.add(
+        UniversitySsoConfig(
+            university_id=university_id,
+            provider="azure",
+            azure_tenant_id="azure-tenant",
+            client_id="client-id",
+            enabled=True,
+        )
+    )
+    db.commit()
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Rotate Runtime OAuth",
+        code="ROTATE-RUNTIME-OAUTH-001",
+    )
+    _, original_raw = seed_course_access_link(course_id=course.id, status="active")
+
+    regenerate_response = client.post(
+        f"/api/admin/courses/{course.id}/access-link/regenerate",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert regenerate_response.status_code == 200, regenerate_response.text
+    new_link = regenerate_response.json()["access_link"]
+    new_raw = new_link.split("=", maxsplit=1)[1]
+
+    old_resolve = client.post("/api/course-access/resolve", json={"course_access_token": original_raw})
+    assert old_resolve.status_code == 410
+    assert old_resolve.json()["detail"] == "course_access_link_rotated"
+
+    activate_response = client.post(
+        "/api/course-access/activate/oauth/complete",
+        json={"course_access_token": new_raw},
+        headers=auth_headers_factory(
+            sub=str(uuid.uuid4()),
+            email="student.rotated.oauth@example.edu",
+            claims={"user_metadata": {"name": "Student Rotated OAuth"}},
+        ),
+    )
+    assert activate_response.status_code == 200, activate_response.text
+
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    )
+    assert membership is not None
+    enrollment = db.scalar(
+        select(CourseMembership).where(
+            CourseMembership.course_id == course.id,
+            CourseMembership.membership_id == membership.id,
+        )
+    )
+    assert enrollment is not None
 
 
 def test_issue56_regenerate_course_access_link_rejects_inactive_course(

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
@@ -277,6 +277,21 @@ describe("AdminDashboardPage", () => {
         });
     });
 
+    it("blocks invalid max_students locally before calling the backend", async () => {
+        renderPage();
+        await screen.findByText("Directorio de Cursos");
+
+        fireEvent.click(screen.getByText("Crear Nuevo Curso"));
+        fillCreateCourseForm("membership:teacher-membership-1");
+        fireEvent.change(screen.getByLabelText("Capacidad maxima"), {
+            target: { value: "3.5" },
+        });
+        fireEvent.submit(screen.getByTestId("create-course-modal").querySelector("form")!);
+
+        expect(await screen.findByText("La capacidad máxima debe ser un número entero mayor o igual a 1.")).toBeTruthy();
+        expect(api.admin.createCourse).not.toHaveBeenCalled();
+    });
+
     it("shows and copies the teacher invite activation link", async () => {
         renderPage();
         await screen.findByText("Directorio de Cursos");
@@ -396,11 +411,15 @@ describe("AdminDashboardPage", () => {
         renderPage();
         await screen.findByText("Directorio de Cursos");
 
+        expect(api.admin.getDashboardSummary).toHaveBeenCalledTimes(1);
         expect(api.admin.listCourses).toHaveBeenCalledTimes(1);
         expect(api.admin.getTeacherOptions).toHaveBeenCalledTimes(1);
 
         fireEvent.focus(window);
 
+        await waitFor(() => {
+            expect(api.admin.getDashboardSummary).toHaveBeenCalledTimes(2);
+        });
         await waitFor(() => {
             expect(api.admin.listCourses).toHaveBeenCalledTimes(2);
         });

--- a/frontend/src/features/admin-dashboard/adminDashboardModel.ts
+++ b/frontend/src/features/admin-dashboard/adminDashboardModel.ts
@@ -8,10 +8,11 @@ import type {
     AdminTeacherInviteResponse,
     AdminTeacherOptionsResponse,
 } from "@/shared/adam-types";
+import { NIVELES } from "@/shared/adam-types";
 import { ApiError } from "@/shared/api";
 
 export const ADMIN_PAGE_SIZE = 8;
-const ACADEMIC_LEVEL_CANONICAL = ["Pregrado", "Especialización", "Maestría", "MBA", "Doctorado"] as const;
+const ACADEMIC_LEVEL_CANONICAL = NIVELES;
 const ACADEMIC_LEVEL_ALIASES: Record<string, (typeof ACADEMIC_LEVEL_CANONICAL)[number]> = {
     Especializacion: "Especialización",
     Maestria: "Maestría",
@@ -113,13 +114,24 @@ export function buildCoursePayload(form: CourseFormState): AdminCourseMutationRe
         code: form.code.trim(),
         semester: form.semester.trim(),
         academic_level: normalizeAcademicLevel(form.academic_level),
-        max_students: Number.parseInt(form.max_students, 10),
+        max_students: parseMaxStudents(form.max_students),
         status: form.status,
         teacher_assignment: teacherAssignment,
     };
 }
 
 export function getAdminErrorMessage(error: unknown, fallback: string): string {
+    if (error instanceof Error) {
+        switch (error.message) {
+            case "teacher_assignment_required":
+                return "Selecciona un docente activo o una invitación pendiente antes de continuar.";
+            case "invalid_max_students":
+                return "La capacidad máxima debe ser un número entero mayor o igual a 1.";
+            default:
+                break;
+        }
+    }
+
     if (!(error instanceof ApiError)) return fallback;
 
     switch (error.detail) {
@@ -251,4 +263,18 @@ export function teacherInviteToPendingOption(response: AdminTeacherInviteRespons
         email: response.email,
         status: "pending",
     };
+}
+
+function parseMaxStudents(rawValue: string): number {
+    const normalized = rawValue.trim();
+    if (!/^\d+$/.test(normalized)) {
+        throw new Error("invalid_max_students");
+    }
+
+    const parsed = Number.parseInt(normalized, 10);
+    if (!Number.isSafeInteger(parsed) || parsed < 1) {
+        throw new Error("invalid_max_students");
+    }
+
+    return parsed;
 }

--- a/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
@@ -97,6 +97,43 @@ describe("AuthCallbackPage", () => {
         expect(screen.getByText(/completando inicio de sesión/i)).toBeTruthy();
     });
 
+    it("waits for a transient session before clearing a valid course-access context", async () => {
+        const authState = {
+            ...baseCtx,
+            session: null,
+            actor: null,
+        };
+        vi.mocked(useAuth).mockImplementation(() => authState as never);
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-access-transient",
+            auth_path: "password_sign_in",
+            expires_at: Date.now() + 300000,
+        });
+
+        const view = render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        expect(clearActivationContext).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(api.auth.activateCourseAccessComplete).not.toHaveBeenCalled();
+
+        authState.session = { access_token: "jwt" } as never;
+        view.rerender(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(api.auth.activateCourseAccessComplete).toHaveBeenCalledWith("course-access-transient"),
+        );
+    });
+
     it("handles teacher invite oauth activation", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",

--- a/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthMeActor } from "@/app/auth/auth-types";
 
@@ -81,6 +81,10 @@ describe("AuthCallbackPage", () => {
         vi.mocked(api.auth.activateCourseAccessOAuthComplete).mockResolvedValue({ status: "activated" });
     });
 
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it("shows loading state while auth is loading", () => {
         vi.mocked(useAuth).mockReturnValue({
             ...baseCtx,
@@ -97,19 +101,22 @@ describe("AuthCallbackPage", () => {
         expect(screen.getByText(/completando inicio de sesión/i)).toBeTruthy();
     });
 
-    it("waits for a transient session before clearing a valid course-access context", async () => {
+    it("keeps the activation context intact while auth is unresolved and resumes once session arrives", async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
         const authState = {
             ...baseCtx,
             session: null,
             actor: null,
         };
         vi.mocked(useAuth).mockImplementation(() => authState as never);
+        const expiresAt = Date.now() + 5000;
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "student_join_course_access",
             token_kind: "course_access",
             course_access_token: "course-access-transient",
             auth_path: "password_sign_in",
-            expires_at: Date.now() + 300000,
+            expires_at: expiresAt,
         });
 
         const view = render(
@@ -122,6 +129,14 @@ describe("AuthCallbackPage", () => {
         expect(mockNavigate).not.toHaveBeenCalled();
         expect(api.auth.activateCourseAccessComplete).not.toHaveBeenCalled();
 
+        act(() => {
+            vi.advanceTimersByTime(4000);
+        });
+
+        expect(clearActivationContext).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+
+        vi.useRealTimers();
         authState.session = { access_token: "jwt" } as never;
         view.rerender(
             <MemoryRouter>
@@ -132,6 +147,49 @@ describe("AuthCallbackPage", () => {
         await waitFor(() =>
             expect(api.auth.activateCourseAccessComplete).toHaveBeenCalledWith("course-access-transient"),
         );
+    });
+
+    it("waits until the activation context really expires before clearing and redirecting", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+        const expiresAt = Date.now() + 5000;
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            session: null,
+            actor: null,
+        });
+        vi.mocked(readActivationContext).mockImplementation(() => {
+            if (Date.now() > expiresAt) {
+                return null;
+            }
+            return {
+                flow: "student_join_course_access",
+                token_kind: "course_access",
+                course_access_token: "course-access-expiry",
+                auth_path: "oauth",
+                expires_at: expiresAt,
+            };
+        });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        act(() => {
+            vi.advanceTimersByTime(4900);
+        });
+
+        expect(clearActivationContext).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+
+        act(() => {
+            vi.advanceTimersByTime(200);
+        });
+
+        expect(clearActivationContext).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
     });
 
     it("handles teacher invite oauth activation", async () => {

--- a/frontend/src/features/auth-callback/AuthCallbackPage.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.tsx
@@ -38,15 +38,11 @@ type ActivationFlow =
     | "student_join_course_access"
     | null;
 
-const SESSION_RETRY_LIMIT = 5;
-const SESSION_RETRY_DELAY_MS = 150;
-
 export function AuthCallbackPage() {
     const { session, actor, loading, error, refreshActor } = useAuth();
     const navigate = useNavigate();
     const handled = useRef(false);
-    const sessionRetryCount = useRef(0);
-    const [sessionRetryTick, setSessionRetryTick] = useState(0);
+    const [activationExpiryTick, setActivationExpiryTick] = useState(0);
     const [activationError, setActivationError] = useState<string | null>(null);
     const [activationFlow, setActivationFlow] = useState<ActivationFlow>(null);
 
@@ -57,11 +53,17 @@ export function AuthCallbackPage() {
         const ctx = readActivationContext();
 
         if (!session) {
-            if (ctx && sessionRetryCount.current < SESSION_RETRY_LIMIT) {
-                sessionRetryCount.current += 1;
+            if (error) {
+                handled.current = true;
+                clearActivationContext();
+                return;
+            }
+
+            if (ctx) {
+                const remainingMs = Math.max(ctx.expires_at - Date.now(), 0);
                 const timeoutId = window.setTimeout(() => {
-                    setSessionRetryTick((current) => current + 1);
-                }, SESSION_RETRY_DELAY_MS);
+                    setActivationExpiryTick((current) => current + 1);
+                }, remainingMs + 1);
                 return () => {
                     window.clearTimeout(timeoutId);
                 };
@@ -72,8 +74,6 @@ export function AuthCallbackPage() {
             navigate("/", { replace: true });
             return;
         }
-
-        sessionRetryCount.current = 0;
 
         if (ctx?.flow === "teacher_activate") {
             handled.current = true;
@@ -185,7 +185,7 @@ export function AuthCallbackPage() {
             default:
                 navigate("/", { replace: true });
         }
-    }, [actor, loading, navigate, refreshActor, session, sessionRetryTick]);
+    }, [actor, error, loading, navigate, refreshActor, session, activationExpiryTick]);
 
     if (error) {
         return (

--- a/frontend/src/features/auth-callback/AuthCallbackPage.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.tsx
@@ -38,27 +38,45 @@ type ActivationFlow =
     | "student_join_course_access"
     | null;
 
+const SESSION_RETRY_LIMIT = 5;
+const SESSION_RETRY_DELAY_MS = 150;
+
 export function AuthCallbackPage() {
     const { session, actor, loading, error, refreshActor } = useAuth();
     const navigate = useNavigate();
     const handled = useRef(false);
+    const sessionRetryCount = useRef(0);
+    const [sessionRetryTick, setSessionRetryTick] = useState(0);
     const [activationError, setActivationError] = useState<string | null>(null);
     const [activationFlow, setActivationFlow] = useState<ActivationFlow>(null);
 
     useEffect(() => {
         if (loading) return;
         if (handled.current) return;
-        handled.current = true;
 
         const ctx = readActivationContext();
 
         if (!session) {
+            if (ctx && sessionRetryCount.current < SESSION_RETRY_LIMIT) {
+                sessionRetryCount.current += 1;
+                const timeoutId = window.setTimeout(() => {
+                    setSessionRetryTick((current) => current + 1);
+                }, SESSION_RETRY_DELAY_MS);
+                return () => {
+                    window.clearTimeout(timeoutId);
+                };
+            }
+
+            handled.current = true;
             clearActivationContext();
             navigate("/", { replace: true });
             return;
         }
 
+        sessionRetryCount.current = 0;
+
         if (ctx?.flow === "teacher_activate") {
+            handled.current = true;
             const teacherCtx = ctx;
             async function runTeacherActivation() {
                 try {
@@ -77,6 +95,7 @@ export function AuthCallbackPage() {
         }
 
         if (ctx?.flow === "student_join_invite") {
+            handled.current = true;
             const inviteCtx = ctx;
             async function runStudentInviteActivation() {
                 try {
@@ -99,6 +118,7 @@ export function AuthCallbackPage() {
         }
 
         if (ctx?.flow === "student_join_course_access") {
+            handled.current = true;
             const courseAccessCtx = ctx;
             async function runCourseAccessActivation() {
                 try {
@@ -141,6 +161,7 @@ export function AuthCallbackPage() {
             return;
         }
 
+        handled.current = true;
         if (!actor) {
             navigate("/", { replace: true });
             return;
@@ -164,7 +185,7 @@ export function AuthCallbackPage() {
             default:
                 navigate("/", { replace: true });
         }
-    }, [loading, session, actor, navigate, refreshActor]);
+    }, [actor, loading, navigate, refreshActor, session, sessionRetryTick]);
 
     if (error) {
         return (

--- a/frontend/src/features/student-auth/StudentJoinPage.test.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.test.tsx
@@ -79,6 +79,34 @@ describe("StudentJoinPage", () => {
         expect(screen.getByText(/este enlace de acceso no es válido/i)).toBeTruthy();
     });
 
+    it("captures a realistic course_access_token from the hash fragment before resolving", async () => {
+        window.history.replaceState(null, "", "/join#course_access_token=course-hash-123");
+        vi.mocked(api.auth.resolveCourseAccess).mockResolvedValue({
+            course_id: "course-1",
+            course_title: "Gerencia Estrategica",
+            university_name: "Universidad Demo",
+            teacher_display_name: "Julio Paz",
+            course_status: "active",
+            link_status: "active",
+            allowed_auth_methods: ["password"],
+        });
+
+        renderPage();
+
+        await waitFor(() => {
+            expect(saveActivationContext).toHaveBeenCalledWith({
+                flow: "student_join_course_access",
+                token_kind: "course_access",
+                course_access_token: "course-hash-123",
+            });
+        });
+        await waitFor(() => {
+            expect(api.auth.resolveCourseAccess).toHaveBeenCalledWith("course-hash-123");
+        });
+
+        window.history.replaceState(null, "", "/join");
+    });
+
     it("keeps invite_token flow working", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "student_join_invite",


### PR DESCRIPTION
## Summary

Closes #63.

This PR closes the production-hardening follow-up for the Phase 2 admin dashboard after `#62`, without reopening the visual scope of `#61`.

It focuses on the two critical operational flows that still needed stronger guarantees before rollout:

- `admin -> invite teacher -> teacher activation -> consistent admin dashboard`
- `admin -> regenerate course link -> student join -> activation/enroll -> valid access`

## What changed

### Backend hardening
- made pending teacher course promotion explicitly tenant-scoped and transactional
- restored the legacy `User` bridge during teacher activation so admin teacher-options stays consistent after password and OAuth activation
- kept the public activation routes unchanged:
  - `/api/auth/activate/password`
  - `/api/auth/activate/oauth/complete`

### Backend regression coverage
- added integrated assertions so that after teacher activation:
  - `/api/admin/courses` returns `teacher_state=active` and `teacher_assignment.kind=membership`
  - `/api/admin/dashboard/summary` reflects the activated teacher
  - `/api/admin/teacher-options` removes the consumed pending invite and exposes the active teacher
- added end-to-end course access regression coverage from admin-issued regenerated links:
  - new token resolves correctly
  - rotated token fails with `410`
  - password activation creates membership + enrollment
  - OAuth completion creates membership + enrollment
- froze canonical contract behavior around academic level aliases and invalid values

### Frontend continuity
- hardened `AuthCallbackPage` so a transient missing session does not destroy `activationContext` prematurely during course-access resumption
- aligned admin dashboard payload building with canonical academic levels
- added local validation for invalid `max_students` before backend submission
- extended coverage for:
  - auth callback continuation
  - realistic `course_access_token` hash-fragment handling on student join
  - admin dashboard refetch on returning to the admin context

## Validation

- `uv run --directory backend pytest -q` -> `154 passed, 12 skipped`
- `uv run --directory backend mypy src`
- `npm --prefix frontend run test` -> `101 passed`
- `npm --prefix frontend run build`
- `npm --prefix frontend run lint`

## Follow-up explicitly split out

Non-blocking frontend performance and warning cleanup found during final validation was split into #64 so this PR stays scoped to the functional hardening required by `#63`.
