### PR TITLE
fix: harden frontend performance before traffic ramp

### DIFF
--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -14,6 +14,15 @@ vi.mock("@/features/admin-dashboard/AdminDashboardPage", () => ({
 vi.mock("@/features/admin-auth/AdminLoginPage", () => ({
     AdminLoginPage: () => <div data-testid="admin-login-page">Admin login</div>,
 }));
+vi.mock("@/features/auth-callback/AuthCallbackPage", () => ({
+    AuthCallbackPage: () => <div data-testid="auth-callback-page">Auth callback</div>,
+}));
+vi.mock("@/features/student-auth/StudentJoinPage", () => ({
+    StudentJoinPage: () => <div data-testid="student-join-page">Student join</div>,
+}));
+vi.mock("@/features/student-auth/StudentLoginPage", () => ({
+    StudentLoginPage: () => <div data-testid="student-login-page">Student login</div>,
+}));
 vi.mock("@/app/AppLanding", () => ({
     AppLanding: () => <div data-testid="app-landing">Landing</div>,
 }));
@@ -123,5 +132,41 @@ describe("App admin shell layout", () => {
         );
 
         expect(screen.getByTestId("site-header")).toBeTruthy();
+    });
+
+    it("resolves the lazy auth callback route", async () => {
+        vi.mocked(useAuth).mockReturnValue(baseContext);
+
+        render(
+            <MemoryRouter initialEntries={["/auth/callback"]}>
+                <App />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByTestId("auth-callback-page")).toBeTruthy();
+    });
+
+    it("resolves the lazy student join route with an access token", async () => {
+        vi.mocked(useAuth).mockReturnValue(baseContext);
+
+        render(
+            <MemoryRouter initialEntries={["/join?course_access_token=test-token"]}>
+                <App />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByTestId("student-join-page")).toBeTruthy();
+    });
+
+    it("resolves the lazy student login route with an access token", async () => {
+        vi.mocked(useAuth).mockReturnValue(baseContext);
+
+        render(
+            <MemoryRouter initialEntries={["/student/login?course_access_token=test-token"]}>
+                <App />
+            </MemoryRouter>,
+        );
+
+        expect(await screen.findByTestId("student-login-page")).toBeTruthy();
     });
 });

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -58,7 +58,7 @@ function RouteFallback() {
     return (
         <div className="flex items-center justify-center py-24">
             <span className="text-sm text-muted-foreground">
-                Cargando pagina...
+                Cargando página...
             </span>
         </div>
     );
@@ -112,7 +112,7 @@ function App() {
                                     <div className="flex flex-col items-center justify-center gap-4 px-4 py-24 text-center">
                                         <h1 className="text-xl font-semibold">Panel del estudiante</h1>
                                         <p className="max-w-xs text-sm text-muted-foreground">
-                                            El panel completo estara disponible en la proxima version.
+                                            El panel completo estará disponible en la próxima versión.
                                         </p>
                                     </div>
                                 </RequireRole>

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,21 +1,68 @@
-import { Routes, Route, Navigate, useLocation } from "react-router-dom";
+import { Suspense, lazy } from "react";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { SiteHeader } from "@/shared/SiteHeader";
 import { useToast } from "@/shared/Toast";
 
-import { TeacherAuthoringPage } from "@/features/teacher-authoring/TeacherAuthoringPage";
-import { AuthCallbackPage } from "@/features/auth-callback/AuthCallbackPage";
-import { TeacherLoginPage } from "@/features/teacher-auth/TeacherLoginPage";
-import { TeacherActivatePage } from "@/features/teacher-auth/TeacherActivatePage";
-import { StudentLoginPage } from "@/features/student-auth/StudentLoginPage";
-import { StudentJoinPage } from "@/features/student-auth/StudentJoinPage";
-import { AdminLoginPage } from "@/features/admin-auth/AdminLoginPage";
-import { AdminChangePasswordPage } from "@/features/admin-auth/AdminChangePasswordPage";
-import { AdminDashboardPage } from "@/features/admin-dashboard/AdminDashboardPage";
-
-import { RootRedirect } from "./auth/RootRedirect";
-import { RequireRole } from "./auth/RequireRole";
-import { RequirePasswordRotation } from "./auth/RequirePasswordRotation";
 import { GuestOnlyRoute } from "./auth/GuestOnlyRoute";
+import { RequirePasswordRotation } from "./auth/RequirePasswordRotation";
+import { RequireRole } from "./auth/RequireRole";
+import { RootRedirect } from "./auth/RootRedirect";
+
+const TeacherAuthoringPage = lazy(() =>
+    import("@/features/teacher-authoring/TeacherAuthoringPage").then(
+        (module) => ({ default: module.TeacherAuthoringPage }),
+    ),
+);
+const AuthCallbackPage = lazy(() =>
+    import("@/features/auth-callback/AuthCallbackPage").then((module) => ({
+        default: module.AuthCallbackPage,
+    })),
+);
+const TeacherLoginPage = lazy(() =>
+    import("@/features/teacher-auth/TeacherLoginPage").then((module) => ({
+        default: module.TeacherLoginPage,
+    })),
+);
+const TeacherActivatePage = lazy(() =>
+    import("@/features/teacher-auth/TeacherActivatePage").then((module) => ({
+        default: module.TeacherActivatePage,
+    })),
+);
+const StudentLoginPage = lazy(() =>
+    import("@/features/student-auth/StudentLoginPage").then((module) => ({
+        default: module.StudentLoginPage,
+    })),
+);
+const StudentJoinPage = lazy(() =>
+    import("@/features/student-auth/StudentJoinPage").then((module) => ({
+        default: module.StudentJoinPage,
+    })),
+);
+const AdminLoginPage = lazy(() =>
+    import("@/features/admin-auth/AdminLoginPage").then((module) => ({
+        default: module.AdminLoginPage,
+    })),
+);
+const AdminChangePasswordPage = lazy(() =>
+    import("@/features/admin-auth/AdminChangePasswordPage").then((module) => ({
+        default: module.AdminChangePasswordPage,
+    })),
+);
+const AdminDashboardPage = lazy(() =>
+    import("@/features/admin-dashboard/AdminDashboardPage").then((module) => ({
+        default: module.AdminDashboardPage,
+    })),
+);
+
+function RouteFallback() {
+    return (
+        <div className="flex items-center justify-center py-24">
+            <span className="text-sm text-muted-foreground">
+                Cargando pagina...
+            </span>
+        </div>
+    );
+}
 
 function App() {
     const { ToastContainer, showToast } = useToast();
@@ -27,64 +74,80 @@ function App() {
             {!isAdminDashboardRoute && <SiteHeader />}
 
             <main className="flex-1">
-                <Routes>
-                    {/* Root — redirects by session/role or shows landing */}
-                    <Route path="/" element={<RootRedirect />} />
+                <Suspense fallback={<RouteFallback />}>
+                    <Routes>
+                        <Route path="/" element={<RootRedirect />} />
 
-                    {/* Teacher routes */}
-                    <Route path="/teacher/login" element={<GuestOnlyRoute role="teacher"><TeacherLoginPage /></GuestOnlyRoute>} />
-                    <Route path="/teacher/activate" element={<TeacherActivatePage />} />
-                    <Route
-                        path="/teacher/*"
-                        element={
-                            <RequireRole role="teacher">
-                                <TeacherAuthoringPage />
-                            </RequireRole>
-                        }
-                    />
+                        <Route
+                            path="/teacher/login"
+                            element={
+                                <GuestOnlyRoute role="teacher">
+                                    <TeacherLoginPage />
+                                </GuestOnlyRoute>
+                            }
+                        />
+                        <Route path="/teacher/activate" element={<TeacherActivatePage />} />
+                        <Route
+                            path="/teacher/*"
+                            element={
+                                <RequireRole role="teacher">
+                                    <TeacherAuthoringPage />
+                                </RequireRole>
+                            }
+                        />
 
-                    {/* Student routes */}
-                    <Route path="/student/login" element={<GuestOnlyRoute role="student"><StudentLoginPage /></GuestOnlyRoute>} />
-                    <Route path="/join" element={<StudentJoinPage />} />
-                    <Route
-                        path="/student/*"
-                        element={
-                            <RequireRole role="student">
-                                <div className="flex flex-col items-center justify-center gap-4 px-4 py-24 text-center">
-                                    <h1 className="text-xl font-semibold">Panel del estudiante</h1>
-                                    <p className="text-sm text-muted-foreground max-w-xs">
-                                        El panel completo estará disponible en la próxima versión.
-                                    </p>
-                                </div>
-                            </RequireRole>
-                        }
-                    />
+                        <Route
+                            path="/student/login"
+                            element={
+                                <GuestOnlyRoute role="student">
+                                    <StudentLoginPage />
+                                </GuestOnlyRoute>
+                            }
+                        />
+                        <Route path="/join" element={<StudentJoinPage />} />
+                        <Route
+                            path="/student/*"
+                            element={
+                                <RequireRole role="student">
+                                    <div className="flex flex-col items-center justify-center gap-4 px-4 py-24 text-center">
+                                        <h1 className="text-xl font-semibold">Panel del estudiante</h1>
+                                        <p className="max-w-xs text-sm text-muted-foreground">
+                                            El panel completo estara disponible en la proxima version.
+                                        </p>
+                                    </div>
+                                </RequireRole>
+                            }
+                        />
 
-                    {/* Admin routes */}
-                    <Route path="/admin/login" element={<GuestOnlyRoute role="university_admin"><AdminLoginPage /></GuestOnlyRoute>} />
-                    <Route
-                        path="/admin/change-password"
-                        element={
-                            <RequirePasswordRotation>
-                                <AdminChangePasswordPage />
-                            </RequirePasswordRotation>
-                        }
-                    />
-                    <Route
-                        path="/admin/dashboard"
-                        element={
-                            <RequireRole role="university_admin">
-                                <AdminDashboardPage showToast={showToast} />
-                            </RequireRole>
-                        }
-                    />
+                        <Route
+                            path="/admin/login"
+                            element={
+                                <GuestOnlyRoute role="university_admin">
+                                    <AdminLoginPage />
+                                </GuestOnlyRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/change-password"
+                            element={
+                                <RequirePasswordRotation>
+                                    <AdminChangePasswordPage />
+                                </RequirePasswordRotation>
+                            }
+                        />
+                        <Route
+                            path="/admin/dashboard"
+                            element={
+                                <RequireRole role="university_admin">
+                                    <AdminDashboardPage showToast={showToast} />
+                                </RequireRole>
+                            }
+                        />
 
-                    {/* OAuth callback — PKCE code exchange handled by Supabase */}
-                    <Route path="/auth/callback" element={<AuthCallbackPage />} />
-
-                    {/* Catch-all */}
-                    <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
+                        <Route path="/auth/callback" element={<AuthCallbackPage />} />
+                        <Route path="*" element={<Navigate to="/" replace />} />
+                    </Routes>
+                </Suspense>
             </main>
 
             <ToastContainer />

--- a/frontend/src/app/auth/AuthContext.tsx
+++ b/frontend/src/app/auth/AuthContext.tsx
@@ -1,17 +1,8 @@
-import {
-    createContext,
-    useCallback,
-    useEffect,
-    useState,
-    type ReactNode,
-} from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 import { apiFetch } from "@/shared/api";
-import type { AuthContextValue, AuthMeActor, Session } from "./auth-types";
-
-export const AuthContext = createContext<AuthContextValue | undefined>(
-    undefined,
-);
+import type { AuthMeActor, Session } from "./auth-types";
+import { AuthContext } from "./auth-context";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
     const [session, setSession] = useState<Session | null>(null);
@@ -41,6 +32,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
 
         let cancelled = false;
+        let actorRefreshTimeoutId: number | null = null;
 
         async function bootstrap() {
             const { data, error: sessionError } =
@@ -91,7 +83,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                         // PKCE storage lock: onAuthStateChange fires while the
                         // lock is still held, so calling getSession() here
                         // (via getBearerToken) blocks forever.
-                        setTimeout(() => {
+                        actorRefreshTimeoutId = window.setTimeout(() => {
                             if (cancelled) return;
                             void fetchActor().then((resolvedActor) => {
                                 if (!cancelled) {
@@ -111,6 +103,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         return () => {
             cancelled = true;
+            if (actorRefreshTimeoutId !== null) {
+                window.clearTimeout(actorRefreshTimeoutId);
+            }
             listenerData.subscription.unsubscribe();
         };
     }, [fetchActor]);

--- a/frontend/src/app/auth/auth-context.ts
+++ b/frontend/src/app/auth/auth-context.ts
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+import type { AuthContextValue } from "./auth-types";
+
+export const AuthContext = createContext<AuthContextValue | undefined>(
+    undefined,
+);

--- a/frontend/src/app/auth/useAuth.ts
+++ b/frontend/src/app/auth/useAuth.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
-import { AuthContext } from "./AuthContext";
 import type { AuthContextValue } from "./auth-types";
+import { AuthContext } from "./auth-context";
 
 export function useAuth(): AuthContextValue {
     const ctx = useContext(AuthContext);

--- a/frontend/src/features/case-preview/NotebookViewer.tsx
+++ b/frontend/src/features/case-preview/NotebookViewer.tsx
@@ -72,7 +72,7 @@ export function NotebookViewer({ code }: NotebookViewerProps) {
                             <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                             </svg>
-                            <span>Copiar Codigo</span>
+                            <span>Copiar Código</span>
                         </>
                     )}
                 </button>

--- a/frontend/src/features/case-preview/NotebookViewer.tsx
+++ b/frontend/src/features/case-preview/NotebookViewer.tsx
@@ -1,60 +1,83 @@
-import { useState } from "react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { useEffect, useRef, useState } from "react";
+import { PrismAsyncLight as SyntaxHighlighter } from "react-syntax-highlighter";
+import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 
 interface NotebookViewerProps {
     code: string;
 }
 
+SyntaxHighlighter.registerLanguage("python", python);
+
 export function NotebookViewer({ code }: NotebookViewerProps) {
     const [copied, setCopied] = useState(false);
+    const resetCopiedTimeoutRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (resetCopiedTimeoutRef.current !== null) {
+                window.clearTimeout(resetCopiedTimeoutRef.current);
+            }
+        };
+    }, []);
 
     const handleCopy = async () => {
         try {
             await navigator.clipboard.writeText(code);
             setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
-        } catch (err) {
-            console.error("Failed to copy code", err);
+
+            if (resetCopiedTimeoutRef.current !== null) {
+                window.clearTimeout(resetCopiedTimeoutRef.current);
+            }
+
+            resetCopiedTimeoutRef.current = window.setTimeout(() => {
+                setCopied(false);
+                resetCopiedTimeoutRef.current = null;
+            }, 2000);
+        } catch {
+            setCopied(false);
         }
     };
 
-    if (!code || code.trim() === "") return null;
+    if (!code || code.trim() === "") {
+        return null;
+    }
 
     return (
-        <div className="w-full rounded-lg border border-slate-700 overflow-hidden bg-[#1e1e1e] shadow-xl my-8">
-            <div className="flex items-center justify-between px-4 py-2 bg-[#2d2d2d] border-b border-slate-700">
+        <div className="my-8 w-full overflow-hidden rounded-lg border border-slate-700 bg-[#1e1e1e] shadow-xl">
+            <div className="flex items-center justify-between border-b border-slate-700 bg-[#2d2d2d] px-4 py-2">
                 <div className="flex items-center gap-2">
-                    <svg className="w-4 h-4 text-sky-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <svg className="h-4 w-4 text-sky-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                         <path strokeLinecap="round" strokeLinejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
                     </svg>
-                    <span className="text-xs font-semibold text-slate-300 uppercase tracking-wider">Python Notebook</span>
-                    <span className="text-[9px] font-bold bg-amber-400/20 text-amber-300 border border-amber-400/30 px-2 py-0.5 rounded-full uppercase tracking-wider">
+                    <span className="text-xs font-semibold uppercase tracking-wider text-slate-300">Python Notebook</span>
+                    <span className="rounded-full border border-amber-400/30 bg-amber-400/20 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider text-amber-300">
                         Jupytext · Google Colab
                     </span>
                 </div>
                 <button
+                    type="button"
                     onClick={handleCopy}
-                    className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium text-slate-300 hover:text-white bg-[#3e3e42] hover:bg-[#505055] rounded-md transition-colors"
+                    className="flex items-center gap-1.5 rounded-md bg-[#3e3e42] px-3 py-1 text-xs font-medium text-slate-300 transition-colors hover:bg-[#505055] hover:text-white"
                 >
                     {copied ? (
                         <>
-                            <svg className="w-3.5 h-3.5 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <svg className="h-3.5 w-3.5 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                             </svg>
                             <span>Copiado</span>
                         </>
                     ) : (
                         <>
-                            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                             </svg>
-                            <span>Copiar Código</span>
+                            <span>Copiar Codigo</span>
                         </>
                     )}
                 </button>
             </div>
-            <div className="p-0 m-0 text-sm">
+            <div className="m-0 p-0 text-sm">
                 <SyntaxHighlighter
                     language="python"
                     style={vscDarkPlus}
@@ -64,7 +87,7 @@ export function NotebookViewer({ code }: NotebookViewerProps) {
                         background: "transparent",
                         fontSize: "0.85rem",
                         lineHeight: "1.5",
-                        maxHeight: "600px"
+                        maxHeight: "600px",
                     }}
                     showLineNumbers={true}
                     wrapLines={true}

--- a/frontend/src/features/case-preview/PlotlyChartsRenderer.tsx
+++ b/frontend/src/features/case-preview/PlotlyChartsRenderer.tsx
@@ -1,319 +1,74 @@
 import React, { Suspense, useMemo } from "react";
 import type { EDAChartSpec } from "@/shared/adam-types";
 
-// Lazy-load react-plotly.js to reduce initial bundle size (ISSUE-FE-16)
-const Plot = React.lazy(() => import("react-plotly.js"));
+import {
+    buildLayout,
+    chartHasHeatmap,
+    sanitizeTraces,
+} from "./plotlyChartUtils";
+
+const Plot = React.lazy(() => import("./PlotlyComponent"));
 
 export interface PlotlyChartsRendererProps {
     charts: EDAChartSpec[];
     onRetry?: () => void;
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-function isHeatmapTrace(trace: Record<string, unknown>): boolean {
-    return String(trace.type || "").toLowerCase() === "heatmap";
-}
-
-function chartHasHeatmap(traces: Record<string, unknown>[]): boolean {
-    return traces.some(isHeatmapTrace);
-}
-
-function chartHasDualY(traces: Record<string, unknown>[]): boolean {
-    return traces.some(t => String(t.yaxis || "").toLowerCase() === "y2");
-}
-
-// ── Heatmap validation & normalization ───────────────────────────────────────
-
-interface HeatmapValidationResult {
-    valid: boolean;
-    errors: string[];
-    warnings: string[];
-    /** Normalised 2-D numeric matrix (null = gap cell) */
-    normalizedZ: (number | null)[][] | null;
-    zMin: number | null;
-    zMax: number | null;
-}
-
-/**
- * Validates and normalises a heatmap z value.
- *
- * Handles the most common LLM failure modes:
- *  - z is missing / null / undefined
- *  - z is a flat 1-D array instead of a 2-D matrix
- *  - z cells are numeric strings ("0.87") instead of numbers
- *  - z cells are NaN / Infinity (JSON-serialised Python floats)
- *  - z dimensions don't match x / y label counts
- */
-export function validateHeatmapConfig(
-    trace: Record<string, unknown>,
-): HeatmapValidationResult {
-    const errors: string[] = [];
-    const warnings: string[] = [];
-
-    const rawZ = trace.z;
-    const x = Array.isArray(trace.x) ? (trace.x as unknown[]) : null;
-    const y = Array.isArray(trace.y) ? (trace.y as unknown[]) : null;
-
-    // ── 1. z must exist and be an array ──────────────────────────────────────
-    if (rawZ == null) {
-        errors.push("z is missing or null — heatmap cannot render");
-        return { valid: false, errors, warnings, normalizedZ: null, zMin: null, zMax: null };
-    }
-    if (!Array.isArray(rawZ)) {
-        errors.push(`z is not an array (got ${typeof rawZ}) — heatmap cannot render`);
-        return { valid: false, errors, warnings, normalizedZ: null, zMin: null, zMax: null };
-    }
-    if (rawZ.length === 0) {
-        errors.push("z is an empty array — heatmap cannot render");
-        return { valid: false, errors, warnings, normalizedZ: null, zMin: null, zMax: null };
-    }
-
-    // ── 2. Ensure 2-D: wrap flat arrays into a single-row matrix ─────────────
-    let raw2D: unknown[][];
-    if (!Array.isArray(rawZ[0])) {
-        warnings.push("z is a 1-D array — wrapping into a single-row matrix");
-        raw2D = [rawZ as unknown[]];
-    } else {
-        raw2D = rawZ as unknown[][];
-    }
-
-    // ── 3. Normalise every cell to number | null ──────────────────────────────
-    let hasStrings = false;
-    let hasNulls = false;
-    let zMin: number | null = null;
-    let zMax: number | null = null;
-
-    const normalizedZ: (number | null)[][] = raw2D.map(row => {
-        if (!Array.isArray(row)) return [];
-        return (row as unknown[]).map(v => {
-            if (v === null || v === undefined) { hasNulls = true; return null; }
-            if (typeof v === "string") {
-                hasStrings = true;
-                const n = parseFloat(v);
-                if (!isFinite(n)) { hasNulls = true; return null; }
-                return n;
-            }
-            if (typeof v === "number") {
-                if (!isFinite(v)) { hasNulls = true; return null; }
-                return v;
-            }
-            hasNulls = true;
-            return null;
-        });
-    });
-
-    if (hasStrings) warnings.push("z contained string numerics — parsed to float");
-    if (hasNulls) warnings.push("z contained null/NaN/Infinity — rendered as gap cells");
-
-    // ── 4. Compute actual data range from valid cells ─────────────────────────
-    for (const row of normalizedZ) {
-        for (const v of row) {
-            if (v !== null) {
-                if (zMin === null || v < zMin) zMin = v;
-                if (zMax === null || v > zMax) zMax = v;
-            }
-        }
-    }
-
-    if (zMin === null) {
-        errors.push("z has no valid numeric values — heatmap cannot render");
-        return { valid: false, errors, warnings, normalizedZ, zMin, zMax };
-    }
-
-    // ── 5. Dimension checks against x / y ────────────────────────────────────
-    const nRows = normalizedZ.length;
-    const nCols = normalizedZ[0]?.length ?? 0;
-
-    if (y && y.length !== nRows) {
-        warnings.push(`y has ${y.length} labels but z has ${nRows} rows — axis labels may be misaligned`);
-    }
-    if (x && x.length !== nCols) {
-        warnings.push(`x has ${x.length} labels but z has ${nCols} columns — axis labels may be misaligned`);
-    }
-
-    if (errors.length > 0) {
-        console.error("[PlotlyChartsRenderer] Heatmap validation errors:", errors, { trace });
-    }
-    if (warnings.length > 0) {
-        console.warn("[PlotlyChartsRenderer] Heatmap validation warnings:", warnings);
-    }
-
-    return { valid: errors.length === 0, errors, warnings, normalizedZ, zMin, zMax };
-}
-
-/**
- * Sanitizes traces before passing to Plotly:
- * - Heatmap: validates and normalises z; sets safe defaults; clamps zmin/zmax
- * - Others: replaces null/undefined in x/y with 0
- */
-function sanitizeTraces(traces: Record<string, unknown>[]): Record<string, unknown>[] {
-    return traces.map(trace => {
-        const sanitized = { ...trace };
-
-        if (isHeatmapTrace(trace)) {
-            const validation = validateHeatmapConfig(trace);
-
-            if (validation.valid && validation.normalizedZ) {
-                sanitized.z = validation.normalizedZ;
-
-                // Clamp colorscale to actual data range so LLM-hallucinated outliers
-                // don't stretch the palette and wash out real correlation values.
-                // For correlation matrices (-1..1) this enforces the correct range.
-                const dataMin = validation.zMin!;
-                const dataMax = validation.zMax!;
-                // Correlation matrices have negative values (Pearson ∈ [−1,1]).
-                // Cohort retention data is all-positive (0..1) — must NOT be treated
-                // as a diverging scale or zmin gets set to −1 (wrong baseline).
-                const isCorrelationLike = dataMin >= -1 - 1e-6 && dataMax <= 1 + 1e-6 && dataMin < -1e-6;
-
-                if (isCorrelationLike) {
-                    // Symmetric diverging scale anchored at 0
-                    sanitized.zmin = -1;
-                    sanitized.zmax = 1;
-                } else {
-                    sanitized.zmin = dataMin;
-                    sanitized.zmax = dataMax;
-                }
-                sanitized.zauto = false;
-
-                // texttemplate only when z is valid; unconditional setting in
-                // plotly.js >=3 can suppress cell fill when entries are non-numeric.
-                if (!sanitized.texttemplate) sanitized.texttemplate = "%{z:.2f}";
-                if (sanitized.textfont == null) {
-                    sanitized.textfont = { size: 11, color: "#ffffff" };
-                }
-            } else {
-                // z is broken — clear it so Plotly renders an empty-state gracefully
-                // instead of showing axes + colorbar with invisible cells.
-                sanitized.z = [];
-            }
-
-            if (!sanitized.colorscale) sanitized.colorscale = "RdBu";
-            if (sanitized.showscale == null) sanitized.showscale = true;
-            if (sanitized.hoverongaps == null) sanitized.hoverongaps = false;
-        } else {
-            if (sanitized.x && Array.isArray(sanitized.x)) {
-                sanitized.x = (sanitized.x as unknown[]).map(v => v ?? 0);
-            }
-            if (sanitized.y && Array.isArray(sanitized.y)) {
-                sanitized.y = (sanitized.y as unknown[]).map(v => v ?? 0);
-            }
-        }
-
-        return sanitized;
-    });
-}
-function buildLayout(
-    baseLayout: Record<string, unknown>,
-    traces: Record<string, unknown>[],
-): Record<string, unknown> {
-    const hasHeatmap = chartHasHeatmap(traces);
-    const hasDualY = chartHasDualY(traces);
-
-    // 1. Márgenes base más inteligentes
-    // Quitamos los valores fijos agresivos (l:50, b:50) 
-    // y dejamos que automargin haga su magia.
-    const margin = {
-        t: 40,
-        r: (hasHeatmap || hasDualY) ? 80 : 40,
-        b: 40,
-        l: 40,
-        pad: 10 // Aire extra entre etiquetas y borde
-    };
-
-    const layout: Record<string, unknown> = {
-        ...baseLayout,
-        autosize: true,
-        margin,
-        paper_bgcolor: "transparent",
-        plot_bgcolor: hasHeatmap ? "#f5f5f5" : "transparent",
-        font: { family: "Inter, sans-serif", size: 12 },
-
-        // 2. CONFIGURACIÓN UNIVERSAL DE EJES (Corregido)
-        yaxis: {
-            // USAMOS baseLayout AQUÍ, NO layout
-            ...(typeof baseLayout.yaxis === "object" ? baseLayout.yaxis : {}),
-            automargin: true,
-        },
-        xaxis: {
-            // USAMOS baseLayout AQUÍ TAMBIÉN
-            ...(typeof baseLayout.xaxis === "object" ? baseLayout.xaxis : {}),
-            automargin: true,
-            tickangle: hasHeatmap ? -45 : "auto",
-        }
-    };
-
-    if (hasDualY && !layout.yaxis2) {
-        layout.yaxis2 = {
-            title: "",
-            overlaying: "y",
-            side: "right",
-            automargin: true,
-        };
-    }
-
-    return layout;
-}
-
-// ── Componentes ──────────────────────────────────────────────────────────────
-
-export function PlotlyChartCard({ spec }: { spec: EDAChartSpec }) {
+function PlotlyChartCard({ spec }: { spec: EDAChartSpec }) {
     const hasHeatmap = chartHasHeatmap(spec.traces || []);
     const chartHeight = hasHeatmap ? 450 : 350;
+    const sanitizedTraces = useMemo(
+        () => sanitizeTraces(spec.traces || []),
+        [spec.traces],
+    );
+    const layoutConfig = useMemo(
+        () => buildLayout(spec.layout || {}, sanitizedTraces),
+        [spec.layout, sanitizedTraces],
+    );
 
-    // Memoize sanitized data para evitar re-sanitizaciones en cada render
-    const sanitizedTraces = useMemo(() => sanitizeTraces(spec.traces || []), [spec.traces]);
-    const layoutConfig = useMemo(() => buildLayout(spec.layout || {}, sanitizedTraces), [spec.layout, sanitizedTraces]);
-
-    // Detect heatmap traces where z ended up empty after sanitization.
-    // This happens when both the LLM and the backend repair both failed to
-    // provide a valid matrix. Show a friendly card instead of a grey void.
     const hasUnrenderableHeatmap =
         hasHeatmap &&
         sanitizedTraces.some(
-            t =>
-                String(t.type || "").toLowerCase() === "heatmap" &&
-                (!t.z || (Array.isArray(t.z) && (t.z as unknown[]).length === 0)),
+            (trace) =>
+                String(trace.type || "").toLowerCase() === "heatmap" &&
+                (!trace.z || (Array.isArray(trace.z) && trace.z.length === 0)),
         );
 
     return (
-        <div className="bg-white border border-slate-100 rounded-xl p-5 shadow-sm hover:shadow-md transition-shadow relative">
-
-            {/* Header info */}
+        <div className="relative rounded-xl border border-slate-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
             <div className="mb-4">
                 {spec.title && <h3 className="text-lg font-semibold text-slate-800">{spec.title}</h3>}
-                {spec.subtitle && <h4 className="text-base font-medium text-slate-600 mt-0.5">{spec.subtitle}</h4>}
-                {spec.description && <p className="text-sm text-gray-500 mt-1">{spec.description}</p>}
+                {spec.subtitle && <h4 className="mt-0.5 text-base font-medium text-slate-600">{spec.subtitle}</h4>}
+                {spec.description && <p className="mt-1 text-sm text-gray-500">{spec.description}</p>}
             </div>
 
-            {/* Plotly Chart */}
             <div className="mt-2 w-full overflow-hidden" style={{ minHeight: chartHeight }}>
                 {hasUnrenderableHeatmap ? (
                     <div
-                        className="flex items-center justify-center bg-slate-50 rounded-lg border border-dashed border-slate-200"
+                        className="flex items-center justify-center rounded-lg border border-dashed border-slate-200 bg-slate-50"
                         style={{ height: chartHeight }}
                     >
-                        <p className="text-sm text-slate-400 text-center px-6">
-                            Datos de la matriz no disponibles para este gráfico.
+                        <p className="px-6 text-center text-sm text-slate-400">
+                            Datos de la matriz no disponibles para este grafico.
                         </p>
                     </div>
                 ) : (
-                    <Suspense fallback={
-                        <div className="flex items-center justify-center w-full bg-slate-50/50 rounded-lg" style={{ height: chartHeight }}>
-                            <div className="flex flex-col items-center gap-3">
-                                <div className="w-5 h-5 border-2 border-slate-200 border-t-slate-400 rounded-full animate-spin"></div>
-                                <span className="text-xs font-semibold text-slate-400 tracking-wider uppercase">Cargando Gráfico...</span>
+                    <Suspense
+                        fallback={
+                            <div className="flex w-full items-center justify-center rounded-lg bg-slate-50/50" style={{ height: chartHeight }}>
+                                <div className="flex flex-col items-center gap-3">
+                                    <div className="h-5 w-5 animate-spin rounded-full border-2 border-slate-200 border-t-slate-400" />
+                                    <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                                        Cargando Grafico...
+                                    </span>
+                                </div>
                             </div>
-                        </div>
-                    }>
+                        }
+                    >
                         <Plot
                             data={sanitizedTraces}
                             layout={layoutConfig}
-                            config={{
-                                responsive: true,
-                                displayModeBar: false
-                            }}
+                            config={{ responsive: true, displayModeBar: false }}
                             useResizeHandler={true}
                             style={{ width: "100%", height: `${chartHeight}px` }}
                         />
@@ -321,21 +76,19 @@ export function PlotlyChartCard({ spec }: { spec: EDAChartSpec }) {
                 )}
             </div>
 
-            {/* Rationale y notas */}
             {(spec.academic_rationale || spec.notes) && (
-                <div className="mt-3 pt-3 border-t border-slate-100 space-y-1">
+                <div className="mt-3 space-y-1 border-t border-slate-100 pt-3">
                     {spec.academic_rationale && (
-                        <p className="text-xs text-slate-500 italic leading-relaxed">
+                        <p className="text-xs italic leading-relaxed text-slate-500">
                             <span className="font-semibold not-italic text-slate-600">Racional: </span>
                             {spec.academic_rationale}
                         </p>
                     )}
                     {spec.notes && (
-                        <p className="text-xs text-slate-400 leading-relaxed">{spec.notes}</p>
+                        <p className="text-xs leading-relaxed text-slate-400">{spec.notes}</p>
                     )}
                 </div>
             )}
-
         </div>
     );
 }
@@ -343,17 +96,21 @@ export function PlotlyChartCard({ spec }: { spec: EDAChartSpec }) {
 export function PlotlyChartsRenderer({ charts, onRetry }: PlotlyChartsRendererProps) {
     if (!charts || charts.length === 0) {
         return (
-            <div className="text-center py-10 text-slate-400">
-                <svg className="w-10 h-10 mx-auto mb-3 text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
-                        d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            <div className="py-10 text-center text-slate-400">
+                <svg className="mx-auto mb-3 h-10 w-10 text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                    />
                 </svg>
-                <p className="text-sm">No se generaron gráficos en esta sección.</p>
+                <p className="text-sm">No se generaron graficos en esta seccion.</p>
                 {onRetry && (
                     <button
                         type="button"
                         onClick={onRetry}
-                        className="mt-3 px-4 py-1.5 text-xs font-semibold text-white bg-[#0144a0] rounded-lg hover:bg-[#00337a] transition-colors"
+                        className="mt-3 rounded-lg bg-[#0144a0] px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[#00337a]"
                     >
                         Regenerar
                     </button>
@@ -365,10 +122,7 @@ export function PlotlyChartsRenderer({ charts, onRetry }: PlotlyChartsRendererPr
     return (
         <div className="grid grid-cols-1 gap-5">
             {charts.map((spec, index) => (
-                <PlotlyChartCard
-                    key={spec.id || index}
-                    spec={spec}
-                />
+                <PlotlyChartCard key={spec.id || index} spec={spec} />
             ))}
         </div>
     );

--- a/frontend/src/features/case-preview/PlotlyChartsRenderer.tsx
+++ b/frontend/src/features/case-preview/PlotlyChartsRenderer.tsx
@@ -49,7 +49,7 @@ function PlotlyChartCard({ spec }: { spec: EDAChartSpec }) {
                         style={{ height: chartHeight }}
                     >
                         <p className="px-6 text-center text-sm text-slate-400">
-                            Datos de la matriz no disponibles para este grafico.
+                            Datos de la matriz no disponibles para este gráfico.
                         </p>
                     </div>
                 ) : (
@@ -59,7 +59,7 @@ function PlotlyChartCard({ spec }: { spec: EDAChartSpec }) {
                                 <div className="flex flex-col items-center gap-3">
                                     <div className="h-5 w-5 animate-spin rounded-full border-2 border-slate-200 border-t-slate-400" />
                                     <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                                        Cargando Grafico...
+                                        Cargando Gráfico...
                                     </span>
                                 </div>
                             </div>
@@ -105,7 +105,7 @@ export function PlotlyChartsRenderer({ charts, onRetry }: PlotlyChartsRendererPr
                         d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
                     />
                 </svg>
-                <p className="text-sm">No se generaron graficos en esta seccion.</p>
+                <p className="text-sm">No se generaron gráficos en esta sección.</p>
                 {onRetry && (
                     <button
                         type="button"

--- a/frontend/src/features/case-preview/PlotlyComponent.tsx
+++ b/frontend/src/features/case-preview/PlotlyComponent.tsx
@@ -1,0 +1,14 @@
+import createPlotlyComponent from "react-plotly.js/factory";
+import Plotly from "plotly.js/lib/core";
+import bar from "plotly.js/lib/bar";
+import box from "plotly.js/lib/box";
+import heatmap from "plotly.js/lib/heatmap";
+import scatter from "plotly.js/lib/scatter";
+import violin from "plotly.js/lib/violin";
+import waterfall from "plotly.js/lib/waterfall";
+
+Plotly.register([bar, box, heatmap, scatter, violin, waterfall]);
+
+const PlotlyComponent = createPlotlyComponent(Plotly);
+
+export default PlotlyComponent;

--- a/frontend/src/features/case-preview/modules/M3AuditSection.tsx
+++ b/frontend/src/features/case-preview/modules/M3AuditSection.tsx
@@ -1,7 +1,13 @@
+import { lazy, Suspense } from "react";
 import type { CaseModuleProps } from "./types";
 import { percentPyToIpynb } from "@/shared/notebookUtils";
 import { PlotlyChartsRenderer } from "../PlotlyChartsRenderer";
-import { NotebookViewer } from "../NotebookViewer";
+
+const NotebookViewer = lazy(() =>
+    import("../NotebookViewer").then((module) => ({
+        default: module.NotebookViewer,
+    })),
+);
 
 export function M3AuditSection({ result, content, md, isMLDS, renderPreguntas }: CaseModuleProps) {
     return (
@@ -38,7 +44,15 @@ export function M3AuditSection({ result, content, md, isMLDS, renderPreguntas }:
             {/* Notebook Python — Experiment Engineer (solo ml_ds + visual_plus_notebook) */}
             {isMLDS && content.m3NotebookCode && (
                 <div className="mt-8">
-                    <NotebookViewer code={content.m3NotebookCode} />
+                    <Suspense
+                        fallback={
+                            <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-400">
+                                Cargando notebook...
+                            </div>
+                        }
+                    >
+                        <NotebookViewer code={content.m3NotebookCode} />
+                    </Suspense>
                     <div className="mt-3 flex items-center justify-between gap-3">
                         <p className="type-caption text-slate-400">
                             Sube el <code className="bg-slate-100 px-1 rounded">.ipynb</code> a{" "}

--- a/frontend/src/features/case-preview/plotlyChartUtils.ts
+++ b/frontend/src/features/case-preview/plotlyChartUtils.ts
@@ -1,0 +1,227 @@
+export interface HeatmapValidationResult {
+    valid: boolean;
+    errors: string[];
+    warnings: string[];
+    normalizedZ: (number | null)[][] | null;
+    zMin: number | null;
+    zMax: number | null;
+}
+
+function isHeatmapTrace(trace: Record<string, unknown>): boolean {
+    return String(trace.type || "").toLowerCase() === "heatmap";
+}
+
+function chartHasDualY(traces: Record<string, unknown>[]): boolean {
+    return traces.some((trace) => String(trace.yaxis || "").toLowerCase() === "y2");
+}
+
+export function chartHasHeatmap(traces: Record<string, unknown>[]): boolean {
+    return traces.some(isHeatmapTrace);
+}
+
+export function validateHeatmapConfig(
+    trace: Record<string, unknown>,
+): HeatmapValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    const rawZ = trace.z;
+    const x = Array.isArray(trace.x) ? (trace.x as unknown[]) : null;
+    const y = Array.isArray(trace.y) ? (trace.y as unknown[]) : null;
+
+    if (rawZ == null) {
+        errors.push("z is missing or null - heatmap cannot render");
+        return { valid: false, errors, warnings, normalizedZ: null, zMin: null, zMax: null };
+    }
+    if (!Array.isArray(rawZ)) {
+        errors.push(`z is not an array (got ${typeof rawZ}) - heatmap cannot render`);
+        return { valid: false, errors, warnings, normalizedZ: null, zMin: null, zMax: null };
+    }
+    if (rawZ.length === 0) {
+        errors.push("z is an empty array - heatmap cannot render");
+        return { valid: false, errors, warnings, normalizedZ: null, zMin: null, zMax: null };
+    }
+
+    const raw2D: unknown[][] = Array.isArray(rawZ[0])
+        ? (rawZ as unknown[][])
+        : [rawZ as unknown[]];
+
+    if (!Array.isArray(rawZ[0])) {
+        warnings.push("z is a 1-D array - wrapping into a single-row matrix");
+    }
+
+    let hasStrings = false;
+    let hasNulls = false;
+    let zMin: number | null = null;
+    let zMax: number | null = null;
+
+    const normalizedZ = raw2D.map((row) => {
+        if (!Array.isArray(row)) {
+            return [];
+        }
+
+        return row.map((value) => {
+            if (value === null || value === undefined) {
+                hasNulls = true;
+                return null;
+            }
+            if (typeof value === "string") {
+                hasStrings = true;
+                const parsed = Number.parseFloat(value);
+                if (!Number.isFinite(parsed)) {
+                    hasNulls = true;
+                    return null;
+                }
+                return parsed;
+            }
+            if (typeof value === "number") {
+                if (!Number.isFinite(value)) {
+                    hasNulls = true;
+                    return null;
+                }
+                return value;
+            }
+
+            hasNulls = true;
+            return null;
+        });
+    });
+
+    if (hasStrings) {
+        warnings.push("z contained string numerics - parsed to float");
+    }
+    if (hasNulls) {
+        warnings.push("z contained null/NaN/Infinity - rendered as gap cells");
+    }
+
+    for (const row of normalizedZ) {
+        for (const value of row) {
+            if (value !== null) {
+                if (zMin === null || value < zMin) {
+                    zMin = value;
+                }
+                if (zMax === null || value > zMax) {
+                    zMax = value;
+                }
+            }
+        }
+    }
+
+    if (zMin === null) {
+        errors.push("z has no valid numeric values - heatmap cannot render");
+        return { valid: false, errors, warnings, normalizedZ, zMin, zMax };
+    }
+
+    const nRows = normalizedZ.length;
+    const nCols = normalizedZ[0]?.length ?? 0;
+
+    if (y && y.length !== nRows) {
+        warnings.push(`y has ${y.length} labels but z has ${nRows} rows - axis labels may be misaligned`);
+    }
+    if (x && x.length !== nCols) {
+        warnings.push(`x has ${x.length} labels but z has ${nCols} columns - axis labels may be misaligned`);
+    }
+
+    return { valid: errors.length === 0, errors, warnings, normalizedZ, zMin, zMax };
+}
+
+export function sanitizeTraces(traces: Record<string, unknown>[]): Record<string, unknown>[] {
+    return traces.map((trace) => {
+        const sanitized = { ...trace };
+
+        if (isHeatmapTrace(trace)) {
+            const validation = validateHeatmapConfig(trace);
+
+            if (validation.valid && validation.normalizedZ) {
+                sanitized.z = validation.normalizedZ;
+
+                const dataMin = validation.zMin!;
+                const dataMax = validation.zMax!;
+                const isCorrelationLike =
+                    dataMin >= -1 - 1e-6 &&
+                    dataMax <= 1 + 1e-6 &&
+                    dataMin < -1e-6;
+
+                if (isCorrelationLike) {
+                    sanitized.zmin = -1;
+                    sanitized.zmax = 1;
+                } else {
+                    sanitized.zmin = dataMin;
+                    sanitized.zmax = dataMax;
+                }
+                sanitized.zauto = false;
+
+                if (!sanitized.texttemplate) {
+                    sanitized.texttemplate = "%{z:.2f}";
+                }
+                if (sanitized.textfont == null) {
+                    sanitized.textfont = { size: 11, color: "#ffffff" };
+                }
+            } else {
+                sanitized.z = [];
+            }
+
+            if (!sanitized.colorscale) {
+                sanitized.colorscale = "RdBu";
+            }
+            if (sanitized.showscale == null) {
+                sanitized.showscale = true;
+            }
+            if (sanitized.hoverongaps == null) {
+                sanitized.hoverongaps = false;
+            }
+        } else {
+            if (Array.isArray(sanitized.x)) {
+                sanitized.x = sanitized.x.map((value) => value ?? 0);
+            }
+            if (Array.isArray(sanitized.y)) {
+                sanitized.y = sanitized.y.map((value) => value ?? 0);
+            }
+        }
+
+        return sanitized;
+    });
+}
+
+export function buildLayout(
+    baseLayout: Record<string, unknown>,
+    traces: Record<string, unknown>[],
+): Record<string, unknown> {
+    const hasHeatmap = chartHasHeatmap(traces);
+    const hasDualY = chartHasDualY(traces);
+
+    const layout: Record<string, unknown> = {
+        ...baseLayout,
+        autosize: true,
+        margin: {
+            t: 40,
+            r: hasHeatmap || hasDualY ? 80 : 40,
+            b: 40,
+            l: 40,
+            pad: 10,
+        },
+        paper_bgcolor: "transparent",
+        plot_bgcolor: hasHeatmap ? "#f5f5f5" : "transparent",
+        font: { family: "Inter, sans-serif", size: 12 },
+        yaxis: {
+            ...(typeof baseLayout.yaxis === "object" ? baseLayout.yaxis : {}),
+            automargin: true,
+        },
+        xaxis: {
+            ...(typeof baseLayout.xaxis === "object" ? baseLayout.xaxis : {}),
+            automargin: true,
+            tickangle: hasHeatmap ? -45 : "auto",
+        },
+    };
+
+    if (hasDualY && !layout.yaxis2) {
+        layout.yaxis2 = {
+            title: "",
+            overlaying: "y",
+            side: "right",
+            automargin: true,
+        };
+    }
+
+    return layout;
+}

--- a/frontend/src/features/teacher-authoring/AuthoringForm.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.tsx
@@ -63,6 +63,8 @@ export function AuthoringForm({
     const modules = selectedCourse?.syllabus ?? [];
     const selectedModule = modules.find((m) => m.id === syllabusModule);
     const units = selectedModule?.units ?? [];
+    const selectedUnit = units.find((u) => u.id === topicUnit);
+    const selectedIndustry = INDUSTRIAS_OPTIONS.find((option) => option.value === industry);
 
     // ── EDA depth + notebook toggle logic ──
     // business + harvard_with_eda → edaDepth="charts_plus_explanation", no UI
@@ -112,8 +114,8 @@ export function AuthoringForm({
             const selectedCourseForAI = professorDB.courses.find(c => c.id === subject);
             const modulesForAI = selectedCourseForAI?.syllabus ?? [];
             const moduleName = modulesForAI.find(m => m.id === syllabusModule)?.name ?? "";
-            const unitName = units.find(u => u.id === topicUnit)?.name ?? "";
-            const industryLabel = INDUSTRIAS_OPTIONS.find(i => i.value === industry)?.label ?? industry;
+            const unitName = selectedUnit?.name ?? "";
+            const industryLabel = selectedIndustry?.label ?? industry;
 
             const data = await api.suggest(intent, {
                 subject: selectedCourseForAI?.name ?? "",
@@ -219,8 +221,7 @@ export function AuthoringForm({
         markStale();
     };
     // ── Submit ──
-    const handleSubmit = useCallback(
-        (e: FormEvent) => {
+    const handleSubmit = (e: FormEvent) => {
             e.preventDefault();
             const newErrors: Record<string, boolean> = {};
             if (!subject) newErrors.asignatura = true;
@@ -247,18 +248,13 @@ export function AuthoringForm({
                 return;
             }
 
-            const courseName = selectedCourse?.name ?? "";
-            const moduleName = modules.find((m) => m.id === syllabusModule)?.name ?? "";
-            const unitName = units.find(u => u.id === topicUnit)?.name ?? "";
-            const industryLabel = INDUSTRIAS_OPTIONS.find((i) => i.value === industry)?.label ?? industry;
-
             const formData: CaseFormData = {
-                subject: courseName,
-                academicLevel: academicLevel,
-                targetGroups: targetGroups,
-                syllabusModule: moduleName,
-                topicUnit: unitName,
-                industry: industryLabel,
+                subject: selectedCourse?.name ?? "",
+                academicLevel,
+                targetGroups,
+                syllabusModule: selectedModule?.name ?? "",
+                topicUnit: selectedUnit?.name ?? "",
+                industry: selectedIndustry?.label ?? industry,
                 studentProfile,
                 caseType,
                 edaDepth,
@@ -271,9 +267,7 @@ export function AuthoringForm({
             };
 
             onSubmit(formData);
-        },
-        [subject, syllabusModule, selectedCourse, modules, units, topicUnit, targetGroups, academicLevel, industry, studentProfile, caseType, edaDepth, includePythonCode, scenarioDescription, guidingQuestion, suggestedTechniques, availableFrom, dueAt, onSubmit]
-    );
+        };
 
     // ── Clear ──
     const clearForm = () => {

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./AuthoringForm", () => ({
+    AuthoringForm: () => <div data-testid="authoring-form">Authoring form</div>,
+}));
+vi.mock("./AuthoringProgressTimeline", () => ({
+    AuthoringProgressTimeline: () => <div data-testid="authoring-progress">Progress</div>,
+}));
+vi.mock("./AuthoringErrorState", () => ({
+    AuthoringErrorState: () => <div data-testid="authoring-error">Error</div>,
+}));
+vi.mock("./useAuthoringJobProgress", () => ({
+    useAuthoringJobProgress: vi.fn(),
+}));
+vi.mock("@/features/case-preview/CasePreview", () => ({
+    CasePreview: () => <div data-testid="case-preview">Preview</div>,
+}));
+
+import { useAuthoringJobProgress } from "./useAuthoringJobProgress";
+import { TeacherAuthoringPage } from "./TeacherAuthoringPage";
+
+describe("TeacherAuthoringPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders the authoring form while idle", () => {
+        vi.mocked(useAuthoringJobProgress).mockReturnValue({
+            jobId: null,
+            status: null,
+            errorTrace: null,
+            result: null,
+            activeAgent: undefined,
+            submitJob: vi.fn(),
+            reset: vi.fn(),
+            isStreaming: false,
+        });
+
+        render(<TeacherAuthoringPage />);
+
+        expect(screen.getByTestId("authoring-form")).toBeTruthy();
+        expect(screen.queryByTestId("case-preview")).toBeNull();
+    });
+
+    it("lazy-loads the preview only after a completed job result exists", async () => {
+        vi.mocked(useAuthoringJobProgress).mockReturnValue({
+            jobId: "job-1",
+            status: "completed",
+            errorTrace: null,
+            result: {} as never,
+            activeAgent: undefined,
+            submitJob: vi.fn(),
+            reset: vi.fn(),
+            isStreaming: false,
+        });
+
+        render(<TeacherAuthoringPage />);
+
+        expect(screen.getByText(/cargando vista previa/i)).toBeTruthy();
+        expect(await screen.findByTestId("case-preview")).toBeTruthy();
+        expect(screen.queryByTestId("authoring-form")).toBeNull();
+    });
+});

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
@@ -1,7 +1,6 @@
 /** ADAM v8 - Portal Profesor: Builder Mode (Native SSE Flow) */
 
-import { useCallback, useEffect, useState } from "react";
-import { CasePreview } from "@/features/case-preview/CasePreview";
+import { Suspense, lazy, useCallback, useEffect, useState } from "react";
 import type { CaseFormData, CanonicalCaseOutput } from "@/shared/adam-types";
 import { EMPTY_FORM } from "@/shared/adam-types";
 
@@ -11,6 +10,22 @@ import { AuthoringProgressTimeline } from "./AuthoringProgressTimeline";
 import { useAuthoringJobProgress } from "./useAuthoringJobProgress";
 
 type AppState = "idle" | "generating" | "editing" | "error" | "success" | "paused";
+
+const CasePreview = lazy(() =>
+  import("@/features/case-preview/CasePreview").then((module) => ({
+    default: module.CasePreview,
+  })),
+);
+
+function CasePreviewFallback() {
+  return (
+    <div className="flex items-center justify-center py-24">
+      <span className="text-sm text-muted-foreground">
+        Cargando vista previa...
+      </span>
+    </div>
+  );
+}
 
 export function TeacherAuthoringPage() {
   const [appState, setAppState] = useState<AppState>("idle");
@@ -78,12 +93,14 @@ export function TeacherAuthoringPage() {
       )}
 
       {(appState === "success" || appState === "paused") && caseResult && (
-        <CasePreview
-          caseData={caseResult}
-          onEditParams={() => setAppState("editing")}
-          isPausedWaitingForApproval={appState === "paused"}
-          onResumeEDA={handleResumeEDA}
-        />
+        <Suspense fallback={<CasePreviewFallback />}>
+          <CasePreview
+            caseData={caseResult}
+            onEditParams={() => setAppState("editing")}
+            isPausedWaitingForApproval={appState === "paused"}
+            onResumeEDA={handleResumeEDA}
+          />
+        </Suspense>
       )}
 
       {appState === "error" && (

--- a/frontend/src/shared/Toast.tsx
+++ b/frontend/src/shared/Toast.tsx
@@ -1,6 +1,4 @@
-/** ADAM — Toast notification system with useToast hook */
-
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export type ToastType = "success" | "error" | "default";
 export type ShowToast = (message: string, type?: ToastType) => void;
@@ -15,36 +13,53 @@ let nextId = 0;
 
 export function useToast() {
     const [toasts, setToasts] = useState<ToastItem[]>([]);
+    const timeoutIdsRef = useRef<number[]>([]);
+
+    useEffect(() => {
+        return () => {
+            timeoutIdsRef.current.forEach((timeoutId) => {
+                window.clearTimeout(timeoutId);
+            });
+            timeoutIdsRef.current = [];
+        };
+    }, []);
 
     const showToast = useCallback<ShowToast>((message, type = "default") => {
         const id = nextId++;
         setToasts((prev) => [...prev, { id, message, type }]);
-        setTimeout(() => {
-            setToasts((prev) => prev.filter((t) => t.id !== id));
+
+        const timeoutId = window.setTimeout(() => {
+            setToasts((prev) => prev.filter((toast) => toast.id !== id));
+            timeoutIdsRef.current = timeoutIdsRef.current.filter(
+                (activeTimeoutId) => activeTimeoutId !== timeoutId,
+            );
         }, 2800);
+
+        timeoutIdsRef.current.push(timeoutId);
     }, []);
 
     const ToastContainer = useCallback(
         () => (
             <div className="fixed bottom-4 right-4 z-[300] flex flex-col gap-2">
-                {toasts.map((t) => (
+                {toasts.map((toast) => (
                     <div
-                        key={t.id}
+                        key={toast.id}
                         role="status"
                         aria-live="polite"
-                        className={`animate-toast-in rounded-input px-4 py-2.5 text-sm font-medium text-white shadow-lg ${t.type === "success"
+                        className={`animate-toast-in rounded-input px-4 py-2.5 text-sm font-medium text-white shadow-lg ${
+                            toast.type === "success"
                                 ? "bg-adam-accent"
-                                : t.type === "error"
-                                    ? "bg-danger"
-                                    : "bg-ink"
-                            }`}
+                                : toast.type === "error"
+                                  ? "bg-danger"
+                                  : "bg-ink"
+                        }`}
                     >
-                        {t.message}
+                        {toast.message}
                     </div>
                 ))}
             </div>
         ),
-        [toasts]
+        [toasts],
     );
 
     return { showToast, ToastContainer } as const;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,28 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   base: "/app/",
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("react-plotly.js/factory")) {
+            return "plotly-react";
+          }
+          if (id.includes("plotly.js/lib/")) {
+            return "plotly-traces";
+          }
+          if (
+            id.includes("plotly.js/src/") ||
+            id.includes("gl-") ||
+            id.includes("regl") ||
+            id.includes("mapbox")
+          ) {
+            return "plotly-core";
+          }
+        },
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- lazy-load route pages and the teacher preview path to remove preview-heavy code from the initial shell
- eliminate the fast-refresh and hook warnings by splitting auth context exports and moving Plotly helpers out of component modules
- add regression coverage for lazy route resolution and teacher preview loading

## Validation
- npm --prefix frontend run lint
- npm --prefix frontend run test
- npm --prefix frontend run build

## Notes
- initial entry chunk reduced from 1542.25 kB to 428.24 kB
- Plotly was reduced from 4874.23 kB to an isolated async core chunk of 1193.39 kB
- the remaining Vite chunk warning is only for the async plotly-core chunk, not the synchronous app shell

Closes #64