### PR TITLE
feat(frontend): TanStack Query v5 Global Setup — Issue #0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.101.1",
         "@tailwindcss/vite": "^4.1.5",
+        "@tanstack/react-query": "^5.97.0",
+        "@tanstack/react-query-devtools": "^5.97.0",
         "clsx": "^2.1.1",
         "lucide-react": "^1.7.0",
         "marked": "^17.0.3",
@@ -3667,6 +3669,59 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.97.0.tgz",
+      "integrity": "sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.97.0.tgz",
+      "integrity": "sha512-ZMjAuYhQCKwKLKFMrD+HJDehHwWBVTGOuWBf4vEjR9unO+UGUjQ1mw2TuVbQKoLN/eRwB7qtlPsWBqobBoRBMQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.97.0.tgz",
+      "integrity": "sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.97.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.97.0.tgz",
+      "integrity": "sha512-X4/VZKCbBIRj8cVD/oZCKTwwPmFXrY1VOfwUT5qI/+/JZYAUS+8vGNMqwBXbaAu1ZsVzzDzkT/wtBE/5OtQYGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.97.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.97.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.101.1",
     "@tailwindcss/vite": "^4.1.5",
+    "@tanstack/react-query": "^5.97.0",
+    "@tanstack/react-query-devtools": "^5.97.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
     "marked": "^17.0.3",

--- a/frontend/src/app/main.tsx
+++ b/frontend/src/app/main.tsx
@@ -1,6 +1,9 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { queryClient } from "@/shared/queryClient";
 import "./global.css";
 import App from "./App.tsx";
 import { AuthProvider } from "./auth/AuthContext.tsx";
@@ -8,9 +11,21 @@ import { AuthProvider } from "./auth/AuthContext.tsx";
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter basename="/app/">
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      {/*
+       * QueryClientProvider debe envolver a AuthProvider.
+       * Issue #6 migrará AuthContext para usar useQueryClient() — si el provider
+       * estuviera dentro de App.tsx o por debajo de AuthProvider, ese hook fallaría
+       * con "No QueryClient set, use QueryClientProvider to set one".
+       *
+       * ReactQueryDevtools se excluye automáticamente en builds de producción
+       * (process.env.NODE_ENV !== "development").
+       */}
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>
 );

--- a/frontend/src/shared/queryClient.ts
+++ b/frontend/src/shared/queryClient.ts
@@ -1,0 +1,61 @@
+import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
+
+import { ApiError } from "@/shared/api";
+
+/**
+ * Manejador global de errores para queries y mutations.
+ *
+ * En un 401: el token expiró mientras Supabase auto-refresh estaba en vuelo.
+ * - NO llamamos signOut() directamente (causaría dependencia circular con AuthContext).
+ * - Cancelamos queries activas y limpiamos el caché; esto detiene todos los
+ *   refetchInterval activos (incluido el de summaryQuery cada 30 s).
+ * - Si el token está definitivamente muerto, onAuthStateChange(SIGNED_OUT) en
+ *   AuthContext hará la limpieza final y redirigirá al login.
+ * - Si Supabase refresca el token con éxito, disparará TOKEN_REFRESHED y las
+ *   queries se re-habilitarán normalmente.
+ */
+function handleGlobalError(error: unknown): void {
+    if (error instanceof ApiError && error.status === 401) {
+        queryClient.cancelQueries();
+        queryClient.clear();
+    }
+}
+
+export const queryClient = new QueryClient({
+    queryCache: new QueryCache({ onError: handleGlobalError }),
+    mutationCache: new MutationCache({ onError: handleGlobalError }),
+    defaultOptions: {
+        queries: {
+            /**
+             * staleTime: 30 s — datos considerados frescos durante este período.
+             * No se dispara ningún background-refetch si la data tiene menos de 30 s.
+             */
+            staleTime: 30_000,
+            /**
+             * gcTime: 5 min — tiempo que una query inactiva (sin suscriptores)
+             * permanece en caché antes de ser garbage-collected.
+             * (Era "cacheTime" en v4; renombrado a "gcTime" en v5.)
+             */
+            gcTime: 5 * 60_000,
+            /** Refetch silencioso al volver a la pestaña del navegador. */
+            refetchOnWindowFocus: true,
+            /** Refetch al recuperar conexión de red. */
+            refetchOnReconnect: true,
+            /**
+             * retry personalizado:
+             * - 401/403 son errores de autenticación/autorización, no transitorios.
+             *   Reintentar solo agotaría cuota y daría falsa esperanza.
+             * - Para cualquier otro error, se permite 1 reintento.
+             */
+            retry: (failureCount, error) => {
+                if (
+                    error instanceof ApiError &&
+                    (error.status === 401 || error.status === 403)
+                ) {
+                    return false;
+                }
+                return failureCount < 1;
+            },
+        },
+    },
+});

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -1,0 +1,58 @@
+import type { IntentType, SuggestRequest } from "@/shared/adam-types";
+
+/**
+ * Filtros para la lista de cursos del dashboard de administrador.
+ *
+ * Definido aquí porque no existe como tipo nombrado en el codebase:
+ * `buildCourseFilters()` en AdminDashboardPage retornaba un objeto inline.
+ * Al moverlo aquí lo compartimos entre el componente y las query keys.
+ */
+export interface CourseFilters {
+    search?: string;
+    semester?: string;
+    status?: string;
+    academic_level?: string;
+    page?: number;
+    page_size?: number;
+}
+
+/**
+ * Fábrica centralizada de query keys para toda la aplicación.
+ *
+ * Convenciones:
+ * - Cada key es una función que retorna un array `as const` para type safety.
+ * - Las keys más genéricas (ej. `admin.all()`) permiten invalidación en bloque.
+ * - Las keys con parámetros opcionales (ej. `courses(f?)`) permiten invalidar
+ *   todas las variantes con `queryClient.invalidateQueries({ queryKey: queryKeys.admin.courses() })`.
+ *
+ * Uso:
+ *   useQuery({ queryKey: queryKeys.admin.summary(), queryFn: ... })
+ *   queryClient.invalidateQueries({ queryKey: queryKeys.admin.courses() })
+ */
+export const queryKeys = {
+    auth: {
+        /** ["auth", "actor"] — perfil del usuario autenticado vía /auth/me */
+        actor: () => ["auth", "actor"] as const,
+    },
+    admin: {
+        /** ["admin"] — key raíz para invalidación masiva (ej. al cerrar sesión) */
+        all: () => ["admin"] as const,
+        /** ["admin", "summary"] — KPIs del dashboard (cursos activos, docentes, etc.) */
+        summary: () => ["admin", "summary"] as const,
+        /**
+         * ["admin", "courses", filters?] — lista paginada de cursos con filtros.
+         * Sin argumentos invalida todas las variantes de la lista.
+         */
+        courses: (f?: CourseFilters) => ["admin", "courses", f] as const,
+        /** ["admin", "teacher-options"] — opciones para el dropdown de asignación de docente */
+        teacherOptions: () => ["admin", "teacher-options"] as const,
+    },
+    authoring: {
+        /**
+         * ["authoring", "suggest", intent, payload] — sugerencias de IA en el formulario.
+         * Mutations fire-and-forget — no se cachean, pero la key permite futuras extensiones.
+         */
+        suggest: (intent: IntentType, payload: SuggestRequest) =>
+            ["authoring", "suggest", intent, payload] as const,
+    },
+} as const;


### PR DESCRIPTION
## Resumen

Implementa la infraestructura base de TanStack Query v5 en ADAM-EDU (Issue #0 del [plan de adopción](docs/planPlataforma/tanstack-query-adoption-plan.md)).

Este PR es el **prerequisito** de todos los issues de migración (#1–#7). Sin este setup, ningún componente puede usar `useQuery` o `useMutation`.

---

## Cambios

### `frontend/package.json` + `package-lock.json`
- Agrega `@tanstack/react-query@5.97.0`
- Agrega `@tanstack/react-query-devtools@5.97.0`

### `frontend/src/shared/queryClient.ts` (nuevo)

QueryClient singleton con:
- **`handleGlobalError`** compartido entre `QueryCache` y `MutationCache`
  - En 401: `cancelQueries()` + `clear()` → rompe loops de `refetchInterval` (ej. summaryQuery cada 30 s) sin dependencia circular con `AuthContext`. Supabase auto-refresh recupera el token y re-habilita las queries.
- **`retry` custom**: skippea 401/403 (auth errors, no transitorios); 1 reintento para el resto
- **`gcTime: 5 min`** (v5 — era `cacheTime` en v4)
- **`staleTime: 30 s`**, `refetchOnWindowFocus: true`, `refetchOnReconnect: true`

### `frontend/src/shared/queryKeys.ts` (nuevo)

Fábrica centralizada de query keys tipadas:
- `queryKeys.auth.actor()` → `["auth", "actor"]`
- `queryKeys.admin.all()` → `["admin"]` (invalidación masiva en sign-out)
- `queryKeys.admin.summary()` → `["admin", "summary"]`
- `queryKeys.admin.courses(f?)` → `["admin", "courses", filters?]` (opcional para invalidar todas las variantes)
- `queryKeys.admin.teacherOptions()` → `["admin", "teacher-options"]`
- `queryKeys.authoring.suggest(intent, payload)`

También define `CourseFilters` interface (no existía como tipo nombrado en el codebase).

### `frontend/src/app/main.tsx` (modificado)

```
BrowserRouter
  └── QueryClientProvider       ← nuevo (envuelve AuthProvider)
        ├── AuthProvider
        │     └── App
        └── ReactQueryDevtools  ← nuevo (excluido en producción automáticamente)
```

`QueryClientProvider` debe envolver a `AuthProvider` porque Issue #6 migrará `AuthContext` para usar `useQueryClient()` internamente. Si estuviera dentro o debajo, el hook lanzaría `"No QueryClient set"`.

---

## Decisiones técnicas verificadas contra la documentación oficial (context7)

| Decisión | Justificación |
|----------|--------------|
| `gcTime` (no `cacheTime`) | `cacheTime` fue renombrado en v5 |
| Sin `logger` en QueryClient | Removido en v5 — incluyéndolo da error de compilación |
| `retry: (failureCount, error) => boolean` | Firma v5 confirmada |
| `handleGlobalError` como `function` (no arrow) antes de `queryClient` | Evita TDZ; seguro porque solo se invoca en runtime |
| `ReactQueryDevtools` sin condicional `NODE_ENV` | Se excluye automáticamente en producción |
| `courses(f?: CourseFilters)` argumento opcional | Permite `invalidateQueries({ queryKey: queryKeys.admin.courses() })` para invalidar todas las variantes |

---

## Verificación

```
✅ npm run build  — tsc -b + vite build completado en 17.69s, 0 errores TypeScript
✅ npm run test   — 18 test files, 121 tests passed
✅ npm run lint   — 0 warnings, 0 errors
```

---

## Issues relacionados

- Resuelve el **Issue #0** del plan de adopción
- Habilita: 4Tech-Labs/ADAM-EDU#71 (Testing Infrastructure)
- Habilita: 4Tech-Labs/ADAM-EDU#72 (Teacher Authoring: useMutation)
- Habilita: 4Tech-Labs/ADAM-EDU#73 (Admin Teacher Options: useQuery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
