### PR TITLE
feat(frontend): TanStack Query testing infrastructure

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,6 +44,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
         "jsdom": "^26.1.0",
+        "msw": "^2.13.2",
         "tw-animate-css": "^1.2.9",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.26.1",
@@ -944,6 +945,94 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1055,6 +1144,24 @@
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1092,6 +1199,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@plotly/d3": {
       "version": "3.8.2",
@@ -4067,6 +4199,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
@@ -4465,7 +4604,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4745,6 +4883,49 @@
       "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
       "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA==",
       "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -5319,6 +5500,13 @@
         "strongly-connected-components": "^1.0.1"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -5451,6 +5639,16 @@
         "@esbuild/win32-arm64": "0.25.3",
         "@esbuild/win32-ia32": "0.25.3",
         "@esbuild/win32-x64": "0.25.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -6024,6 +6222,16 @@
       "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
       "license": "ISC"
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-canvas-context": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
@@ -6399,6 +6607,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
@@ -6514,6 +6732,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/highlight.js": {
       "version": "10.7.3",
@@ -6776,6 +7001,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -6812,6 +7047,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-4.0.0.tgz",
       "integrity": "sha512-mlcHZA84t1qLSuWkt2v0I2l61PYdyQDt4aG1mLIXF5FDMm4+haBCxCPYSr/uwqQNRk1MiTizn0ypEuRAOLRAew==",
+      "license": "MIT"
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-number": {
@@ -8451,11 +8693,99 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.2.tgz",
+      "integrity": "sha512-go2H1TIERKkC48pXiwec5l6sbNqYuvqOk3/vHGo1Zd+pq/H63oFawDQerH+WQdUw/flJFHDG7F+QdWMwhntA/A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.41.2",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.0.2",
+        "graphql": "^16.12.0",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.10.1",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^5.2.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/msw/node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw/node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/murmurhash-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -8592,6 +8922,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8726,6 +9063,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -9546,6 +9890,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -9584,6 +9938,13 @@
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
+      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -9792,6 +10153,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/signum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
@@ -9851,6 +10225,16 @@
         "escodegen": "^2.1.0"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
@@ -9888,6 +10272,13 @@
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "license": "MIT"
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -9912,6 +10303,21 @@
         "parenthesis": "^3.1.5"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -9924,6 +10330,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-indent": {
@@ -10068,6 +10487,19 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -10344,6 +10776,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -10495,6 +10943,16 @@
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==",
       "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
     },
     "node_modules/update-diff": {
       "version": "1.1.0",
@@ -10945,6 +11403,21 @@
         "object-assign": "^4.1.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -10998,6 +11471,45 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -11006,6 +11518,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "jsdom": "^26.1.0",
+    "msw": "^2.13.2",
     "tw-animate-css": "^1.2.9",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { screen } from "@testing-library/react";
 
 import type { AuthMeActor } from "./auth/auth-types";
+import { renderWithProviders } from "@/shared/test-utils";
 
 vi.mock("@/app/auth/useAuth");
 vi.mock("@/features/teacher-authoring/TeacherAuthoringPage", () => ({
@@ -83,11 +83,9 @@ describe("App admin shell layout", () => {
             actor: adminActor,
         });
 
-        render(
-            <MemoryRouter initialEntries={["/admin/dashboard"]}>
-                <App />
-            </MemoryRouter>,
-        );
+        renderWithProviders(<App />, {
+            initialEntries: ["/admin/dashboard"],
+        });
 
         expect(await screen.findByTestId("admin-dashboard-page")).toBeTruthy();
         expect(screen.queryByTestId("site-header")).toBeNull();
@@ -100,11 +98,9 @@ describe("App admin shell layout", () => {
             actor: teacherActor,
         });
 
-        render(
-            <MemoryRouter initialEntries={["/admin/dashboard"]}>
-                <App />
-            </MemoryRouter>,
-        );
+        renderWithProviders(<App />, {
+            initialEntries: ["/admin/dashboard"],
+        });
 
         expect(await screen.findByTestId("teacher-authoring-page")).toBeTruthy();
         expect(screen.queryByTestId("admin-dashboard-page")).toBeNull();
@@ -113,11 +109,9 @@ describe("App admin shell layout", () => {
     it("redirects an anonymous user to the admin login route", async () => {
         vi.mocked(useAuth).mockReturnValue(baseContext);
 
-        render(
-            <MemoryRouter initialEntries={["/admin/dashboard"]}>
-                <App />
-            </MemoryRouter>,
-        );
+        renderWithProviders(<App />, {
+            initialEntries: ["/admin/dashboard"],
+        });
 
         expect(await screen.findByTestId("admin-login-page")).toBeTruthy();
     });
@@ -125,11 +119,9 @@ describe("App admin shell layout", () => {
     it("keeps the global SiteHeader on non-admin-dashboard routes", () => {
         vi.mocked(useAuth).mockReturnValue(baseContext);
 
-        render(
-            <MemoryRouter initialEntries={["/teacher/login"]}>
-                <App />
-            </MemoryRouter>,
-        );
+        renderWithProviders(<App />, {
+            initialEntries: ["/teacher/login"],
+        });
 
         expect(screen.getByTestId("site-header")).toBeTruthy();
     });
@@ -137,11 +129,9 @@ describe("App admin shell layout", () => {
     it("resolves the lazy auth callback route", async () => {
         vi.mocked(useAuth).mockReturnValue(baseContext);
 
-        render(
-            <MemoryRouter initialEntries={["/auth/callback"]}>
-                <App />
-            </MemoryRouter>,
-        );
+        renderWithProviders(<App />, {
+            initialEntries: ["/auth/callback"],
+        });
 
         expect(await screen.findByTestId("auth-callback-page")).toBeTruthy();
     });
@@ -149,11 +139,9 @@ describe("App admin shell layout", () => {
     it("resolves the lazy student join route with an access token", async () => {
         vi.mocked(useAuth).mockReturnValue(baseContext);
 
-        render(
-            <MemoryRouter initialEntries={["/join?course_access_token=test-token"]}>
-                <App />
-            </MemoryRouter>,
-        );
+        renderWithProviders(<App />, {
+            initialEntries: ["/join?course_access_token=test-token"],
+        });
 
         expect(await screen.findByTestId("student-join-page")).toBeTruthy();
     });
@@ -161,11 +149,9 @@ describe("App admin shell layout", () => {
     it("resolves the lazy student login route with an access token", async () => {
         vi.mocked(useAuth).mockReturnValue(baseContext);
 
-        render(
-            <MemoryRouter initialEntries={["/student/login?course_access_token=test-token"]}>
-                <App />
-            </MemoryRouter>,
-        );
+        renderWithProviders(<App />, {
+            initialEntries: ["/student/login?course_access_token=test-token"],
+        });
 
         expect(await screen.findByTestId("student-login-page")).toBeTruthy();
     });

--- a/frontend/src/app/auth/AuthProvider.test.tsx
+++ b/frontend/src/app/auth/AuthProvider.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { AuthProvider } from "./AuthContext";
 import { useAuth } from "./useAuth";
 import type { AuthMeActor } from "./auth-types";
+import { createTestQueryClient, createWrapper } from "@/shared/test-utils";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -74,14 +75,23 @@ describe("AuthProvider", () => {
         });
     });
 
-    it("starts with loading=true and resolves to loading=false when no session", async () => {
-        mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
-
-        render(
+    function renderWithAuthProvider() {
+        return render(
             <AuthProvider>
                 <Probe />
             </AuthProvider>,
+            {
+                wrapper: createWrapper({
+                    queryClient: createTestQueryClient(),
+                }),
+            },
         );
+    }
+
+    it("starts with loading=true and resolves to loading=false when no session", async () => {
+        mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
+
+        renderWithAuthProvider();
 
         // loading starts true
         expect(screen.getByTestId("loading").textContent).toBe("true");
@@ -100,11 +110,7 @@ describe("AuthProvider", () => {
             error: null,
         });
 
-        render(
-            <AuthProvider>
-                <Probe />
-            </AuthProvider>,
-        );
+        renderWithAuthProvider();
 
         await waitFor(() =>
             expect(screen.getByTestId("loading").textContent).toBe("false"),
@@ -128,11 +134,7 @@ describe("AuthProvider", () => {
             return { data: { subscription: { unsubscribe: vi.fn() } } };
         });
 
-        render(
-            <AuthProvider>
-                <Probe />
-            </AuthProvider>,
-        );
+        renderWithAuthProvider();
 
         await waitFor(() =>
             expect(screen.getByTestId("actor").textContent).toBe("Test User"),

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
@@ -1,6 +1,5 @@
-import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 
 import { AdminDashboardPage } from "./AdminDashboardPage";
 import type {
@@ -34,6 +33,7 @@ vi.mock("@/shared/api", async () => {
 
 import { useAuth } from "@/app/auth/useAuth";
 import { api } from "@/shared/api";
+import { renderWithProviders } from "@/shared/test-utils";
 
 const showToast = vi.fn();
 const signOut = vi.fn();
@@ -129,7 +129,7 @@ const adminActor: AuthMeActor = {
 };
 
 function renderPage() {
-    return render(<AdminDashboardPage showToast={showToast} />);
+    return renderWithProviders(<AdminDashboardPage showToast={showToast} />);
 }
 
 function getElementLabel(element: Element): string {
@@ -306,11 +306,9 @@ describe("AdminDashboardPage", () => {
     });
 
     it("loads dashboard data correctly inside StrictMode", async () => {
-        render(
-            <StrictMode>
-                <AdminDashboardPage showToast={showToast} />
-            </StrictMode>,
-        );
+        renderWithProviders(<AdminDashboardPage showToast={showToast} />, {
+            strictMode: true,
+        });
 
         expect(await screen.findByText("Directorio de Cursos")).toBeTruthy();
         expect(screen.queryByTestId("admin-dashboard-loading")).toBeNull();

--- a/frontend/src/shared/test-utils.test.tsx
+++ b/frontend/src/shared/test-utils.test.tsx
@@ -1,0 +1,107 @@
+import { screen } from "@testing-library/react";
+import { useQuery } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useLocation } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { useAuth } from "@/app/auth/useAuth";
+import type { AuthContextValue } from "@/app/auth/auth-types";
+import {
+    createTestQueryClient,
+    createWrapper,
+    renderWithProviders,
+} from "@/shared/test-utils";
+
+const authValue: AuthContextValue = {
+    session: null,
+    actor: null,
+    loading: false,
+    error: null,
+    signOut: vi.fn(),
+    refreshActor: vi.fn(),
+};
+
+describe("test-utils", () => {
+    it("creates isolated query clients with test-safe defaults", () => {
+        const first = createTestQueryClient();
+        const second = createTestQueryClient();
+
+        expect(first).not.toBe(second);
+        expect(first.getDefaultOptions().queries?.retry).toBe(false);
+        expect(first.getDefaultOptions().queries?.gcTime).toBe(0);
+        expect(first.getDefaultOptions().queries?.staleTime).toBe(0);
+        expect(first.getDefaultOptions().mutations?.retry).toBe(false);
+    });
+
+    it("renderWithProviders wires QueryClientProvider, MemoryRouter, and auth context", async () => {
+        function Probe() {
+            const { loading } = useAuth();
+            const location = useLocation();
+            const { data } = useQuery({
+                queryKey: ["probe"],
+                queryFn: async () => "resolved",
+            });
+
+            return (
+                <>
+                    <span data-testid="pathname">{location.pathname}</span>
+                    <span data-testid="loading">{String(loading)}</span>
+                    <span data-testid="query-data">{data ?? "pending"}</span>
+                </>
+            );
+        }
+
+        const { queryClient } = renderWithProviders(<Probe />, {
+            initialEntries: ["/admin/dashboard"],
+            authValue,
+        });
+
+        expect(screen.getByTestId("pathname").textContent).toBe("/admin/dashboard");
+        expect(screen.getByTestId("loading").textContent).toBe("false");
+
+        await waitFor(() => {
+            expect(screen.getByTestId("query-data").textContent).toBe("resolved");
+        });
+        expect(queryClient.getQueryData(["probe"])).toBe("resolved");
+    });
+
+    it("createWrapper works with renderHook", async () => {
+        const wrapper = createWrapper();
+        const { result } = renderHook(
+            () =>
+                useQuery({
+                    queryKey: ["hook-probe"],
+                    queryFn: async () => 7,
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => {
+            expect(result.current.data).toBe(7);
+        });
+    });
+
+    it("supports strict mode composition", async () => {
+        const queryClient = createTestQueryClient();
+        const queryFn = vi.fn().mockResolvedValue("ok");
+
+        function Probe() {
+            const { data } = useQuery({
+                queryKey: ["strict-probe"],
+                queryFn,
+            });
+
+            return <span data-testid="strict-data">{data ?? "pending"}</span>;
+        }
+
+        renderWithProviders(<Probe />, {
+            queryClient,
+            strictMode: true,
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId("strict-data").textContent).toBe("ok");
+        });
+        expect(queryFn).toHaveBeenCalled();
+    });
+});

--- a/frontend/src/shared/test-utils.tsx
+++ b/frontend/src/shared/test-utils.tsx
@@ -1,0 +1,78 @@
+import { StrictMode, type ReactElement, type ReactNode } from "react";
+import { render, type RenderOptions } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { AuthContext } from "@/app/auth/auth-context";
+import type { AuthContextValue } from "@/app/auth/auth-types";
+
+export function createTestQueryClient(): QueryClient {
+    return new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+                gcTime: 0,
+                staleTime: 0,
+            },
+            mutations: {
+                retry: false,
+            },
+        },
+    });
+}
+
+interface WrapperOptions {
+    queryClient?: QueryClient;
+    initialEntries?: string[];
+    strictMode?: boolean;
+    authValue?: AuthContextValue;
+}
+
+export function createWrapper(options: WrapperOptions = {}) {
+    const queryClient = options.queryClient ?? createTestQueryClient();
+    const initialEntries = options.initialEntries ?? ["/"];
+    const strictMode = options.strictMode ?? false;
+    const authValue = options.authValue;
+
+    return function Wrapper({ children }: { children: ReactNode }) {
+        const routerContent = (
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+            </QueryClientProvider>
+        );
+        const content = authValue ? (
+            <AuthContext.Provider value={authValue}>
+                {routerContent}
+            </AuthContext.Provider>
+        ) : (
+            routerContent
+        );
+
+        return strictMode ? <StrictMode>{content}</StrictMode> : content;
+    };
+}
+
+type RenderWithProvidersOptions = WrapperOptions &
+    Omit<RenderOptions, "wrapper">;
+
+export function renderWithProviders(
+    ui: ReactElement,
+    options: RenderWithProvidersOptions = {},
+) {
+    const { queryClient, initialEntries, strictMode, authValue, ...renderOptions } =
+        options;
+    const testQueryClient = queryClient ?? createTestQueryClient();
+
+    return {
+        ...render(ui, {
+            wrapper: createWrapper({
+                queryClient: testQueryClient,
+                initialEntries,
+                strictMode,
+                authValue,
+            }),
+            ...renderOptions,
+        }),
+        queryClient: testQueryClient,
+    };
+}

--- a/frontend/src/shared/test-utils.tsx
+++ b/frontend/src/shared/test-utils.tsx
@@ -35,17 +35,20 @@ export function createWrapper(options: WrapperOptions = {}) {
     const authValue = options.authValue;
 
     return function Wrapper({ children }: { children: ReactNode }) {
-        const routerContent = (
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
-            </QueryClientProvider>
-        );
-        const content = authValue ? (
+        const innerContent = authValue ? (
             <AuthContext.Provider value={authValue}>
-                {routerContent}
+                {children}
             </AuthContext.Provider>
         ) : (
-            routerContent
+            children
+        );
+
+        const content = (
+            <MemoryRouter initialEntries={initialEntries}>
+                <QueryClientProvider client={queryClient}>
+                    {innerContent}
+                </QueryClientProvider>
+            </MemoryRouter>
         );
 
         return strictMode ? <StrictMode>{content}</StrictMode> : content;

--- a/frontend/src/shared/testing/msw/handlers.ts
+++ b/frontend/src/shared/testing/msw/handlers.ts
@@ -1,0 +1,9 @@
+import type { RequestHandler } from "msw";
+
+/**
+ * Base handlers for shared test infrastructure.
+ *
+ * Start intentionally minimal. Tests should opt into the specific HTTP contract
+ * they need with `server.use(...)` instead of depending on a hidden global stub.
+ */
+export const handlers: RequestHandler[] = [];

--- a/frontend/src/shared/testing/msw/server.test.ts
+++ b/frontend/src/shared/testing/msw/server.test.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { server } from "@/shared/testing/msw/server";
+
+describe("shared testing msw server", () => {
+    it("intercepts handled API requests", async () => {
+        server.use(
+            http.get("/api/test/health", () =>
+                HttpResponse.json({ ok: true }),
+            ),
+        );
+
+        const response = await fetch("/api/test/health");
+        const body = (await response.json()) as { ok: boolean };
+
+        expect(body.ok).toBe(true);
+    });
+
+    it("fails fast on unhandled API requests", async () => {
+        const response = await fetch("/api/test/unhandled");
+        const body = (await response.json()) as { message: string };
+
+        expect(response.status).toBe(500);
+        expect(body.message).toMatch(/Unhandled API request in test/i);
+    });
+});

--- a/frontend/src/shared/testing/msw/server.ts
+++ b/frontend/src/shared/testing/msw/server.ts
@@ -1,0 +1,5 @@
+import { setupServer } from "msw/node";
+
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,1 +1,25 @@
 import "@testing-library/jest-dom";
+import { cleanup } from "@testing-library/react";
+import { afterAll, afterEach, beforeAll } from "vitest";
+
+import { server } from "@/shared/testing/msw/server";
+
+beforeAll(() => {
+    server.listen({
+        onUnhandledRequest(request) {
+            const { pathname } = new URL(request.url);
+            if (pathname.startsWith("/api/")) {
+                throw new Error(`Unhandled API request in test: ${request.method} ${request.url}`);
+            }
+        },
+    });
+});
+
+afterEach(() => {
+    cleanup();
+    server.resetHandlers();
+});
+
+afterAll(() => {
+    server.close();
+});


### PR DESCRIPTION
## Summary
- add production-ready frontend test infrastructure for TanStack Query adoption
- introduce shared renderWithProviders / createWrapper / isolated test QueryClient helpers
- add MSW server wiring with fail-fast handling for unmocked /api requests
- migrate canary tests (App, AuthProvider, AdminDashboardPage) to the new providers
- add focused coverage for test-utils and MSW behavior

## Context
Issue #71 assumed an earlier repo state where TanStack Query was not installed yet. That part is already done in main, so this PR resolves the remaining testing gap and hardens the base beyond the literal minimum scope.

Closes #71.

## Validation
- npm --prefix frontend run build
- npm --prefix frontend run test
- npm --prefix frontend run lint