### PR TITLE
feat(admin-dashboard): Summary & Courses — TanStack Query (CORE) #4

### DIFF
--- a/frontend/src/app/auth/AuthContext.tsx
+++ b/frontend/src/app/auth/AuthContext.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 import { apiFetch } from "@/shared/api";
 import type { AuthMeActor, Session } from "./auth-types";
 import { AuthContext } from "./auth-context";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+    const queryClient = useQueryClient();
     const [session, setSession] = useState<Session | null>(null);
     const [actor, setActor] = useState<AuthMeActor | null>(null);
     const [loading, setLoading] = useState(true);
@@ -97,6 +99,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                     setSession(null);
                     setActor(null);
                     setError(null);
+                    queryClient.clear();
                 }
             },
         );
@@ -108,7 +111,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             }
             listenerData.subscription.unsubscribe();
         };
-    }, [fetchActor]);
+    }, [fetchActor, queryClient]);
 
     const signOut = useCallback(async () => {
         const supabase = getSupabaseClient();
@@ -118,7 +121,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setSession(null);
         setActor(null);
         setError(null);
-    }, []);
+        queryClient.clear();
+    }, [queryClient]);
 
     return (
         <AuthContext.Provider

--- a/frontend/src/app/auth/AuthProvider.test.tsx
+++ b/frontend/src/app/auth/AuthProvider.test.tsx
@@ -134,11 +134,20 @@ describe("AuthProvider", () => {
             return { data: { subscription: { unsubscribe: vi.fn() } } };
         });
 
-        renderWithAuthProvider();
+        const queryClient = createTestQueryClient();
+        render(
+            <AuthProvider>
+                <Probe />
+            </AuthProvider>,
+            {
+                wrapper: createWrapper({ queryClient }),
+            },
+        );
 
         await waitFor(() =>
             expect(screen.getByTestId("actor").textContent).toBe("Test User"),
         );
+        queryClient.setQueryData(["admin", "summary"], { value: 1 });
 
         // Simulate sign-out event
         capturedCallback!("SIGNED_OUT", null);
@@ -147,5 +156,6 @@ describe("AuthProvider", () => {
             expect(screen.getByTestId("actor").textContent).toBe("none"),
         );
         expect(screen.getByTestId("session").textContent).toBe("no");
+        expect(queryClient.getQueryData(["admin", "summary"])).toBeUndefined();
     });
 });

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { focusManager } from "@tanstack/react-query";
 
@@ -226,7 +226,7 @@ function triggerWindowRefocus() {
 
 describe("AdminDashboardPage", () => {
     beforeEach(() => {
-        vi.clearAllMocks();
+        vi.resetAllMocks();
         focusManager.setFocused(true);
         Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
             configurable: true,
@@ -289,6 +289,10 @@ describe("AdminDashboardPage", () => {
                 writeText: vi.fn().mockResolvedValue(undefined),
             },
         });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
     });
 
     it("renders KPIs and secure access-link placeholder states", async () => {
@@ -679,6 +683,26 @@ describe("AdminDashboardPage", () => {
         });
     });
 
+    it("auto-refreshes the summary every 30 seconds while the dashboard stays open", async () => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.mocked(api.admin.getDashboardSummary)
+            .mockResolvedValueOnce(summaryResponse)
+            .mockResolvedValueOnce({
+                ...summaryResponse,
+                average_occupancy: 78,
+            });
+
+        renderPage();
+        await screen.findByText("Directorio de Cursos");
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(30_000);
+        });
+
+        expect(await screen.findByText("78%")).toBeTruthy();
+        expect(api.admin.getDashboardSummary).toHaveBeenCalledTimes(2);
+    }, 20_000);
+
     it("keeps the current dashboard mounted while a focus revalidation is pending and updates KPIs in place", async () => {
         const refreshSummaryDeferred = createDeferred<AdminDashboardSummaryResponse>();
         const refreshCoursesDeferred = createDeferred<AdminCourseListResponse>();
@@ -700,7 +724,9 @@ describe("AdminDashboardPage", () => {
         expect(screen.queryByTestId("admin-dashboard-loading")).toBeNull();
         expect(screen.getByText("62%")).toBeTruthy();
         expect(screen.getByText("Finanzas Corporativas")).toBeTruthy();
-        expect(screen.getByTestId("dashboard-refresh-status").textContent).toContain("Actualizando datos");
+        await waitFor(() => {
+            expect(screen.getByTestId("dashboard-refresh-status").textContent).toContain("Actualizando datos");
+        });
 
         await act(async () => {
             refreshSummaryDeferred.resolve({
@@ -728,7 +754,9 @@ describe("AdminDashboardPage", () => {
         renderPage();
         await screen.findByText("Directorio de Cursos");
 
-        fireEvent.focus(window);
+        await act(async () => {
+            triggerWindowRefocus();
+        });
 
         expect(screen.getByText("Estrategia Operativa")).toBeTruthy();
         expect(screen.getByText("Finanzas Corporativas")).toBeTruthy();
@@ -806,7 +834,9 @@ describe("AdminDashboardPage", () => {
         renderPage();
         await screen.findByText("Directorio de Cursos");
 
-        fireEvent.focus(window);
+        await act(async () => {
+            triggerWindowRefocus();
+        });
 
         await waitFor(() => {
             expect(screen.getByTestId("dashboard-refresh-status").textContent).toContain("No se pudo actualizar");
@@ -817,6 +847,76 @@ describe("AdminDashboardPage", () => {
         expect(screen.queryByTestId("global-page-error")).toBeNull();
         expect(screen.queryByTestId("admin-dashboard-loading")).toBeNull();
     });
+
+    it("applies fresh course rows even when the summary refetch fails", async () => {
+        vi.mocked(api.admin.getDashboardSummary)
+            .mockResolvedValueOnce(summaryResponse)
+            .mockRejectedValueOnce(new ApiError(500, "summary failed", "teacher_email_unavailable"));
+        vi.mocked(api.admin.listCourses)
+            .mockResolvedValueOnce(coursesResponse)
+            .mockResolvedValueOnce({
+                ...coursesResponse,
+                items: [
+                    { ...activeCourse, title: "Finanzas Corporativas Avanzadas" },
+                    inactiveCourse,
+                ],
+            });
+
+        renderPage();
+        await screen.findByText("Directorio de Cursos");
+
+        await act(async () => {
+            triggerWindowRefocus();
+        });
+
+        expect(await screen.findByText("Finanzas Corporativas Avanzadas")).toBeTruthy();
+        expect(screen.getByText("62%")).toBeTruthy();
+    });
+
+    it("applies fresh summary KPIs even when the courses refetch fails", async () => {
+        vi.mocked(api.admin.getDashboardSummary)
+            .mockResolvedValueOnce(summaryResponse)
+            .mockResolvedValueOnce({
+                ...summaryResponse,
+                average_occupancy: 78,
+            });
+        vi.mocked(api.admin.listCourses)
+            .mockResolvedValueOnce(coursesResponse)
+            .mockRejectedValueOnce(new ApiError(500, "courses failed", "teacher_email_unavailable"));
+
+        renderPage();
+        await screen.findByText("Directorio de Cursos");
+
+        await act(async () => {
+            triggerWindowRefocus();
+        });
+
+        expect(await screen.findByText("78%")).toBeTruthy();
+        expect(screen.getByText("Finanzas Corporativas")).toBeTruthy();
+    });
+
+    it("keeps create-course success visible even if the invalidated queries fail afterwards", async () => {
+        vi.mocked(api.admin.getDashboardSummary)
+            .mockResolvedValueOnce(summaryResponse)
+            .mockRejectedValueOnce(new ApiError(500, "summary failed", "teacher_email_unavailable"));
+        vi.mocked(api.admin.listCourses)
+            .mockResolvedValueOnce(coursesResponse)
+            .mockRejectedValueOnce(new ApiError(500, "courses failed", "teacher_email_unavailable"));
+
+        renderPage();
+        await screen.findByText("Directorio de Cursos");
+
+        fireEvent.click(screen.getByText("Crear Nuevo Curso"));
+        await fillCreateCourseForm("membership:teacher-membership-1");
+        fireEvent.submit(screen.getByTestId("create-course-modal").querySelector("form")!);
+
+        await waitFor(() => {
+            expect(api.admin.createCourse).toHaveBeenCalledTimes(1);
+        });
+        expect(showToast).toHaveBeenCalledWith("Curso creado correctamente.", "success");
+        expect(screen.queryByTestId("create-course-modal")).toBeNull();
+        expect(screen.queryByText("No se pudo crear el curso.")).toBeNull();
+    }, 20_000);
 
     it("regenerates a hidden active link and keeps the new raw link visible after refresh", async () => {
         renderPage();

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
@@ -407,7 +407,7 @@ describe("AdminDashboardPage", () => {
                 },
             }));
         });
-    });
+    }, 20_000);
 
     it("blocks invalid max_students locally before calling the backend", async () => {
         renderPage();
@@ -422,7 +422,7 @@ describe("AdminDashboardPage", () => {
 
         expect(await screen.findByText("La capacidad máxima debe ser un número entero mayor o igual a 1.")).toBeTruthy();
         expect(api.admin.createCourse).not.toHaveBeenCalled();
-    });
+    }, 20_000);
 
     it("uses guided semester selectors when creating a course", async () => {
         renderPage();
@@ -437,7 +437,7 @@ describe("AdminDashboardPage", () => {
                 semester: "2026-II",
             }));
         });
-    });
+    }, 20_000);
 
     it("blocks editing when a course arrives with an invalid inherited semester", async () => {
         vi.mocked(api.admin.listCourses).mockResolvedValueOnce({
@@ -518,7 +518,7 @@ describe("AdminDashboardPage", () => {
                 },
             }));
         });
-    });
+    }, 20_000);
 
     it("keeps dashboard quick actions as placeholders with no side effects", async () => {
         renderPage();

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
@@ -420,7 +420,7 @@ export function AdminDashboardPage({ showToast }: Props) {
         }
     }
 
-        return (
+    return (
         <div className="min-h-screen bg-[#f0f4f8] text-slate-800" data-testid="admin-dashboard-shell">
             <header className="border-b-[3px] border-[#0144a0] bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800" data-testid="admin-dashboard-header">
                 <div className="mx-auto flex h-20 w-full max-w-7xl items-center justify-between gap-5 px-6">

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
@@ -22,7 +22,6 @@ import {
     useEffect,
     useId,
     useMemo,
-    useRef,
     useState,
     type Dispatch,
     type FormEvent,
@@ -30,18 +29,16 @@ import {
     type ReactNode,
     type SetStateAction,
 } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useAuth } from "@/app/auth/useAuth";
 import type {
     AdminCourseListItem,
-    AdminCourseListResponse,
     AdminCourseStatus,
-    AdminDashboardSummaryResponse,
     AdminTeacherOptionsResponse,
 } from "@/shared/adam-types";
 import { ApiError, api } from "@/shared/api";
-import { queryKeys } from "@/shared/queryKeys";
+import { queryKeys, type CourseFilters } from "@/shared/queryKeys";
 import type { ShowToast } from "@/shared/Toast";
 import {
     Select,
@@ -70,8 +67,6 @@ import {
     getCourseStatusMeta,
     getInitials,
     getTeacherStateMeta,
-    reconcileCourseListResponse,
-    reconcileDashboardSummary,
     sortPendingInvites,
     summarizePageRange,
     teacherInviteToPendingOption,
@@ -91,7 +86,6 @@ interface Props {
     showToast: ShowToast;
 }
 
-type RefreshMode = "initial" | "background";
 const ALL_FILTER_VALUE = "all";
 const UI_UNSET_SELECT_VALUE = "__unset_select_value__";
 const UI_UNASSIGNED_TEACHER_VALUE = "__unassigned_teacher_value__";
@@ -100,13 +94,6 @@ export function AdminDashboardPage({ showToast }: Props) {
     const { actor, signOut } = useAuth();
     const queryClient = useQueryClient();
 
-    const [summary, setSummary] = useState<AdminDashboardSummaryResponse | null>(null);
-    const [coursesResponse, setCoursesResponse] = useState<AdminCourseListResponse | null>(null);
-    const [isInitialLoading, setIsInitialLoading] = useState(true);
-    const [isRefreshing, setIsRefreshing] = useState(false);
-    const [pageError, setPageError] = useState<string | null>(null);
-    const [refreshError, setRefreshError] = useState<string | null>(null);
-    const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
     const [transientAccessLinks, setTransientAccessLinks] = useState<Record<string, string>>({});
     const [search, setSearch] = useState("");
     const deferredSearch = useDeferredValue(search);
@@ -133,26 +120,30 @@ export function AdminDashboardPage({ showToast }: Props) {
     const [regeneratingCourseId, setRegeneratingCourseId] = useState<string | null>(null);
     const [courseFormError, setCourseFormError] = useState<string | null>(null);
     const [inviteFormError, setInviteFormError] = useState<string | null>(null);
-    const isMountedRef = useRef(true);
-    const didLoadDashboardRef = useRef(false);
-    const dashboardRequestIdRef = useRef(0);
-    const lastExternalRefreshAtRef = useRef(0);
-
-    useEffect(() => {
-        isMountedRef.current = true;
-        return () => {
-            isMountedRef.current = false;
-        };
-    }, []);
-
-    const currentItems = useMemo(() => coursesResponse?.items ?? EMPTY_COURSES, [coursesResponse]);
-    const hasDashboardData = summary !== null && coursesResponse !== null;
-    const editingCourse = editingCourseId
-        ? currentItems.find((item) => item.id === editingCourseId) ?? null
-        : null;
-    const archivingCourse = archivingCourseId
-        ? currentItems.find((item) => item.id === archivingCourseId) ?? null
-        : null;
+    const courseFilters = useMemo<CourseFilters>(() => ({
+        search: deferredSearch.trim() || undefined,
+        semester: semesterFilter === ALL_FILTER_VALUE ? undefined : semesterFilter,
+        status: statusFilter === ALL_FILTER_VALUE ? undefined : statusFilter,
+        academic_level:
+            academicLevelFilter === ALL_FILTER_VALUE ? undefined : academicLevelFilter,
+        page,
+        page_size: ADMIN_PAGE_SIZE,
+    }), [academicLevelFilter, deferredSearch, page, semesterFilter, statusFilter]);
+    const summaryQuery = useQuery({
+        queryKey: queryKeys.admin.summary(),
+        queryFn: () => api.admin.getDashboardSummary(),
+        staleTime: 30_000,
+        refetchInterval: 30_000,
+        refetchIntervalInBackground: false,
+        refetchOnWindowFocus: "always",
+    });
+    const coursesQuery = useQuery({
+        queryKey: queryKeys.admin.courses(courseFilters),
+        queryFn: () => api.admin.listCourses(courseFilters),
+        staleTime: 30_000,
+        placeholderData: keepPreviousData,
+        refetchOnWindowFocus: "always",
+    });
     const teacherOptionsQuery = useQuery({
         queryKey: queryKeys.admin.teacherOptions(),
         queryFn: () => api.admin.getTeacherOptions(),
@@ -169,6 +160,49 @@ export function AdminDashboardPage({ showToast }: Props) {
             "No se pudieron cargar las opciones de docentes para los formularios.",
         )
         : null;
+    const summary = summaryQuery.data ?? null;
+    const coursesResponse = coursesQuery.data ?? null;
+    const currentItems = useMemo(() => coursesResponse?.items ?? EMPTY_COURSES, [coursesResponse]);
+    const hasDashboardData = summary !== null && coursesResponse !== null;
+    const isDashboardRefreshing =
+        hasDashboardData && (summaryQuery.isFetching || coursesQuery.isFetching);
+    const editingCourse = editingCourseId
+        ? currentItems.find((item) => item.id === editingCourseId) ?? null
+        : null;
+    const archivingCourse = archivingCourseId
+        ? currentItems.find((item) => item.id === archivingCourseId) ?? null
+        : null;
+    const pageError = useMemo(() => {
+        if (summary === null && summaryQuery.error) {
+            return getAdminErrorMessage(
+                summaryQuery.error,
+                "No se pudo cargar el dashboard administrativo.",
+            );
+        }
+        if (coursesResponse === null && coursesQuery.error) {
+            return getAdminErrorMessage(
+                coursesQuery.error,
+                "No se pudo cargar el dashboard administrativo.",
+            );
+        }
+        return null;
+    }, [coursesQuery.error, coursesResponse, summary, summaryQuery.error]);
+    const refreshError = useMemo(() => {
+        if (summary !== null && summaryQuery.error) {
+            return getAdminErrorMessage(
+                summaryQuery.error,
+                "No se pudo actualizar el dashboard administrativo.",
+            );
+        }
+        if (coursesResponse !== null && coursesQuery.error) {
+            return getAdminErrorMessage(
+                coursesQuery.error,
+                "No se pudo actualizar el dashboard administrativo.",
+            );
+        }
+        return null;
+    }, [coursesQuery.error, coursesResponse, summary, summaryQuery.error]);
+    const lastSyncedAt = summaryQuery.dataUpdatedAt || coursesQuery.dataUpdatedAt || null;
     const semesterSuggestions = useMemo(() => {
         const values = new Set<string>();
         for (const item of currentItems) {
@@ -180,113 +214,6 @@ export function AdminDashboardPage({ showToast }: Props) {
 
     const adminName = actor?.profile.full_name ?? "Administrador ADAM";
     const adminInitials = getInitials(adminName);
-
-    const buildCourseFilters = useCallback((nextPage = page) => ({
-            search: deferredSearch,
-            semester: semesterFilter === ALL_FILTER_VALUE ? undefined : semesterFilter,
-            status: statusFilter === ALL_FILTER_VALUE ? undefined : statusFilter,
-            academic_level: academicLevelFilter === ALL_FILTER_VALUE ? undefined : academicLevelFilter,
-            page: nextPage,
-            page_size: ADMIN_PAGE_SIZE,
-        }), [academicLevelFilter, deferredSearch, page, semesterFilter, statusFilter]);
-
-    const applyDashboardSnapshot = useCallback((
-        summaryResponse: AdminDashboardSummaryResponse,
-        courses: AdminCourseListResponse,
-    ) => {
-        didLoadDashboardRef.current = true;
-        setSummary((prev) => reconcileDashboardSummary(prev, summaryResponse));
-        setCoursesResponse((prev) => reconcileCourseListResponse(prev, courses));
-        setPageError(null);
-        setRefreshError(null);
-        setLastSyncedAt(Date.now());
-    }, []);
-
-    const refreshDashboard = useCallback(async (
-        { nextPage = page, mode }: { nextPage?: number; mode?: RefreshMode } = {},
-    ) => {
-        const requestId = ++dashboardRequestIdRef.current;
-        const refreshMode = mode ?? (didLoadDashboardRef.current ? "background" : "initial");
-        const isBlocking = refreshMode === "initial" && !didLoadDashboardRef.current;
-
-        if (isBlocking) {
-            setIsInitialLoading(true);
-            setPageError(null);
-        } else {
-            setIsRefreshing(true);
-            setRefreshError(null);
-        }
-
-        try {
-            const [summaryResponse, courses] = await Promise.all([
-                api.admin.getDashboardSummary(),
-                api.admin.listCourses(buildCourseFilters(nextPage)),
-            ]);
-            if (!isMountedRef.current || requestId !== dashboardRequestIdRef.current) {
-                return;
-            }
-
-            applyDashboardSnapshot(summaryResponse, courses);
-        } catch (error) {
-            if (!isMountedRef.current || requestId !== dashboardRequestIdRef.current) {
-                throw error;
-            }
-
-            const message = getAdminErrorMessage(error, "No se pudo cargar el dashboard administrativo.");
-            if (isBlocking) {
-                setPageError(message);
-            } else {
-                setRefreshError(message);
-            }
-            throw error;
-        } finally {
-            if (isMountedRef.current && requestId === dashboardRequestIdRef.current) {
-                if (isBlocking) {
-                    setIsInitialLoading(false);
-                } else {
-                    setIsRefreshing(false);
-                }
-            }
-        }
-    }, [applyDashboardSnapshot, buildCourseFilters, page]);
-
-    useEffect(() => {
-        void refreshDashboard().catch(() => undefined);
-    }, [refreshDashboard]);
-
-    const requestExternalRefresh = useCallback(() => {
-        if (!didLoadDashboardRef.current) {
-            return;
-        }
-
-        const now = Date.now();
-        if (now - lastExternalRefreshAtRef.current < 750) {
-            return;
-        }
-        lastExternalRefreshAtRef.current = now;
-        void refreshDashboard({ mode: "background" }).catch(() => undefined);
-    }, [refreshDashboard]);
-
-    useEffect(() => {
-        function handleWindowFocus() {
-            if (document.visibilityState === "visible") {
-                requestExternalRefresh();
-            }
-        }
-
-        function handleVisibilityChange() {
-            if (document.visibilityState === "visible") {
-                requestExternalRefresh();
-            }
-        }
-
-        window.addEventListener("focus", handleWindowFocus);
-        document.addEventListener("visibilitychange", handleVisibilityChange);
-        return () => {
-            window.removeEventListener("focus", handleWindowFocus);
-            document.removeEventListener("visibilitychange", handleVisibilityChange);
-        };
-    }, [requestExternalRefresh]);
 
     const retryTeacherOptions = useCallback(() => {
         void queryClient.invalidateQueries({ queryKey: queryKeys.admin.teacherOptions() });
@@ -301,13 +228,6 @@ export function AdminDashboardPage({ showToast }: Props) {
                 : prev
         ));
     }, []);
-
-    const refreshSummaryAndCourses = useCallback(async (nextPage = page) => {
-        await refreshDashboard({
-            nextPage,
-            mode: didLoadDashboardRef.current ? "background" : "initial",
-        });
-    }, [page, refreshDashboard]);
 
     const openCreateModal = useCallback(() => {
         setCourseFormError(null);
@@ -356,7 +276,8 @@ export function AdminDashboardPage({ showToast }: Props) {
             }
             setIsCreateOpen(false);
             setPage(1);
-            await refreshSummaryAndCourses(1);
+            void queryClient.invalidateQueries({ queryKey: queryKeys.admin.summary() });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.admin.courses() });
             showToast("Curso creado correctamente.", "success");
         } catch (error) {
             setCourseFormError(getAdminErrorMessage(error, "No se pudo crear el curso."));
@@ -380,9 +301,9 @@ export function AdminDashboardPage({ showToast }: Props) {
             if (updatedAccessLink) {
                 setTransientAccessLinks((prev) => ({ ...prev, [updatedItem.id]: updatedAccessLink }));
             }
-            await refreshSummaryAndCourses();
             setEditingCourseId(null);
             setIsEditOpen(false);
+            void queryClient.invalidateQueries({ queryKey: queryKeys.admin.courses() });
             showToast("Curso actualizado correctamente.", "success");
         } catch (error) {
             setCourseFormError(getAdminErrorMessage(error, "No se pudo actualizar el curso."));
@@ -411,7 +332,8 @@ export function AdminDashboardPage({ showToast }: Props) {
             });
             setArchivingCourseId(null);
             setIsArchiveOpen(false);
-            await refreshSummaryAndCourses();
+            void queryClient.invalidateQueries({ queryKey: queryKeys.admin.summary() });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.admin.courses() });
             showToast("Curso archivado correctamente.", "success");
         } catch (error) {
             const message = getAdminErrorMessage(error, "No se pudo archivar el curso.");
@@ -487,7 +409,7 @@ export function AdminDashboardPage({ showToast }: Props) {
         try {
             const regenerated = await api.admin.regenerateCourseAccessLink(item.id);
             setTransientAccessLinks((prev) => ({ ...prev, [regenerated.course_id]: regenerated.access_link }));
-            await refreshSummaryAndCourses();
+            void queryClient.invalidateQueries({ queryKey: queryKeys.admin.courses() });
             showToast("Enlace regenerado correctamente.", "success");
         } catch (error) {
             const message = getAdminErrorMessage(error, "No se pudo regenerar el enlace del curso.");
@@ -498,7 +420,7 @@ export function AdminDashboardPage({ showToast }: Props) {
         }
     }
 
-    return (
+        return (
         <div className="min-h-screen bg-[#f0f4f8] text-slate-800" data-testid="admin-dashboard-shell">
             <header className="border-b-[3px] border-[#0144a0] bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800" data-testid="admin-dashboard-header">
                 <div className="mx-auto flex h-20 w-full max-w-7xl items-center justify-between gap-5 px-6">
@@ -530,13 +452,14 @@ export function AdminDashboardPage({ showToast }: Props) {
             </header>
 
             <main className="mx-auto w-full max-w-7xl px-6 py-8">
-                {!hasDashboardData && isInitialLoading ? (
+                {!hasDashboardData && (summaryQuery.isPending || coursesQuery.isPending) ? (
                     <DashboardLoadingState />
                 ) : !hasDashboardData && pageError ? (
                     <PageErrorState
                         message={pageError}
                         onRetry={() => {
-                            void refreshDashboard({ mode: "initial" }).catch(() => undefined);
+                            void queryClient.invalidateQueries({ queryKey: queryKeys.admin.summary() });
+                            void queryClient.invalidateQueries({ queryKey: queryKeys.admin.courses() });
                         }}
                     />
                 ) : (
@@ -576,11 +499,12 @@ export function AdminDashboardPage({ showToast }: Props) {
                             <div className="mb-4 flex items-center gap-4">
                                 <h2 className="text-xl font-bold tracking-tight text-slate-900">Directorio de Cursos</h2>
                                 <DashboardRefreshStatus
-                                    isRefreshing={isRefreshing}
+                                    isRefreshing={isDashboardRefreshing}
                                     refreshError={refreshError}
                                     lastSyncedAt={lastSyncedAt}
                                     onRetry={() => {
-                                        void refreshDashboard({ mode: "background" }).catch(() => undefined);
+                                        void queryClient.invalidateQueries({ queryKey: queryKeys.admin.summary() });
+                                        void queryClient.invalidateQueries({ queryKey: queryKeys.admin.courses() });
                                     }}
                                 />
                                 <div className="h-[2px] flex-1 rounded-full bg-gradient-to-r from-slate-200 to-transparent" />

--- a/frontend/src/features/admin-dashboard/adminDashboardModel.ts
+++ b/frontend/src/features/admin-dashboard/adminDashboardModel.ts
@@ -3,7 +3,6 @@ import type {
     AdminCourseListResponse,
     AdminCourseMutationRequest,
     AdminCourseStatus,
-    AdminDashboardSummaryResponse,
     AdminPendingTeacherInviteOption,
     AdminTeacherAssignment,
     AdminTeacherInviteResponse,
@@ -159,93 +158,6 @@ export function buildCoursePayload(form: CourseFormState): AdminCourseMutationRe
         status: form.status,
         teacher_assignment: teacherAssignment,
     };
-}
-
-export function reconcileDashboardSummary(
-    previous: AdminDashboardSummaryResponse | null,
-    next: AdminDashboardSummaryResponse,
-): AdminDashboardSummaryResponse {
-    if (
-        previous &&
-        previous.active_courses === next.active_courses &&
-        previous.active_teachers === next.active_teachers &&
-        previous.enrolled_students === next.enrolled_students &&
-        previous.average_occupancy === next.average_occupancy
-    ) {
-        return previous;
-    }
-
-    return next;
-}
-
-export function reconcileCourseListResponse(
-    previous: AdminCourseListResponse | null,
-    next: AdminCourseListResponse,
-): AdminCourseListResponse {
-    if (!previous) return next;
-
-    const previousItemsById = new Map(previous.items.map((item) => [item.id, item]));
-    let itemsChanged = previous.items.length !== next.items.length;
-
-    const items = next.items.map((item) => {
-        const previousItem = previousItemsById.get(item.id);
-        if (previousItem && areCourseItemsEqual(previousItem, item)) {
-            return previousItem;
-        }
-
-        itemsChanged = true;
-        return item;
-    });
-
-    if (
-        !itemsChanged &&
-        previous.page === next.page &&
-        previous.page_size === next.page_size &&
-        previous.total === next.total &&
-        previous.total_pages === next.total_pages
-    ) {
-        return previous;
-    }
-
-    return {
-        ...next,
-        items,
-    };
-}
-
-function areCourseItemsEqual(left: AdminCourseListItem, right: AdminCourseListItem): boolean {
-    return (
-        left.id === right.id &&
-        left.title === right.title &&
-        left.code === right.code &&
-        left.semester === right.semester &&
-        left.academic_level === right.academic_level &&
-        left.status === right.status &&
-        left.teacher_display_name === right.teacher_display_name &&
-        left.teacher_state === right.teacher_state &&
-        left.students_count === right.students_count &&
-        left.max_students === right.max_students &&
-        left.occupancy_percent === right.occupancy_percent &&
-        left.access_link === right.access_link &&
-        left.access_link_status === right.access_link_status &&
-        areTeacherAssignmentsEqual(left.teacher_assignment, right.teacher_assignment)
-    );
-}
-
-function areTeacherAssignmentsEqual(
-    left: AdminTeacherAssignment,
-    right: AdminTeacherAssignment,
-): boolean {
-    if (left.kind !== right.kind) return false;
-    if (left.kind === "membership" && right.kind === "membership") {
-        return left.membership_id === right.membership_id;
-    }
-
-    if (left.kind === "pending_invite" && right.kind === "pending_invite") {
-        return left.invite_id === right.invite_id;
-    }
-
-    return false;
 }
 
 export function getAdminErrorMessage(error: unknown, fallback: string): string {

--- a/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
@@ -80,7 +80,7 @@ describe("AuthoringForm", () => {
 
         expect(await screen.findByDisplayValue("Escenario sugerido")).toBeInTheDocument();
         expect(screen.getByDisplayValue("Pregunta sugerida")).toBeInTheDocument();
-    });
+    }, 20_000);
 
     it("fills suggested techniques from the techniques mutation and clears the stale warning", async () => {
         const user = userEvent.setup();
@@ -125,7 +125,7 @@ describe("AuthoringForm", () => {
         expect(
             screen.queryByText(/podr[ií]an estar desactualizadas/i),
         ).not.toBeInTheDocument();
-    });
+    }, 20_000);
 
     it("prevents duplicate scenario requests on rapid double click", async () => {
         const user = userEvent.setup();

--- a/frontend/src/shared/queryClient.test.ts
+++ b/frontend/src/shared/queryClient.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ApiError } from "@/shared/api";
+import { queryClient } from "@/shared/queryClient";
+
+describe("queryClient", () => {
+    beforeEach(() => {
+        queryClient.clear();
+    });
+
+    it("clears cached data when a 401 reaches the global query error handler", () => {
+        queryClient.setQueryData(["admin", "summary"], { active_courses: 2 });
+
+        queryClient.getQueryCache().config.onError?.(
+            new ApiError(401, "unauthorized", "invalid_token"),
+            {} as never,
+        );
+
+        expect(queryClient.getQueryData(["admin", "summary"])).toBeUndefined();
+    });
+});

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -43,7 +43,12 @@ export const queryKeys = {
          * ["admin", "courses", filters?] — lista paginada de cursos con filtros.
          * Sin argumentos invalida todas las variantes de la lista.
          */
-        courses: (f?: CourseFilters) => ["admin", "courses", f] as const,
+        courses: (f?: CourseFilters) => {
+            if (f === undefined) {
+                return ["admin", "courses"] as const;
+            }
+            return ["admin", "courses", f] as const;
+        },
         /** ["admin", "teacher-options"] — opciones para el dropdown de asignación de docente */
         teacherOptions: () => ["admin", "teacher-options"] as const,
     },


### PR DESCRIPTION
## Summary
- migrate admin dashboard summary and course listing to independent TanStack queries
- remove the manual dashboard refresh/reconciliation stack and switch post-write flows to targeted query invalidation
- harden auth sign-out by clearing the query cache and add regression coverage for dashboard refresh and global 401 handling

## Validation
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test`
- `npm --prefix frontend run build`

Closes #78