### PR TITLE
feat(auth): Auth Actor Query con protección PKCE

### DIFF
--- a/frontend/src/app/auth/AuthContext.tsx
+++ b/frontend/src/app/auth/AuthContext.tsx
@@ -1,126 +1,147 @@
 import { useCallback, useEffect, useState, type ReactNode } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/shared/queryKeys";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 import { apiFetch } from "@/shared/api";
+
 import type { AuthMeActor, Session } from "./auth-types";
 import { AuthContext } from "./auth-context";
+
+const ACTOR_PROFILE_ERROR =
+    "No se pudo cargar tu perfil. Intenta iniciar sesión de nuevo.";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
     const queryClient = useQueryClient();
     const [session, setSession] = useState<Session | null>(null);
-    const [actor, setActor] = useState<AuthMeActor | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+    const [bootstrapComplete, setBootstrapComplete] = useState(false);
+    const [bootstrapError, setBootstrapError] = useState<string | null>(null);
+    const [actorQueryEnabled, setActorQueryEnabled] = useState(false);
 
-    const fetchActor = useCallback(async (): Promise<AuthMeActor | null> => {
-        try {
-            const res = await apiFetch("/auth/me");
-            return (await res.json()) as AuthMeActor;
-        } catch {
-            return null;
-        }
+    const fetchActorOrThrow = useCallback(async (): Promise<AuthMeActor> => {
+        const res = await apiFetch("/auth/me");
+        return (await res.json()) as AuthMeActor;
     }, []);
 
+    const actorQuery = useQuery({
+        queryKey: queryKeys.auth.actor(),
+        queryFn: fetchActorOrThrow,
+        enabled: bootstrapComplete && !!session && actorQueryEnabled,
+        staleTime: 5 * 60_000,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: true,
+        retry: false,
+    });
+
+    const actor = actorQuery.data ?? null;
+    const loading =
+        !bootstrapComplete ||
+        (!!session && actorQuery.isPending && !actorQuery.data);
+    const error =
+        bootstrapError ??
+        (session && !actor && actorQuery.isError ? ACTOR_PROFILE_ERROR : null);
+
     const refreshActor = useCallback(async () => {
-        const next = await fetchActor();
-        setActor(next);
-    }, [fetchActor]);
+        if (!session) {
+            queryClient.removeQueries({ queryKey: queryKeys.auth.actor() });
+            return;
+        }
+
+        await queryClient.fetchQuery({
+            queryKey: queryKeys.auth.actor(),
+            queryFn: fetchActorOrThrow,
+            staleTime: 0,
+        });
+    }, [fetchActorOrThrow, queryClient, session]);
 
     useEffect(() => {
         const supabase = getSupabaseClient();
         if (!supabase) {
-            setLoading(false);
+            setBootstrapComplete(true);
             return;
         }
+        const auth = supabase.auth;
 
-        let cancelled = false;
         let actorRefreshTimeoutId: number | null = null;
 
         async function bootstrap() {
-            const { data, error: sessionError } =
-                await supabase!.auth.getSession();
-
-            if (cancelled) return;
+            const { data, error: sessionError } = await auth.getSession();
 
             if (sessionError) {
-                setError(sessionError.message);
-                setLoading(false);
+                setBootstrapError(sessionError.message);
+                setActorQueryEnabled(false);
+                setBootstrapComplete(true);
                 return;
             }
 
-            const currentSession = data.session ?? null;
-            setSession(currentSession);
-
-            if (currentSession) {
-                const resolvedActor = await fetchActor();
-                if (!cancelled) {
-                    setActor(resolvedActor);
-                    if (!resolvedActor) {
-                        setError(
-                            "No se pudo cargar tu perfil. Intenta iniciar sesión de nuevo.",
-                        );
-                    }
-                }
-            }
-
-            if (!cancelled) {
-                setLoading(false);
-            }
+            setBootstrapError(null);
+            setSession(data.session ?? null);
+            setActorQueryEnabled(!!data.session);
+            setBootstrapComplete(true);
         }
 
         void bootstrap();
 
-        const { data: listenerData } = supabase.auth.onAuthStateChange(
+        const { data: listenerData } = auth.onAuthStateChange(
             (event, nextSession) => {
-                if (cancelled) return;
-
-                if (
-                    event === "SIGNED_IN" ||
-                    event === "TOKEN_REFRESHED" ||
-                    event === "INITIAL_SESSION"
-                ) {
+                if (event === "SIGNED_IN") {
                     setSession(nextSession);
+                    setBootstrapError(null);
+                    setActorQueryEnabled(false);
+
                     if (nextSession) {
-                        // Defer fetchActor to avoid deadlocking on the Supabase
-                        // PKCE storage lock: onAuthStateChange fires while the
-                        // lock is still held, so calling getSession() here
-                        // (via getBearerToken) blocks forever.
+                        // Defer invalidation to the next macrotask so apiFetch()
+                        // does not re-enter Supabase getSession() while the PKCE
+                        // storage lock is still held inside onAuthStateChange.
                         actorRefreshTimeoutId = window.setTimeout(() => {
-                            if (cancelled) return;
-                            void fetchActor().then((resolvedActor) => {
-                                if (!cancelled) {
-                                    setActor(resolvedActor);
-                                    setError(null);
-                                }
+                            setActorQueryEnabled(true);
+                            void queryClient.fetchQuery({
+                                queryKey: queryKeys.auth.actor(),
+                                queryFn: fetchActorOrThrow,
+                                staleTime: 0,
                             });
                         }, 0);
                     }
-                } else if (event === "SIGNED_OUT") {
+
+                    return;
+                }
+
+                if (
+                    event === "INITIAL_SESSION" ||
+                    event === "TOKEN_REFRESHED"
+                ) {
+                    setSession(nextSession);
+                    setBootstrapError(null);
+                    setActorQueryEnabled(!!nextSession);
+                    return;
+                }
+
+                if (event === "SIGNED_OUT") {
                     setSession(null);
-                    setActor(null);
-                    setError(null);
+                    setBootstrapError(null);
+                    setActorQueryEnabled(false);
                     queryClient.clear();
                 }
             },
         );
 
         return () => {
-            cancelled = true;
             if (actorRefreshTimeoutId !== null) {
                 window.clearTimeout(actorRefreshTimeoutId);
             }
             listenerData.subscription.unsubscribe();
         };
-    }, [fetchActor, queryClient]);
+    }, [fetchActorOrThrow, queryClient]);
 
     const signOut = useCallback(async () => {
         const supabase = getSupabaseClient();
         if (supabase) {
             await supabase.auth.signOut();
         }
+
         setSession(null);
-        setActor(null);
-        setError(null);
+        setBootstrapError(null);
+        setActorQueryEnabled(false);
         queryClient.clear();
     }, [queryClient]);
 

--- a/frontend/src/app/auth/AuthProvider.test.tsx
+++ b/frontend/src/app/auth/AuthProvider.test.tsx
@@ -1,18 +1,24 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import { AuthProvider } from "./AuthContext";
-import { useAuth } from "./useAuth";
-import type { AuthMeActor } from "./auth-types";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import { createTestQueryClient, createWrapper } from "@/shared/test-utils";
 
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
+import { AuthProvider } from "./AuthContext";
+import type { AuthMeActor } from "./auth-types";
+import { useAuth } from "./useAuth";
 
-const mockGetSession = vi.fn();
-const mockSignOut = vi.fn();
-const mockOnAuthStateChange = vi.fn(() => ({
-    data: { subscription: { unsubscribe: vi.fn() } },
+const {
+    mockGetSession,
+    mockSignOut,
+    mockOnAuthStateChange,
+    mockApiFetch,
+} = vi.hoisted(() => ({
+    mockGetSession: vi.fn(),
+    mockSignOut: vi.fn(),
+    mockOnAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+    })),
+    mockApiFetch: vi.fn(),
 }));
 
 vi.mock("@/shared/supabaseClient", () => ({
@@ -23,6 +29,10 @@ vi.mock("@/shared/supabaseClient", () => ({
             onAuthStateChange: mockOnAuthStateChange,
         },
     }),
+}));
+
+vi.mock("@/shared/api", () => ({
+    apiFetch: mockApiFetch,
 }));
 
 const mockActor: AuthMeActor = {
@@ -41,59 +51,53 @@ const mockActor: AuthMeActor = {
     primary_role: "teacher",
 };
 
-vi.mock("@/shared/api", () => ({
-    apiFetch: vi.fn().mockResolvedValue({
-        json: () => Promise.resolve(mockActor),
-    }),
-}));
-
-// ---------------------------------------------------------------------------
-// Helper component
-// ---------------------------------------------------------------------------
-
 function Probe() {
-    const { session, actor, loading, error } = useAuth();
+    const { session, actor, loading, error, refreshActor } = useAuth();
+
     return (
         <div>
             <span data-testid="loading">{String(loading)}</span>
             <span data-testid="session">{session ? "yes" : "no"}</span>
+            <span data-testid="session-token">{session?.access_token ?? "none"}</span>
             <span data-testid="actor">{actor ? actor.profile.full_name : "none"}</span>
             <span data-testid="error">{error ?? "none"}</span>
+            <button type="button" onClick={() => void refreshActor()}>
+                refresh
+            </button>
         </div>
     );
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe("AuthProvider", () => {
     beforeEach(() => {
+        vi.useRealTimers();
         vi.clearAllMocks();
+        mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
         mockOnAuthStateChange.mockReturnValue({
             data: { subscription: { unsubscribe: vi.fn() } },
         });
+        mockApiFetch.mockImplementation(async () => ({
+            json: async () => mockActor,
+        }));
     });
 
-    function renderWithAuthProvider() {
-        return render(
-            <AuthProvider>
-                <Probe />
-            </AuthProvider>,
-            {
-                wrapper: createWrapper({
-                    queryClient: createTestQueryClient(),
-                }),
-            },
-        );
+    function renderWithAuthProvider(queryClient = createTestQueryClient()) {
+        return {
+            queryClient,
+            ...render(
+                <AuthProvider>
+                    <Probe />
+                </AuthProvider>,
+                {
+                    wrapper: createWrapper({ queryClient }),
+                },
+            ),
+        };
     }
 
     it("starts with loading=true and resolves to loading=false when no session", async () => {
-        mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
-
         renderWithAuthProvider();
 
-        // loading starts true
         expect(screen.getByTestId("loading").textContent).toBe("true");
 
         await waitFor(() =>
@@ -101,9 +105,10 @@ describe("AuthProvider", () => {
         );
         expect(screen.getByTestId("session").textContent).toBe("no");
         expect(screen.getByTestId("actor").textContent).toBe("none");
+        expect(mockApiFetch).not.toHaveBeenCalled();
     });
 
-    it("fetches actor from /api/auth/me when session exists", async () => {
+    it("fetches actor from /api/auth/me when session exists on bootstrap", async () => {
         const fakeSession = { access_token: "jwt-abc" };
         mockGetSession.mockResolvedValue({
             data: { session: fakeSession },
@@ -115,8 +120,12 @@ describe("AuthProvider", () => {
         await waitFor(() =>
             expect(screen.getByTestId("loading").textContent).toBe("false"),
         );
+
         expect(screen.getByTestId("session").textContent).toBe("yes");
+        expect(screen.getByTestId("session-token").textContent).toBe("jwt-abc");
         expect(screen.getByTestId("actor").textContent).toBe("Test User");
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+        expect(mockApiFetch).toHaveBeenCalledWith("/auth/me");
     });
 
     it("clears actor on SIGNED_OUT event", async () => {
@@ -135,21 +144,13 @@ describe("AuthProvider", () => {
         });
 
         const queryClient = createTestQueryClient();
-        render(
-            <AuthProvider>
-                <Probe />
-            </AuthProvider>,
-            {
-                wrapper: createWrapper({ queryClient }),
-            },
-        );
+        renderWithAuthProvider(queryClient);
 
         await waitFor(() =>
             expect(screen.getByTestId("actor").textContent).toBe("Test User"),
         );
-        queryClient.setQueryData(["admin", "summary"], { value: 1 });
 
-        // Simulate sign-out event
+        queryClient.setQueryData(["admin", "summary"], { value: 1 });
         capturedCallback!("SIGNED_OUT", null);
 
         await waitFor(() =>
@@ -157,5 +158,103 @@ describe("AuthProvider", () => {
         );
         expect(screen.getByTestId("session").textContent).toBe("no");
         expect(queryClient.getQueryData(["admin", "summary"])).toBeUndefined();
+    });
+
+    it("defers the SIGNED_IN actor fetch until the PKCE-safe timeout fires", async () => {
+        type AuthChangeCallback = (event: string, session: unknown) => void;
+        let capturedCallback: AuthChangeCallback | null = null;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockOnAuthStateChange as any).mockImplementation((cb: AuthChangeCallback) => {
+            capturedCallback = cb;
+            return { data: { subscription: { unsubscribe: vi.fn() } } };
+        });
+
+        renderWithAuthProvider();
+
+        await waitFor(() =>
+            expect(screen.getByTestId("loading").textContent).toBe("false"),
+        );
+        expect(mockApiFetch).not.toHaveBeenCalled();
+
+        vi.useFakeTimers();
+
+        await act(async () => {
+            capturedCallback!("SIGNED_IN", { access_token: "jwt-signed-in" });
+        });
+
+        expect(screen.getByTestId("session-token").textContent).toBe("jwt-signed-in");
+        expect(mockApiFetch).not.toHaveBeenCalled();
+        expect(screen.getByTestId("actor").textContent).toBe("none");
+
+        await act(async () => {
+            await vi.runOnlyPendingTimersAsync();
+        });
+
+        expect(screen.getByTestId("actor").textContent).toBe("Test User");
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("updates the session on TOKEN_REFRESHED without refetching the actor immediately", async () => {
+        const fakeSession = { access_token: "jwt-abc" };
+        mockGetSession.mockResolvedValue({
+            data: { session: fakeSession },
+            error: null,
+        });
+
+        type AuthChangeCallback = (event: string, session: unknown) => void;
+        let capturedCallback: AuthChangeCallback | null = null;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockOnAuthStateChange as any).mockImplementation((cb: AuthChangeCallback) => {
+            capturedCallback = cb;
+            return { data: { subscription: { unsubscribe: vi.fn() } } };
+        });
+
+        renderWithAuthProvider();
+
+        await waitFor(() =>
+            expect(screen.getByTestId("actor").textContent).toBe("Test User"),
+        );
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+
+        capturedCallback!("TOKEN_REFRESHED", { access_token: "jwt-refreshed" });
+
+        await waitFor(() =>
+            expect(screen.getByTestId("session-token").textContent).toBe("jwt-refreshed"),
+        );
+        expect(screen.getByTestId("actor").textContent).toBe("Test User");
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshActor waits until the query cache has the new actor", async () => {
+        const fakeSession = { access_token: "jwt-abc" };
+        mockGetSession.mockResolvedValue({
+            data: { session: fakeSession },
+            error: null,
+        });
+
+        let currentActor = mockActor;
+        mockApiFetch.mockImplementation(async () => ({
+            json: async () => currentActor,
+        }));
+
+        const { queryClient } = renderWithAuthProvider();
+
+        await waitFor(() =>
+            expect(screen.getByTestId("actor").textContent).toBe("Test User"),
+        );
+
+        currentActor = {
+            ...mockActor,
+            profile: { ...mockActor.profile, full_name: "Updated User" },
+        };
+
+        fireEvent.click(screen.getByRole("button", { name: "refresh" }));
+
+        await waitFor(() =>
+            expect(screen.getByTestId("actor").textContent).toBe("Updated User"),
+        );
+        expect(
+            queryClient.getQueryData<AuthMeActor>(["auth", "actor"])?.profile.full_name,
+        ).toBe("Updated User");
     });
 });


### PR DESCRIPTION
## Summary
- migrate `AuthProvider` actor loading to TanStack Query without redoing the already-landed query infrastructure
- preserve PKCE safety by deferring the post-`SIGNED_IN` actor fetch until the next macrotask and keeping the query disabled until then
- harden auth tests around `SIGNED_IN`, `TOKEN_REFRESHED`, cache clearing, and `refreshActor()` semantics

## Notes
- `Issue #0` and `Issue #1` were already materialized in the repo (`QueryClientProvider`, `queryClient`, `queryKeys`, and test utilities)
- this PR implements the remaining auth-specific work for TanStack Query adoption issue #6 / issue #82

## Validation
- `npm --prefix frontend run test`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`

Closes #82
