### PR TITLE
feat(frontend): Cleanup post-migración TanStack Query

### DIFF
--- a/docs/planPlataforma/tanstack-query-cleanup-issue-83-status.md
+++ b/docs/planPlataforma/tanstack-query-cleanup-issue-83-status.md
@@ -1,0 +1,23 @@
+# Issue #83 — Cleanup post-TanStack Query
+
+Estado real verificado en `main`:
+
+- Los símbolos legacy que `#83` pedía eliminar del admin dashboard ya no existen en `frontend/src`.
+- `AuthContext.tsx` todavía conserva guardrails activos de PKCE (`fetchActorOrThrow`, `actorQueryEnabled`, `actorRefreshTimeoutId` y el `setTimeout(0)` diferido). No son deuda técnica eliminable.
+- El cierre correcto del issue es verificación final y documentación del estado, no simplificación agresiva del flujo auth ni poda de estado derivado del dashboard.
+
+Verificaciones ejecutadas:
+
+- `rg -n "reconcile|dashboardRequestIdRef|teacherOptionsRequestIdRef|isMountedRef|didLoadDashboard|RefreshMode|TeacherOptionsState|setIsRefreshing|setIsInitialLoading|setLastSyncedAt|setPageError|setRefreshError" frontend/src`
+  Resultado: sin coincidencias.
+- `rg -n "setInterval" frontend/src`
+  Resultado: solo `frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx`.
+- `npm --prefix frontend run test`
+- `npm --prefix frontend run lint`
+- `npm --prefix frontend run build`
+- `uv run --directory backend pytest -q`
+
+Conclusión:
+
+- `#83` quedó absorbido casi por completo por `#72`, `#73`, `#78`, `#79` y `#82`.
+- No se requieren cambios de código adicionales para considerar cerrado el cleanup ejecutable del frontend.


### PR DESCRIPTION
## Summary
- document the verified real status of TanStack Query cleanup for issue #83
- record that the admin cleanup is already absorbed and that the remaining auth machinery is active PKCE protection, not dead code
- close the issue with a minimal documentation PR instead of unsafe code churn

## Notes
- the issue was partially stale against `main`
- the legacy admin symbols listed in #83 no longer exist in `frontend/src`
- `AuthContext` retains intentional PKCE guardrails and was not simplified

## Validation
- `rg -n "reconcile|dashboardRequestIdRef|teacherOptionsRequestIdRef|isMountedRef|didLoadDashboard|RefreshMode|TeacherOptionsState|setIsRefreshing|setIsInitialLoading|setLastSyncedAt|setPageError|setRefreshError" frontend/src`
- `rg -n "setInterval" frontend/src`
- `npm --prefix frontend run test`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `uv run --directory backend pytest -q`

Closes #83
