### PR TITLE
feat(admin-dashboard): implement teacher directory

### DIFF
--- a/backend/alembic/versions/c2f8a58d6d1e_issue86_teacher_directory.py
+++ b/backend/alembic/versions/c2f8a58d6d1e_issue86_teacher_directory.py
@@ -1,0 +1,44 @@
+"""Issue 86 teacher directory
+
+Revision ID: c2f8a58d6d1e
+Revises: a6f6d7ac9c2b
+Create Date: 2026-04-11 23:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c2f8a58d6d1e"
+down_revision: Union[str, Sequence[str], None] = "a6f6d7ac9c2b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("ck_courses_teacher_assignment_xor", "courses", type_="check")
+    op.create_check_constraint(
+        "ck_courses_teacher_assignment_xor",
+        "courses",
+        "NOT (teacher_membership_id IS NOT NULL AND pending_teacher_invite_id IS NOT NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_courses_teacher_assignment_xor", "courses", type_="check")
+    op.create_check_constraint(
+        "ck_courses_teacher_assignment_xor",
+        "courses",
+        """
+        (
+            teacher_membership_id IS NOT NULL
+            AND pending_teacher_invite_id IS NULL
+        ) OR (
+            teacher_membership_id IS NULL
+            AND pending_teacher_invite_id IS NOT NULL
+        )
+        """,
+    )

--- a/backend/src/shared/admin_reads.py
+++ b/backend/src/shared/admin_reads.py
@@ -17,7 +17,7 @@ from shared.invite_status import invite_effective_status_from_fields
 from shared.models import Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, User
 
 
-TeacherState = Literal["active", "pending", "stale_pending_invite"]
+TeacherState = Literal["active", "pending", "stale_pending_invite", "unassigned"]
 AccessLinkStatus = Literal["active", "missing"]
 _MISSING_TEACHER_EMAIL = "__missing_teacher_email__"
 _teacher_email_cache: TTLCache[str, str] = TTLCache(maxsize=500, ttl=300)
@@ -41,6 +41,35 @@ class TeacherPendingInviteAssignmentResponse(BaseModel):
     invite_id: str
 
 
+class AdminCourseRef(BaseModel):
+    course_id: str
+    title: str
+    code: str
+    semester: str
+    status: Literal["active", "inactive"]
+
+
+class AdminTeacherDirectoryEntry(BaseModel):
+    membership_id: str
+    full_name: str
+    email: str
+    assigned_courses: list[AdminCourseRef]
+
+
+class AdminTeacherDirectoryInvite(BaseModel):
+    invite_id: str
+    full_name: str
+    email: str
+    status: Literal["pending"]
+    expires_at: str
+    assigned_courses: list[AdminCourseRef]
+
+
+class AdminTeacherDirectoryResponse(BaseModel):
+    active_teachers: list[AdminTeacherDirectoryEntry]
+    pending_invites: list[AdminTeacherDirectoryInvite]
+
+
 class CourseListItemResponse(BaseModel):
     id: str
     title: str
@@ -50,7 +79,7 @@ class CourseListItemResponse(BaseModel):
     status: str
     teacher_display_name: str
     teacher_state: TeacherState
-    teacher_assignment: TeacherMembershipAssignmentResponse | TeacherPendingInviteAssignmentResponse
+    teacher_assignment: TeacherMembershipAssignmentResponse | TeacherPendingInviteAssignmentResponse | None
     students_count: int
     max_students: int
     occupancy_percent: int
@@ -341,7 +370,25 @@ def _serialize_course_item(row: dict[str, Any], *, access_link: str | None = Non
             access_link_status="active" if row["active_link_status"] == "active" else "missing",
         )
 
-    if course_pending_teacher_invite_id is None or row["pending_invite_id"] is None:
+    if course_pending_teacher_invite_id is None:
+        return CourseListItemResponse(
+            id=row["id"],
+            title=row["title"],
+            code=row["code"],
+            semester=row["semester"],
+            academic_level=row["academic_level"],
+            status=row["status"],
+            teacher_display_name="Sin docente asignado",
+            teacher_state="unassigned",
+            teacher_assignment=None,
+            students_count=students_count,
+            max_students=max_students,
+            occupancy_percent=_calculate_percent(students_count, max_students),
+            access_link=access_link,
+            access_link_status="active" if row["active_link_status"] == "active" else "missing",
+        )
+
+    if row["pending_invite_id"] is None:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="invalid_teacher_assignment",
@@ -564,6 +611,141 @@ def list_teacher_options(db: Session, context: AdminContext) -> TeacherOptionsRe
     )
 
     return TeacherOptionsResponse(
+        active_teachers=active_teachers,
+        pending_invites=pending_invites,
+    )
+
+
+def _serialize_course_ref(row: dict[str, Any]) -> AdminCourseRef:
+    return AdminCourseRef(
+        course_id=row["course_id"],
+        title=row["title"],
+        code=row["code"],
+        semester=row["semester"],
+        status=row["status"],
+    )
+
+
+def list_teacher_directory(db: Session, context: AdminContext) -> AdminTeacherDirectoryResponse:
+    teacher_rows = (
+        db.execute(
+            select(
+                Membership.id.label("membership_id"),
+                Membership.user_id.label("user_id"),
+                Profile.full_name.label("full_name"),
+                User.email.label("legacy_email"),
+                Course.id.label("course_id"),
+                Course.title.label("title"),
+                Course.code.label("code"),
+                Course.semester.label("semester"),
+                Course.status.label("status"),
+            )
+            .select_from(Membership)
+            .join(Profile, Membership.user_id == Profile.id)
+            .outerjoin(User, User.id == Membership.user_id)
+            .outerjoin(
+                Course,
+                and_(
+                    Course.teacher_membership_id == Membership.id,
+                    Course.university_id == context.university_id,
+                ),
+            )
+            .where(
+                Membership.university_id == context.university_id,
+                Membership.role == "teacher",
+                Membership.status == "active",
+            )
+            .order_by(Profile.full_name.asc(), Membership.id.asc(), Course.created_at.desc(), Course.id.desc())
+        )
+        .mappings()
+        .all()
+    )
+
+    teacher_map: dict[str, AdminTeacherDirectoryEntry] = {}
+    for row in teacher_rows:
+        membership_id = row["membership_id"]
+        if membership_id not in teacher_map:
+            teacher_map[membership_id] = AdminTeacherDirectoryEntry(
+                membership_id=membership_id,
+                full_name=row["full_name"],
+                email=_resolve_teacher_email(row["user_id"], row["legacy_email"]),
+                assigned_courses=[],
+            )
+        if row["course_id"] is not None:
+            teacher_map[membership_id].assigned_courses.append(_serialize_course_ref(dict(row)))
+
+    active_teachers = sorted(
+        teacher_map.values(),
+        key=lambda teacher: ((teacher.full_name or teacher.email).lower(), teacher.membership_id),
+    )
+
+    invite_rows = (
+        db.execute(
+            select(
+                Invite.id.label("invite_id"),
+                Invite.full_name.label("full_name"),
+                Invite.email.label("email"),
+                Invite.status.label("invite_status"),
+                Invite.expires_at.label("expires_at"),
+                Course.id.label("course_id"),
+                Course.title.label("title"),
+                Course.code.label("code"),
+                Course.semester.label("semester"),
+                Course.status.label("course_status"),
+            )
+            .select_from(Invite)
+            .outerjoin(
+                Course,
+                and_(
+                    Course.pending_teacher_invite_id == Invite.id,
+                    Course.university_id == context.university_id,
+                ),
+            )
+            .where(
+                Invite.university_id == context.university_id,
+                Invite.role == "teacher",
+            )
+            .order_by(Invite.full_name.asc(), Invite.id.asc(), Course.created_at.desc(), Course.id.desc())
+        )
+        .mappings()
+        .all()
+    )
+
+    invite_map: dict[str, AdminTeacherDirectoryInvite] = {}
+    for row in invite_rows:
+        effective_status = invite_effective_status_from_fields(row["invite_status"], row["expires_at"])
+        if effective_status != "pending":
+            continue
+        invite_id = row["invite_id"]
+        if invite_id not in invite_map:
+            full_name = row["full_name"] or row["email"]
+            invite_map[invite_id] = AdminTeacherDirectoryInvite(
+                invite_id=invite_id,
+                full_name=full_name,
+                email=row["email"],
+                status="pending",
+                expires_at=row["expires_at"].astimezone(timezone.utc).isoformat(),
+                assigned_courses=[],
+            )
+        if row["course_id"] is not None:
+            invite_map[invite_id].assigned_courses.append(
+                _serialize_course_ref(
+                    {
+                        "course_id": row["course_id"],
+                        "title": row["title"],
+                        "code": row["code"],
+                        "semester": row["semester"],
+                        "status": row["course_status"],
+                    }
+                )
+            )
+
+    pending_invites = sorted(
+        invite_map.values(),
+        key=lambda invite: ((invite.full_name or invite.email).lower(), invite.invite_id),
+    )
+
+    return AdminTeacherDirectoryResponse(
         active_teachers=active_teachers,
         pending_invites=pending_invites,
     )

--- a/backend/src/shared/admin_router.py
+++ b/backend/src/shared/admin_router.py
@@ -7,22 +7,30 @@ from sqlalchemy.orm import Session
 
 from shared.admin_context import AdminContext, require_admin_context
 from shared.admin_reads import (
+    AdminTeacherDirectoryResponse,
     AdminCoursesResponse,
     CourseListItemResponse,
     DashboardSummaryResponse,
     TeacherOptionsResponse,
     get_dashboard_summary,
+    list_teacher_directory,
     list_admin_courses,
     list_teacher_options,
 )
 from shared.admin_writes import (
+    AdminRemoveTeacherResponse,
+    AdminResendInviteResponse,
+    AdminRevokeInviteResponse,
     AdminCourseMutationRequest,
     CourseAccessLinkRegenerateResponse,
     CreateTeacherInviteRequest,
     TeacherInviteResponse,
     create_admin_course,
     create_teacher_invite,
+    remove_teacher_membership,
     regenerate_admin_course_access_link,
+    resend_teacher_invite,
+    revoke_teacher_invite,
     update_admin_course,
 )
 from shared.database import get_db
@@ -69,6 +77,14 @@ def get_admin_teacher_options(
     return list_teacher_options(db, context)
 
 
+@router.get("/teacher-directory", response_model=AdminTeacherDirectoryResponse)
+def get_admin_teacher_directory(
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+) -> AdminTeacherDirectoryResponse:
+    return list_teacher_directory(db, context)
+
+
 @router.post("/courses", response_model=CourseListItemResponse, status_code=201)
 def post_admin_course(
     request: AdminCourseMutationRequest,
@@ -95,6 +111,33 @@ def post_teacher_invite(
     db: Session = Depends(get_db),
 ) -> TeacherInviteResponse:
     return create_teacher_invite(db, context, request)
+
+
+@router.post("/teacher-invites/{invite_id}/resend", response_model=AdminResendInviteResponse)
+def post_resend_teacher_invite(
+    invite_id: str,
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+) -> AdminResendInviteResponse:
+    return resend_teacher_invite(db, context, invite_id)
+
+
+@router.delete("/memberships/{membership_id}", response_model=AdminRemoveTeacherResponse)
+def delete_teacher_membership(
+    membership_id: str,
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+) -> AdminRemoveTeacherResponse:
+    return remove_teacher_membership(db, context, membership_id)
+
+
+@router.delete("/teacher-invites/{invite_id}", response_model=AdminRevokeInviteResponse)
+def delete_teacher_invite(
+    invite_id: str,
+    context: Annotated[AdminContext, Depends(require_admin_context)],
+    db: Session = Depends(get_db),
+) -> AdminRevokeInviteResponse:
+    return revoke_teacher_invite(db, context, invite_id)
 
 
 @router.post(

--- a/backend/src/shared/admin_writes.py
+++ b/backend/src/shared/admin_writes.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, NoReturn
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator
-from sqlalchemy import select
+from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Session
 
@@ -22,7 +22,7 @@ from shared.course_access_links import (
     try_acquire_course_regeneration_lock,
 )
 from shared.invite_status import invite_effective_status, utc_now
-from shared.models import Course, Invite, Membership
+from shared.models import Assignment, AuthoringJob, Course, Invite, Membership
 
 
 ACADEMIC_LEVELS = frozenset({"Pregrado", "Especialización", "Maestría", "MBA", "Doctorado"})
@@ -116,6 +116,22 @@ class CourseAccessLinkRegenerateResponse(BaseModel):
     course_id: str
     access_link: str
     access_link_status: Literal["active"]
+
+
+class AdminResendInviteResponse(BaseModel):
+    invite_id: str
+    activation_link: str
+    expires_at: str
+
+
+class AdminRemoveTeacherResponse(BaseModel):
+    removed_membership_id: str
+    affected_course_ids: list[str]
+
+
+class AdminRevokeInviteResponse(BaseModel):
+    revoked_invite_id: str
+    affected_course_ids: list[str]
 
 
 @dataclass(slots=True)
@@ -410,6 +426,221 @@ def create_teacher_invite(
         email=normalized_email,
         status="pending",
         activation_link=_build_teacher_activation_link(raw_token),
+    )
+
+
+def resend_teacher_invite(
+    db: Session,
+    context: AdminContext,
+    invite_id: str,
+) -> AdminResendInviteResponse:
+    try:
+        invite = db.scalar(
+            select(Invite)
+            .where(
+                Invite.id == invite_id,
+                Invite.university_id == context.university_id,
+                Invite.role == "teacher",
+            )
+            .with_for_update(nowait=True)
+        )
+    except OperationalError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="invite_update_in_progress",
+        ) from exc
+
+    if invite is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="invite_not_found",
+        )
+    if invite.status == "consumed":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="invite_already_consumed",
+        )
+    if invite.status == "revoked":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="invite_not_found",
+        )
+
+    raw_token = secrets.token_urlsafe(32)
+    expires_at = utc_now() + TEACHER_INVITE_TTL
+    try:
+        invite.token_hash = hash_invite_token(raw_token)
+        invite.status = "pending"
+        invite.expires_at = expires_at
+        invite.consumed_at = None
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="teacher_invite_resend_failed",
+        ) from exc
+
+    audit_log(
+        "admin.teacher.invite_resent",
+        "success",
+        auth_user_id=context.auth_user_id,
+        university_id=context.university_id,
+        invite_id=invite.id,
+        http_status=status.HTTP_200_OK,
+    )
+    return AdminResendInviteResponse(
+        invite_id=invite.id,
+        activation_link=_build_teacher_activation_link(raw_token),
+        expires_at=expires_at.isoformat(),
+    )
+
+
+def _teacher_has_active_cases(db: Session, *, membership: Membership) -> bool:
+    active_job = db.scalar(
+        select(AuthoringJob.id)
+        .join(Assignment, Assignment.id == AuthoringJob.assignment_id)
+        .where(
+            Assignment.teacher_id == membership.user_id,
+            AuthoringJob.status.in_(("pending", "processing")),
+        )
+        .limit(1)
+    )
+    return active_job is not None
+
+
+def remove_teacher_membership(
+    db: Session,
+    context: AdminContext,
+    membership_id: str,
+) -> AdminRemoveTeacherResponse:
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.id == membership_id,
+            Membership.university_id == context.university_id,
+            Membership.role == "teacher",
+        )
+    )
+    if membership is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="membership_not_found",
+        )
+    if _teacher_has_active_cases(db, membership=membership):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="teacher_has_active_cases",
+        )
+
+    affected_course_ids = list(
+        db.scalars(
+            select(Course.id).where(
+                Course.university_id == context.university_id,
+                Course.teacher_membership_id == membership.id,
+            )
+        )
+    )
+    try:
+        db.execute(
+            update(Course)
+            .where(
+                Course.university_id == context.university_id,
+                Course.teacher_membership_id == membership.id,
+            )
+            .values(teacher_membership_id=None)
+        )
+        db.execute(delete(Membership).where(Membership.id == membership.id))
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="teacher_membership_remove_failed",
+        ) from exc
+
+    audit_log(
+        "admin.teacher.removed",
+        "success",
+        auth_user_id=context.auth_user_id,
+        university_id=context.university_id,
+        membership_id=membership.id,
+        http_status=status.HTTP_200_OK,
+    )
+    return AdminRemoveTeacherResponse(
+        removed_membership_id=membership.id,
+        affected_course_ids=affected_course_ids,
+    )
+
+
+def revoke_teacher_invite(
+    db: Session,
+    context: AdminContext,
+    invite_id: str,
+) -> AdminRevokeInviteResponse:
+    try:
+        invite = db.scalar(
+            select(Invite)
+            .where(
+                Invite.id == invite_id,
+                Invite.university_id == context.university_id,
+                Invite.role == "teacher",
+            )
+            .with_for_update(nowait=True)
+        )
+    except OperationalError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="invite_update_in_progress",
+        ) from exc
+
+    if invite is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="invite_not_found",
+        )
+    if invite.status == "consumed":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="invite_already_consumed",
+        )
+
+    affected_course_ids = list(
+        db.scalars(
+            select(Course.id).where(
+                Course.university_id == context.university_id,
+                Course.pending_teacher_invite_id == invite.id,
+            )
+        )
+    )
+    try:
+        invite.status = "revoked"
+        db.execute(
+            update(Course)
+            .where(
+                Course.university_id == context.university_id,
+                Course.pending_teacher_invite_id == invite.id,
+            )
+            .values(pending_teacher_invite_id=None)
+        )
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="teacher_invite_revoke_failed",
+        ) from exc
+
+    audit_log(
+        "admin.teacher.invite_revoked",
+        "success",
+        auth_user_id=context.auth_user_id,
+        university_id=context.university_id,
+        invite_id=invite.id,
+        http_status=status.HTTP_200_OK,
+    )
+    return AdminRevokeInviteResponse(
+        revoked_invite_id=invite.id,
+        affected_course_ids=affected_course_ids,
     )
 
 

--- a/backend/src/shared/admin_writes.py
+++ b/backend/src/shared/admin_writes.py
@@ -514,13 +514,21 @@ def remove_teacher_membership(
     context: AdminContext,
     membership_id: str,
 ) -> AdminRemoveTeacherResponse:
-    membership = db.scalar(
-        select(Membership).where(
-            Membership.id == membership_id,
-            Membership.university_id == context.university_id,
-            Membership.role == "teacher",
+    try:
+        membership = db.scalar(
+            select(Membership)
+            .where(
+                Membership.id == membership_id,
+                Membership.university_id == context.university_id,
+                Membership.role == "teacher",
+            )
+            .with_for_update(nowait=True)
         )
-    )
+    except OperationalError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="membership_update_in_progress",
+        ) from exc
     if membership is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -166,15 +166,7 @@ class Course(Base):
             name="ck_courses_academic_level",
         ),
         CheckConstraint(
-            """
-            (
-                teacher_membership_id IS NOT NULL
-                AND pending_teacher_invite_id IS NULL
-            ) OR (
-                teacher_membership_id IS NULL
-                AND pending_teacher_invite_id IS NOT NULL
-            )
-            """,
+            "NOT (teacher_membership_id IS NOT NULL AND pending_teacher_invite_id IS NOT NULL)",
             name="ck_courses_teacher_assignment_xor",
         ),
     )

--- a/backend/tests/test_issue52_admin_catalog_infra.py
+++ b/backend/tests/test_issue52_admin_catalog_infra.py
@@ -355,7 +355,7 @@ def test_issue52_course_constraints_allow_pending_teacher_assignment(db, seed_in
     assert course.pending_teacher_invite_id == invite.id
 
 
-def test_issue52_course_rejects_invalid_teacher_assignment_xor(db, seed_identity, seed_invite) -> None:
+def test_issue52_course_rejects_both_teacher_assignment_columns_set(db, seed_identity, seed_invite) -> None:
     teacher = seed_identity(
         user_id=str(uuid.uuid4()),
         email="teacher-xor@example.edu",
@@ -384,20 +384,29 @@ def test_issue52_course_rejects_invalid_teacher_assignment_xor(db, seed_identity
         db.commit()
     db.rollback()
 
-    both_null = Course(
+def test_issue52_course_allows_unassigned_shape_after_issue86(db, seed_identity) -> None:
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-unassigned@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000870",
+    )
+
+    unassigned = Course(
         university_id=teacher["tenant"].id,
         teacher_membership_id=None,
         pending_teacher_invite_id=None,
-        title="Invalid Both Null",
+        title="Unassigned Course",
         code="ISSUE52-XOR-002",
         semester="2026-I",
         academic_level="Pregrado",
         max_students=30,
         status="active",
     )
-    db.add(both_null)
-    with pytest.raises(IntegrityError):
-        db.commit()
+    db.add(unassigned)
+    db.commit()
+
+    assert unassigned.id is not None
 
 
 def test_issue52_course_rejects_duplicate_code_per_university_and_semester(db, seed_identity) -> None:

--- a/backend/tests/test_issue86_teacher_directory.py
+++ b/backend/tests/test_issue86_teacher_directory.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+from datetime import timedelta
+import uuid
+
+from sqlalchemy import select
+
+from shared.models import Assignment, AuthoringJob, Course, Invite, Membership
+
+
+def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
+    return auth_headers_factory(sub=user_id, email=email)
+
+
+def _seed_admin(seed_identity, *, university_id: str) -> tuple[str, str]:
+    user_id = str(uuid.uuid4())
+    email = f"admin-{uuid.uuid4().hex[:8]}@example.edu"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="university_admin",
+        university_id=university_id,
+        create_legacy_user=False,
+        full_name="Admin User",
+    )
+    return user_id, email
+
+
+def test_issue86_teacher_directory_lists_active_and_pending_with_courses(
+    client,
+    seed_identity,
+    seed_course,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000861"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-directory@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Directory",
+    )
+    invite, _ = seed_invite(
+        email="pending-directory@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Pending Directory",
+    )
+    seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Active Teacher Course",
+        code="TD-001",
+    )
+    seed_course(
+        university_id=university_id,
+        pending_teacher_invite_id=invite.id,
+        title="Pending Teacher Course",
+        code="TD-002",
+    )
+
+    response = client.get(
+        "/api/admin/teacher-directory",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["active_teachers"] == [
+        {
+            "membership_id": teacher["membership"].id,
+            "full_name": "Teacher Directory",
+            "email": "teacher-directory@example.edu",
+            "assigned_courses": [
+                {
+                    "course_id": payload["active_teachers"][0]["assigned_courses"][0]["course_id"],
+                    "title": "Active Teacher Course",
+                    "code": "TD-001",
+                    "semester": "2026-I",
+                    "status": "active",
+                }
+            ],
+        }
+    ]
+    assert payload["pending_invites"][0]["invite_id"] == invite.id
+    assert payload["pending_invites"][0]["full_name"] == "Pending Directory"
+    assert payload["pending_invites"][0]["email"] == "pending-directory@example.edu"
+    assert payload["pending_invites"][0]["status"] == "pending"
+    assert payload["pending_invites"][0]["assigned_courses"][0]["title"] == "Pending Teacher Course"
+    assert "activation_link" not in response.text
+
+
+def test_issue86_teacher_directory_excludes_consumed_and_revoked_invites(
+    client,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000862"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    seed_invite(
+        email="consumed-directory@example.edu",
+        university_id=university_id,
+        role="teacher",
+        status="consumed",
+    )
+    seed_invite(
+        email="revoked-directory@example.edu",
+        university_id=university_id,
+        role="teacher",
+        status="revoked",
+    )
+
+    response = client.get(
+        "/api/admin/teacher-directory",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["pending_invites"] == []
+
+
+def test_issue86_resend_teacher_invite_rotates_hash_and_resets_expiration(
+    client,
+    db,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000863"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    invite, _ = seed_invite(
+        email="resend-directory@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Resend Directory",
+    )
+    original_hash = invite.token_hash
+    original_expires_at = invite.expires_at
+
+    response = client.post(
+        f"/api/admin/teacher-invites/{invite.id}/resend",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["invite_id"] == invite.id
+    assert payload["activation_link"].startswith("/app/teacher/activate#invite_token=")
+    db.expire_all()
+    refreshed = db.get(Invite, invite.id)
+    assert refreshed is not None
+    assert refreshed.token_hash != original_hash
+    assert refreshed.expires_at > original_expires_at
+
+
+def test_issue86_resend_teacher_invite_rejects_consumed_invites(
+    client,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000864"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    invite, _ = seed_invite(
+        email="consumed-resend@example.edu",
+        university_id=university_id,
+        role="teacher",
+        status="consumed",
+    )
+
+    response = client.post(
+        f"/api/admin/teacher-invites/{invite.id}/resend",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "invite_already_consumed"
+
+
+def test_issue86_remove_teacher_membership_nullifies_courses_and_deletes_membership(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000865"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="remove-teacher@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Remove Teacher",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Course To Unassign",
+        code="TD-REMOVE-001",
+    )
+    membership_id = teacher["membership"].id
+
+    response = client.delete(
+        f"/api/admin/memberships/{membership_id}",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "removed_membership_id": membership_id,
+        "affected_course_ids": [course.id],
+    }
+    db.expire_all()
+    refreshed_course = db.get(Course, course.id)
+    assert refreshed_course is not None
+    assert refreshed_course.teacher_membership_id is None
+    assert refreshed_course.pending_teacher_invite_id is None
+    assert db.get(Membership, membership_id) is None
+
+
+def test_issue86_remove_teacher_membership_blocks_when_active_cases_exist(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000866"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher_user_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email="teacher-active-cases@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Active Cases",
+    )
+    assignment = Assignment(teacher_id=teacher_user_id, title="Owned Assignment", status="draft")
+    db.add(assignment)
+    db.flush()
+    db.add(
+        AuthoringJob(
+            assignment_id=assignment.id,
+            idempotency_key=f"issue86-job-{uuid.uuid4()}",
+            status="processing",
+            task_payload={"step": "authoring"},
+        )
+    )
+    db.commit()
+
+    response = client.delete(
+        f"/api/admin/memberships/{teacher['membership'].id}",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "teacher_has_active_cases"
+
+
+def test_issue86_revoke_teacher_invite_revokes_and_unassigns_courses(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000867"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    invite, _ = seed_invite(
+        email="revoke-invite@example.edu",
+        university_id=university_id,
+        role="teacher",
+        full_name="Revoke Invite",
+    )
+    course = seed_course(
+        university_id=university_id,
+        pending_teacher_invite_id=invite.id,
+        title="Invite Assigned Course",
+        code="TD-REVOKE-001",
+    )
+
+    response = client.delete(
+        f"/api/admin/teacher-invites/{invite.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "revoked_invite_id": invite.id,
+        "affected_course_ids": [course.id],
+    }
+    db.expire_all()
+    refreshed_invite = db.get(Invite, invite.id)
+    refreshed_course = db.get(Course, course.id)
+    assert refreshed_invite is not None
+    assert refreshed_invite.status == "revoked"
+    assert refreshed_course is not None
+    assert refreshed_course.pending_teacher_invite_id is None
+
+
+def test_issue86_admin_courses_support_unassigned_shape_after_teacher_removal(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000868"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="unassigned-course@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Unassigned Teacher",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Eventually Unassigned",
+        code="TD-UNASSIGNED-001",
+    )
+    course.teacher_membership_id = None
+    db.commit()
+
+    response = client.get(
+        "/api/admin/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200, response.text
+    item = response.json()["items"][0]
+    assert item["id"] == course.id
+    assert item["teacher_state"] == "unassigned"
+    assert item["teacher_display_name"] == "Sin docente asignado"
+    assert item["teacher_assignment"] is None
+
+
+def test_issue86_revoke_teacher_invite_allows_expired_pending_invites(
+    client,
+    db,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000869"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    invite, _ = seed_invite(
+        email="expired-revoke@example.edu",
+        university_id=university_id,
+        role="teacher",
+    )
+    invite.expires_at = invite.expires_at - timedelta(days=2)
+    db.commit()
+
+    response = client.delete(
+        f"/api/admin/teacher-invites/{invite.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 200, response.text
+    db.expire_all()
+    assert db.get(Invite, invite.id).status == "revoked"

--- a/backend/tests/test_issue86_teacher_directory.py
+++ b/backend/tests/test_issue86_teacher_directory.py
@@ -340,6 +340,79 @@ def test_issue86_admin_courses_support_unassigned_shape_after_teacher_removal(
     assert item["teacher_assignment"] is None
 
 
+def test_issue86_remove_teacher_membership_cross_university_isolation(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_a = "10000000-0000-0000-0000-000000000870"
+    university_b = "10000000-0000-0000-0000-000000000871"
+    admin_b_id, admin_b_email = _seed_admin(seed_identity, university_id=university_b)
+    teacher_a = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-isolation-a@example.edu",
+        role="teacher",
+        university_id=university_a,
+        full_name="Teacher Isolation A",
+    )
+
+    response = client.delete(
+        f"/api/admin/memberships/{teacher_a['membership'].id}",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_b_id, email=admin_b_email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "membership_not_found"
+
+
+def test_issue86_revoke_teacher_invite_cross_university_isolation(
+    client,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_a = "10000000-0000-0000-0000-000000000872"
+    university_b = "10000000-0000-0000-0000-000000000873"
+    admin_b_id, admin_b_email = _seed_admin(seed_identity, university_id=university_b)
+    invite_a, _ = seed_invite(
+        email="invite-isolation-a@example.edu",
+        university_id=university_a,
+        role="teacher",
+    )
+
+    response = client.delete(
+        f"/api/admin/teacher-invites/{invite_a.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_b_id, email=admin_b_email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "invite_not_found"
+
+
+def test_issue86_resend_teacher_invite_rejects_revoked_invites(
+    client,
+    seed_identity,
+    seed_invite,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000874"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    invite, _ = seed_invite(
+        email="revoked-resend@example.edu",
+        university_id=university_id,
+        role="teacher",
+        status="revoked",
+    )
+
+    response = client.post(
+        f"/api/admin/teacher-invites/{invite.id}/resend",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "invite_not_found"
+
+
 def test_issue86_revoke_teacher_invite_allows_expired_pending_invites(
     client,
     db,

--- a/frontend/src/features/admin-dashboard/AdminDashboardModals.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardModals.tsx
@@ -1,0 +1,33 @@
+export function ConfirmationModal({
+    isOpen,
+    title,
+    description,
+    confirmLabel,
+    isSubmitting,
+    onClose,
+    onConfirm,
+}: {
+    isOpen: boolean;
+    title: string;
+    description: string;
+    confirmLabel: string;
+    isSubmitting: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+}) {
+    if (!isOpen) return null;
+    return (
+        <div className="fixed inset-0 z-[70] flex items-center justify-center bg-slate-950/60 px-4 py-6 backdrop-blur-sm">
+            <div className="w-full max-w-md overflow-hidden rounded-[20px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.22)]">
+                <div className="px-6 py-5">
+                    <h2 className="text-xl font-bold tracking-tight text-slate-900">{title}</h2>
+                    <p className="mt-3 text-sm leading-6 text-slate-500">{description}</p>
+                </div>
+                <div className="flex items-center justify-end gap-3 border-t border-slate-200 px-6 py-4">
+                    <button type="button" onClick={onClose} className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900">Cancelar</button>
+                    <button type="button" onClick={onConfirm} disabled={isSubmitting} className="inline-flex items-center justify-center rounded-xl bg-red-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50">{confirmLabel}</button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
@@ -23,9 +23,13 @@ vi.mock("@/shared/api", async () => {
                 getDashboardSummary: vi.fn(),
                 listCourses: vi.fn(),
                 getTeacherOptions: vi.fn(),
+                getTeacherDirectory: vi.fn(),
                 createCourse: vi.fn(),
                 updateCourse: vi.fn(),
                 createTeacherInvite: vi.fn(),
+                resendInvite: vi.fn(),
+                removeTeacher: vi.fn(),
+                revokeInvite: vi.fn(),
                 regenerateCourseAccessLink: vi.fn(),
             },
         },
@@ -263,6 +267,10 @@ describe("AdminDashboardPage", () => {
         vi.mocked(api.admin.getDashboardSummary).mockResolvedValue(summaryResponse);
         vi.mocked(api.admin.listCourses).mockResolvedValue(coursesResponse);
         vi.mocked(api.admin.getTeacherOptions).mockResolvedValue(teacherOptionsResponse);
+        vi.mocked(api.admin.getTeacherDirectory).mockResolvedValue({
+            active_teachers: [],
+            pending_invites: [],
+        });
         vi.mocked(api.admin.createCourse).mockResolvedValue({
             ...activeCourse,
             id: "course-3",
@@ -277,6 +285,19 @@ describe("AdminDashboardPage", () => {
             email: "maria@example.edu",
             status: "pending",
             activation_link: "/app/teacher/activate#invite_token=abc123",
+        });
+        vi.mocked(api.admin.resendInvite).mockResolvedValue({
+            invite_id: "invite-2",
+            activation_link: "/app/teacher/activate#invite_token=resent",
+            expires_at: new Date().toISOString(),
+        });
+        vi.mocked(api.admin.removeTeacher).mockResolvedValue({
+            removed_membership_id: "teacher-membership-1",
+            affected_course_ids: [],
+        });
+        vi.mocked(api.admin.revokeInvite).mockResolvedValue({
+            revoked_invite_id: "invite-2",
+            affected_course_ids: [],
         });
         vi.mocked(api.admin.regenerateCourseAccessLink).mockResolvedValue({
             course_id: activeCourse.id,
@@ -538,15 +559,15 @@ describe("AdminDashboardPage", () => {
         });
     }, 20_000);
 
-    it("keeps dashboard quick actions as placeholders with no side effects", async () => {
+    it("opens the teacher directory modal and keeps reportes as placeholder", async () => {
         renderPage();
         await screen.findByText("Directorio de Cursos");
 
         fireEvent.click(screen.getByText("Gestion de Docentes"));
         fireEvent.click(screen.getByText("Reportes Globales"));
 
-        expect(showToast).toHaveBeenCalledWith("La gestion de docentes estara disponible proximamente.", "default");
         expect(showToast).toHaveBeenCalledWith("Modulo de reportes proximamente disponible.", "default");
+        expect(api.admin.getTeacherDirectory).toHaveBeenCalledTimes(1);
         expect(api.admin.createTeacherInvite).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
@@ -79,6 +79,8 @@ import {
     type LinkPresentation,
     type SemesterTerm,
 } from "./adminDashboardModel";
+import { ConfirmationModal } from "./AdminDashboardModals";
+import { TeacherDirectoryModal } from "./TeacherDirectoryModal";
 
 type ModalInviteTarget = "create" | "edit";
 
@@ -110,6 +112,7 @@ export function AdminDashboardPage({ showToast }: Props) {
     const [isEditOpen, setIsEditOpen] = useState(false);
     const [isArchiveOpen, setIsArchiveOpen] = useState(false);
     const [isInviteOpen, setIsInviteOpen] = useState(false);
+    const [isTeacherDirectoryOpen, setIsTeacherDirectoryOpen] = useState(false);
     const [createForm, setCreateForm] = useState<CourseFormState>(createEmptyCourseForm());
     const [editForm, setEditForm] = useState<CourseFormState>(createEmptyCourseForm());
     const [inviteTarget, setInviteTarget] = useState<ModalInviteTarget>("create");
@@ -392,7 +395,7 @@ export function AdminDashboardPage({ showToast }: Props) {
     }
 
     function handleArchiveCourse() {
-        if (!archivingCourse) return;
+        if (!archivingCourse || !archivingCourse.teacher_assignment) return;
         setCourseFormError(null);
         archiveCourseMutation.mutate({
             courseId: archivingCourse.id,
@@ -546,7 +549,7 @@ export function AdminDashboardPage({ showToast }: Props) {
 
                         <section className="mb-7 grid grid-cols-1 gap-4 md:grid-cols-3">
                             <ActionCard title="Crear Nuevo Curso" subtitle="Asigna un docente y genera link" onClick={openCreateModal} variant="primary" icon={<Plus className="h-5 w-5 text-white" strokeWidth={2.4} />} />
-                            <ActionCard title="Gestion de Docentes" subtitle="Proximamente disponible" onClick={() => showToast("La gestion de docentes estara disponible proximamente.", "default")} variant="primary" icon={<Users className="h-5 w-5 text-white" strokeWidth={2.4} />} />
+                            <ActionCard title="Gestion de Docentes" subtitle="Directorio e invitaciones" onClick={() => setIsTeacherDirectoryOpen(true)} variant="primary" icon={<Users className="h-5 w-5 text-white" strokeWidth={2.4} />} />
                             <ActionCard title="Reportes Globales" subtitle="Proximamente disponible" onClick={() => showToast("Modulo de reportes proximamente disponible.", "default")} variant="placeholder" icon={<ExternalLink className="h-5 w-5 text-slate-400" />} />
                         </section>
 
@@ -716,6 +719,11 @@ export function AdminDashboardPage({ showToast }: Props) {
                     setInviteEmail("");
                     setInviteFormError(null);
                 }}
+            />
+            <TeacherDirectoryModal
+                isOpen={isTeacherDirectoryOpen}
+                onClose={() => setIsTeacherDirectoryOpen(false)}
+                showToast={showToast}
             />
         </div>
     );
@@ -1015,7 +1023,7 @@ function ActionsCell({
                     <ExternalLink className="h-5 w-5" />
                 </button>
             ) : null}
-            <button type="button" disabled={item.status === "inactive"} onClick={onArchive} className="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-40" aria-label={`Archivar ${item.title}`}>
+            <button type="button" disabled={item.status === "inactive" || item.teacher_assignment === null} onClick={onArchive} className="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-40" aria-label={`Archivar ${item.title}`}>
                 <Archive className="h-5 w-5" />
             </button>
         </div>
@@ -1398,40 +1406,6 @@ function TeacherOptionsRefreshNotice({
             <button type="button" onClick={onRetry} className="font-semibold text-[#0144a0] transition hover:text-[#00337a]">
                 Reintentar
             </button>
-        </div>
-    );
-}
-
-function ConfirmationModal({
-    isOpen,
-    title,
-    description,
-    confirmLabel,
-    isSubmitting,
-    onClose,
-    onConfirm,
-}: {
-    isOpen: boolean;
-    title: string;
-    description: string;
-    confirmLabel: string;
-    isSubmitting: boolean;
-    onClose: () => void;
-    onConfirm: () => void;
-}) {
-    if (!isOpen) return null;
-    return (
-        <div className="fixed inset-0 z-[70] flex items-center justify-center bg-slate-950/60 px-4 py-6 backdrop-blur-sm">
-            <div className="w-full max-w-md overflow-hidden rounded-[20px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.22)]">
-                <div className="px-6 py-5">
-                    <h2 className="text-xl font-bold tracking-tight text-slate-900">{title}</h2>
-                    <p className="mt-3 text-sm leading-6 text-slate-500">{description}</p>
-                </div>
-                <div className="flex items-center justify-end gap-3 border-t border-slate-200 px-6 py-4">
-                    <button type="button" onClick={onClose} className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900">Cancelar</button>
-                    <button type="button" onClick={onConfirm} disabled={isSubmitting} className="inline-flex items-center justify-center rounded-xl bg-red-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50">{confirmLabel}</button>
-                </div>
-            </div>
         </div>
     );
 }

--- a/frontend/src/features/admin-dashboard/TeacherDirectoryModal.test.tsx
+++ b/frontend/src/features/admin-dashboard/TeacherDirectoryModal.test.tsx
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { TeacherDirectoryModal } from "./TeacherDirectoryModal";
+import { api, ApiError } from "@/shared/api";
+import { queryKeys } from "@/shared/queryKeys";
+import { createTestQueryClient } from "@/shared/test-utils";
+import { QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@/shared/api", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/api")>("@/shared/api");
+    return {
+        ...actual,
+        api: {
+            ...actual.api,
+            admin: {
+                getTeacherDirectory: vi.fn(),
+                resendInvite: vi.fn(),
+                removeTeacher: vi.fn(),
+                revokeInvite: vi.fn(),
+            },
+        },
+    };
+});
+
+const showToast = vi.fn();
+
+const directoryResponse = {
+    active_teachers: [
+        {
+            membership_id: "membership-1",
+            full_name: "Juan Garcia",
+            email: "juan@uni.edu",
+            assigned_courses: [
+                {
+                    course_id: "course-1",
+                    title: "Finanzas 2027-I",
+                    code: "FIN-101",
+                    semester: "2027-I",
+                    status: "active" as const,
+                },
+                {
+                    course_id: "course-2",
+                    title: "Estrategia 2027-I",
+                    code: "EST-101",
+                    semester: "2027-I",
+                    status: "active" as const,
+                },
+                {
+                    course_id: "course-3",
+                    title: "Operaciones 2027-I",
+                    code: "OPS-101",
+                    semester: "2027-I",
+                    status: "inactive" as const,
+                },
+            ],
+        },
+    ],
+    pending_invites: [
+        {
+            invite_id: "invite-1",
+            full_name: "Ana Torres",
+            email: "ana@uni.edu",
+            status: "pending" as const,
+            expires_at: "2099-01-01T00:00:00+00:00",
+            assigned_courses: [],
+        },
+        {
+            invite_id: "invite-2",
+            full_name: "Carlos Ruiz",
+            email: "carlos@uni.edu",
+            status: "pending" as const,
+            expires_at: "2000-01-01T00:00:00+00:00",
+            assigned_courses: [],
+        },
+    ],
+};
+
+function renderModal(isOpen = true) {
+    const queryClient = createTestQueryClient();
+    return {
+        queryClient,
+        ...render(
+            <QueryClientProvider client={queryClient}>
+                <TeacherDirectoryModal isOpen={isOpen} onClose={vi.fn()} showToast={showToast} />
+            </QueryClientProvider>,
+        ),
+    };
+}
+
+describe("TeacherDirectoryModal", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        Object.defineProperty(navigator, "clipboard", {
+            value: { writeText: vi.fn().mockResolvedValue(undefined) },
+            writable: true,
+        });
+        vi.mocked(api.admin.getTeacherDirectory).mockResolvedValue(directoryResponse);
+        vi.mocked(api.admin.resendInvite).mockResolvedValue({
+            invite_id: "invite-1",
+            activation_link: "/app/teacher/activate#invite_token=fresh-token",
+            expires_at: "2099-01-08T00:00:00+00:00",
+        });
+        vi.mocked(api.admin.removeTeacher).mockResolvedValue({
+            removed_membership_id: "membership-1",
+            affected_course_ids: ["course-1"],
+        });
+        vi.mocked(api.admin.revokeInvite).mockResolvedValue({
+            revoked_invite_id: "invite-1",
+            affected_course_ids: [],
+        });
+    });
+
+    it("fetches only when opened and renders active and pending sections", async () => {
+        renderModal(false);
+        expect(api.admin.getTeacherDirectory).not.toHaveBeenCalled();
+
+        renderModal(true);
+        expect(await screen.findByText("Juan Garcia")).toBeTruthy();
+        expect(screen.getByText("juan@uni.edu")).toBeTruthy();
+        expect(screen.getByText("Finanzas 2027-I (2027-I)")).toBeTruthy();
+        expect(screen.getByText("+1 mas")).toBeTruthy();
+        expect(screen.getByText("Ana Torres")).toBeTruthy();
+        expect(screen.getByText("Vencida")).toBeTruthy();
+    });
+
+    it("renders empty states", async () => {
+        vi.mocked(api.admin.getTeacherDirectory).mockResolvedValue({
+            active_teachers: [],
+            pending_invites: [],
+        });
+
+        renderModal(true);
+
+        expect(await screen.findByText("Aun no hay docentes activos. Invita al primero desde un curso.")).toBeTruthy();
+        expect(screen.getByText("No hay invitaciones pendientes.")).toBeTruthy();
+    });
+
+    it("resends invite, copies absolute link, shows toast and refreshes teacher directory", async () => {
+        const { queryClient } = renderModal(true);
+        await screen.findByText("Ana Torres");
+
+        Object.defineProperty(window, "location", {
+            value: { origin: "http://localhost:5173" },
+            writable: true,
+        });
+
+        fireEvent.click(screen.getAllByText("Reenviar y copiar")[0]);
+
+        await waitFor(() => {
+            expect(api.admin.resendInvite).toHaveBeenCalledWith("invite-1");
+        });
+        await waitFor(() => {
+            expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+                "http://localhost:5173/app/teacher/activate#invite_token=fresh-token",
+            );
+        });
+        expect(showToast).toHaveBeenCalledWith("Enlace reenviado y copiado al portapapeles.", "success");
+        await waitFor(() => {
+            expect(api.admin.getTeacherDirectory).toHaveBeenCalledTimes(2);
+        });
+        expect(queryClient.getQueryData(queryKeys.admin.teacherDirectory())).toBeTruthy();
+    });
+
+    it("shows resend errors", async () => {
+        vi.mocked(api.admin.resendInvite).mockRejectedValueOnce(
+            new ApiError(409, "invite already consumed", "invite_already_consumed"),
+        );
+        renderModal(true);
+        await screen.findByText("Ana Torres");
+
+        fireEvent.click(screen.getAllByText("Reenviar y copiar")[0]);
+
+        await waitFor(() => {
+            expect(showToast).toHaveBeenCalledWith(
+                "La invitacion ya fue utilizada y no puede reenviarse ni revocarse.",
+                "error",
+            );
+        });
+    });
+
+    it("removes a teacher with confirmation and clears related caches", async () => {
+        const { queryClient } = renderModal(true);
+        queryClient.setQueryData(queryKeys.admin.teacherOptions(), { active_teachers: [1], pending_invites: [] });
+        queryClient.setQueryData(queryKeys.admin.courses(), { items: [1] });
+
+        await screen.findByText("Juan Garcia");
+        fireEvent.click(screen.getByText("Eliminar"));
+        fireEvent.click(screen.getByRole("button", { name: "Eliminar docente" }));
+
+        await waitFor(() => {
+            expect(api.admin.removeTeacher).toHaveBeenCalledWith("membership-1");
+        });
+        expect(showToast).toHaveBeenCalledWith("Docente eliminado correctamente.", "success");
+        await waitFor(() => {
+            expect(queryClient.getQueryData(queryKeys.admin.teacherOptions())).toBeUndefined();
+        });
+        await waitFor(() => {
+            expect(queryClient.getQueryData(queryKeys.admin.courses())).toBeUndefined();
+        });
+    });
+
+    it("rolls back remove teacher optimistic update on error", async () => {
+        vi.mocked(api.admin.removeTeacher).mockRejectedValueOnce(
+            new ApiError(409, "active cases", "teacher_has_active_cases"),
+        );
+
+        renderModal(true);
+        await screen.findByText("Juan Garcia");
+        fireEvent.click(screen.getByText("Eliminar"));
+        fireEvent.click(screen.getByRole("button", { name: "Eliminar docente" }));
+
+        await waitFor(() => {
+            expect(showToast).toHaveBeenCalledWith(
+                "No se puede eliminar este docente porque tiene casos con authoring activo.",
+                "error",
+            );
+        });
+        expect(await screen.findByText("Juan Garcia")).toBeTruthy();
+    });
+
+    it("revokes invites with confirmation and clears teacher-options cache", async () => {
+        const { queryClient } = renderModal(true);
+        queryClient.setQueryData(queryKeys.admin.teacherOptions(), { active_teachers: [], pending_invites: [1] });
+
+        await screen.findByText("Ana Torres");
+        fireEvent.click(screen.getAllByText("Revocar")[0]);
+        fireEvent.click(screen.getByRole("button", { name: "Revocar invitacion" }));
+
+        await waitFor(() => {
+            expect(api.admin.revokeInvite).toHaveBeenCalledWith("invite-1");
+        });
+        expect(showToast).toHaveBeenCalledWith("Invitacion revocada.", "success");
+        await waitFor(() => {
+            expect(queryClient.getQueryData(queryKeys.admin.teacherOptions())).toBeUndefined();
+        });
+    });
+
+    it("rolls back revoke invite optimistic update on error", async () => {
+        vi.mocked(api.admin.revokeInvite).mockRejectedValueOnce(
+            new ApiError(500, "network", "network_error"),
+        );
+
+        renderModal(true);
+        await screen.findByText("Ana Torres");
+        fireEvent.click(screen.getAllByText("Revocar")[0]);
+        fireEvent.click(screen.getByRole("button", { name: "Revocar invitacion" }));
+
+        await waitFor(() => {
+            expect(showToast).toHaveBeenCalledWith("network", "error");
+        });
+        expect(await screen.findByText("Ana Torres")).toBeTruthy();
+    });
+});

--- a/frontend/src/features/admin-dashboard/TeacherDirectoryModal.tsx
+++ b/frontend/src/features/admin-dashboard/TeacherDirectoryModal.tsx
@@ -1,0 +1,370 @@
+import { Mail, Trash2, X } from "lucide-react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type {
+    AdminTeacherDirectoryEntry,
+    AdminTeacherDirectoryInvite,
+    AdminTeacherDirectoryResponse,
+} from "@/shared/adam-types";
+import { api } from "@/shared/api";
+import { queryKeys } from "@/shared/queryKeys";
+import type { ShowToast } from "@/shared/Toast";
+
+import { ConfirmationModal } from "./AdminDashboardModals";
+import { copyToClipboard, getAdminErrorMessage, getInitials } from "./adminDashboardModel";
+
+interface Props {
+    isOpen: boolean;
+    onClose: () => void;
+    showToast: ShowToast;
+}
+
+type ConfirmState =
+    | {
+        kind: "remove";
+        teacher: AdminTeacherDirectoryEntry;
+    }
+    | {
+        kind: "revoke";
+        invite: AdminTeacherDirectoryInvite;
+    }
+    | null;
+
+export function TeacherDirectoryModal({ isOpen, onClose, showToast }: Props) {
+    const queryClient = useQueryClient();
+    const [confirmState, setConfirmState] = useState<ConfirmState>(null);
+
+    useEffect(() => {
+        if (!isOpen) return undefined;
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        return () => {
+            document.body.style.overflow = previousOverflow;
+        };
+    }, [isOpen]);
+
+    const teacherDirectoryQuery = useQuery({
+        queryKey: queryKeys.admin.teacherDirectory(),
+        queryFn: api.admin.getTeacherDirectory,
+        staleTime: 30_000,
+        enabled: isOpen,
+    });
+
+    const removeTeacherMutation = useMutation({
+        mutationFn: (membershipId: string) => api.admin.removeTeacher(membershipId),
+        onMutate: async (membershipId) => {
+            await queryClient.cancelQueries({ queryKey: queryKeys.admin.teacherDirectory() });
+            const snapshot = queryClient.getQueryData<AdminTeacherDirectoryResponse>(
+                queryKeys.admin.teacherDirectory(),
+            );
+            queryClient.setQueryData<AdminTeacherDirectoryResponse | undefined>(
+                queryKeys.admin.teacherDirectory(),
+                (previous) => previous ? {
+                    ...previous,
+                    active_teachers: previous.active_teachers.filter(
+                        (teacher) => teacher.membership_id !== membershipId,
+                    ),
+                } : previous,
+            );
+            return { snapshot };
+        },
+        onSuccess: () => {
+            showToast("Docente eliminado correctamente.", "success");
+            setConfirmState(null);
+        },
+        onError: (error, _membershipId, context) => {
+            if (context?.snapshot) {
+                queryClient.setQueryData(queryKeys.admin.teacherDirectory(), context.snapshot);
+            }
+            showToast(getAdminErrorMessage(error, "No se pudo eliminar el docente."), "error");
+        },
+        onSettled: async () => {
+            await queryClient.invalidateQueries({ queryKey: queryKeys.admin.teacherDirectory() });
+            queryClient.removeQueries({ queryKey: queryKeys.admin.teacherOptions() });
+            queryClient.removeQueries({ queryKey: queryKeys.admin.courses() });
+        },
+    });
+
+    const revokeInviteMutation = useMutation({
+        mutationFn: (inviteId: string) => api.admin.revokeInvite(inviteId),
+        onMutate: async (inviteId) => {
+            await queryClient.cancelQueries({ queryKey: queryKeys.admin.teacherDirectory() });
+            const snapshot = queryClient.getQueryData<AdminTeacherDirectoryResponse>(
+                queryKeys.admin.teacherDirectory(),
+            );
+            queryClient.setQueryData<AdminTeacherDirectoryResponse | undefined>(
+                queryKeys.admin.teacherDirectory(),
+                (previous) => previous ? {
+                    ...previous,
+                    pending_invites: previous.pending_invites.filter((invite) => invite.invite_id !== inviteId),
+                } : previous,
+            );
+            return { snapshot };
+        },
+        onSuccess: () => {
+            showToast("Invitacion revocada.", "success");
+            setConfirmState(null);
+        },
+        onError: (error, _inviteId, context) => {
+            if (context?.snapshot) {
+                queryClient.setQueryData(queryKeys.admin.teacherDirectory(), context.snapshot);
+            }
+            showToast(getAdminErrorMessage(error, "No se pudo revocar la invitacion."), "error");
+        },
+        onSettled: async () => {
+            await queryClient.invalidateQueries({ queryKey: queryKeys.admin.teacherDirectory() });
+            queryClient.removeQueries({ queryKey: queryKeys.admin.teacherOptions() });
+        },
+    });
+
+    const resendInviteMutation = useMutation({
+        mutationFn: (inviteId: string) => api.admin.resendInvite(inviteId),
+        onSuccess: async (data) => {
+            const copied = await copyToClipboard(`${window.location.origin}${data.activation_link}`);
+            showToast(
+                copied ? "Enlace reenviado y copiado al portapapeles." : "No se pudo copiar el enlace reenviado.",
+                copied ? "success" : "error",
+            );
+        },
+        onError: (error) => {
+            showToast(getAdminErrorMessage(error, "No se pudo reenviar la invitacion."), "error");
+        },
+        onSettled: async () => {
+            await queryClient.invalidateQueries({ queryKey: queryKeys.admin.teacherDirectory() });
+        },
+    });
+
+    const confirmationDescription = useMemo(() => {
+        if (confirmState?.kind === "remove") {
+            const { teacher } = confirmState;
+            return `¿Eliminar a ${teacher.full_name} (${teacher.email})? Esta accion retirara al docente del sistema. ${teacher.assigned_courses.length} curso(s) perderan su docente asignado. Esta accion no se puede deshacer.`;
+        }
+        if (confirmState?.kind === "revoke") {
+            const { invite } = confirmState;
+            return `¿Revocar la invitacion enviada a ${invite.full_name} (${invite.email})? El enlace de activacion quedara invalido inmediatamente. ${invite.assigned_courses.length} curso(s) perderan su docente asignado.`;
+        }
+        return "";
+    }, [confirmState]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 px-4 py-6 backdrop-blur-sm">
+            <div className="w-full max-w-5xl overflow-hidden rounded-[24px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.22)]">
+                <div className="flex items-start justify-between border-b border-slate-200 px-6 py-5">
+                    <div>
+                        <h2 className="text-xl font-bold tracking-tight text-slate-900">Gestion de Docentes</h2>
+                        <p className="mt-1 text-sm text-slate-500">Directorio institucional de docentes activos e invitaciones pendientes.</p>
+                    </div>
+                    <button type="button" onClick={onClose} className="rounded-lg p-1 text-slate-400 transition hover:text-slate-700" aria-label="Cerrar directorio de docentes">
+                        <X className="h-5 w-5" />
+                    </button>
+                </div>
+
+                <div className="max-h-[80vh] overflow-y-auto px-6 py-6">
+                    {teacherDirectoryQuery.isLoading ? (
+                        <p className="py-10 text-sm text-slate-500">Cargando directorio de docentes...</p>
+                    ) : teacherDirectoryQuery.error ? (
+                        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                            {getAdminErrorMessage(teacherDirectoryQuery.error, "No se pudo cargar el directorio de docentes.")}
+                        </div>
+                    ) : (
+                        <div className="space-y-8">
+                            <DirectorySection
+                                title="Docentes activos"
+                                headers={["Docente", "Cursos asignados", "Acciones"]}
+                            >
+                                {(teacherDirectoryQuery.data?.active_teachers.length ?? 0) === 0 ? (
+                                    <EmptyDirectoryRow colSpan={3} message="Aun no hay docentes activos. Invita al primero desde un curso." />
+                                ) : (
+                                    teacherDirectoryQuery.data?.active_teachers.map((teacher) => (
+                                        <tr key={teacher.membership_id} className="border-t border-slate-100">
+                                            <td className="px-4 py-4 align-top">
+                                                <PersonCell name={teacher.full_name} email={teacher.email} />
+                                            </td>
+                                            <td className="px-4 py-4 align-top">
+                                                <CourseChips courses={teacher.assigned_courses} />
+                                            </td>
+                                            <td className="px-4 py-4 align-top">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setConfirmState({ kind: "remove", teacher })}
+                                                    className="inline-flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm font-semibold text-red-700 transition hover:bg-red-100"
+                                                >
+                                                    <Trash2 className="h-4 w-4" />
+                                                    Eliminar
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    ))
+                                )}
+                            </DirectorySection>
+
+                            <DirectorySection
+                                title="Pendientes por ingresar"
+                                headers={["Docente", "Expira", "Cursos asignados", "Acciones"]}
+                            >
+                                {(teacherDirectoryQuery.data?.pending_invites.length ?? 0) === 0 ? (
+                                    <EmptyDirectoryRow colSpan={4} message="No hay invitaciones pendientes." />
+                                ) : (
+                                    teacherDirectoryQuery.data?.pending_invites.map((invite) => (
+                                        <tr key={invite.invite_id} className="border-t border-slate-100">
+                                            <td className="px-4 py-4 align-top">
+                                                <PersonCell name={invite.full_name} email={invite.email} />
+                                            </td>
+                                            <td className="px-4 py-4 align-top">
+                                                <ExpiryBadge expiresAt={invite.expires_at} />
+                                            </td>
+                                            <td className="px-4 py-4 align-top">
+                                                <CourseChips courses={invite.assigned_courses} />
+                                            </td>
+                                            <td className="px-4 py-4 align-top">
+                                                <div className="flex flex-wrap gap-2">
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => resendInviteMutation.mutate(invite.invite_id)}
+                                                        disabled={resendInviteMutation.isPending}
+                                                        className="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-[#0144a0] transition hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50"
+                                                    >
+                                                        <Mail className="h-4 w-4" />
+                                                        Reenviar y copiar
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => setConfirmState({ kind: "revoke", invite })}
+                                                        className="inline-flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm font-semibold text-red-700 transition hover:bg-red-100"
+                                                    >
+                                                        <Trash2 className="h-4 w-4" />
+                                                        Revocar
+                                                    </button>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    ))
+                                )}
+                            </DirectorySection>
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            <ConfirmationModal
+                isOpen={confirmState !== null}
+                title={confirmState?.kind === "remove" ? "Eliminar docente" : "Revocar invitacion"}
+                description={confirmationDescription}
+                confirmLabel={
+                    confirmState?.kind === "remove"
+                        ? (removeTeacherMutation.isPending ? "Eliminando..." : "Eliminar docente")
+                        : (revokeInviteMutation.isPending ? "Revocando..." : "Revocar invitacion")
+                }
+                isSubmitting={removeTeacherMutation.isPending || revokeInviteMutation.isPending}
+                onClose={() => setConfirmState(null)}
+                onConfirm={() => {
+                    if (confirmState?.kind === "remove") {
+                        removeTeacherMutation.mutate(confirmState.teacher.membership_id);
+                    } else if (confirmState?.kind === "revoke") {
+                        revokeInviteMutation.mutate(confirmState.invite.invite_id);
+                    }
+                }}
+            />
+        </div>
+    );
+}
+
+function DirectorySection({
+    title,
+    headers,
+    children,
+}: {
+    title: string;
+    headers: string[];
+    children: ReactNode;
+}) {
+    return (
+        <section className="space-y-3">
+            <h3 className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">{title}</h3>
+            <div className="overflow-hidden rounded-2xl border-[1.5px] border-slate-200 bg-white shadow-sm">
+                <div className="overflow-x-auto">
+                    <table className="w-full border-collapse text-left">
+                        <thead>
+                            <tr className="bg-slate-50 text-[12px] font-bold uppercase tracking-[0.18em] text-slate-500">
+                                {headers.map((header) => (
+                                    <th key={header} className="px-4 py-3">{header}</th>
+                                ))}
+                            </tr>
+                        </thead>
+                        <tbody className="text-sm text-slate-700">{children}</tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+function EmptyDirectoryRow({ colSpan, message }: { colSpan: number; message: string }) {
+    return (
+        <tr className="border-t border-slate-100">
+            <td colSpan={colSpan} className="px-4 py-8 text-sm text-slate-500">{message}</td>
+        </tr>
+    );
+}
+
+function PersonCell({ name, email }: { name: string; email: string }) {
+    return (
+        <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-200 text-xs font-bold text-slate-600">
+                {getInitials(name)}
+            </div>
+            <div className="min-w-0">
+                <p className="truncate font-semibold text-slate-800">{name}</p>
+                <p className="truncate text-slate-500">{email}</p>
+            </div>
+        </div>
+    );
+}
+
+function CourseChips({
+    courses,
+}: {
+    courses: Array<{ course_id: string; title: string; code: string; semester: string }>;
+}) {
+    if (courses.length === 0) {
+        return <span className="text-slate-400">(sin cursos asignados)</span>;
+    }
+
+    const visible = courses.slice(0, 2);
+    const hiddenCount = courses.length - visible.length;
+
+    return (
+        <div className="flex flex-wrap gap-2">
+            {visible.map((course) => (
+                <span key={course.course_id} className="inline-flex rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">
+                    {course.title} ({course.semester})
+                </span>
+            ))}
+            {hiddenCount > 0 ? (
+                <span className="inline-flex rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-[#0144a0]">
+                    +{hiddenCount} mas
+                </span>
+            ) : null}
+        </div>
+    );
+}
+
+function ExpiryBadge({ expiresAt }: { expiresAt: string }) {
+    const expiry = new Date(expiresAt);
+    const diffMs = expiry.getTime() - Date.now();
+    const expired = Number.isFinite(diffMs) ? diffMs < 0 : false;
+
+    if (expired) {
+        return <span className="inline-flex rounded-full bg-red-100 px-2.5 py-1 text-xs font-semibold text-red-700">Vencida</span>;
+    }
+
+    const diffDays = Math.max(0, Math.ceil(diffMs / (1000 * 60 * 60 * 24)));
+    return (
+        <span className="inline-flex rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-800">
+            {diffDays === 0 ? "hoy" : `en ${diffDays} dia${diffDays === 1 ? "" : "s"}`}
+        </span>
+    );
+}

--- a/frontend/src/features/admin-dashboard/adminDashboardModel.ts
+++ b/frontend/src/features/admin-dashboard/adminDashboardModel.ts
@@ -138,7 +138,7 @@ export function buildCourseFormFromItem(item: AdminCourseListItem): CourseFormSt
         academic_level: normalizeAcademicLevel(item.academic_level),
         max_students: String(item.max_students),
         status: item.status,
-        teacher_option_value: encodeTeacherOptionValue(item.teacher_assignment),
+        teacher_option_value: item.teacher_assignment ? encodeTeacherOptionValue(item.teacher_assignment) : "",
     };
 }
 
@@ -216,6 +216,14 @@ export function getAdminErrorMessage(error: unknown, fallback: string): string {
             return "Ya hay una regeneracion de enlace en curso para este curso.";
         case "course_not_found":
             return "El curso ya no existe o pertenece a otra universidad.";
+        case "invite_already_consumed":
+            return "La invitacion ya fue utilizada y no puede reenviarse ni revocarse.";
+        case "teacher_has_active_cases":
+            return "No se puede eliminar este docente porque tiene casos con authoring activo.";
+        case "invite_not_found":
+            return "La invitacion ya no existe o pertenece a otra universidad.";
+        case "membership_not_found":
+            return "La membresia docente ya no existe o pertenece a otra universidad.";
         default:
             return error.message || fallback;
     }
@@ -231,6 +239,8 @@ export function getTeacherStateMeta(
             return { label: "Invitacion pendiente", classes: "bg-amber-100 text-amber-800" };
         case "stale_pending_invite":
             return { label: "Invitacion vencida", classes: "bg-red-100 text-red-700" };
+        case "unassigned":
+            return { label: "Sin docente", classes: "bg-slate-200 text-slate-600" };
     }
 }
 

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -353,7 +353,7 @@ export type AdminTeacherAssignment =
     | AdminTeacherMembershipAssignment
     | AdminTeacherPendingInviteAssignment;
 
-export type AdminTeacherState = "active" | "pending" | "stale_pending_invite";
+export type AdminTeacherState = "active" | "pending" | "stale_pending_invite" | "unassigned";
 export type AdminCourseStatus = "active" | "inactive";
 export type AdminCourseAccessLinkStatus = "active" | "missing";
 
@@ -366,7 +366,7 @@ export interface AdminCourseListItem {
     status: AdminCourseStatus;
     teacher_display_name: string;
     teacher_state: AdminTeacherState;
-    teacher_assignment: AdminTeacherAssignment;
+    teacher_assignment: AdminTeacherAssignment | null;
     students_count: number;
     max_students: number;
     occupancy_percent: number;
@@ -427,6 +427,51 @@ export interface AdminCourseAccessLinkRegenerateResponse {
     course_id: string;
     access_link: string;
     access_link_status: "active";
+}
+
+export interface AdminCourseRef {
+    course_id: string;
+    title: string;
+    code: string;
+    semester: string;
+    status: AdminCourseStatus;
+}
+
+export interface AdminTeacherDirectoryEntry {
+    membership_id: string;
+    full_name: string;
+    email: string;
+    assigned_courses: AdminCourseRef[];
+}
+
+export interface AdminTeacherDirectoryInvite {
+    invite_id: string;
+    full_name: string;
+    email: string;
+    status: "pending";
+    expires_at: string;
+    assigned_courses: AdminCourseRef[];
+}
+
+export interface AdminTeacherDirectoryResponse {
+    active_teachers: AdminTeacherDirectoryEntry[];
+    pending_invites: AdminTeacherDirectoryInvite[];
+}
+
+export interface AdminRemoveTeacherResponse {
+    removed_membership_id: string;
+    affected_course_ids: string[];
+}
+
+export interface AdminRevokeInviteResponse {
+    revoked_invite_id: string;
+    affected_course_ids: string[];
+}
+
+export interface AdminResendInviteResponse {
+    invite_id: string;
+    activation_link: string;
+    expires_at: string;
 }
 
 export const EMPTY_FORM: CaseFormData = {

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -8,7 +8,11 @@ import type {
     AdminCourseListItem,
     AdminCourseListResponse,
     AdminCourseMutationRequest,
+    AdminRemoveTeacherResponse,
+    AdminResendInviteResponse,
+    AdminRevokeInviteResponse,
     AdminDashboardSummaryResponse,
+    AdminTeacherDirectoryResponse,
     AdminTeacherInviteRequest,
     AdminTeacherInviteResponse,
     AdminTeacherOptionsResponse,
@@ -432,6 +436,9 @@ export const api = {
         async getTeacherOptions(): Promise<AdminTeacherOptionsResponse> {
             return parseJsonResponse<AdminTeacherOptionsResponse>("/admin/teacher-options");
         },
+        async getTeacherDirectory(): Promise<AdminTeacherDirectoryResponse> {
+            return parseJsonResponse<AdminTeacherDirectoryResponse>("/admin/teacher-directory");
+        },
         async createCourse(req: AdminCourseMutationRequest): Promise<AdminCourseListItem> {
             return parseJsonResponse<AdminCourseListItem>("/admin/courses", {
                 method: "POST",
@@ -454,6 +461,21 @@ export const api = {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(req),
+            });
+        },
+        async resendInvite(inviteId: string): Promise<AdminResendInviteResponse> {
+            return parseJsonResponse<AdminResendInviteResponse>(`/admin/teacher-invites/${inviteId}/resend`, {
+                method: "POST",
+            });
+        },
+        async removeTeacher(membershipId: string): Promise<AdminRemoveTeacherResponse> {
+            return parseJsonResponse<AdminRemoveTeacherResponse>(`/admin/memberships/${membershipId}`, {
+                method: "DELETE",
+            });
+        },
+        async revokeInvite(inviteId: string): Promise<AdminRevokeInviteResponse> {
+            return parseJsonResponse<AdminRevokeInviteResponse>(`/admin/teacher-invites/${inviteId}`, {
+                method: "DELETE",
             });
         },
         async regenerateCourseAccessLink(

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -51,6 +51,7 @@ export const queryKeys = {
         },
         /** ["admin", "teacher-options"] — opciones para el dropdown de asignación de docente */
         teacherOptions: () => ["admin", "teacher-options"] as const,
+        teacherDirectory: () => ["admin", "teacher-directory"] as const,
     },
     authoring: {
         /**


### PR DESCRIPTION
## Summary
- implement the admin teacher directory modal with resend, revoke, and remove flows
- add backend admin endpoints, teacher-directory reads, and the XOR-relaxing migration needed for unassigned courses
- cover the new behavior with backend and frontend tests, including optimistic updates and unassigned-course handling

## Validation
- uv run --directory backend pytest -q
- uv run --directory backend mypy src
- npm --prefix frontend run lint
- npm --prefix frontend run test
- npm --prefix frontend run build

Closes #86