### PR TITLE
feat: add teacher courses endpoint

### DIFF
--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -29,6 +29,7 @@ from case_generator.core.authoring import AuthoringService
 from case_generator.suggest_service import SuggestRequest, SuggestResponse, generate_suggestion
 from shared.admin_router import router as admin_router
 from shared.course_access_router import router as course_access_router
+from shared.teacher_router import router as teacher_router
 from shared.auth import (
     AuthError,
     CurrentActor,
@@ -245,6 +246,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(title="adam-v8.0 - Case Generation API", lifespan=lifespan)
 app.include_router(admin_router)
 app.include_router(course_access_router)
+app.include_router(teacher_router)
 
 
 @app.middleware("http")

--- a/backend/src/shared/teacher_context.py
+++ b/backend/src/shared/teacher_context.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import Depends, HTTPException, status
+
+from shared.auth import CurrentActor, require_current_actor
+
+
+@dataclass(slots=True)
+class TeacherContext:
+    """Tenant-scoped teacher context resolved from the authenticated actor."""
+
+    auth_user_id: str
+    teacher_membership_id: str
+    university_id: str
+
+
+def resolve_teacher_context(actor: CurrentActor) -> TeacherContext:
+    """Resolve the single active teacher membership required by teacher APIs."""
+    active_teacher_memberships = [
+        membership
+        for membership in actor.active_memberships
+        if membership.role == "teacher"
+    ]
+
+    if not active_teacher_memberships:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="teacher_role_required",
+        )
+
+    if len(active_teacher_memberships) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="teacher_membership_context_required",
+        )
+
+    membership = active_teacher_memberships[0]
+    return TeacherContext(
+        auth_user_id=actor.auth_user_id,
+        teacher_membership_id=membership.id,
+        university_id=membership.university_id,
+    )
+
+
+def require_teacher_context(
+    actor: CurrentActor = Depends(require_current_actor),
+) -> TeacherContext:
+    """FastAPI dependency that enforces a single active teacher membership."""
+    return resolve_teacher_context(actor)

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+from sqlalchemy import and_, func, select
+from sqlalchemy.orm import Session
+
+from shared.models import Course, CourseMembership, Membership
+from shared.teacher_context import TeacherContext
+
+
+class TeacherCourseItemResponse(BaseModel):
+    id: str
+    title: str
+    code: str
+    semester: str
+    academic_level: str
+    status: Literal["active", "inactive"]
+    students_count: int
+    active_cases_count: int
+
+
+class TeacherCoursesResponse(BaseModel):
+    courses: list[TeacherCourseItemResponse]
+    total: int
+
+
+def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCoursesResponse:
+    """Return the teacher-scoped course directory for the authenticated membership."""
+    student_counts = (
+        select(
+            CourseMembership.course_id.label("course_id"),
+            func.count().label("students_count"),
+        )
+        .select_from(CourseMembership)
+        .join(
+            Membership,
+            and_(
+                CourseMembership.membership_id == Membership.id,
+                Membership.university_id == context.university_id,
+                Membership.role == "student",
+                Membership.status == "active",
+            ),
+        )
+        .group_by(CourseMembership.course_id)
+        .subquery()
+    )
+
+    rows = (
+        db.execute(
+            select(
+                Course.id.label("id"),
+                Course.title.label("title"),
+                Course.code.label("code"),
+                Course.semester.label("semester"),
+                Course.academic_level.label("academic_level"),
+                Course.status.label("status"),
+                func.coalesce(student_counts.c.students_count, 0).label("students_count"),
+            )
+            .select_from(Course)
+            .outerjoin(student_counts, student_counts.c.course_id == Course.id)
+            .where(
+                Course.university_id == context.university_id,
+                Course.teacher_membership_id == context.teacher_membership_id,
+            )
+            .order_by(Course.title.asc(), Course.id.asc())
+        )
+        .mappings()
+        .all()
+    )
+
+    courses = [
+        TeacherCourseItemResponse(
+            id=row["id"],
+            title=row["title"],
+            code=row["code"],
+            semester=row["semester"],
+            academic_level=row["academic_level"],
+            status=row["status"],
+            students_count=int(row["students_count"]),
+            active_cases_count=0,
+        )
+        for row in rows
+    ]
+
+    return TeacherCoursesResponse(courses=courses, total=len(courses))

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -79,7 +79,7 @@ def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCourses
             academic_level=row["academic_level"],
             status=row["status"],
             students_count=int(row["students_count"]),
-            active_cases_count=0,
+            active_cases_count=0,  # TODO(#90): populate once Assignment gains course_id FK
         )
         for row in rows
     ]

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from shared.database import get_db
+from shared.teacher_context import TeacherContext, require_teacher_context
+from shared.teacher_reads import TeacherCoursesResponse, list_teacher_courses
+
+router = APIRouter(prefix="/api/teacher", tags=["teacher"])
+
+
+@router.get("/courses", response_model=TeacherCoursesResponse)
+def get_teacher_courses(
+    context: Annotated[TeacherContext, Depends(require_teacher_context)],
+    db: Session = Depends(get_db),
+) -> TeacherCoursesResponse:
+    return list_teacher_courses(db, context)

--- a/backend/tests/test_issue88_teacher_courses.py
+++ b/backend/tests/test_issue88_teacher_courses.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import uuid
+
+from shared.models import Membership
+
+
+def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
+    return auth_headers_factory(sub=user_id, email=email)
+
+
+def test_issue88_teacher_courses_returns_assigned_courses_with_student_counts(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000881"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-courses@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Courses",
+    )
+    course_b = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Zoologia Aplicada",
+        code="BIO-220",
+        status="inactive",
+    )
+    course_a = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Analisis de Casos",
+        code="ADM-101",
+    )
+    active_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-active@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Student Active",
+    )
+    suspended_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-suspended@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Student Suspended",
+        membership_status="suspended",
+    )
+    seed_course_membership(course_id=course_a.id, membership_id=active_student["membership"].id)
+    seed_course_membership(course_id=course_a.id, membership_id=suspended_student["membership"].id)
+
+    response = client.get(
+        "/api/teacher/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "courses": [
+            {
+                "id": course_a.id,
+                "title": "Analisis de Casos",
+                "code": "ADM-101",
+                "semester": "2026-I",
+                "academic_level": "Pregrado",
+                "status": "active",
+                "students_count": 1,
+                "active_cases_count": 0,
+            },
+            {
+                "id": course_b.id,
+                "title": "Zoologia Aplicada",
+                "code": "BIO-220",
+                "semester": "2026-I",
+                "academic_level": "Pregrado",
+                "status": "inactive",
+                "students_count": 0,
+                "active_cases_count": 0,
+            },
+        ],
+        "total": 2,
+    }
+
+
+def test_issue88_teacher_courses_only_returns_authenticated_teacher_courses(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000882"
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-owned@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Owned",
+    )
+    other_teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-other@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Other",
+    )
+    owned_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Owned Course",
+        code="OWN-101",
+    )
+    seed_course(
+        university_id=university_id,
+        teacher_membership_id=other_teacher["membership"].id,
+        title="Foreign Course",
+        code="FOR-201",
+    )
+
+    response = client.get(
+        "/api/teacher/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher["profile"].id, email="teacher-owned@example.edu"),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "courses": [
+            {
+                "id": owned_course.id,
+                "title": "Owned Course",
+                "code": "OWN-101",
+                "semester": "2026-I",
+                "academic_level": "Pregrado",
+                "status": "active",
+                "students_count": 0,
+                "active_cases_count": 0,
+            }
+        ],
+        "total": 1,
+    }
+
+
+def test_issue88_teacher_courses_returns_empty_when_teacher_has_no_courses(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000883"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-empty@example.edu"
+    seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Empty",
+    )
+
+    response = client.get(
+        "/api/teacher/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"courses": [], "total": 0}
+
+
+def test_issue88_teacher_courses_missing_token_returns_401(client) -> None:
+    response = client.get("/api/teacher/courses")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "invalid_token"
+
+
+def test_issue88_teacher_courses_student_token_returns_403(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000884"
+    student_user_id = str(uuid.uuid4())
+    student_email = "student-only@example.edu"
+    seed_identity(
+        user_id=student_user_id,
+        email=student_email,
+        role="student",
+        university_id=university_id,
+        full_name="Student Only",
+    )
+
+    response = client.get(
+        "/api/teacher/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=student_user_id, email=student_email),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "teacher_role_required"
+
+
+def test_issue88_teacher_courses_admin_token_returns_403(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000885"
+    admin_user_id = str(uuid.uuid4())
+    admin_email = "admin-only@example.edu"
+    seed_identity(
+        user_id=admin_user_id,
+        email=admin_email,
+        role="university_admin",
+        university_id=university_id,
+        create_legacy_user=False,
+        full_name="Admin Only",
+    )
+
+    response = client.get(
+        "/api/teacher/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_user_id, email=admin_email),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "teacher_role_required"
+
+
+def test_issue88_teacher_courses_enforces_tenant_isolation(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_a = "10000000-0000-0000-0000-000000000886"
+    university_b = "10000000-0000-0000-0000-000000000887"
+    teacher_a_id = str(uuid.uuid4())
+    teacher_a_email = "teacher-a@example.edu"
+    teacher_a = seed_identity(
+        user_id=teacher_a_id,
+        email=teacher_a_email,
+        role="teacher",
+        university_id=university_a,
+        full_name="Teacher A",
+    )
+    teacher_b = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-b@example.edu",
+        role="teacher",
+        university_id=university_b,
+        full_name="Teacher B",
+    )
+    course_a = seed_course(
+        university_id=university_a,
+        teacher_membership_id=teacher_a["membership"].id,
+        title="Course A",
+        code="TA-101",
+    )
+    seed_course(
+        university_id=university_b,
+        teacher_membership_id=teacher_b["membership"].id,
+        title="Course B",
+        code="TB-101",
+    )
+
+    response = client.get(
+        "/api/teacher/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_a_id, email=teacher_a_email),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["courses"] == [
+        {
+            "id": course_a.id,
+            "title": "Course A",
+            "code": "TA-101",
+            "semester": "2026-I",
+            "academic_level": "Pregrado",
+            "status": "active",
+            "students_count": 0,
+            "active_cases_count": 0,
+        }
+    ]
+
+
+def test_issue88_teacher_courses_multiple_teacher_memberships_returns_409(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-multi@example.edu"
+    seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000888",
+        full_name="Teacher Multi",
+    )
+    seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000889",
+        full_name="Teacher Multi",
+        create_legacy_user=False,
+    )
+
+    response = client.get(
+        "/api/teacher/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "teacher_membership_context_required"
+
+    memberships = db.scalars(
+        db.query(Membership)
+        .filter(Membership.user_id == teacher_user_id)
+        .statement
+    ).all()
+    assert len(memberships) == 2


### PR DESCRIPTION
## Summary
- add a teacher-scoped context dependency that fail-closes on ambiguous multi-membership actors
- implement GET /api/teacher/courses with tenant-safe course reads and aggregated active student counts
- add backend coverage for auth, tenant isolation, empty states, and the multi-membership invariant

## Validation
- uv run --directory backend pytest -q
- uv run --directory backend mypy src

Closes #88