### PR TITLE
feat(frontend): add teacher dashboard landing scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ADAM EDU es un Teacher Authoring + Preview MVP en transicion a una plataforma multi-rol con autenticacion real. El repositorio incluye:
 
 - Flujo docente completo: sugerencias en formulario, generacion asincrona con LangGraph, timeline por SSE y preview del caso.
-- Shell frontend auth-aware (Issue #5): `AuthProvider`, guards por rol, rutas reales para teacher/student/admin, callback OAuth PKCE, helper `sessionStorage` de activacion con TTL 5 minutos.
+- Shell frontend auth-aware (Issue #5): `AuthProvider`, guards por rol, rutas reales para teacher/student/admin, callback OAuth PKCE, helper `sessionStorage` de activacion con TTL 5 minutos y landing docente en `/app/teacher/dashboard`.
 - Auth perimeter backend (Issue #3): verificacion JWT via JWKS, actor resolution por memberships, `GET /api/auth/me`, endpoints de activacion body-only.
 
 Los flujos de negocio completos de teacher activation, student join y admin provisioning siguen en Issues #6, #7 y #8 respectivamente. El shell actual deja listos los placeholders y contratos de routing para esas historias.

--- a/docs/adr/0001-auth-perimeter-fase1.md
+++ b/docs/adr/0001-auth-perimeter-fase1.md
@@ -25,7 +25,7 @@ debe retirar de forma explicita:
   [`backend/src/shared/app.py`](../../backend/src/shared/app.py).
 - `POST /api/authoring/jobs` autocrea `Tenant` y `User` si no existen, en el mismo
   endpoint y sin identidad verificada.
-- El shell funcional actual vive bajo `/app/teacher`, montado por
+- El shell funcional actual del docente vive bajo `/app/teacher` y `/app/teacher/dashboard`, montado por
   [`frontend/src/app/App.tsx`](../../frontend/src/app/App.tsx) con
   `BrowserRouter basename="/app/"` en
   [`frontend/src/app/main.tsx`](../../frontend/src/app/main.tsx).

--- a/docs/runbooks/local-dev-auth.md
+++ b/docs/runbooks/local-dev-auth.md
@@ -107,7 +107,7 @@ Nunca lleves `SUPABASE_SERVICE_ROLE_KEY` al browser ni a ejemplos frontend.
 - `GET /health` responde `200`
 - `GET /api/auth/me` sin bearer responde `401`
 - `http://localhost:5173/app/` sin sesion muestra la landing con 3 entrypoints por rol
-- `http://localhost:5173/app/teacher` sin sesion redirige a `/teacher/login`
+- `http://localhost:5173/app/teacher/dashboard` sin sesion redirige a `/teacher/login`
 - `http://localhost:5173/app/auth/callback` muestra spinner de "Completando inicio de sesion"
 
 ## Prerequisito manual para produccion
@@ -128,7 +128,7 @@ El scaffold local de `supabase/config.toml` deja preparado el bloque Azure, pero
 habilita en esta issue.
 
 - usa `localhost`, no `127.0.0.1`, para redirect URIs locales
-- las rutas activas hoy en el scaffold local son solo `/app/` y `/app/teacher`
+- las rutas activas hoy en el scaffold local incluyen `/app/`, `/app/teacher` y `/app/teacher/dashboard`
 - completa client id/secret y activa el provider antes de Issue 5
 - callback local esperado: `http://localhost:54321/auth/v1/callback`
 

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -8,6 +8,12 @@ vi.mock("@/app/auth/useAuth");
 vi.mock("@/features/teacher-authoring/TeacherAuthoringPage", () => ({
     TeacherAuthoringPage: () => <div data-testid="teacher-authoring-page">Teacher area</div>,
 }));
+vi.mock("@/features/teacher-auth/TeacherLoginPage", () => ({
+    TeacherLoginPage: () => <div data-testid="teacher-login-page">Teacher login</div>,
+}));
+vi.mock("@/features/teacher-dashboard/TeacherDashboardPage", () => ({
+    TeacherDashboardPage: () => <div data-testid="teacher-dashboard-page">Teacher dashboard</div>,
+}));
 vi.mock("@/features/admin-dashboard/AdminDashboardPage", () => ({
     AdminDashboardPage: () => <div data-testid="admin-dashboard-page">Dashboard admin</div>,
 }));
@@ -102,7 +108,7 @@ describe("App admin shell layout", () => {
             initialEntries: ["/admin/dashboard"],
         });
 
-        expect(await screen.findByTestId("teacher-authoring-page")).toBeTruthy();
+        expect(await screen.findByTestId("teacher-dashboard-page")).toBeTruthy();
         expect(screen.queryByTestId("admin-dashboard-page")).toBeNull();
     });
 
@@ -116,6 +122,16 @@ describe("App admin shell layout", () => {
         expect(await screen.findByTestId("admin-login-page")).toBeTruthy();
     });
 
+    it("redirects an anonymous user to the teacher login route from /teacher/dashboard", async () => {
+        vi.mocked(useAuth).mockReturnValue(baseContext);
+
+        renderWithProviders(<App />, {
+            initialEntries: ["/teacher/dashboard"],
+        });
+
+        expect(await screen.findByTestId("teacher-login-page")).toBeTruthy();
+    });
+
     it("keeps the global SiteHeader on non-admin-dashboard routes", () => {
         vi.mocked(useAuth).mockReturnValue(baseContext);
 
@@ -124,6 +140,51 @@ describe("App admin shell layout", () => {
         });
 
         expect(screen.getByTestId("site-header")).toBeTruthy();
+    });
+
+    it("does not render the global SiteHeader on /teacher/dashboard", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseContext,
+            session: { access_token: "jwt" } as never,
+            actor: teacherActor,
+        });
+
+        renderWithProviders(<App />, {
+            initialEntries: ["/teacher/dashboard"],
+        });
+
+        expect(await screen.findByTestId("teacher-dashboard-page")).toBeTruthy();
+        expect(screen.queryByTestId("site-header")).toBeNull();
+    });
+
+    it("keeps /teacher routed to the existing authoring page", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseContext,
+            session: { access_token: "jwt" } as never,
+            actor: teacherActor,
+        });
+
+        renderWithProviders(<App />, {
+            initialEntries: ["/teacher"],
+        });
+
+        expect(await screen.findByTestId("teacher-authoring-page")).toBeTruthy();
+        expect(screen.queryByTestId("teacher-dashboard-page")).toBeNull();
+    });
+
+    it("redirects a non-teacher actor away from /teacher/dashboard", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseContext,
+            session: { access_token: "jwt" } as never,
+            actor: adminActor,
+        });
+
+        renderWithProviders(<App />, {
+            initialEntries: ["/teacher/dashboard"],
+        });
+
+        expect(await screen.findByTestId("admin-dashboard-page")).toBeTruthy();
+        expect(screen.queryByTestId("teacher-dashboard-page")).toBeNull();
     });
 
     it("resolves the lazy auth callback route", async () => {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -13,6 +13,11 @@ const TeacherAuthoringPage = lazy(() =>
         (module) => ({ default: module.TeacherAuthoringPage }),
     ),
 );
+const TeacherDashboardPage = lazy(() =>
+    import("@/features/teacher-dashboard/TeacherDashboardPage").then(
+        (module) => ({ default: module.TeacherDashboardPage }),
+    ),
+);
 const AuthCallbackPage = lazy(() =>
     import("@/features/auth-callback/AuthCallbackPage").then((module) => ({
         default: module.AuthCallbackPage,
@@ -68,10 +73,12 @@ function App() {
     const { ToastContainer, showToast } = useToast();
     const location = useLocation();
     const isAdminDashboardRoute = location.pathname.startsWith("/admin/dashboard");
+    const isTeacherDashboardRoute =
+        location.pathname.startsWith("/teacher/dashboard");
 
     return (
         <div className="flex min-h-screen flex-col bg-bg-page font-sans type-body">
-            {!isAdminDashboardRoute && <SiteHeader />}
+            {!isAdminDashboardRoute && !isTeacherDashboardRoute && <SiteHeader />}
 
             <main className="flex-1">
                 <Suspense fallback={<RouteFallback />}>
@@ -87,6 +94,14 @@ function App() {
                             }
                         />
                         <Route path="/teacher/activate" element={<TeacherActivatePage />} />
+                        <Route
+                            path="/teacher/dashboard"
+                            element={
+                                <RequireRole role="teacher">
+                                    <TeacherDashboardPage showToast={showToast} />
+                                </RequireRole>
+                            }
+                        />
                         <Route
                             path="/teacher/*"
                             element={

--- a/frontend/src/app/auth/GuestOnlyRoute.test.tsx
+++ b/frontend/src/app/auth/GuestOnlyRoute.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import type { AuthMeActor } from "./auth-types";
+
+vi.mock("./useAuth");
+import { useAuth } from "./useAuth";
+import { GuestOnlyRoute } from "./GuestOnlyRoute";
+
+const baseContext = {
+    session: null,
+    actor: null,
+    loading: false,
+    error: null,
+    signOut: vi.fn(),
+    refreshActor: vi.fn(),
+};
+
+const teacherActor: AuthMeActor = {
+    auth_user_id: "teacher-1",
+    profile: { id: "profile-1", full_name: "Carlos Ruiz" },
+    memberships: [
+        {
+            id: "membership-1",
+            university_id: "uni-1",
+            role: "teacher",
+            status: "active",
+            must_rotate_password: false,
+        },
+    ],
+    must_rotate_password: false,
+    primary_role: "teacher",
+};
+
+function renderTeacherGuestRoute() {
+    return render(
+        <MemoryRouter initialEntries={["/teacher/login"]}>
+            <Routes>
+                <Route
+                    path="/teacher/login"
+                    element={
+                        <GuestOnlyRoute role="teacher">
+                            <div data-testid="guest-content">Teacher login</div>
+                        </GuestOnlyRoute>
+                    }
+                />
+                <Route
+                    path="/teacher/dashboard"
+                    element={<div data-testid="teacher-dashboard-destination" />}
+                />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe("GuestOnlyRoute", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders children when there is no session", () => {
+        vi.mocked(useAuth).mockReturnValue(baseContext);
+
+        renderTeacherGuestRoute();
+
+        expect(screen.getByTestId("guest-content")).toBeTruthy();
+    });
+
+    it("redirects an authenticated teacher to /teacher/dashboard", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseContext,
+            session: { access_token: "jwt" } as never,
+            actor: teacherActor,
+        });
+
+        renderTeacherGuestRoute();
+
+        expect(
+            await screen.findByTestId("teacher-dashboard-destination"),
+        ).toBeTruthy();
+        expect(screen.queryByTestId("guest-content")).toBeNull();
+    });
+});

--- a/frontend/src/app/auth/GuestOnlyRoute.tsx
+++ b/frontend/src/app/auth/GuestOnlyRoute.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 type Role = MembershipSnapshot["role"];
 
 const ROLE_DASHBOARD: Record<Role, string> = {
-    teacher: "/teacher",
+    teacher: "/teacher/dashboard",
     student: "/student",
     university_admin: "/admin/dashboard",
 };

--- a/frontend/src/app/auth/RootRedirect.test.tsx
+++ b/frontend/src/app/auth/RootRedirect.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import type { AuthMeActor } from "./auth-types";
+
+vi.mock("./useAuth");
+vi.mock("@/app/AppLanding", () => ({
+    AppLanding: () => <div data-testid="app-landing">Landing</div>,
+}));
+
+import { useAuth } from "./useAuth";
+import { RootRedirect } from "./RootRedirect";
+
+const baseContext = {
+    session: null,
+    actor: null,
+    loading: false,
+    error: null,
+    signOut: vi.fn(),
+    refreshActor: vi.fn(),
+};
+
+const teacherActor: AuthMeActor = {
+    auth_user_id: "teacher-1",
+    profile: { id: "profile-1", full_name: "Carlos Ruiz" },
+    memberships: [
+        {
+            id: "membership-1",
+            university_id: "uni-1",
+            role: "teacher",
+            status: "active",
+            must_rotate_password: false,
+        },
+    ],
+    must_rotate_password: false,
+    primary_role: "teacher",
+};
+
+const adminActor: AuthMeActor = {
+    auth_user_id: "admin-1",
+    profile: { id: "profile-2", full_name: "Laura Gomez" },
+    memberships: [
+        {
+            id: "membership-2",
+            university_id: "uni-1",
+            role: "university_admin",
+            status: "active",
+            must_rotate_password: false,
+        },
+    ],
+    must_rotate_password: false,
+    primary_role: "university_admin",
+};
+
+const rotatingAdminActor: AuthMeActor = {
+    ...adminActor,
+    must_rotate_password: true,
+    memberships: [
+        {
+            ...adminActor.memberships[0],
+            must_rotate_password: true,
+        },
+    ],
+};
+
+function LocationProbe() {
+    const location = useLocation();
+
+    return <div data-testid="location">{location.pathname}</div>;
+}
+
+function renderRootRedirect() {
+    return render(
+        <MemoryRouter initialEntries={["/"]}>
+            <Routes>
+                <Route path="/" element={<RootRedirect />} />
+                <Route path="*" element={<LocationProbe />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe("RootRedirect", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("redirects a teacher actor to /teacher/dashboard", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseContext,
+            session: { access_token: "jwt" } as never,
+            actor: teacherActor,
+        });
+
+        renderRootRedirect();
+
+        expect(await screen.findByTestId("location")).toHaveTextContent(
+            "/teacher/dashboard",
+        );
+    });
+
+    it("redirects an admin actor to /admin/dashboard", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseContext,
+            session: { access_token: "jwt" } as never,
+            actor: adminActor,
+        });
+
+        renderRootRedirect();
+
+        expect(await screen.findByTestId("location")).toHaveTextContent(
+            "/admin/dashboard",
+        );
+    });
+
+    it("renders AppLanding when there is no session", () => {
+        vi.mocked(useAuth).mockReturnValue(baseContext);
+
+        renderRootRedirect();
+
+        expect(screen.getByTestId("app-landing")).toBeTruthy();
+    });
+
+    it("prioritizes password rotation over role redirects", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseContext,
+            session: { access_token: "jwt" } as never,
+            actor: rotatingAdminActor,
+        });
+
+        renderRootRedirect();
+
+        expect(await screen.findByTestId("location")).toHaveTextContent(
+            "/admin/change-password",
+        );
+    });
+});

--- a/frontend/src/app/auth/RootRedirect.tsx
+++ b/frontend/src/app/auth/RootRedirect.tsx
@@ -6,11 +6,11 @@ import { AppLanding } from "@/app/AppLanding";
  * Handles the root route `/app/`.
  *
  * Redirect precedence (deterministic, per Issue #33):
- *  1. must_rotate_password=true      → /admin/change-password  (always wins)
- *  2. primary_role=university_admin  → /admin/dashboard (placeholder)
- *  3. primary_role=teacher           → /teacher
- *  4. primary_role=student           → /student
- *  5. no session or unknown role     → AppLanding (role entrypoints)
+ *  1. must_rotate_password=true      -> /admin/change-password (always wins)
+ *  2. primary_role=university_admin  -> /admin/dashboard (placeholder)
+ *  3. primary_role=teacher           -> /teacher/dashboard
+ *  4. primary_role=student           -> /student
+ *  5. no session or unknown role     -> AppLanding (role entrypoints)
  */
 export function RootRedirect() {
     const { session, actor, loading } = useAuth();
@@ -26,7 +26,7 @@ export function RootRedirect() {
         case "university_admin":
             return <Navigate to="/admin/dashboard" replace />;
         case "teacher":
-            return <Navigate to="/teacher" replace />;
+            return <Navigate to="/teacher/dashboard" replace />;
         case "student":
             return <Navigate to="/student" replace />;
         default:

--- a/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
@@ -212,7 +212,7 @@ describe("AuthCallbackPage", () => {
             expect(api.auth.activateOAuthComplete).toHaveBeenCalledWith("teacher-tok"),
         );
         await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith("/teacher", { replace: true }),
+            expect(mockNavigate).toHaveBeenCalledWith("/teacher/dashboard", { replace: true }),
         );
     });
 
@@ -359,6 +359,37 @@ describe("AuthCallbackPage", () => {
 
         await waitFor(() =>
             expect(screen.getByText(/fue rotado/i)).toBeTruthy(),
+        );
+    });
+
+    it("redirects a teacher actor without activation context to /teacher/dashboard", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseCtx,
+            actor: {
+                auth_user_id: "teacher-1",
+                profile: { id: "teacher-1", full_name: "Docente" },
+                memberships: [
+                    {
+                        id: "membership-1",
+                        university_id: "uni1",
+                        role: "teacher",
+                        status: "active",
+                        must_rotate_password: false,
+                    },
+                ],
+                must_rotate_password: false,
+                primary_role: "teacher",
+            },
+        });
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(mockNavigate).toHaveBeenCalledWith("/teacher/dashboard", { replace: true }),
         );
     });
 });

--- a/frontend/src/features/auth-callback/AuthCallbackPage.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.tsx
@@ -83,7 +83,7 @@ export function AuthCallbackPage() {
                     await api.auth.activateOAuthComplete(teacherCtx.invite_token);
                     clearActivationContext();
                     await refreshActor();
-                    navigate("/teacher", { replace: true });
+                    navigate("/teacher/dashboard", { replace: true });
                 } catch (err: unknown) {
                     clearActivationContext();
                     setActivationFlow("teacher_activate");
@@ -177,7 +177,7 @@ export function AuthCallbackPage() {
                 navigate("/admin/dashboard", { replace: true });
                 break;
             case "teacher":
-                navigate("/teacher", { replace: true });
+                navigate("/teacher/dashboard", { replace: true });
                 break;
             case "student":
                 navigate("/student", { replace: true });

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.test.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.test.tsx
@@ -211,7 +211,7 @@ describe("TeacherActivatePage", () => {
     });
 
     // 7. Submit válido → llama activatePassword, luego signInWithPassword con res.email, navega /teacher
-    it("calls activatePassword then signInWithPassword with res.email and navigates to /teacher", async () => {
+    it("calls activatePassword then signInWithPassword with res.email and navigates to /teacher/dashboard", async () => {
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
             token_kind: "invite",
@@ -259,7 +259,7 @@ describe("TeacherActivatePage", () => {
         });
 
         await waitFor(() =>
-            expect(mockNavigate).toHaveBeenCalledWith("/teacher", { replace: true }),
+            expect(mockNavigate).toHaveBeenCalledWith("/teacher/dashboard", { replace: true }),
         );
     });
 

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
@@ -155,7 +155,7 @@ export function TeacherActivatePage() {
             }
 
             // AuthContext onAuthStateChange fires SIGNED_IN → fetchActor automatically
-            navigate("/teacher", { replace: true });
+            navigate("/teacher/dashboard", { replace: true });
         } catch (err: unknown) {
             const apiErr = err as ApiError;
             if (apiErr.detail === "invalid_invite") {

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
@@ -1,0 +1,53 @@
+import { Link } from "react-router-dom";
+import { useAuth } from "@/app/auth/useAuth";
+import type { ShowToast } from "@/shared/Toast";
+
+interface TeacherDashboardPageProps {
+    showToast: ShowToast;
+}
+
+export function TeacherDashboardPage({
+    showToast: _showToast,
+}: TeacherDashboardPageProps) {
+    const { actor, signOut } = useAuth();
+    void _showToast;
+
+    return (
+        <div className="min-h-screen bg-[#F0F4F8]" data-testid="teacher-dashboard-page">
+            <header className="border-b border-slate-200 bg-white">
+                <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-4">
+                    <div className="space-y-1">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                            Portal Docente
+                        </p>
+                        <h1 className="text-lg font-semibold text-slate-900">
+                            {actor?.profile.full_name ?? "Docente"}
+                        </h1>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <Link
+                            to="/teacher"
+                            className="rounded-md bg-[#0144a0] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+                        >
+                            Crear nuevo caso
+                        </Link>
+                        <button
+                            type="button"
+                            onClick={() => void signOut()}
+                            className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
+                        >
+                            Cerrar sesiÃ³n
+                        </button>
+                    </div>
+                </div>
+            </header>
+            <main className="mx-auto max-w-6xl px-6 py-8">
+                <div className="rounded-2xl border border-dashed border-slate-300 bg-white px-6 py-10">
+                    <p className="text-sm text-slate-500">
+                        Teacher Dashboard - WIP
+                    </p>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
@@ -36,7 +36,7 @@ export function TeacherDashboardPage({
                             onClick={() => void signOut()}
                             className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
                         >
-                            Cerrar sesiÃ³n
+                            Cerrar sesión
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add the /teacher/dashboard route and scaffold a minimal production-safe teacher dashboard shell
- align all teacher post-auth redirects to the new landing (RootRedirect, GuestOnlyRoute, activation, OAuth callback)
- extend frontend regression coverage for dashboard routing and redirect behavior, and update docs that referenced the old landing

## Validation
- npm --prefix frontend run lint
- npm --prefix frontend run test
- npm --prefix frontend run build

Closes #89