### PR TITLE
[Backend] Add assignment deadline persistence and teacher cases API

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ En este corte no se renombran carpetas del frontend.
 
 1. `POST /api/suggest` ayuda a completar escenario y tecnicas del formulario.
 2. `POST /api/authoring/jobs` es teacher-only y requiere bearer JWT valido; crea `Assignment` + `AuthoringJob` sin confiar en `teacher_id` del cliente.
+   Si el payload incluye `due_at`, el backend lo interpreta como hora local `America/Bogota`, lo persiste en UTC en `Assignment.deadline` y conserva `task_payload["dueAt"]` como string ISO-8601 normalizado.
 3. `AuthoringService.run_job()` ejecuta el grafo y persiste el resultado.
 4. `GET /api/authoring/jobs/{job_id}/progress` emite progreso por SSE autenticado con ownership exacto por docente.
 5. `GET /api/authoring/jobs/{job_id}` permite polling autenticado del job.
@@ -95,6 +96,16 @@ En este corte no se renombran carpetas del frontend.
 8. `POST /api/invites/resolve`, `POST /api/invites/redeem`, `POST /api/auth/activate/password` y `POST /api/auth/activate/oauth/complete` consumen `invite_token` por body.
 
 El frontend usa ese flujo para renderizar el timeline y el `CasePreview` del profesor.
+
+### Deploy note for `Assignment.deadline`
+
+El rollout de cualquier cambio que escriba o lea `Assignment.deadline` exige este orden:
+
+1. aplicar `uv run --directory backend alembic upgrade head`
+2. desplegar backend
+3. desplegar frontend
+
+No despliegues backend antes de aplicar la migracion. `POST /api/authoring/jobs` y `GET /api/teacher/cases` dependen de que la columna exista.
 
 ## Setup local
 

--- a/backend/alembic/versions/d4f4c2f9c1aa_issue90_assignment_deadline.py
+++ b/backend/alembic/versions/d4f4c2f9c1aa_issue90_assignment_deadline.py
@@ -1,0 +1,37 @@
+"""Issue 90 assignment deadline
+
+Revision ID: d4f4c2f9c1aa
+Revises: c2f8a58d6d1e
+Create Date: 2026-04-12 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d4f4c2f9c1aa"
+down_revision: Union[str, Sequence[str], None] = "c2f8a58d6d1e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "assignments",
+        sa.Column("deadline", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_assignments_teacher_id_deadline",
+        "assignments",
+        ["teacher_id", "deadline"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_assignments_teacher_id_deadline", table_name="assignments")
+    op.drop_column("assignments", "deadline")

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -11,6 +11,7 @@ import pathlib
 import time
 from typing import Any
 import uuid
+from zoneinfo import ZoneInfo
 
 from pythonjsonlogger.json import JsonFormatter
 
@@ -75,9 +76,35 @@ _json_handler = logging.StreamHandler()
 _json_handler.setFormatter(JsonFormatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
 logging.basicConfig(handlers=[_json_handler], level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)
+_BOGOTA_TZ = ZoneInfo("America/Bogota")
 
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _normalize_deadline_input(raw_due_at: str | None) -> tuple[datetime | None, str | None]:
+    if raw_due_at is None:
+        return None, None
+
+    stripped_due_at = raw_due_at.strip()
+    if not stripped_due_at:
+        return None, None
+
+    try:
+        parsed_due_at = datetime.fromisoformat(stripped_due_at)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="invalid_due_at",
+        ) from exc
+
+    localized_due_at = (
+        parsed_due_at.replace(tzinfo=_BOGOTA_TZ)
+        if parsed_due_at.tzinfo is None
+        else parsed_due_at
+    )
+    deadline_utc = localized_due_at.astimezone(timezone.utc)
+    return deadline_utc, deadline_utc.isoformat()
 
 
 def get_legacy_teacher_or_500(db: Session, actor: CurrentActor) -> User:
@@ -335,8 +362,14 @@ def create_authoring_job(
     db: Session = Depends(get_db),
 ) -> JobCreatedResponse:
     teacher = get_legacy_teacher_or_500(db, actor)
+    deadline, normalized_due_at = _normalize_deadline_input(req.due_at)
 
-    assignment = Assignment(teacher_id=teacher.id, title=req.assignment_title, status="draft")
+    assignment = Assignment(
+        teacher_id=teacher.id,
+        title=req.assignment_title,
+        status="draft",
+        deadline=deadline,
+    )
     db.add(assignment)
     db.commit()
     db.refresh(assignment)
@@ -362,7 +395,7 @@ def create_authoring_job(
             "includePythonCode": req.include_python_code,
             "algoritmos": req.suggested_techniques,
             "availableFrom": req.available_from,
-            "dueAt": req.due_at,
+            "dueAt": normalized_due_at,
         },
     )
     db.add(job)

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -331,6 +331,7 @@ class Assignment(Base):
     canonical_output: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
 
     status: Mapped[str] = mapped_column(String(50), default="draft")
+    deadline: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel
 from sqlalchemy import and_, func, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, load_only
 
 from shared.auth import CurrentActor, ensure_legacy_teacher_bridge
-from shared.models import Course, CourseMembership, Membership
+from shared.models import Assignment, Course, CourseMembership, Membership
 from shared.teacher_context import TeacherContext
-from shared.models import Assignment
 
 
 class TeacherCourseItemResponse(BaseModel):
@@ -100,12 +99,36 @@ def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCourses
     return TeacherCoursesResponse(courses=courses, total=len(courses))
 
 
-def list_teacher_active_cases(db: Session, actor: CurrentActor) -> list[TeacherCaseItem]:
+def list_teacher_active_cases(
+    db: Session,
+    actor: CurrentActor,
+    *,
+    now: datetime,
+) -> list[TeacherCaseItem]:
+    """Return active (deadline >= now) cases for the authenticated teacher.
+
+    ``now`` must be injected by the caller so that the DB filter and the
+    ``days_remaining`` calculation in the router share a single logical instant,
+    eliminating drift between the two captures.
+
+    Invariant: ``ensure_legacy_teacher_bridge`` raises HTTP 500
+    (``legacy_bridge_missing``) when the legacy User row does not exist.  This
+    should never happen in production because the bridge is created atomically
+    with every Membership at sign-up.  A 500 here signals a data-integrity gap
+    that requires a backfill, not a user-facing error.
+    """
     legacy_user = ensure_legacy_teacher_bridge(db, actor)
-    now = datetime.now(timezone.utc)
 
     assignments = db.scalars(
         select(Assignment)
+        .options(
+            load_only(
+                Assignment.id,
+                Assignment.title,
+                Assignment.deadline,
+                Assignment.status,
+            )
+        )
         .where(
             Assignment.teacher_id == legacy_user.id,
             Assignment.status == "published",

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Literal
 
 from pydantic import BaseModel
 from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session
 
+from shared.auth import CurrentActor, ensure_legacy_teacher_bridge
 from shared.models import Course, CourseMembership, Membership
 from shared.teacher_context import TeacherContext
+from shared.models import Assignment
 
 
 class TeacherCourseItemResponse(BaseModel):
@@ -24,6 +28,15 @@ class TeacherCourseItemResponse(BaseModel):
 class TeacherCoursesResponse(BaseModel):
     courses: list[TeacherCourseItemResponse]
     total: int
+
+
+@dataclass(slots=True)
+class TeacherCaseItem:
+    id: str
+    title: str
+    deadline: datetime | None
+    status: str
+    course_codes: list[str]
 
 
 def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCoursesResponse:
@@ -85,3 +98,30 @@ def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCourses
     ]
 
     return TeacherCoursesResponse(courses=courses, total=len(courses))
+
+
+def list_teacher_active_cases(db: Session, actor: CurrentActor) -> list[TeacherCaseItem]:
+    legacy_user = ensure_legacy_teacher_bridge(db, actor)
+    now = datetime.now(timezone.utc)
+
+    assignments = db.scalars(
+        select(Assignment)
+        .where(
+            Assignment.teacher_id == legacy_user.id,
+            Assignment.status == "published",
+            Assignment.deadline.is_not(None),
+            Assignment.deadline >= now,
+        )
+        .order_by(Assignment.deadline.asc(), Assignment.id.asc())
+    ).all()
+
+    return [
+        TeacherCaseItem(
+            id=assignment.id,
+            title=assignment.title,
+            deadline=assignment.deadline,
+            status=assignment.status,
+            course_codes=[],
+        )
+        for assignment in assignments
+    ]

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -57,7 +57,7 @@ def get_teacher_cases(
     db: Session = Depends(get_db),
 ) -> TeacherCasesResponse:
     now = datetime.now(timezone.utc)
-    cases = list_teacher_active_cases(db, actor)
+    cases = list_teacher_active_cases(db, actor, now=now)
     items = [
         TeacherCaseItemResponse(
             id=item.id,

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -1,15 +1,45 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+import math
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from shared.auth import CurrentActor, require_current_actor
 from shared.database import get_db
 from shared.teacher_context import TeacherContext, require_teacher_context
-from shared.teacher_reads import TeacherCoursesResponse, list_teacher_courses
+from shared.teacher_reads import TeacherCoursesResponse, list_teacher_active_cases, list_teacher_courses
 
 router = APIRouter(prefix="/api/teacher", tags=["teacher"])
+
+
+class TeacherCaseItemResponse(BaseModel):
+    id: str
+    title: str
+    deadline: datetime | None
+    status: str
+    course_codes: list[str]
+    days_remaining: int | None
+
+
+class TeacherCasesResponse(BaseModel):
+    cases: list[TeacherCaseItemResponse]
+    total: int
+
+
+def _days_remaining(deadline: datetime | None, now: datetime) -> int | None:
+    if deadline is None:
+        return None
+
+    remaining_seconds = (deadline - now).total_seconds()
+    if remaining_seconds <= 0:
+        return 0
+    if remaining_seconds < 86400:
+        return 0
+    return math.ceil(remaining_seconds / 86400)
 
 
 @router.get("/courses", response_model=TeacherCoursesResponse)
@@ -18,3 +48,25 @@ def get_teacher_courses(
     db: Session = Depends(get_db),
 ) -> TeacherCoursesResponse:
     return list_teacher_courses(db, context)
+
+
+@router.get("/cases", response_model=TeacherCasesResponse)
+def get_teacher_cases(
+    _: Annotated[TeacherContext, Depends(require_teacher_context)],
+    actor: CurrentActor = Depends(require_current_actor),
+    db: Session = Depends(get_db),
+) -> TeacherCasesResponse:
+    now = datetime.now(timezone.utc)
+    cases = list_teacher_active_cases(db, actor)
+    items = [
+        TeacherCaseItemResponse(
+            id=item.id,
+            title=item.title,
+            deadline=item.deadline,
+            status=item.status,
+            course_codes=item.course_codes,
+            days_remaining=_days_remaining(item.deadline, now),
+        )
+        for item in cases
+    ]
+    return TeacherCasesResponse(cases=items, total=len(items))

--- a/backend/tests/test_issue90_assignment_deadline_migration.py
+++ b/backend/tests/test_issue90_assignment_deadline_migration.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+import uuid
+
+from alembic import command
+from alembic.config import Config
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import URL, make_url
+
+from shared.database import settings
+
+
+ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
+PRE_ISSUE90_REVISION = "c2f8a58d6d1e"
+ISSUE90_REVISION = "d4f4c2f9c1aa"
+
+
+def _make_temp_database_urls() -> tuple[str, URL, URL]:
+    base_url = make_url(settings.database_url)
+    temp_name = f"issue90_{uuid.uuid4().hex[:10]}"
+    temp_url = base_url.set(database=temp_name)
+    admin_url = base_url.set(database="postgres")
+    return temp_name, temp_url, admin_url
+
+
+@contextmanager
+def temporary_database() -> str:
+    db_name, temp_url, admin_url = _make_temp_database_urls()
+    admin_engine = create_engine(admin_url.render_as_string(hide_password=False), isolation_level="AUTOCOMMIT")
+    temp_engine = None
+    try:
+        with admin_engine.connect() as conn:
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+        temp_engine = create_engine(temp_url.render_as_string(hide_password=False))
+        yield temp_url.render_as_string(hide_password=False)
+    finally:
+        if temp_engine is not None:
+            temp_engine.dispose()
+        with admin_engine.connect() as conn:
+            conn.execute(
+                text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :db_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"db_name": db_name},
+            )
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        admin_engine.dispose()
+
+
+def _alembic_config(db_url: str) -> Config:
+    config = Config(str(ALEMBIC_INI))
+    config.set_main_option("sqlalchemy.url", db_url)
+    return config
+
+
+@pytest.fixture
+def clean_db():
+    yield
+
+
+def test_issue90_alembic_upgrade_and_downgrade() -> None:
+    with temporary_database() as db_url:
+        config = _alembic_config(db_url)
+
+        command.upgrade(config, PRE_ISSUE90_REVISION)
+        engine = create_engine(db_url)
+        inspector = inspect(engine)
+        assignment_columns = {column["name"] for column in inspector.get_columns("assignments")}
+        assert "deadline" not in assignment_columns
+
+        command.upgrade(config, ISSUE90_REVISION)
+
+        upgraded_inspector = inspect(engine)
+        upgraded_columns = {column["name"] for column in upgraded_inspector.get_columns("assignments")}
+        assert "deadline" in upgraded_columns
+        upgraded_indexes = {index["name"] for index in upgraded_inspector.get_indexes("assignments")}
+        assert "ix_assignments_teacher_id_deadline" in upgraded_indexes
+
+        command.downgrade(config, PRE_ISSUE90_REVISION)
+
+        downgraded_inspector = inspect(engine)
+        downgraded_columns = {column["name"] for column in downgraded_inspector.get_columns("assignments")}
+        assert "deadline" not in downgraded_columns
+        downgraded_indexes = {index["name"] for index in downgraded_inspector.get_indexes("assignments")}
+        assert "ix_assignments_teacher_id_deadline" not in downgraded_indexes
+
+        engine.dispose()

--- a/backend/tests/test_issue90_teacher_cases.py
+++ b/backend/tests/test_issue90_teacher_cases.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+import uuid
+
+from shared.models import Assignment, Membership
+
+
+def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
+    return auth_headers_factory(sub=user_id, email=email)
+
+
+def test_issue90_authoring_job_persists_deadline_and_normalizes_due_at(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-deadline@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    with patch("fastapi.BackgroundTasks.add_task"):
+        response = client.post(
+            "/api/authoring/jobs",
+            json={
+                "assignment_title": "Deadline Case",
+                "subject": "Deadline Case",
+                "due_at": "2026-04-15T09:30",
+            },
+            headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+        )
+
+    assert response.status_code == 202, response.text
+    assignment = db.query(Assignment).order_by(Assignment.created_at.desc()).first()
+    assert assignment is not None
+    assert assignment.deadline == datetime(2026, 4, 15, 14, 30, tzinfo=timezone.utc)
+
+
+def test_issue90_authoring_job_preserves_string_payload_shape_and_allows_null_deadline(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-null-deadline@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    with patch("fastapi.BackgroundTasks.add_task"):
+        response = client.post(
+            "/api/authoring/jobs",
+            json={
+                "assignment_title": "Null Deadline Case",
+                "due_at": None,
+            },
+            headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+        )
+
+    assert response.status_code == 202, response.text
+    assignment = db.query(Assignment).order_by(Assignment.created_at.desc()).first()
+    assert assignment is not None
+    assert assignment.deadline is None
+    assert assignment.authoring_jobs[0].task_payload["dueAt"] is None
+
+
+def test_issue90_authoring_job_rejects_invalid_due_at(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-invalid-deadline@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    with patch("fastapi.BackgroundTasks.add_task"):
+        response = client.post(
+            "/api/authoring/jobs",
+            json={
+                "assignment_title": "Invalid Deadline Case",
+                "due_at": "not-a-date",
+            },
+            headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "invalid_due_at"
+
+
+def test_issue90_teacher_cases_returns_only_future_published_assignments_sorted(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-cases@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    now = datetime.now(timezone.utc)
+
+    later_assignment = Assignment(
+        teacher_id=teacher_id,
+        title="Later",
+        status="published",
+        deadline=now + timedelta(hours=25),
+    )
+    sooner_assignment = Assignment(
+        teacher_id=teacher_id,
+        title="Sooner",
+        status="published",
+        deadline=now + timedelta(hours=3),
+    )
+    draft_assignment = Assignment(
+        teacher_id=teacher_id,
+        title="Draft",
+        status="draft",
+        deadline=now + timedelta(days=2),
+    )
+    failed_assignment = Assignment(
+        teacher_id=teacher_id,
+        title="Failed",
+        status="failed",
+        deadline=now + timedelta(days=3),
+    )
+    expired_assignment = Assignment(
+        teacher_id=teacher_id,
+        title="Expired",
+        status="published",
+        deadline=now - timedelta(seconds=1),
+    )
+    null_deadline_assignment = Assignment(
+        teacher_id=teacher_id,
+        title="No Deadline",
+        status="published",
+        deadline=None,
+    )
+    db.add_all(
+        [
+            later_assignment,
+            sooner_assignment,
+            draft_assignment,
+            failed_assignment,
+            expired_assignment,
+            null_deadline_assignment,
+        ]
+    )
+    db.commit()
+
+    response = client.get(
+        "/api/teacher/cases",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 2
+    assert [item["title"] for item in body["cases"]] == ["Sooner", "Later"]
+    assert body["cases"][0]["days_remaining"] == 0
+    assert body["cases"][1]["days_remaining"] == 2
+    assert body["cases"][0]["course_codes"] == []
+
+
+def test_issue90_teacher_cases_returns_empty_when_teacher_has_no_active_cases(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-empty-cases@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    response = client.get(
+        "/api/teacher/cases",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"cases": [], "total": 0}
+
+
+def test_issue90_teacher_cases_missing_token_returns_401(client) -> None:
+    response = client.get("/api/teacher/cases")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "invalid_token"
+
+
+def test_issue90_teacher_cases_student_token_returns_403(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    student_id = str(uuid.uuid4())
+    student_email = "student-cases@example.edu"
+    seed_identity(user_id=student_id, email=student_email, role="student")
+
+    response = client.get(
+        "/api/teacher/cases",
+        headers=_auth_headers(auth_headers_factory, user_id=student_id, email=student_email),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "teacher_role_required"
+
+
+def test_issue90_teacher_cases_admin_token_returns_403(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    admin_id = str(uuid.uuid4())
+    admin_email = "admin-cases@example.edu"
+    seed_identity(
+        user_id=admin_id,
+        email=admin_email,
+        role="university_admin",
+        create_legacy_user=False,
+    )
+
+    response = client.get(
+        "/api/teacher/cases",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "teacher_role_required"
+
+
+def test_issue90_teacher_cases_multiple_teacher_memberships_returns_409(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-multi-cases@example.edu"
+    seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000990",
+        full_name="Teacher Multi Cases",
+    )
+    seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000991",
+        full_name="Teacher Multi Cases",
+        create_legacy_user=False,
+    )
+
+    response = client.get(
+        "/api/teacher/cases",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "teacher_membership_context_required"
+
+    memberships = db.scalars(
+        db.query(Membership)
+        .filter(Membership.user_id == teacher_user_id)
+        .statement
+    ).all()
+    assert len(memberships) == 2
+
+
+def test_issue90_teacher_cases_requires_legacy_bridge_for_teacher_reads(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-missing-bridge-cases@example.edu"
+    seed_identity(
+        user_id=teacher_id,
+        email=teacher_email,
+        role="teacher",
+        create_legacy_user=False,
+    )
+
+    response = client.get(
+        "/api/teacher/cases",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "legacy_bridge_missing"


### PR DESCRIPTION
## Summary
- add Assignment.deadline with Alembic migration and composite index for teacher dashboard reads
- persist normalized due_at as UTC in POST /api/authoring/jobs while preserving string task_payload["dueAt"]
- add GET /api/teacher/cases behind the existing teacher context guard with published+future filtering
- add issue-specific Alembic and endpoint regression tests, plus rollout note in README.md

## Validation
- uv run --directory backend pytest -q
- uv run --directory backend mypy src

## Deploy
1. uv run --directory backend alembic upgrade head
2. deploy backend
3. deploy frontend

Closes #90
