### PR TITLE
feat(frontend): add teacher query namespace and hooks

### DIFF
--- a/frontend/src/features/teacher-dashboard/useTeacherDashboard.test.tsx
+++ b/frontend/src/features/teacher-dashboard/useTeacherDashboard.test.tsx
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/shared/api";
+import { queryKeys } from "@/shared/queryKeys";
+
+import { useTeacherCases, useTeacherCourses } from "./useTeacherDashboard";
+
+vi.mock("@tanstack/react-query", () => ({
+    useQuery: vi.fn(),
+}));
+
+vi.mock("@/shared/api", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/api")>("@/shared/api");
+
+    return {
+        ...actual,
+        api: {
+            ...actual.api,
+            teacher: {
+                getCourses: vi.fn(),
+                getCases: vi.fn(),
+            },
+        },
+    };
+});
+
+describe("useTeacherDashboard", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("configures the teacher courses query with the shared cache policy", async () => {
+        vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+
+        useTeacherCourses();
+
+        expect(useQuery).toHaveBeenCalledWith({
+            queryKey: queryKeys.teacher.courses(),
+            queryFn: expect.any(Function),
+            staleTime: 30_000,
+            refetchOnWindowFocus: "always",
+        });
+
+        const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as {
+            queryFn: (context: { queryKey: readonly string[]; signal: AbortSignal }) => Promise<unknown>;
+        };
+        await options.queryFn({
+            queryKey: queryKeys.teacher.courses(),
+            signal: new AbortController().signal,
+        });
+        expect(api.teacher.getCourses).toHaveBeenCalledTimes(1);
+    });
+
+    it("configures the teacher cases query with foreground polling", async () => {
+        vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+
+        useTeacherCases();
+
+        expect(useQuery).toHaveBeenCalledWith({
+            queryKey: queryKeys.teacher.cases(),
+            queryFn: expect.any(Function),
+            staleTime: 30_000,
+            refetchOnWindowFocus: "always",
+            refetchInterval: 60_000,
+            refetchIntervalInBackground: false,
+        });
+
+        const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as {
+            queryFn: (context: { queryKey: readonly string[]; signal: AbortSignal }) => Promise<unknown>;
+        };
+        await options.queryFn({
+            queryKey: queryKeys.teacher.cases(),
+            signal: new AbortController().signal,
+        });
+        expect(api.teacher.getCases).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/src/features/teacher-dashboard/useTeacherDashboard.ts
+++ b/frontend/src/features/teacher-dashboard/useTeacherDashboard.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/shared/api";
+import { queryKeys } from "@/shared/queryKeys";
+
+export function useTeacherCourses() {
+    return useQuery({
+        queryKey: queryKeys.teacher.courses(),
+        queryFn: () => api.teacher.getCourses(),
+        staleTime: 30_000,
+        refetchOnWindowFocus: "always",
+    });
+}
+
+export function useTeacherCases() {
+    return useQuery({
+        queryKey: queryKeys.teacher.cases(),
+        queryFn: () => api.teacher.getCases(),
+        staleTime: 30_000,
+        refetchOnWindowFocus: "always",
+        refetchInterval: 60_000,
+        refetchIntervalInBackground: false,
+    });
+}

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -474,6 +474,38 @@ export interface AdminResendInviteResponse {
     expires_at: string;
 }
 
+export type TeacherCourseStatus = "active" | "inactive";
+
+export interface TeacherCourseItem {
+    id: string;
+    title: string;
+    code: string;
+    semester: string;
+    academic_level: string;
+    status: TeacherCourseStatus;
+    students_count: number;
+    active_cases_count: number;
+}
+
+export interface TeacherCoursesResponse {
+    courses: TeacherCourseItem[];
+    total: number;
+}
+
+export interface TeacherCaseItem {
+    id: string;
+    title: string;
+    deadline: string | null;
+    status: string;
+    course_codes: string[];
+    days_remaining: number | null;
+}
+
+export interface TeacherCasesResponse {
+    cases: TeacherCaseItem[];
+    total: number;
+}
+
 export const EMPTY_FORM: CaseFormData = {
     subject: "",
     academicLevel: "Pregrado",

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -120,6 +120,15 @@ describe("api auth + stream glue", () => {
         );
     });
 
+    it("maps teacher-specific context and provisioning errors to actionable messages", () => {
+        expect(formatHttpError(409, "teacher_membership_context_required")).toBe(
+            "Tu cuenta tiene multiples membresias docentes activas y requiere seleccion de contexto.",
+        );
+        expect(formatHttpError(500, "legacy_bridge_missing")).toBe(
+            "Tu cuenta docente no esta completamente aprovisionada para consultar casos.",
+        );
+    });
+
     it("surfaces validation messages from structured FastAPI 422 errors", () => {
         expect(formatHttpError(422, [{
             type: "value_error",
@@ -190,5 +199,53 @@ describe("api auth + stream glue", () => {
                 },
             }),
         );
+    });
+
+    it("requests teacher courses from the shared teacher endpoint with bearer auth", async () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+        getSessionMock.mockResolvedValue({
+            data: { session: { access_token: "teacher-token" } },
+            error: null,
+        });
+
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ courses: [], total: 0 }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await api.teacher.getCourses();
+
+        expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/teacher/courses");
+        const options = fetchMock.mock.calls[0]?.[1] as RequestInit;
+        expect(options.method).toBeUndefined();
+        expect(new Headers(options.headers).get("Authorization")).toBe("Bearer teacher-token");
+    });
+
+    it("requests teacher cases from the shared teacher endpoint with bearer auth", async () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+        getSessionMock.mockResolvedValue({
+            data: { session: { access_token: "teacher-token" } },
+            error: null,
+        });
+
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ cases: [], total: 0 }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await api.teacher.getCases();
+
+        expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/teacher/cases");
+        const options = fetchMock.mock.calls[0]?.[1] as RequestInit;
+        expect(options.method).toBeUndefined();
+        expect(new Headers(options.headers).get("Authorization")).toBe("Bearer teacher-token");
     });
 });

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -33,6 +33,8 @@ import type {
     InviteResolveResponse,
     SuggestRequest,
     SuggestResponse,
+    TeacherCasesResponse,
+    TeacherCoursesResponse,
 } from "@/shared/adam-types";
 
 /**
@@ -49,7 +51,8 @@ type ApiErrorCode =
     | "membership_required"
     | "account_suspended"
     | "authoring_forbidden"
-    | "legacy_bridge_missing";
+    | "legacy_bridge_missing"
+    | "teacher_membership_context_required";
 
 export interface SseEvent {
     event: string;
@@ -132,6 +135,14 @@ export function formatHttpError(status: number, detail?: ApiErrorDetail) {
             default:
                 return "No tienes permisos para esta accion.";
         }
+    }
+
+    if (status === 409 && code === "teacher_membership_context_required") {
+        return "Tu cuenta tiene multiples membresias docentes activas y requiere seleccion de contexto.";
+    }
+
+    if (status === 500 && code === "legacy_bridge_missing") {
+        return "Tu cuenta docente no esta completamente aprovisionada para consultar casos.";
     }
 
     if (Array.isArray(detail)) {
@@ -487,6 +498,14 @@ export const api = {
                     method: "POST",
                 },
             );
+        },
+    },
+    teacher: {
+        async getCourses(): Promise<TeacherCoursesResponse> {
+            return parseJsonResponse<TeacherCoursesResponse>("/teacher/courses");
+        },
+        async getCases(): Promise<TeacherCasesResponse> {
+            return parseJsonResponse<TeacherCasesResponse>("/teacher/cases");
         },
     },
 };

--- a/frontend/src/shared/queryKeys.test.ts
+++ b/frontend/src/shared/queryKeys.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { queryKeys } from "./queryKeys";
+
+describe("queryKeys.teacher", () => {
+    it("returns the teacher root key", () => {
+        expect(queryKeys.teacher.all()).toEqual(["teacher"]);
+    });
+
+    it("returns the teacher courses key", () => {
+        expect(queryKeys.teacher.courses()).toEqual(["teacher", "courses"]);
+    });
+
+    it("returns the teacher cases key", () => {
+        expect(queryKeys.teacher.cases()).toEqual(["teacher", "cases"]);
+    });
+});

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -62,11 +62,11 @@ export const queryKeys = {
             ["authoring", "suggest", intent, payload] as const,
     },
     teacher: {
-        /** [“teacher”] — key raíz para invalidación masiva */
-        all: () => [“teacher”] as const,
-        /** [“teacher”, “courses”] — cursos del docente autenticado */
-        courses: () => [“teacher”, “courses”] as const,
-        /** [“teacher”, “cases”] — casos activos del docente autenticado */
-        cases: () => [“teacher”, “cases”] as const,
+        /** ["teacher"] — key raíz para invalidación masiva */
+        all: () => ["teacher"] as const,
+        /** ["teacher", "courses"] — cursos del docente autenticado */
+        courses: () => ["teacher", "courses"] as const,
+        /** ["teacher", "cases"] — casos activos del docente autenticado */
+        cases: () => ["teacher", "cases"] as const,
     },
 } as const;

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -62,11 +62,11 @@ export const queryKeys = {
             ["authoring", "suggest", intent, payload] as const,
     },
     teacher: {
-        /** ["teacher"] â€” key raÃ­z para invalidaciÃ³n masiva */
-        all: () => ["teacher"] as const,
-        /** ["teacher", "courses"] â€” cursos del docente autenticado */
-        courses: () => ["teacher", "courses"] as const,
-        /** ["teacher", "cases"] â€” casos activos del docente autenticado */
-        cases: () => ["teacher", "cases"] as const,
+        /** [“teacher”] — key raíz para invalidación masiva */
+        all: () => [“teacher”] as const,
+        /** [“teacher”, “courses”] — cursos del docente autenticado */
+        courses: () => [“teacher”, “courses”] as const,
+        /** [“teacher”, “cases”] — casos activos del docente autenticado */
+        cases: () => [“teacher”, “cases”] as const,
     },
 } as const;

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -61,4 +61,12 @@ export const queryKeys = {
         suggest: (intent: IntentType, payload: SuggestRequest) =>
             ["authoring", "suggest", intent, payload] as const,
     },
+    teacher: {
+        /** ["teacher"] â€” key raÃ­z para invalidaciÃ³n masiva */
+        all: () => ["teacher"] as const,
+        /** ["teacher", "courses"] â€” cursos del docente autenticado */
+        courses: () => ["teacher", "courses"] as const,
+        /** ["teacher", "cases"] â€” casos activos del docente autenticado */
+        cases: () => ["teacher", "cases"] as const,
+    },
 } as const;


### PR DESCRIPTION
## Summary
- add teacher API contracts and query key namespace
- add pi.teacher methods and useTeacherDashboard hooks
- add focused tests for teacher query keys, API requests, and hook config
- map known teacher backend errors to actionable shared API messages

## Validation
- npm run test
- npm run lint
- npm run build

Closes #93