### PR TITLE
feat(frontend): implement teacher dashboard header

### DIFF
--- a/frontend/src/features/teacher-dashboard/DashboardHeader.test.tsx
+++ b/frontend/src/features/teacher-dashboard/DashboardHeader.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthMeActor } from "@/app/auth/auth-types";
+import { renderWithProviders } from "@/shared/test-utils";
+
+vi.mock("@/app/auth/useAuth");
+
+import { useAuth } from "@/app/auth/useAuth";
+
+import { DashboardHeader } from "./DashboardHeader";
+
+const signOut = vi.fn();
+
+const teacherActor: AuthMeActor = {
+    auth_user_id: "teacher-1",
+    profile: { id: "profile-2", full_name: "Julio César Paz" },
+    memberships: [
+        {
+            id: "membership-2",
+            university_id: "uni-1",
+            role: "teacher",
+            status: "active",
+            must_rotate_password: false,
+        },
+    ],
+    must_rotate_password: false,
+    primary_role: "teacher",
+};
+
+describe("DashboardHeader", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useAuth).mockReturnValue({
+            session: { access_token: "jwt" } as never,
+            actor: teacherActor,
+            loading: false,
+            error: null,
+            signOut,
+            refreshActor: vi.fn(),
+        });
+    });
+
+    it("renders the brand, teacher identity, and notification affordance", () => {
+        renderWithProviders(<DashboardHeader />);
+
+        expect(screen.getByText("ADAM")).toBeTruthy();
+        expect(screen.getByText("Diseñador de Casos")).toBeTruthy();
+        expect(screen.getByText("Julio César Paz")).toBeTruthy();
+        expect(screen.getByText("Docente · Facultad de Administración")).toBeTruthy();
+        expect(screen.getByLabelText("Notificaciones")).toBeTruthy();
+        expect(screen.getByLabelText("Iniciales de Julio César Paz")).toHaveTextContent("JC");
+        expect(screen.getByRole("button", { name: "Cerrar sesión" })).toBeTruthy();
+    });
+
+    it("keeps the identity block truncation classes for long names", () => {
+        renderWithProviders(<DashboardHeader />);
+
+        const fullName = screen.getByText("Julio César Paz");
+        expect(fullName.className).toContain("truncate");
+        expect(fullName.parentElement?.className).toContain("min-w-0");
+    });
+
+    it("derives initials from a single-token name", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            session: { access_token: "jwt" } as never,
+            actor: {
+                ...teacherActor,
+                profile: { ...teacherActor.profile, full_name: "Plato" },
+            },
+            loading: false,
+            error: null,
+            signOut,
+            refreshActor: vi.fn(),
+        });
+
+        renderWithProviders(<DashboardHeader />);
+
+        expect(screen.getByLabelText("Iniciales de Plato")).toHaveTextContent("PL");
+    });
+
+    it("falls back to a generic teacher identity when actor is missing", () => {
+        vi.mocked(useAuth).mockReturnValue({
+            session: { access_token: "jwt" } as never,
+            actor: null,
+            loading: false,
+            error: null,
+            signOut,
+            refreshActor: vi.fn(),
+        });
+
+        renderWithProviders(<DashboardHeader />);
+
+        expect(screen.getByText("Docente")).toBeTruthy();
+        expect(screen.getByLabelText("Iniciales de Docente")).toHaveTextContent("DO");
+    });
+
+    it("triggers signOut from the header action", () => {
+        renderWithProviders(<DashboardHeader />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Cerrar sesión" }));
+
+        expect(signOut).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders the notification dot as a decorative element", () => {
+        const { container } = renderWithProviders(<DashboardHeader />);
+
+        expect(container.querySelector("[aria-hidden].bg-red-500")).toBeTruthy();
+    });
+});

--- a/frontend/src/features/teacher-dashboard/DashboardHeader.tsx
+++ b/frontend/src/features/teacher-dashboard/DashboardHeader.tsx
@@ -1,0 +1,99 @@
+import { Bell } from "lucide-react";
+
+import { useAuth } from "@/app/auth/useAuth";
+
+const FACULTY_SUBTITLE = "Docente · Facultad de Administración";
+
+function getTeacherInitials(fullName: string): string {
+    const parts = fullName.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return "D";
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase() || "D";
+    return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+}
+
+export function DashboardHeader() {
+    const { actor, signOut } = useAuth();
+    const fullName = actor?.profile?.full_name?.trim() || "Docente";
+    const initials = getTeacherInitials(fullName);
+
+    return (
+        <header
+            className="w-full"
+            style={{ background: "linear-gradient(135deg, #0144a0 0%, #0255c5 100%)" }}
+        >
+            <div className="mx-auto flex h-20 max-w-6xl items-center justify-between gap-4 px-6">
+                <div className="flex min-w-0 items-center gap-3.5">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white/20">
+                        <svg
+                            className="h-6 w-6 text-white"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                            aria-hidden
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M19.428 15.428a2 2 0 00-1.022-.547l-2.384-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"
+                            />
+                        </svg>
+                    </div>
+                    <div className="min-w-0">
+                        <span className="block text-lg font-bold leading-none tracking-tight text-white">
+                            ADAM
+                        </span>
+                        <p className="mt-1 text-xs leading-none text-blue-200">
+                            Diseñador de Casos
+                        </p>
+                    </div>
+                </div>
+
+                <div className="flex items-center gap-2 sm:gap-4">
+                    <button
+                        type="button"
+                        aria-label="Notificaciones"
+                        title="Notificaciones"
+                        className="relative flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 text-white transition-colors hover:bg-white/20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                    >
+                        <Bell className="h-5 w-5" />
+                        <span
+                            aria-hidden
+                            className="absolute -right-0.5 -top-0.5 h-[9px] w-[9px] rounded-full border-2 border-white bg-red-500"
+                        />
+                    </button>
+                    <div className="h-8 w-px bg-white/20" />
+                    <div className="flex min-w-0 items-center gap-3">
+                        <div
+                            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/20 text-[15px] font-extrabold text-white"
+                            style={{ border: "2px solid rgba(255,255,255,0.35)" }}
+                            aria-label={`Iniciales de ${fullName}`}
+                        >
+                            {initials}
+                        </div>
+                        <div className="hidden min-w-0 sm:block">
+                            <p
+                                className="truncate text-[15px] font-semibold leading-tight text-white"
+                                title={fullName}
+                            >
+                                {fullName}
+                            </p>
+                            <p className="mt-0.5 text-xs leading-tight text-blue-200">
+                                {FACULTY_SUBTITLE}
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => void signOut()}
+                        aria-label="Cerrar sesión"
+                        className="inline-flex h-10 shrink-0 items-center justify-center rounded-xl border border-white/20 bg-white/10 px-3 text-sm font-semibold text-white transition-colors hover:bg-white/20 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                    >
+                        <span className="sm:hidden">Salir</span>
+                        <span className="hidden sm:inline">Cerrar sesión</span>
+                    </button>
+                </div>
+            </div>
+        </header>
+    );
+}

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.test.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.test.tsx
@@ -1,0 +1,19 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/shared/test-utils";
+
+vi.mock("./DashboardHeader", () => ({
+    DashboardHeader: () => <div data-testid="dashboard-header">Header</div>,
+}));
+
+import { TeacherDashboardPage } from "./TeacherDashboardPage";
+
+describe("TeacherDashboardPage", () => {
+    it("composes the dashboard header and preserves the page test id", () => {
+        renderWithProviders(<TeacherDashboardPage showToast={vi.fn()} />);
+
+        expect(screen.getByTestId("teacher-dashboard-page")).toBeTruthy();
+        expect(screen.getByTestId("dashboard-header")).toBeTruthy();
+    });
+});

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
@@ -1,6 +1,6 @@
-import { Link } from "react-router-dom";
-import { useAuth } from "@/app/auth/useAuth";
 import type { ShowToast } from "@/shared/Toast";
+
+import { DashboardHeader } from "./DashboardHeader";
 
 interface TeacherDashboardPageProps {
     showToast: ShowToast;
@@ -9,39 +9,12 @@ interface TeacherDashboardPageProps {
 export function TeacherDashboardPage({
     showToast: _showToast,
 }: TeacherDashboardPageProps) {
-    const { actor, signOut } = useAuth();
     void _showToast;
 
     return (
         <div className="min-h-screen bg-[#F0F4F8]" data-testid="teacher-dashboard-page">
-            <header className="border-b border-slate-200 bg-white">
-                <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-4">
-                    <div className="space-y-1">
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
-                            Portal Docente
-                        </p>
-                        <h1 className="text-lg font-semibold text-slate-900">
-                            {actor?.profile.full_name ?? "Docente"}
-                        </h1>
-                    </div>
-                    <div className="flex items-center gap-3">
-                        <Link
-                            to="/teacher"
-                            className="rounded-md bg-[#0144a0] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
-                        >
-                            Crear nuevo caso
-                        </Link>
-                        <button
-                            type="button"
-                            onClick={() => void signOut()}
-                            className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
-                        >
-                            Cerrar sesión
-                        </button>
-                    </div>
-                </div>
-            </header>
-            <main className="mx-auto max-w-6xl px-6 py-8">
+            <DashboardHeader />
+            <main className="mx-auto max-w-6xl space-y-10 px-6 py-9">
                 <div className="rounded-2xl border border-dashed border-slate-300 bg-white px-6 py-10">
                     <p className="text-sm text-slate-500">
                         Teacher Dashboard - WIP


### PR DESCRIPTION
## Summary
- implementa DashboardHeader para /teacher/dashboard replicando el bloque del mockup del Portal Docente
- reemplaza el header provisional de TeacherDashboardPage sin perder la salida visible de sesión
- agrega tests del header y smoke test del page shell

## Why
- #96 pide el header final del dashboard, pero quitar signOut del shell era una regresión funcional
- este cambio preserva la salida de sesión y endurece el layout para nombres largos

## Validation
- 
pm --prefix frontend run test
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run build

Closes #96