### PR TITLE
feat: implement quick actions section for teacher dashboard

### DIFF
--- a/frontend/src/features/teacher-dashboard/QuickActionsSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/QuickActionsSection.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/shared/test-utils";
+
+const navigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+
+    return {
+        ...actual,
+        useNavigate: () => navigate,
+    };
+});
+
+import { QuickActionsSection } from "./QuickActionsSection";
+
+describe("QuickActionsSection", () => {
+    beforeEach(() => {
+        navigate.mockReset();
+        document.body.innerHTML = "";
+    });
+
+    it("renders the three quick action cards", () => {
+        renderWithProviders(<QuickActionsSection showToast={vi.fn()} />);
+
+        expect(screen.getByRole("button", { name: /crear nuevo caso/i })).toBeTruthy();
+        expect(screen.getByRole("button", { name: /gestión de casos/i })).toBeTruthy();
+        expect(screen.getByRole("button", { name: /reportes globales/i })).toBeTruthy();
+        expect(screen.getByText("Genera con ADAM IA")).toBeTruthy();
+        expect(screen.getByText("Administra y edita casos activos")).toBeTruthy();
+        expect(screen.getByText("Próximamente en nuevas versiones")).toBeTruthy();
+    });
+
+    it("navigates to /teacher from the create case card", () => {
+        renderWithProviders(<QuickActionsSection showToast={vi.fn()} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /crear nuevo caso/i }));
+
+        expect(navigate).toHaveBeenCalledWith("/teacher");
+    });
+
+    it("scrolls smoothly to the cases section", () => {
+        const scrollIntoView = vi.fn();
+        const anchor = document.createElement("div");
+        anchor.id = "cases-section";
+        anchor.scrollIntoView = scrollIntoView;
+        document.body.appendChild(anchor);
+
+        renderWithProviders(<QuickActionsSection showToast={vi.fn()} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /gestión de casos/i }));
+
+        expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
+    });
+
+    it("shows the placeholder toast for reports", () => {
+        const showToast = vi.fn();
+
+        renderWithProviders(<QuickActionsSection showToast={showToast} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /reportes globales/i }));
+
+        expect(showToast).toHaveBeenCalledWith(
+            "Reportes Globales - Próximamente en nuevas versiones...",
+            "default",
+        );
+    });
+});

--- a/frontend/src/features/teacher-dashboard/QuickActionsSection.tsx
+++ b/frontend/src/features/teacher-dashboard/QuickActionsSection.tsx
@@ -1,0 +1,120 @@
+import { useNavigate } from "react-router-dom";
+
+import type { ShowToast } from "@/shared/Toast";
+import { DashboardActionCard } from "@/shared/ui/DashboardActionCard";
+
+interface QuickActionsSectionProps {
+    showToast: ShowToast;
+}
+
+function SparklesIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            className="h-5 w-5 text-white"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.8}
+        >
+            <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
+            />
+            <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z"
+            />
+        </svg>
+    );
+}
+
+function ArchiveIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            className="h-5 w-5 text-white"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.8}
+        >
+            <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+            />
+        </svg>
+    );
+}
+
+function ChartIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            className="h-5 w-5 text-white"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.8}
+        >
+            <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+            />
+        </svg>
+    );
+}
+
+export function QuickActionsSection({ showToast }: QuickActionsSectionProps) {
+    const navigate = useNavigate();
+
+    const scrollToCases = () => {
+        document.getElementById("cases-section")?.scrollIntoView({ behavior: "smooth" });
+    };
+
+    return (
+        <section aria-label="Acciones rápidas">
+            <div className="grid grid-cols-1 gap-5 md:grid-cols-3">
+                <DashboardActionCard
+                    title="Crear Nuevo Caso"
+                    subtitle="Genera con ADAM IA"
+                    subtitleClassName="text-blue-100"
+                    gradient="linear-gradient(to bottom right, #06b6d4, #3b82f6, #1d4ed8)"
+                    decorativeBlurLeftClassName="bg-cyan-300/20 group-hover:bg-cyan-300/30"
+                    decorativeBlurRightClassName="bg-white/10 group-hover:bg-white/20"
+                    onClick={() => navigate("/teacher")}
+                    icon={<SparklesIcon />}
+                />
+                <DashboardActionCard
+                    title="Gestión de Casos"
+                    subtitle="Administra y edita casos activos"
+                    subtitleClassName="text-indigo-100"
+                    gradient="linear-gradient(to bottom right, #8b5cf6, #6366f1, #4338ca)"
+                    decorativeBlurLeftClassName="bg-violet-300/20 group-hover:bg-violet-300/30"
+                    decorativeBlurRightClassName="bg-white/10 group-hover:bg-white/20"
+                    onClick={scrollToCases}
+                    icon={<ArchiveIcon />}
+                />
+                <DashboardActionCard
+                    title="Reportes Globales"
+                    subtitle="Próximamente en nuevas versiones"
+                    subtitleClassName="text-emerald-100"
+                    gradient="linear-gradient(to bottom right, #10b981, #14b8a6, #0f766e)"
+                    decorativeBlurLeftClassName="bg-emerald-300/20 group-hover:bg-emerald-300/30"
+                    decorativeBlurRightClassName="bg-white/10 group-hover:bg-white/20"
+                    onClick={() =>
+                        showToast(
+                            "Reportes Globales - Próximamente en nuevas versiones...",
+                            "default",
+                        )
+                    }
+                    icon={<ChartIcon />}
+                />
+            </div>
+        </section>
+    );
+}

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.test.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.test.tsx
@@ -7,13 +7,29 @@ vi.mock("./DashboardHeader", () => ({
     DashboardHeader: () => <div data-testid="dashboard-header">Header</div>,
 }));
 
+const quickActionsSectionSpy = vi.fn();
+
+vi.mock("./QuickActionsSection", () => ({
+    QuickActionsSection: (props: { showToast: (message: string, type?: string) => void }) => {
+        quickActionsSectionSpy(props);
+        return <div data-testid="quick-actions-section">Quick actions</div>;
+    },
+}));
+
 import { TeacherDashboardPage } from "./TeacherDashboardPage";
 
 describe("TeacherDashboardPage", () => {
-    it("composes the dashboard header and preserves the page test id", () => {
-        renderWithProviders(<TeacherDashboardPage showToast={vi.fn()} />);
+    it("composes the dashboard header, quick actions, and cases anchor", () => {
+        const showToast = vi.fn();
+
+        renderWithProviders(<TeacherDashboardPage showToast={showToast} />);
 
         expect(screen.getByTestId("teacher-dashboard-page")).toBeTruthy();
         expect(screen.getByTestId("dashboard-header")).toBeTruthy();
+        expect(screen.getByTestId("quick-actions-section")).toBeTruthy();
+        expect(document.getElementById("cases-section")).toBeTruthy();
+        expect(quickActionsSectionSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ showToast }),
+        );
     });
 });

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
@@ -1,25 +1,21 @@
 import type { ShowToast } from "@/shared/Toast";
 
 import { DashboardHeader } from "./DashboardHeader";
+import { QuickActionsSection } from "./QuickActionsSection";
 
 interface TeacherDashboardPageProps {
     showToast: ShowToast;
 }
 
 export function TeacherDashboardPage({
-    showToast: _showToast,
+    showToast,
 }: TeacherDashboardPageProps) {
-    void _showToast;
-
     return (
         <div className="min-h-screen bg-[#F0F4F8]" data-testid="teacher-dashboard-page">
             <DashboardHeader />
             <main className="mx-auto max-w-6xl space-y-10 px-6 py-9">
-                <div className="rounded-2xl border border-dashed border-slate-300 bg-white px-6 py-10">
-                    <p className="text-sm text-slate-500">
-                        Teacher Dashboard - WIP
-                    </p>
-                </div>
+                <QuickActionsSection showToast={showToast} />
+                <div id="cases-section" aria-hidden="true" className="h-px w-full" />
             </main>
         </div>
     );

--- a/frontend/src/shared/ui/DashboardActionCard.tsx
+++ b/frontend/src/shared/ui/DashboardActionCard.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/shared/utils";
+
+interface DashboardActionCardProps {
+    title: string;
+    subtitle: string;
+    subtitleClassName: string;
+    gradient: string;
+    decorativeBlurLeftClassName: string;
+    decorativeBlurRightClassName: string;
+    icon: ReactNode;
+    onClick: () => void;
+    className?: string;
+}
+
+export function DashboardActionCard({
+    title,
+    subtitle,
+    subtitleClassName,
+    gradient,
+    decorativeBlurLeftClassName,
+    decorativeBlurRightClassName,
+    icon,
+    onClick,
+    className,
+}: DashboardActionCardProps) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={cn(
+                "group relative h-[100px] overflow-hidden rounded-2xl p-5 text-left text-white shadow-lg transition-all duration-200",
+                "hover:scale-[1.02] hover:shadow-2xl active:scale-[0.98]",
+                "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0144a0]",
+                className,
+            )}
+            style={{ background: gradient, borderRadius: 16 }}
+        >
+            <div
+                aria-hidden="true"
+                className="absolute inset-x-0 top-0 h-px rounded-t-2xl bg-gradient-to-r from-transparent via-white/50 to-transparent"
+            />
+            <div
+                aria-hidden="true"
+                className={cn(
+                    "absolute -bottom-5 -right-5 h-24 w-24 rounded-full blur-2xl transition-all duration-500",
+                    decorativeBlurRightClassName,
+                )}
+            />
+            <div
+                aria-hidden="true"
+                className={cn(
+                    "absolute -left-4 -top-4 h-16 w-16 rounded-full blur-xl transition-all duration-500",
+                    decorativeBlurLeftClassName,
+                )}
+            />
+            <div className="relative z-10 flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                    <h3 className="text-[16px] font-bold tracking-tight">{title}</h3>
+                    <p className={cn("mt-1 text-xs font-medium opacity-80", subtitleClassName)}>
+                        {subtitle}
+                    </p>
+                </div>
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-white/20 bg-white/20 backdrop-blur-sm transition-colors group-hover:bg-white/30">
+                    {icon}
+                </div>
+            </div>
+        </button>
+    );
+}


### PR DESCRIPTION
## Summary
- implement the teacher dashboard quick actions section for issue #97 using a shared dashboard action card primitive
- remove the WIP stub from TeacherDashboardPage and mount the new section with a temporary #cases-section anchor
- add focused tests for navigation, smooth scrolling, toast behavior, and page composition

## Validation
- npm --prefix frontend run lint
- npm --prefix frontend run test
- npm --prefix frontend run build

Closes #97