### PR TITLE
[Frontend] Issue 7: CursosActivosSection — CourseCard grid with client-side search

### DIFF
--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -14,6 +14,11 @@ vi.mock("@/features/teacher-auth/TeacherLoginPage", () => ({
 vi.mock("@/features/teacher-dashboard/TeacherDashboardPage", () => ({
     TeacherDashboardPage: () => <div data-testid="teacher-dashboard-page">Teacher dashboard</div>,
 }));
+vi.mock("@/features/teacher-dashboard/TeacherCoursePlaceholderPage", () => ({
+    TeacherCoursePlaceholderPage: () => (
+        <div data-testid="teacher-course-placeholder-page">Teacher course placeholder</div>
+    ),
+}));
 vi.mock("@/features/admin-dashboard/AdminDashboardPage", () => ({
     AdminDashboardPage: () => <div data-testid="admin-dashboard-page">Dashboard admin</div>,
 }));
@@ -170,6 +175,21 @@ describe("App admin shell layout", () => {
 
         expect(await screen.findByTestId("teacher-authoring-page")).toBeTruthy();
         expect(screen.queryByTestId("teacher-dashboard-page")).toBeNull();
+    });
+
+    it("resolves the teacher course placeholder route before the authoring catch-all", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseContext,
+            session: { access_token: "jwt" } as never,
+            actor: teacherActor,
+        });
+
+        renderWithProviders(<App />, {
+            initialEntries: ["/teacher/courses/course-1"],
+        });
+
+        expect(await screen.findByTestId("teacher-course-placeholder-page")).toBeTruthy();
+        expect(screen.queryByTestId("teacher-authoring-page")).toBeNull();
     });
 
     it("redirects a non-teacher actor away from /teacher/dashboard", async () => {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -18,6 +18,11 @@ const TeacherDashboardPage = lazy(() =>
         (module) => ({ default: module.TeacherDashboardPage }),
     ),
 );
+const TeacherCoursePlaceholderPage = lazy(() =>
+    import("@/features/teacher-dashboard/TeacherCoursePlaceholderPage").then(
+        (module) => ({ default: module.TeacherCoursePlaceholderPage }),
+    ),
+);
 const AuthCallbackPage = lazy(() =>
     import("@/features/auth-callback/AuthCallbackPage").then((module) => ({
         default: module.AuthCallbackPage,
@@ -99,6 +104,14 @@ function App() {
                             element={
                                 <RequireRole role="teacher">
                                     <TeacherDashboardPage showToast={showToast} />
+                                </RequireRole>
+                            }
+                        />
+                        <Route
+                            path="/teacher/courses/:courseId"
+                            element={
+                                <RequireRole role="teacher">
+                                    <TeacherCoursePlaceholderPage />
                                 </RequireRole>
                             }
                         />

--- a/frontend/src/app/global.css
+++ b/frontend/src/app/global.css
@@ -249,6 +249,18 @@
   }
 }
 
+@keyframes cardIn {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* Animation Classes */
 .animate-fadeIn {
   animation: fadeIn 0.5s ease-out forwards;

--- a/frontend/src/features/teacher-dashboard/CursosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CursosActivosSection.test.tsx
@@ -1,0 +1,184 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/shared/test-utils";
+
+const navigate = vi.fn();
+const useTeacherCourses = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+
+    return {
+        ...actual,
+        useNavigate: () => navigate,
+    };
+});
+
+vi.mock("./useTeacherDashboard", () => ({
+    useTeacherCourses: () => useTeacherCourses(),
+}));
+
+import { CursosActivosSection } from "./CursosActivosSection";
+
+const courses = [
+    {
+        id: "course-1",
+        title: "Gerencia Estratégica y Modelos de Negocio",
+        code: "GTD-GEME-01",
+        semester: "2026-I",
+        academic_level: "Especialización",
+        status: "active" as const,
+        students_count: 24,
+        active_cases_count: 3,
+    },
+    {
+        id: "course-2",
+        title: "Gobernanza de Datos",
+        code: "GTD-GODA-01",
+        semester: "2026-I",
+        academic_level: "Especialización",
+        status: "inactive" as const,
+        students_count: 18,
+        active_cases_count: 0,
+    },
+];
+
+describe("CursosActivosSection", () => {
+    beforeEach(() => {
+        navigate.mockReset();
+        useTeacherCourses.mockReset();
+    });
+
+    it("renders the heading, semester badge, and search input", () => {
+        useTeacherCourses.mockReturnValue({
+            data: { courses, total: courses.length },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CursosActivosSection />);
+
+        expect(
+            screen.getByRole("heading", { name: "Cursos Activos", level: 2 }),
+        ).toBeTruthy();
+        expect(screen.getByText("2026-I")).toBeTruthy();
+        expect(screen.getByRole("searchbox", { name: "Buscar curso" })).toBeTruthy();
+    });
+
+    it("shows two skeleton cards while loading", () => {
+        useTeacherCourses.mockReturnValue({
+            data: undefined,
+            isLoading: true,
+            isError: false,
+        });
+
+        const { container } = renderWithProviders(<CursosActivosSection />);
+
+        expect(container.querySelectorAll(".animate-pulse")).toHaveLength(2);
+    });
+
+    it("shows an error message when the query fails", () => {
+        useTeacherCourses.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+        });
+
+        renderWithProviders(<CursosActivosSection />);
+
+        expect(screen.getByRole("alert")).toHaveTextContent(
+            "No se pudieron cargar los cursos. Intenta refrescar la página.",
+        );
+    });
+
+    it("shows the empty state when there are no assigned courses", () => {
+        useTeacherCourses.mockReturnValue({
+            data: { courses: [], total: 0 },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CursosActivosSection />);
+
+        expect(screen.getByText("No tienes cursos asignados.")).toBeTruthy();
+        expect(screen.getByText("—")).toBeTruthy();
+    });
+
+    it("shows a search-specific empty state when there are no matches", () => {
+        useTeacherCourses.mockReturnValue({
+            data: { courses, total: courses.length },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CursosActivosSection />);
+
+        fireEvent.change(screen.getByRole("searchbox", { name: "Buscar curso" }), {
+            target: { value: "finanzas" },
+        });
+
+        expect(screen.getByText("Sin resultados para esa búsqueda.")).toBeTruthy();
+    });
+
+    it("renders active and inactive course cards with the correct CTAs", () => {
+        useTeacherCourses.mockReturnValue({
+            data: { courses, total: courses.length },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CursosActivosSection />);
+
+        expect(screen.getByText("Gerencia Estratégica y Modelos de Negocio")).toBeTruthy();
+        expect(screen.getByText("Gobernanza de Datos")).toBeTruthy();
+        expect(screen.getByText("Activo")).toBeTruthy();
+        expect(screen.getByText("Inactivo")).toBeTruthy();
+        expect(screen.getByRole("button", { name: /entrar al curso/i })).toBeTruthy();
+        expect(screen.getByRole("button", { name: /ver historial/i })).toBeDisabled();
+    });
+
+    it("filters courses case-insensitively by title", () => {
+        useTeacherCourses.mockReturnValue({
+            data: { courses, total: courses.length },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CursosActivosSection />);
+
+        fireEvent.change(screen.getByRole("searchbox", { name: "Buscar curso" }), {
+            target: { value: "gobernanza" },
+        });
+
+        expect(screen.getByText("Gobernanza de Datos")).toBeTruthy();
+        expect(screen.queryByText("Gerencia Estratégica y Modelos de Negocio")).toBeNull();
+    });
+
+    it("navigates to the teacher course placeholder route from an active card", () => {
+        useTeacherCourses.mockReturnValue({
+            data: { courses, total: courses.length },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CursosActivosSection />);
+
+        fireEvent.click(screen.getByRole("button", { name: /entrar al curso/i }));
+
+        expect(navigate).toHaveBeenCalledWith("/teacher/courses/course-1");
+    });
+
+    it("falls back to a dash semester badge when there are no courses", () => {
+        useTeacherCourses.mockReturnValue({
+            data: { courses: [], total: 0 },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CursosActivosSection />);
+
+        const heading = screen.getByRole("heading", { name: "Cursos Activos", level: 2 });
+        expect(heading.parentElement).toHaveTextContent("Cursos Activos—");
+    });
+});

--- a/frontend/src/features/teacher-dashboard/CursosActivosSection.tsx
+++ b/frontend/src/features/teacher-dashboard/CursosActivosSection.tsx
@@ -1,0 +1,276 @@
+import { useDeferredValue, useMemo, useState } from "react";
+import { Calendar, Search } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+import type { TeacherCourseItem, TeacherCourseStatus } from "@/shared/adam-types";
+
+import { useTeacherCourses } from "./useTeacherDashboard";
+
+function StatusBadge({ status }: { status: TeacherCourseStatus }) {
+    const statusMeta = {
+        active: {
+            className: "bg-[#dcfce7] text-[#15803d]",
+            label: "Activo",
+        },
+        inactive: {
+            className: "bg-[#f1f5f9] text-[#64748b]",
+            label: "Inactivo",
+        },
+    } as const;
+
+    const meta = statusMeta[status];
+
+    return (
+        <span
+            className={`inline-flex items-center gap-1 rounded-[7px] px-[10px] py-1 text-[11.5px] font-semibold whitespace-nowrap ${meta.className}`}
+        >
+            {meta.label}
+        </span>
+    );
+}
+
+function StatPill({ value, label }: { value: string | number; label: string }) {
+    return (
+        <div className="stat-pill flex min-w-0 flex-1 flex-col items-center justify-center rounded-[12px] border border-[#f1f5f9] bg-[#f8fafc] px-4 py-[10px]">
+            <span className="text-[20px] font-extrabold leading-none text-[#0f172a]">
+                {value}
+            </span>
+            <span className="mt-[3px] text-[11.5px] font-semibold whitespace-nowrap text-[#64748b]">
+                {label}
+            </span>
+        </div>
+    );
+}
+
+function AccentBar({ status }: { status: TeacherCourseStatus }) {
+    const background =
+        status === "active"
+            ? "linear-gradient(to bottom, #0144a0, #60a5fa)"
+            : "#e2e8f0";
+
+    return (
+        <div
+            aria-hidden="true"
+            className="absolute top-0 bottom-0 left-0 w-[5px] rounded-l-[18px]"
+            style={{ background }}
+        />
+    );
+}
+
+interface CourseCardProps {
+    course: TeacherCourseItem;
+}
+
+function CourseCard({ course }: CourseCardProps) {
+    const navigate = useNavigate();
+    const isActive = course.status === "active";
+    // TODO: add "upcoming" variant when backend supports it
+
+    return (
+        <article
+            className={[
+                "course-card relative overflow-hidden rounded-[18px] border-[1.5px] border-[#e2e8f0] bg-white transition-all duration-[180ms]",
+                isActive
+                    ? "hover:-translate-y-0.5 hover:border-[#bfdbfe] hover:shadow-[0_12px_40px_-8px_rgba(1,68,160,0.13)]"
+                    : "opacity-75",
+            ].join(" ")}
+        >
+            <AccentBar status={course.status} />
+
+            <div className="p-6 pl-8">
+                <div className="mb-4 flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                        <div className="mb-2 flex flex-wrap items-center gap-2">
+                            <span className="inline-flex items-center rounded-[7px] bg-[#e8f0fe] px-[10px] py-1 text-[11.5px] font-semibold text-[#0144a0]">
+                                {course.academic_level}
+                            </span>
+                            <span className="text-[11.5px] font-medium text-slate-400">
+                                {course.semester} · {course.code}
+                            </span>
+                        </div>
+                        <h3 className="text-[16px] font-bold leading-snug text-slate-900">
+                            {course.title}
+                        </h3>
+                    </div>
+                    <StatusBadge status={course.status} />
+                </div>
+
+                <div className="mb-5 flex w-full items-center gap-3">
+                    <StatPill value={course.students_count} label="Estudiantes" />
+                    <StatPill value={course.active_cases_count} label="Casos asignados" />
+                    <StatPill value="—" label="Promedio" />
+                </div>
+
+                <div className="border-t border-slate-100 pt-5">
+                    {isActive ? (
+                        <button
+                            type="button"
+                            onClick={() => {
+                                navigate(`/teacher/courses/${course.id}`);
+                            }}
+                            className="inline-flex w-full items-center justify-center gap-[7px] rounded-[11px] px-5 py-[10px] text-[14px] font-bold text-white transition-all"
+                            style={{
+                                background: "#0144a0",
+                                boxShadow: "0 2px 8px rgba(1,68,160,0.25)",
+                            }}
+                        >
+                            <svg
+                                aria-hidden="true"
+                                className="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M13 7l5 5m0 0l-5 5m5-5H6"
+                                />
+                            </svg>
+                            Entrar al curso
+                        </button>
+                    ) : (
+                        <button
+                            type="button"
+                            disabled
+                            className="inline-flex w-full cursor-not-allowed items-center justify-center gap-[7px] rounded-[11px] border-[1.5px] border-[#e2e8f0] bg-[#f8fafc] px-5 py-[10px] text-[14px] font-semibold text-slate-500"
+                        >
+                            <svg
+                                aria-hidden="true"
+                                className="h-5 w-5"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                                />
+                            </svg>
+                            Ver historial
+                        </button>
+                    )}
+                </div>
+            </div>
+        </article>
+    );
+}
+
+function CourseCardSkeleton() {
+    return (
+        <div
+            aria-hidden="true"
+            className="h-[260px] animate-pulse rounded-[18px] bg-slate-200"
+        />
+    );
+}
+
+export function CursosActivosSection() {
+    const [search, setSearch] = useState("");
+    const deferredSearch = useDeferredValue(search);
+    const { data, error, isLoading, isError } = useTeacherCourses();
+
+    const courses = useMemo(() => data?.courses ?? [], [data]);
+    const normalizedSearch = deferredSearch.trim().toLowerCase();
+    const filteredCourses = useMemo(
+        () =>
+            courses.filter((course) =>
+                course.title.toLowerCase().includes(normalizedSearch),
+            ),
+        [courses, normalizedSearch],
+    );
+    const semesterLabel =
+        filteredCourses[0]?.semester ??
+        courses.find((course) => course.status === "active")?.semester ??
+        courses[0]?.semester ??
+        "—";
+    const errorMessage =
+        error instanceof Error
+            ? error.message
+            : "No se pudieron cargar los cursos. Intenta refrescar la página.";
+
+    return (
+        <section aria-labelledby="cursos-heading">
+            <div className="mb-6 flex items-center gap-4">
+                <div className="flex items-center gap-3 whitespace-nowrap">
+                    <h2
+                        id="cursos-heading"
+                        className="text-2xl font-bold tracking-tight text-slate-900"
+                    >
+                        Cursos Activos
+                    </h2>
+                    <div className="flex items-center gap-1.5 rounded-full border border-indigo-100 bg-indigo-50 px-3 py-1 text-[12px] font-bold text-indigo-700">
+                        <Calendar aria-hidden="true" className="h-3.5 w-3.5" />
+                        {semesterLabel}
+                    </div>
+                </div>
+                <div
+                    aria-hidden="true"
+                    className="ml-2 h-[2px] flex-1 rounded-full"
+                    style={{
+                        background: "linear-gradient(to right, #0144a0, transparent)",
+                    }}
+                />
+            </div>
+
+            <div className="relative mb-6">
+                <Search
+                    aria-hidden="true"
+                    className="absolute top-1/2 left-4 h-5 w-5 -translate-y-1/2 text-slate-400"
+                />
+                <input
+                    type="search"
+                    aria-label="Buscar curso"
+                    placeholder="Buscar curso..."
+                    value={search}
+                    onChange={(event) => {
+                        setSearch(event.target.value);
+                    }}
+                    className="w-full rounded-[11px] border-[1.5px] border-[#e2e8f0] bg-white py-[11px] pr-4 pl-[38px] text-[14.5px] text-slate-900 shadow-sm outline-none transition-[border-color,box-shadow] hover:shadow focus:border-[#0144a0] focus:shadow-[0_0_0_3px_rgba(1,68,160,0.1)]"
+                />
+            </div>
+
+            {isLoading ? (
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                    <CourseCardSkeleton />
+                    <CourseCardSkeleton />
+                </div>
+            ) : null}
+
+            {!isLoading && isError ? (
+                <p role="alert" className="text-sm text-red-600">
+                    {errorMessage}
+                </p>
+            ) : null}
+
+            {!isLoading && !isError && filteredCourses.length === 0 ? (
+                <p aria-live="polite" className="text-sm text-slate-500">
+                    {normalizedSearch
+                        ? "Sin resultados para esa búsqueda."
+                        : "No tienes cursos asignados."}
+                </p>
+            ) : null}
+
+            {!isLoading && !isError && filteredCourses.length > 0 ? (
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                    {filteredCourses.map((course, index) => (
+                        <div
+                            key={course.id}
+                            className="fade-card"
+                            style={{
+                                opacity: 0,
+                                animation: "cardIn 0.35s ease forwards",
+                                animationDelay: `${index * 0.07}s`,
+                            }}
+                        >
+                            <CourseCard course={course} />
+                        </div>
+                    ))}
+                </div>
+            ) : null}
+        </section>
+    );
+}

--- a/frontend/src/features/teacher-dashboard/TeacherCoursePlaceholderPage.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherCoursePlaceholderPage.tsx
@@ -1,0 +1,48 @@
+import { useNavigate, useParams } from "react-router-dom";
+
+export function TeacherCoursePlaceholderPage() {
+    const navigate = useNavigate();
+    const { courseId } = useParams<{ courseId: string }>();
+
+    return (
+        <div className="min-h-screen bg-[#F0F4F8]">
+            <div
+                className="w-full"
+                style={{ background: "linear-gradient(135deg, #0144a0 0%, #0255c5 100%)" }}
+            >
+                <div className="mx-auto max-w-6xl px-6 py-10">
+                    <p className="text-sm font-semibold uppercase tracking-[0.12em] text-blue-100">
+                        Portal Docente
+                    </p>
+                    <h1 className="mt-2 text-3xl font-bold tracking-tight text-white">
+                        Curso en preparación
+                    </h1>
+                    <p className="mt-3 max-w-2xl text-sm text-blue-100">
+                        La vista detallada del curso
+                        {courseId ? ` ${courseId}` : ""} todavía no está disponible.
+                    </p>
+                </div>
+            </div>
+
+            <main className="mx-auto max-w-6xl px-6 py-9">
+                <section className="rounded-[18px] border border-[#e2e8f0] bg-white p-8 shadow-sm">
+                    <h2 className="text-xl font-bold tracking-tight text-slate-900">
+                        Esta ruta ya está reservada
+                    </h2>
+                    <p className="mt-3 max-w-2xl text-sm text-slate-600">
+                        El dashboard docente puede navegar de forma segura sin caer en el
+                        authoring por error. Cuando se implemente el detalle real del curso,
+                        esta pantalla se reemplaza sin romper el enlace existente.
+                    </p>
+                    <button
+                        type="button"
+                        onClick={() => navigate("/teacher/dashboard")}
+                        className="mt-6 inline-flex items-center justify-center rounded-[11px] bg-[#0144a0] px-5 py-[10px] text-[14px] font-bold text-white"
+                    >
+                        Volver al dashboard
+                    </button>
+                </section>
+            </main>
+        </div>
+    );
+}

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.test.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.test.tsx
@@ -16,10 +16,14 @@ vi.mock("./QuickActionsSection", () => ({
     },
 }));
 
+vi.mock("./CursosActivosSection", () => ({
+    CursosActivosSection: () => <div data-testid="cursos-activos-section">Cursos</div>,
+}));
+
 import { TeacherDashboardPage } from "./TeacherDashboardPage";
 
 describe("TeacherDashboardPage", () => {
-    it("composes the dashboard header, quick actions, and cases anchor", () => {
+    it("composes the dashboard header, quick actions, courses section, and cases anchor", () => {
         const showToast = vi.fn();
 
         renderWithProviders(<TeacherDashboardPage showToast={showToast} />);
@@ -27,6 +31,7 @@ describe("TeacherDashboardPage", () => {
         expect(screen.getByTestId("teacher-dashboard-page")).toBeTruthy();
         expect(screen.getByTestId("dashboard-header")).toBeTruthy();
         expect(screen.getByTestId("quick-actions-section")).toBeTruthy();
+        expect(screen.getByTestId("cursos-activos-section")).toBeTruthy();
         expect(document.getElementById("cases-section")).toBeTruthy();
         expect(quickActionsSectionSpy).toHaveBeenCalledWith(
             expect.objectContaining({ showToast }),

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
@@ -1,5 +1,6 @@
 import type { ShowToast } from "@/shared/Toast";
 
+import { CursosActivosSection } from "./CursosActivosSection";
 import { DashboardHeader } from "./DashboardHeader";
 import { QuickActionsSection } from "./QuickActionsSection";
 
@@ -15,6 +16,7 @@ export function TeacherDashboardPage({
             <DashboardHeader />
             <main className="mx-auto max-w-6xl space-y-10 px-6 py-9">
                 <QuickActionsSection showToast={showToast} />
+                <CursosActivosSection />
                 <div id="cases-section" aria-hidden="true" className="h-px w-full" />
             </main>
         </div>


### PR DESCRIPTION
## Summary
- implement CursosActivosSection with client-side search, loading/error/empty states, and course cards from useTeacherCourses()
- integrate the section into TeacherDashboardPage and add coverage for section behavior and page composition
- reserve /teacher/courses/:courseId with a safe placeholder route so course-card navigation does not fall into the authoring catch-all

## Validation
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run test
- 
pm --prefix frontend run build

Closes #98