### PR TITLE
feat(frontend): implement CasosActivosSection with client-side pagination

### DIFF
--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
@@ -58,6 +58,10 @@ describe("CasosActivosSection", () => {
         expect(screen.getByText("Cursos / Asignaciones")).toBeTruthy();
         expect(screen.getByText("Deadline")).toBeTruthy();
         expect(screen.getByText("Acciones")).toBeTruthy();
+        expect(screen.getByRole("columnheader", { name: "Caso" })).toHaveAttribute(
+            "scope",
+            "col",
+        );
         expect(screen.getByText("Mostrando 3 de 3 casos activos")).toBeTruthy();
         expect(screen.getByText("—")).toBeTruthy();
         expect(document.getElementById("cases-section")).toBeTruthy();
@@ -86,7 +90,9 @@ describe("CasosActivosSection", () => {
 
         const { rerender } = renderWithProviders(<CasosActivosSection showToast={vi.fn()} />);
 
+        expect(screen.getByRole("status")).toBeTruthy();
         expect(screen.getByText("Cargando casos...")).toBeTruthy();
+        expect(screen.getAllByRole("rowgroup")[1]).toHaveAttribute("aria-busy", "true");
 
         useTeacherCases.mockReturnValue({
             data: undefined,
@@ -96,6 +102,7 @@ describe("CasosActivosSection", () => {
 
         rerender(<CasosActivosSection showToast={vi.fn()} />);
 
+        expect(screen.getByRole("alert")).toBeTruthy();
         expect(screen.getByText("Error al cargar casos. Intenta refrescar la página.")).toBeTruthy();
 
         useTeacherCases.mockReturnValue({
@@ -106,7 +113,9 @@ describe("CasosActivosSection", () => {
 
         rerender(<CasosActivosSection showToast={vi.fn()} />);
 
+        expect(screen.getByRole("status")).toBeTruthy();
         expect(screen.getByText("No hay casos activos con deadline vigente.")).toBeTruthy();
+        expect(screen.getAllByRole("rowgroup")[1]).toHaveAttribute("aria-busy", "false");
     });
 
     it("renders deadline badge variants", () => {

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
@@ -1,0 +1,215 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TeacherCaseItem } from "@/shared/adam-types";
+import { renderWithProviders } from "@/shared/test-utils";
+
+const navigate = vi.fn();
+const useTeacherCases = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+
+    return {
+        ...actual,
+        useNavigate: () => navigate,
+    };
+});
+
+vi.mock("./useTeacherDashboard", () => ({
+    useTeacherCases: () => useTeacherCases(),
+}));
+
+import { CasosActivosSection } from "./CasosActivosSection";
+
+function createCase(index: number, overrides?: Partial<TeacherCaseItem>): TeacherCaseItem {
+    return {
+        id: `case-${index}`,
+        title: `Caso ${index}`,
+        deadline: "2026-12-01T00:00:00Z",
+        status: "published",
+        course_codes: ["GTD-GEME-01"],
+        days_remaining: 12,
+        ...overrides,
+    };
+}
+
+describe("CasosActivosSection", () => {
+    beforeEach(() => {
+        navigate.mockReset();
+        useTeacherCases.mockReset();
+    });
+
+    it("renders section shell, columns, and create case button", () => {
+        useTeacherCases.mockReturnValue({
+            data: {
+                cases: [createCase(1), createCase(2, { course_codes: [] }), createCase(3)],
+                total: 3,
+            },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CasosActivosSection showToast={vi.fn()} />);
+
+        expect(screen.getByRole("heading", { name: "Casos Activos", level: 2 })).toBeTruthy();
+        expect(screen.getByRole("button", { name: /crear nuevo caso/i })).toBeTruthy();
+        expect(screen.getByText("Caso")).toBeTruthy();
+        expect(screen.getByText("Cursos / Asignaciones")).toBeTruthy();
+        expect(screen.getByText("Deadline")).toBeTruthy();
+        expect(screen.getByText("Acciones")).toBeTruthy();
+        expect(screen.getByText("Mostrando 3 de 3 casos activos")).toBeTruthy();
+        expect(screen.getByText("—")).toBeTruthy();
+        expect(document.getElementById("cases-section")).toBeTruthy();
+    });
+
+    it("navigates to /teacher from create case button", () => {
+        useTeacherCases.mockReturnValue({
+            data: { cases: [createCase(1)], total: 1 },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CasosActivosSection showToast={vi.fn()} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /crear nuevo caso/i }));
+
+        expect(navigate).toHaveBeenCalledWith("/teacher");
+    });
+
+    it("renders loading, error and empty states", () => {
+        useTeacherCases.mockReturnValue({
+            data: undefined,
+            isLoading: true,
+            isError: false,
+        });
+
+        const { rerender } = renderWithProviders(<CasosActivosSection showToast={vi.fn()} />);
+
+        expect(screen.getByText("Cargando casos...")).toBeTruthy();
+
+        useTeacherCases.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+        });
+
+        rerender(<CasosActivosSection showToast={vi.fn()} />);
+
+        expect(screen.getByText("Error al cargar casos. Intenta refrescar la página.")).toBeTruthy();
+
+        useTeacherCases.mockReturnValue({
+            data: { cases: [], total: 0 },
+            isLoading: false,
+            isError: false,
+        });
+
+        rerender(<CasosActivosSection showToast={vi.fn()} />);
+
+        expect(screen.getByText("No hay casos activos con deadline vigente.")).toBeTruthy();
+    });
+
+    it("renders deadline badge variants", () => {
+        useTeacherCases.mockReturnValue({
+            data: {
+                cases: [
+                    createCase(1, { days_remaining: null }),
+                    createCase(2, { days_remaining: 0 }),
+                    createCase(3, { days_remaining: 4 }),
+                    createCase(4, { days_remaining: 6 }),
+                ],
+                total: 4,
+            },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CasosActivosSection showToast={vi.fn()} />);
+
+        const noDate = screen.getByText("Sin fecha");
+        const today = screen.getByText("Hoy");
+        const urgent = screen.getByText("4 días");
+        const normal = screen.getByText("6 días");
+
+        expect(noDate.className).toContain("text-slate-400");
+        expect(today.className).toContain("bg-[#fee2e2]");
+        expect(urgent.className).toContain("bg-[#fee2e2]");
+        expect(normal.className).toContain("bg-[#e8f0fe]");
+    });
+
+    it("triggers placeholder toasts from row actions", () => {
+        const showToast = vi.fn();
+
+        useTeacherCases.mockReturnValue({
+            data: { cases: [createCase(1)], total: 1 },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CasosActivosSection showToast={showToast} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Ver Caso" }));
+        fireEvent.click(screen.getByRole("button", { name: "Entregas" }));
+        fireEvent.click(screen.getByRole("button", { name: "Editar" }));
+
+        expect(showToast).toHaveBeenCalledTimes(3);
+        expect(showToast).toHaveBeenNthCalledWith(1, "Vista disponible próximamente", "default");
+        expect(showToast).toHaveBeenNthCalledWith(2, "Vista disponible próximamente", "default");
+        expect(showToast).toHaveBeenNthCalledWith(3, "Vista disponible próximamente", "default");
+    });
+
+    it("handles client-side pagination and button boundaries", () => {
+        useTeacherCases.mockReturnValue({
+            data: {
+                cases: Array.from({ length: 12 }, (_, index) => createCase(index + 1)),
+                total: 12,
+            },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CasosActivosSection showToast={vi.fn()} />);
+
+        const prevButton = screen.getByRole("button", { name: "Página anterior" });
+        const nextButton = screen.getByRole("button", { name: "Página siguiente" });
+
+        expect(screen.getByText("Mostrando 10 de 12 casos activos")).toBeTruthy();
+        expect(prevButton).toBeDisabled();
+        expect(nextButton).not.toBeDisabled();
+
+        fireEvent.click(nextButton);
+
+        expect(screen.getByText("Mostrando 2 de 12 casos activos")).toBeTruthy();
+        expect(screen.getByText("Caso 12")).toBeTruthy();
+        expect(prevButton).not.toBeDisabled();
+        expect(nextButton).toBeDisabled();
+    });
+
+    it("resets to page 0 only when dataset changes", () => {
+        const showToast = vi.fn();
+        let currentCases = Array.from({ length: 12 }, (_, index) => createCase(index + 1));
+
+        useTeacherCases.mockImplementation(() => ({
+            data: { cases: currentCases, total: currentCases.length },
+            isLoading: false,
+            isError: false,
+        }));
+
+        const { rerender } = renderWithProviders(<CasosActivosSection showToast={showToast} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Página siguiente" }));
+        expect(screen.getByText("Mostrando 2 de 12 casos activos")).toBeTruthy();
+
+        rerender(<CasosActivosSection showToast={showToast} />);
+        expect(screen.getByText("Mostrando 2 de 12 casos activos")).toBeTruthy();
+
+        currentCases = Array.from({ length: 15 }, (_, index) =>
+            createCase(index + 1, { title: `Caso nuevo ${index + 1}` }),
+        );
+
+        rerender(<CasosActivosSection showToast={showToast} />);
+
+        expect(screen.getByText("Mostrando 10 de 15 casos activos")).toBeTruthy();
+        expect(screen.getByRole("button", { name: "Página anterior" })).toBeDisabled();
+    });
+});

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.tsx
@@ -13,18 +13,16 @@ const CASES_LOAD_ERROR_MSG = "Error al cargar casos. Intenta refrescar la págin
 const EMPTY_CASES: TeacherCaseItem[] = [];
 
 function buildCasesSignature(cases: TeacherCaseItem[]): string {
-    return cases
-        .map((item) =>
-            [
-                item.id,
-                item.title,
-                item.deadline ?? "null",
-                item.status,
-                item.days_remaining ?? "null",
-                item.course_codes.join(","),
-            ].join("|"),
-        )
-        .join("||");
+    return JSON.stringify(
+        cases.map((item) => [
+            item.id,
+            item.title,
+            item.deadline,
+            item.status,
+            item.days_remaining,
+            item.course_codes,
+        ]),
+    );
 }
 
 function DeadlineBadge({ days }: { days: number | null }) {
@@ -217,6 +215,7 @@ export function CasosActivosSection({ showToast }: CasosActivosSectionProps) {
                                 ] as const).map((column) => (
                                     <th
                                         key={column}
+                                        scope="col"
                                         className={[
                                             "px-6 py-4 text-[14px] font-bold tracking-wide",
                                             column === "Acciones" ? "text-right" : "text-left",
@@ -227,10 +226,18 @@ export function CasosActivosSection({ showToast }: CasosActivosSectionProps) {
                                 ))}
                             </tr>
                         </thead>
-                        <tbody className="divide-y divide-slate-100 text-[15px] text-slate-700">
+                        <tbody
+                            aria-busy={isLoading}
+                            className="divide-y divide-slate-100 text-[15px] text-slate-700"
+                        >
                             {isLoading ? (
                                 <tr>
-                                    <td className="px-6 py-8 text-center text-sm text-slate-400" colSpan={4}>
+                                    <td
+                                        role="status"
+                                        aria-live="polite"
+                                        className="px-6 py-8 text-center text-sm text-slate-400"
+                                        colSpan={4}
+                                    >
                                         Cargando casos...
                                     </td>
                                 </tr>
@@ -238,7 +245,12 @@ export function CasosActivosSection({ showToast }: CasosActivosSectionProps) {
 
                             {!isLoading && isError ? (
                                 <tr>
-                                    <td className="px-6 py-8 text-center text-sm text-red-600" colSpan={4}>
+                                    <td
+                                        role="alert"
+                                        aria-live="assertive"
+                                        className="px-6 py-8 text-center text-sm text-red-600"
+                                        colSpan={4}
+                                    >
                                         {CASES_LOAD_ERROR_MSG}
                                     </td>
                                 </tr>
@@ -246,7 +258,12 @@ export function CasosActivosSection({ showToast }: CasosActivosSectionProps) {
 
                             {!isLoading && !isError && pageCases.length === 0 ? (
                                 <tr>
-                                    <td className="px-6 py-8 text-center text-sm text-slate-400" colSpan={4}>
+                                    <td
+                                        role="status"
+                                        aria-live="polite"
+                                        className="px-6 py-8 text-center text-sm text-slate-400"
+                                        colSpan={4}
+                                    >
                                         No hay casos activos con deadline vigente.
                                     </td>
                                 </tr>

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.tsx
@@ -1,0 +1,298 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+import type { TeacherCaseItem } from "@/shared/adam-types";
+import type { ShowToast } from "@/shared/Toast";
+
+import { useTeacherCases } from "./useTeacherDashboard";
+
+const PAGE_SIZE = 10;
+const PLACEHOLDER_MSG = "Vista disponible próximamente";
+const CASES_LOAD_ERROR_MSG = "Error al cargar casos. Intenta refrescar la página.";
+const EMPTY_CASES: TeacherCaseItem[] = [];
+
+function buildCasesSignature(cases: TeacherCaseItem[]): string {
+    return cases
+        .map((item) =>
+            [
+                item.id,
+                item.title,
+                item.deadline ?? "null",
+                item.status,
+                item.days_remaining ?? "null",
+                item.course_codes.join(","),
+            ].join("|"),
+        )
+        .join("||");
+}
+
+function DeadlineBadge({ days }: { days: number | null }) {
+    if (days === null) {
+        return <span className="text-sm font-medium text-slate-400">Sin fecha</span>;
+    }
+
+    const isUrgent = days <= 5;
+
+    return (
+        <span
+            className={[
+                "inline-flex items-center rounded-[7px] border px-[10px] py-1 text-[11.5px] font-semibold whitespace-nowrap",
+                isUrgent
+                    ? "border-red-100 bg-[#fee2e2] text-[#b91c1c]"
+                    : "border-blue-100 bg-[#e8f0fe] text-[#0144a0]",
+            ].join(" ")}
+        >
+            {days === 0 ? "Hoy" : `${days} día${days === 1 ? "" : "s"}`}
+        </span>
+    );
+}
+
+interface CasoRowProps {
+    caso: TeacherCaseItem;
+    showToast: ShowToast;
+}
+
+function CasoRow({ caso, showToast }: CasoRowProps) {
+    const handleViewCase = (id: string) => {
+        void id;
+        showToast(PLACEHOLDER_MSG, "default");
+    };
+
+    const handleDeliverables = (id: string) => {
+        void id;
+        showToast(PLACEHOLDER_MSG, "default");
+    };
+
+    const handleEdit = (id: string) => {
+        void id;
+        showToast(PLACEHOLDER_MSG, "default");
+    };
+
+    return (
+        <tr className="group transition-colors hover:bg-slate-50">
+            <td className="px-6 py-5 align-middle">
+                <div className="text-[15px] font-bold text-slate-900">{caso.title}</div>
+                <div className="mt-1 text-[12.5px] text-slate-400">{caso.status}</div>
+            </td>
+            <td className="px-6 py-5 align-middle">
+                {caso.course_codes.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                        {caso.course_codes.map((code, index) => (
+                            <span
+                                key={`${caso.id}-${code}-${index}`}
+                                className="inline-flex items-center rounded-[7px] bg-[#e8f0fe] px-[10px] py-1 text-[11.5px] font-semibold text-[#0144a0]"
+                            >
+                                {code}
+                            </span>
+                        ))}
+                    </div>
+                ) : (
+                    <span className="text-slate-400">—</span>
+                )}
+            </td>
+            <td className="px-6 py-5 align-middle">
+                <DeadlineBadge days={caso.days_remaining} />
+            </td>
+            <td className="px-6 py-5 align-middle">
+                <div className="flex items-center justify-end gap-2.5 opacity-90 transition-opacity group-hover:opacity-100">
+                    <button
+                        type="button"
+                        onClick={() => {
+                            handleViewCase(caso.id);
+                        }}
+                        className="inline-flex h-9 items-center justify-center gap-1.5 rounded-[9px] border border-indigo-100 bg-indigo-50 px-3.5 py-2 text-[13px] font-semibold text-indigo-600 transition-all hover:border-indigo-200 hover:bg-indigo-100 hover:shadow-sm"
+                    >
+                        Ver Caso
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            handleDeliverables(caso.id);
+                        }}
+                        className="inline-flex h-9 items-center justify-center gap-1.5 rounded-[9px] border-none bg-gradient-to-r from-blue-600 to-indigo-600 px-3.5 py-2 text-[13px] font-bold text-white shadow-md shadow-blue-500/20 transition-all hover:scale-[1.02] hover:shadow-lg hover:shadow-blue-500/30"
+                    >
+                        Entregas
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            handleEdit(caso.id);
+                        }}
+                        className="inline-flex h-9 items-center justify-center gap-1.5 rounded-[9px] border border-amber-100 bg-amber-50 px-3.5 py-2 text-[13px] font-semibold text-amber-600 transition-all hover:border-amber-200 hover:bg-amber-100 hover:shadow-sm"
+                    >
+                        Editar
+                    </button>
+                </div>
+            </td>
+        </tr>
+    );
+}
+
+interface CasosActivosSectionProps {
+    showToast: ShowToast;
+}
+
+export function CasosActivosSection({ showToast }: CasosActivosSectionProps) {
+    const navigate = useNavigate();
+    const [page, setPage] = useState(0);
+    const { data, isLoading, isError } = useTeacherCases();
+
+    const allCases = data?.cases ?? EMPTY_CASES;
+    const totalCases = allCases.length;
+    const totalPages = Math.max(1, Math.ceil(totalCases / PAGE_SIZE));
+    const currentPage = Math.min(page, totalPages - 1);
+    const casesSignature = useMemo(() => buildCasesSignature(allCases), [allCases]);
+    const previousCasesSignature = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (page !== currentPage) {
+            setPage(currentPage);
+        }
+    }, [currentPage, page]);
+
+    useEffect(() => {
+        if (previousCasesSignature.current === null) {
+            previousCasesSignature.current = casesSignature;
+            return;
+        }
+
+        if (previousCasesSignature.current !== casesSignature) {
+            previousCasesSignature.current = casesSignature;
+            setPage(0);
+        }
+    }, [casesSignature]);
+
+    const pageCases = useMemo(
+        () =>
+            allCases.slice(
+                currentPage * PAGE_SIZE,
+                (currentPage + 1) * PAGE_SIZE,
+            ),
+        [allCases, currentPage],
+    );
+
+    return (
+        <section id="cases-section" aria-labelledby="cases-heading">
+            <div className="mb-6 flex items-center gap-4">
+                <h2
+                    id="cases-heading"
+                    className="text-2xl font-bold tracking-tight text-slate-900 whitespace-nowrap"
+                >
+                    Casos Activos
+                </h2>
+                <div
+                    aria-hidden="true"
+                    className="ml-2 h-[2px] flex-1 rounded-full"
+                    style={{
+                        background: "linear-gradient(to right, #0144a0, transparent)",
+                    }}
+                />
+                <button
+                    type="button"
+                    onClick={() => {
+                        navigate("/teacher");
+                    }}
+                    className="btn-primary inline-flex shrink-0 items-center gap-[7px] rounded-[11px] px-5 py-[10px] text-[14px] font-bold text-white"
+                    style={{
+                        background: "#0144a0",
+                        boxShadow: "0 2px 8px rgba(1,68,160,0.25)",
+                    }}
+                >
+                    <Plus aria-hidden="true" className="h-5 w-5" />
+                    Crear nuevo caso
+                </button>
+            </div>
+
+            <div className="overflow-hidden rounded-[18px] border-[1.5px] border-slate-200 bg-white shadow-sm">
+                <div className="overflow-x-auto">
+                    <table className="min-w-[900px] w-full border-collapse text-left">
+                        <thead>
+                            <tr style={{ background: "#0144a0", color: "#fff" }}>
+                                {([
+                                    "Caso",
+                                    "Cursos / Asignaciones",
+                                    "Deadline",
+                                    "Acciones",
+                                ] as const).map((column) => (
+                                    <th
+                                        key={column}
+                                        className={[
+                                            "px-6 py-4 text-[14px] font-bold tracking-wide",
+                                            column === "Acciones" ? "text-right" : "text-left",
+                                        ].join(" ")}
+                                    >
+                                        {column}
+                                    </th>
+                                ))}
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-100 text-[15px] text-slate-700">
+                            {isLoading ? (
+                                <tr>
+                                    <td className="px-6 py-8 text-center text-sm text-slate-400" colSpan={4}>
+                                        Cargando casos...
+                                    </td>
+                                </tr>
+                            ) : null}
+
+                            {!isLoading && isError ? (
+                                <tr>
+                                    <td className="px-6 py-8 text-center text-sm text-red-600" colSpan={4}>
+                                        {CASES_LOAD_ERROR_MSG}
+                                    </td>
+                                </tr>
+                            ) : null}
+
+                            {!isLoading && !isError && pageCases.length === 0 ? (
+                                <tr>
+                                    <td className="px-6 py-8 text-center text-sm text-slate-400" colSpan={4}>
+                                        No hay casos activos con deadline vigente.
+                                    </td>
+                                </tr>
+                            ) : null}
+
+                            {!isLoading && !isError
+                                ? pageCases.map((caso) => (
+                                      <CasoRow key={caso.id} caso={caso} showToast={showToast} />
+                                  ))
+                                : null}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div className="flex items-center justify-between border-t border-slate-100 bg-slate-50 px-6 py-4">
+                    <span className="text-[12px] font-medium uppercase tracking-wider text-slate-400">
+                        Mostrando {pageCases.length} de {totalCases} casos activos
+                    </span>
+                    <div className="flex gap-1.5">
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setPage((previousPage) => Math.max(0, previousPage - 1));
+                            }}
+                            disabled={isLoading || currentPage === 0}
+                            aria-label="Página anterior"
+                            className="flex h-8 w-8 items-center justify-center rounded text-slate-400 transition-all hover:bg-white hover:text-slate-600 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-40"
+                        >
+                            <ChevronLeft className="h-5 w-5" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setPage((previousPage) =>
+                                    Math.min(totalPages - 1, previousPage + 1),
+                                );
+                            }}
+                            disabled={isLoading || currentPage >= totalPages - 1}
+                            aria-label="Página siguiente"
+                            className="flex h-8 w-8 items-center justify-center rounded text-slate-400 transition-all hover:bg-white hover:text-slate-600 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-40"
+                        >
+                            <ChevronRight className="h-5 w-5" />
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.test.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.test.tsx
@@ -20,6 +20,19 @@ vi.mock("./CursosActivosSection", () => ({
     CursosActivosSection: () => <div data-testid="cursos-activos-section">Cursos</div>,
 }));
 
+const casosActivosSectionSpy = vi.fn();
+
+vi.mock("./CasosActivosSection", () => ({
+    CasosActivosSection: (props: { showToast: (message: string, type?: string) => void }) => {
+        casosActivosSectionSpy(props);
+        return (
+            <section id="cases-section" data-testid="casos-activos-section">
+                Casos
+            </section>
+        );
+    },
+}));
+
 import { TeacherDashboardPage } from "./TeacherDashboardPage";
 
 describe("TeacherDashboardPage", () => {
@@ -32,8 +45,12 @@ describe("TeacherDashboardPage", () => {
         expect(screen.getByTestId("dashboard-header")).toBeTruthy();
         expect(screen.getByTestId("quick-actions-section")).toBeTruthy();
         expect(screen.getByTestId("cursos-activos-section")).toBeTruthy();
+        expect(screen.getByTestId("casos-activos-section")).toBeTruthy();
         expect(document.getElementById("cases-section")).toBeTruthy();
         expect(quickActionsSectionSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ showToast }),
+        );
+        expect(casosActivosSectionSpy).toHaveBeenCalledWith(
             expect.objectContaining({ showToast }),
         );
     });

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
@@ -1,5 +1,6 @@
 import type { ShowToast } from "@/shared/Toast";
 
+import { CasosActivosSection } from "./CasosActivosSection";
 import { CursosActivosSection } from "./CursosActivosSection";
 import { DashboardHeader } from "./DashboardHeader";
 import { QuickActionsSection } from "./QuickActionsSection";
@@ -17,7 +18,7 @@ export function TeacherDashboardPage({
             <main className="mx-auto max-w-6xl space-y-10 px-6 py-9">
                 <QuickActionsSection showToast={showToast} />
                 <CursosActivosSection />
-                <div id="cases-section" aria-hidden="true" className="h-px w-full" />
+                <CasosActivosSection showToast={showToast} />
             </main>
         </div>
     );


### PR DESCRIPTION
## Summary
- implement `CasosActivosSection` for the teacher dashboard with full table UX, deadline badges, action placeholders, and client-side pagination (`PAGE_SIZE=10`)
- integrate final dashboard assembly by replacing the old `#cases-section` placeholder in `TeacherDashboardPage` with the real section component
- add dedicated tests for loading/error/empty states, actions, deadline rendering, pagination boundaries, and page reset-on-data-change behavior
- update dashboard page composition test to assert `CasosActivosSection` wiring and `showToast` prop propagation

## Validation
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test -- CasosActivosSection TeacherDashboardPage QuickActionsSection`
- `npm --prefix frontend run test`
- `npm --prefix frontend run build`

Closes #99