### PR TITLE
Issue #110: Runtime profile guardrails for Uvicorn startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ supabase start
 cd backend
 uv sync --dev
 uv run alembic upgrade head
-uv run uvicorn shared.app:app --reload --host 0.0.0.0 --port 8000
+uv run python -m shared.app
 ```
 
 `docker compose up` starts PostgreSQL, but does not apply migrations. Alembic bootstrap is required before using the API locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Resumen del arranque:
 4. prepara `backend/.env` y `frontend/.env` desde sus ejemplos con el mapping local correcto
 5. `uv sync --directory backend --dev`
 6. `uv run --directory backend alembic upgrade head`
-7. `uv run --directory backend uvicorn shared.app:app --reload --host 0.0.0.0 --port 8000`
+7. `uv run --directory backend python -m shared.app`
 8. `npm --prefix frontend install`
 9. `npm --prefix frontend run dev`
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 help:
 	@echo "Available commands:"
 	@echo "  make dev-frontend    - Starts the frontend development server (Vite)"
-	@echo "  make dev-backend     - Starts the backend API server (Uvicorn with reload)"
+	@echo "  make dev-backend     - Starts the backend API server (runtime profile launcher)"
 	@echo "  make dev-langgraph   - Starts the LangGraph development server"
 	@echo "  make dev             - Starts both frontend and backend API development servers"
 
@@ -14,7 +14,7 @@ dev-frontend:
 
 dev-backend:
 	@echo "Starting backend API development server..."
-	@cd backend && uv run uvicorn shared.app:app --reload --host 0.0.0.0 --port 8000
+	@cd backend && uv run python -m shared.app
 
 dev-langgraph:
 	@echo "Starting LangGraph development server..."

--- a/TODOS.md
+++ b/TODOS.md
@@ -86,3 +86,19 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** Identificado en Issue #46 (Plan Issue #10, plan-eng-review decisión 1A). La decisión de diferir fue explícita: no hay Redis disponible en la infra actual, y `slowapi` in-memory da falsa seguridad con max-instances=10. Ver sección "Rate Limiting Strategy" en `docs/runbooks/cloud-run-deploy.md` para los límites target y el contexto de la decisión.
 
 **Depends on / blocked by:** Aprovisionamiento de Cloud Memorystore en el proyecto GCP, o reducción de `maxInstances` a 1 en `public-api`. No bloquea Issue #11.
+
+---
+
+## TODO-006: Migración total de contrato runtime a `APP_ENV`
+
+**What:** Migrar el contrato de entorno runtime para que `APP_ENV` sea la variable única en todo el stack (código, runbooks, compose, CI y despliegue), retirando gradualmente `ENVIRONMENT`.
+
+**Why:** Issue #110 introduce `APP_ENV` como override para aplicar guardrails de runtime sin romper compatibilidad. Mantener dos variables de entorno a largo plazo aumenta ambigüedad operativa y riesgo de configuraciones inconsistentes.
+
+**Pros:** Contrato único y explícito para perfil runtime, menos drift documental, menor riesgo de errores de despliegue por variables cruzadas.
+
+**Cons:** Toca múltiples superficies (docker-compose, Cloud Run env bindings, tests, `.env.example`, runbooks y validaciones), requiere coordinación de rollout para no romper entornos existentes.
+
+**Context:** En la implementación de Issue #110 se decidió mantener `ENVIRONMENT` como canónico temporal y soportar `APP_ENV` con prioridad para minimizar riesgo inmediato. Esta deuda se registra para cerrar la dualidad una vez estabilicen los guardrails.
+
+**Depends on / blocked by:** Plan de migración coordinado por fases, validación de todos los entornos activos y ventana de despliegue para cortar compatibilidad con `ENVIRONMENT`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,6 +35,18 @@ DB_POOL_RECYCLE=1800
 # development -> BackgroundTasks (local)
 # production  -> Google Cloud Tasks (Cloud Run)
 ENVIRONMENT=development
+# Optional override used by the runtime launcher.
+# If set, APP_ENV takes precedence over ENVIRONMENT.
+APP_ENV=
+
+# -- Runtime launcher profile (shared.app) ------------------------
+# Launcher command: uv run python -m shared.app
+# reload is enabled only when effective env is development.
+APP_HOST=0.0.0.0
+APP_PORT=8000
+APP_WORKERS=2
+APP_TIMEOUT_KEEP_ALIVE=30
+APP_TIMEOUT_GRACEFUL_SHUTDOWN=60
 
 # -- Supabase auth perimeter (Issue 23 + Issue 30) ----------------
 # Required for JWT verification, activation flows and admin auth operations.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -16,7 +16,7 @@ supabase start
 cd backend
 uv sync --dev
 uv run alembic upgrade head
-uv run uvicorn shared.app:app --reload --host 0.0.0.0 --port 8000
+uv run python -m shared.app
 ```
 
 `docker compose up` starts PostgreSQL, but it does not apply migrations. `uv run alembic upgrade head` is required for a usable local schema.

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 import asyncio
 import json
 import logging
 import os
 import pathlib
+import sys
 import time
 from typing import Any
 import uuid
@@ -77,6 +79,123 @@ _json_handler.setFormatter(JsonFormatter("%(asctime)s %(levelname)s %(name)s %(m
 logging.basicConfig(handlers=[_json_handler], level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)
 _BOGOTA_TZ = ZoneInfo("America/Bogota")
+
+_DEVELOPMENT_ENV = "development"
+_DEFAULT_HOST = "0.0.0.0"
+_DEFAULT_PORT = 8000
+_DEFAULT_WORKERS = 2
+_DEFAULT_TIMEOUT_KEEP_ALIVE = 30
+_DEFAULT_TIMEOUT_GRACEFUL_SHUTDOWN = 60
+_DEFAULT_RELOAD_EXCLUDES = [
+    ".venv/*",
+    "*/.venv/*",
+    "*site-packages*",
+    "node_modules/*",
+    "*/node_modules/*",
+    ".git/*",
+    "*/.git/*",
+    "build/*",
+    "*/build/*",
+    "dist/*",
+    "*/dist/*",
+]
+
+
+@dataclass(frozen=True)
+class UvicornRuntimeProfile:
+    app_env: str
+    host: str
+    port: int
+    reload: bool
+    reload_dirs: list[str]
+    reload_excludes: list[str]
+    workers: int
+    timeout_keep_alive: int
+    timeout_graceful_shutdown: int
+
+
+def _effective_app_env() -> str:
+    app_env_override = os.getenv("APP_ENV", "").strip().lower()
+    if app_env_override:
+        return app_env_override
+    environment = os.getenv("ENVIRONMENT", _DEVELOPMENT_ENV).strip().lower()
+    return environment or _DEVELOPMENT_ENV
+
+
+def _read_int_env(name: str, default: int, *, minimum: int = 1) -> int:
+    raw_value = os.getenv(name, "").strip()
+    if not raw_value:
+        return default
+    try:
+        parsed_value = int(raw_value)
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be an integer value") from exc
+    if parsed_value < minimum:
+        raise RuntimeError(f"{name} must be >= {minimum}")
+    return parsed_value
+
+
+def _build_uvicorn_runtime_profile(argv: list[str] | None = None) -> UvicornRuntimeProfile:
+    app_env = _effective_app_env()
+    cli_args = argv if argv is not None else sys.argv[1:]
+    reload_requested = "--reload" in cli_args
+    if reload_requested and app_env != _DEVELOPMENT_ENV:
+        raise RuntimeError("Reload is forbidden when APP_ENV/ENVIRONMENT is not 'development'")
+
+    source_dir = pathlib.Path(__file__).resolve().parents[1]
+    return UvicornRuntimeProfile(
+        app_env=app_env,
+        host=os.getenv("APP_HOST", _DEFAULT_HOST),
+        port=_read_int_env("APP_PORT", _DEFAULT_PORT),
+        reload=app_env == _DEVELOPMENT_ENV,
+        reload_dirs=[str(source_dir)],
+        reload_excludes=list(_DEFAULT_RELOAD_EXCLUDES),
+        workers=_read_int_env("APP_WORKERS", _DEFAULT_WORKERS),
+        timeout_keep_alive=_read_int_env("APP_TIMEOUT_KEEP_ALIVE", _DEFAULT_TIMEOUT_KEEP_ALIVE),
+        timeout_graceful_shutdown=_read_int_env(
+            "APP_TIMEOUT_GRACEFUL_SHUTDOWN",
+            _DEFAULT_TIMEOUT_GRACEFUL_SHUTDOWN,
+        ),
+    )
+
+
+def _run_uvicorn_profile(profile: UvicornRuntimeProfile) -> None:
+    import uvicorn
+
+    logger.info(
+        "runtime_profile",
+        extra={
+            "runtime_profile": {
+                "app_env": profile.app_env,
+                "reload_enabled": profile.reload,
+                "reload_dirs": profile.reload_dirs,
+                "reload_excludes": profile.reload_excludes,
+                "workers": profile.workers if not profile.reload else 1,
+                "timeout_keep_alive": profile.timeout_keep_alive,
+                "timeout_graceful_shutdown": profile.timeout_graceful_shutdown,
+            }
+        },
+    )
+
+    run_kwargs: dict[str, Any] = {
+        "app": "shared.app:app",
+        "host": profile.host,
+        "port": profile.port,
+        "reload": profile.reload,
+        "reload_dirs": profile.reload_dirs,
+        "reload_excludes": profile.reload_excludes,
+        "timeout_keep_alive": profile.timeout_keep_alive,
+        "timeout_graceful_shutdown": profile.timeout_graceful_shutdown,
+    }
+    if not profile.reload:
+        run_kwargs["workers"] = profile.workers
+
+    uvicorn.run(**run_kwargs)
+
+
+def main() -> None:
+    runtime_profile = _build_uvicorn_runtime_profile()
+    _run_uvicorn_profile(runtime_profile)
 
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
@@ -1139,3 +1258,7 @@ def create_frontend_router(build_dir: str = "../frontend/dist") -> Any:
 
 
 app.mount("/app", create_frontend_router(), name="frontend")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_issue110_runtime_profile_guardrails.py
+++ b/backend/tests/test_issue110_runtime_profile_guardrails.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from shared.app import _build_uvicorn_runtime_profile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _clear_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env_name in [
+        "APP_ENV",
+        "ENVIRONMENT",
+        "APP_HOST",
+        "APP_PORT",
+        "APP_WORKERS",
+        "APP_TIMEOUT_KEEP_ALIVE",
+        "APP_TIMEOUT_GRACEFUL_SHUTDOWN",
+    ]:
+        monkeypatch.delenv(env_name, raising=False)
+
+
+def _read_repo_file(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_runtime_profile_matrix_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    profile = _build_uvicorn_runtime_profile([])
+    assert profile.reload is False
+
+    monkeypatch.setenv("APP_ENV", "development")
+    profile = _build_uvicorn_runtime_profile([])
+    assert profile.reload is True
+
+
+def test_dev_reload_scope_is_source_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("APP_ENV", "development")
+
+    profile = _build_uvicorn_runtime_profile([])
+
+    assert profile.reload is True
+    assert profile.reload_dirs == [str((REPO_ROOT / "backend" / "src").resolve())]
+    assert any(pattern == ".venv/*" for pattern in profile.reload_excludes)
+
+
+def test_non_dev_rejects_reload_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("APP_ENV", "production")
+
+    with pytest.raises(RuntimeError, match="Reload is forbidden"):
+        _build_uvicorn_runtime_profile(["--reload"])
+
+
+def test_non_dev_defaults_are_institutional(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("APP_ENV", "production")
+
+    profile = _build_uvicorn_runtime_profile([])
+
+    assert profile.reload is False
+    assert profile.workers == 2
+    assert profile.timeout_keep_alive == 30
+    assert profile.timeout_graceful_shutdown == 60
+
+
+def test_command_surfaces_are_consistent() -> None:
+    expected_commands = {
+        "Makefile": "uv run python -m shared.app",
+        "CONTRIBUTING.md": "uv run --directory backend python -m shared.app",
+        "docs/runbooks/local-dev-auth.md": "uv run --directory backend python -m shared.app",
+        "backend/AGENTS.md": "uv run python -m shared.app",
+        "CLAUDE.md": "uv run python -m shared.app",
+    }
+
+    for relative_path, command_fragment in expected_commands.items():
+        content = _read_repo_file(relative_path)
+        assert command_fragment in content, f"Missing command fragment in {relative_path}"
+        assert "uvicorn shared.app:app --reload" not in content
+
+
+def test_ci_guardrail_fails_when_reload_appears_in_prod_path() -> None:
+    production_surfaces = [
+        "backend/Dockerfile.worker",
+        "docs/runbooks/cloud-run-deploy.md",
+    ]
+
+    for relative_path in production_surfaces:
+        content = _read_repo_file(relative_path)
+        bad_lines = [
+            line
+            for line in content.splitlines()
+            if (
+                (line.strip().lower().startswith("uvicorn ") or line.strip().lower().startswith("uv run "))
+                and "--reload" in line.lower()
+            )
+        ]
+        assert not bad_lines, f"Unsafe reload command found in production surface {relative_path}: {bad_lines[0]}"

--- a/backend/tests/test_issue110_runtime_profile_guardrails.py
+++ b/backend/tests/test_issue110_runtime_profile_guardrails.py
@@ -44,10 +44,34 @@ def test_dev_reload_scope_is_source_only(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setenv("APP_ENV", "development")
 
     profile = _build_uvicorn_runtime_profile([])
+    expected_excludes = {
+        ".venv/*",
+        "*/.venv/*",
+        "*site-packages*",
+        "node_modules/*",
+        "*/node_modules/*",
+        ".git/*",
+        "*/.git/*",
+        "build/*",
+        "*/build/*",
+        "dist/*",
+        "*/dist/*",
+    }
 
     assert profile.reload is True
     assert profile.reload_dirs == [str((REPO_ROOT / "backend" / "src").resolve())]
-    assert any(pattern == ".venv/*" for pattern in profile.reload_excludes)
+    assert expected_excludes.issubset(set(profile.reload_excludes))
+
+
+def test_reload_excludes_cover_dependency_churn_patterns(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("APP_ENV", "development")
+
+    profile = _build_uvicorn_runtime_profile([])
+
+    # These patterns prevent restarts triggered by external dependency/file churn.
+    for expected_pattern in ("*site-packages*", "*/.venv/*", "*/node_modules/*"):
+        assert expected_pattern in profile.reload_excludes
 
 
 def test_non_dev_rejects_reload_flag(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/docs/runbooks/cloud-run-deploy.md
+++ b/docs/runbooks/cloud-run-deploy.md
@@ -14,6 +14,9 @@
 The `public-api` service handles all user-facing traffic (SPA, auth endpoints, authoring job intake).
 The `authoring-worker` service processes async authoring jobs dispatched by Cloud Tasks — it has no public ingress.
 
+Runtime guardrail: `--reload` is forbidden in non-development runtimes.
+Production startup paths must never include `uvicorn ... --reload`.
+
 ---
 
 ## Database connection mode

--- a/docs/runbooks/cloud-run-deploy.md
+++ b/docs/runbooks/cloud-run-deploy.md
@@ -16,6 +16,8 @@ The `authoring-worker` service processes async authoring jobs dispatched by Clou
 
 Runtime guardrail: `--reload` is forbidden in non-development runtimes.
 Production startup paths must never include `uvicorn ... --reload`.
+La matriz runtime canonica (precedencia `APP_ENV` sobre `ENVIRONMENT`) vive en
+`docs/runbooks/local-dev-auth.md`, seccion "Matriz runtime canonica".
 
 ---
 

--- a/docs/runbooks/local-dev-auth.md
+++ b/docs/runbooks/local-dev-auth.md
@@ -60,7 +60,7 @@ Los prerrequisitos anteriores no cuentan dentro de este flujo.
 4. preparar `backend/.env` y `frontend/.env` desde sus ejemplos, con el mapping local correcto
 5. `uv sync --directory backend --dev`
 6. `uv run --directory backend alembic upgrade head`
-7. `uv run --directory backend uvicorn shared.app:app --reload --host 0.0.0.0 --port 8000`
+7. `uv run --directory backend python -m shared.app`
 8. `npm --prefix frontend install`
 9. `npm --prefix frontend run dev`
 

--- a/docs/runbooks/local-dev-auth.md
+++ b/docs/runbooks/local-dev-auth.md
@@ -50,6 +50,22 @@ El `supabase/config.toml` incluye redirects del shell auth-aware de Issue 5:
 - `5432`: Supavisor session mode o conexion remota equivalente. No es el default local del repo.
 - `6543`: Supavisor transaction mode remoto/serverless. No es setup local.
 
+## Matriz runtime canonica
+
+La fuente de verdad del perfil runtime de la API es el launcher:
+`uv run --directory backend python -m shared.app`.
+
+Resolucion de entorno efectivo:
+
+- si `APP_ENV` esta definido y no vacio, tiene prioridad
+- si `APP_ENV` no esta definido, usa `ENVIRONMENT`
+- si ninguna variable esta definida, el default es `development`
+
+| Entorno efectivo | Politica de reload | Evidencia operativa |
+| --- | --- | --- |
+| `development` | permitido, con watch scope solo en `backend/src` y exclusiones explicitas (`.venv`, `site-packages`, `node_modules`, `.git`, `build`, `dist`) | log `runtime_profile` con `reload_enabled=true` |
+| cualquier valor distinto de `development` (por ejemplo `staging`, `production`) | deshabilitado; cualquier intento explicito de `--reload` falla en startup | error `Reload is forbidden...` + `reload_enabled=false` |
+
 ## Flujo recomendado en menos de 10 comandos
 
 Los prerrequisitos anteriores no cuentan dentro de este flujo.


### PR DESCRIPTION
## Summary
- add a centralized Uvicorn runtime launcher in ackend/src/shared/app.py
- enforce reload only when effective env is development (APP_ENV override, fallback ENVIRONMENT)
- scope reload watchers to ackend/src and explicitly exclude external churn paths (.venv, site-packages, 
ode_modules, .git, uild, dist)
- add non-development runtime defaults (workers=2, 	imeout_keep_alive=30, 	imeout_graceful_shutdown=60)
- add CI guardrail tests for runtime profile matrix and command-surface drift
- align startup command surfaces to uv run ... python -m shared.app
- document production guardrail: no uvicorn ... --reload in non-development paths

## Validation
- uv run --directory backend pytest -q
- uv run --directory backend mypy src

## Issue
- Closes #110