### PR TITLE
feat(authoring): canonical progress contract and real-time rehydration

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -102,3 +102,35 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** En la implementación de Issue #110 se decidió mantener `ENVIRONMENT` como canónico temporal y soportar `APP_ENV` con prioridad para minimizar riesgo inmediato. Esta deuda se registra para cerrar la dualidad una vez estabilicen los guardrails.
 
 **Depends on / blocked by:** Plan de migración coordinado por fases, validación de todos los entornos activos y ventana de despliegue para cortar compatibilidad con `ENVIRONMENT`.
+
+---
+
+## TODO-007: Watchdog de progreso en frontend para fallback de stream
+
+**What:** Implementar un watchdog en `useAuthoringJobProgress` que detecte silencio prolongado del stream (sin snapshots ni eventos realtime durante una ventana configurable) y ejecute fallback controlado: re-fetch del snapshot, reintento de suscripción y señalización explícita de estado degradado en UI.
+
+**Why:** Aunque la PR actual mejora la rehidratación y normalización de pasos, todavía existe el riesgo de "stream zombie" cuando el canal realtime se degrada sin error hard. Sin watchdog, el usuario puede quedar viendo un progreso congelado sin feedback.
+
+**Pros:** Mejora percepción de confiabilidad, reduce casos de estancamiento silencioso, y limita dependencia de reconexión manual (F5).
+
+**Cons:** Añade complejidad de estado en el hook (timers + debounce + estados degradados), requiere cuidado para no generar polling excesivo ni ruido visual.
+
+**Context:** Diferido explícitamente para mantener el scope de esta PR en contrato canónico + rehidratación. El síntoma principal (0% -> 100%) ya quedó resuelto; este ítem apunta a hardening operativo adicional.
+
+**Depends on / blocked by:** Definir política final de timeout/retry por entorno (local/staging/prod) y métricas mínimas de reconexión aceptables.
+
+---
+
+## TODO-008: Monitoreo y alertas de salud del stream de authoring
+
+**What:** Agregar telemetría estructurada y tableros/alertas para el flujo realtime de authoring: tasa de suscripción fallida, reconexiones por job, latencia entre persistencia backend y render frontend, y porcentaje de jobs que llegan a `completed` sin eventos intermedios.
+
+**Why:** Hoy hay logs de suscripción en frontend y resiliencia en backend, pero falta observabilidad agregada para detectar regresiones antes de que lleguen como reportes manuales.
+
+**Pros:** Detección temprana de incidentes, baseline para SLO de progreso en tiempo real y diagnóstico más rápido de problemas de red/realtime/publicación.
+
+**Cons:** Requiere definir pipeline de ingestión (frontend + backend), cardinalidad de etiquetas y umbrales de alerta para evitar fatiga por ruido.
+
+**Context:** Registrado como follow-up de hardening después de estabilizar el contrato canónico de pasos y la persistencia resiliente introducidos en esta entrega.
+
+**Depends on / blocked by:** Alineación con la estrategia de observabilidad de la plataforma (métricas, logs y alerting) y disponibilidad del destino de métricas en ambientes compartidos.

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -42,6 +42,210 @@ SUPPORTED_CONTEXT_KEYS = [
 NARRATIVE_ARTIFACT_LIMIT = 30000
 EDA_ARTIFACT_LIMIT = 40000
 
+# Keep this list synchronized with frontend PIPELINE_STEPS ids in
+# frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx.
+CANONICAL_TIMELINE_STEP_IDS = (
+    "case_architect",
+    "case_writer",
+    "eda_text_analyst",
+    "m3_content_generator",
+    "m4_content_generator",
+    "m5_content_generator",
+    "teaching_note_part1",
+)
+TERMINAL_PROGRESS_STEPS = ("completed", "failed")
+_FIRST_CANONICAL_STEP = CANONICAL_TIMELINE_STEP_IDS[0]
+
+# Internal graph nodes are translated to stable timeline steps so the UI receives
+# deterministic progress values even if the orchestration graph evolves.
+_GRAPH_AGENT_TO_CANONICAL_STEP = {
+    "case_architect": "case_architect",
+    "case_writer": "case_writer",
+    "case_questions": "case_writer",
+    "doc3_generation": "case_writer",
+    "data_generator": "eda_text_analyst",
+    "data_validator": "eda_text_analyst",
+    "eda_text_analyst": "eda_text_analyst",
+    "eda_chart_generator": "eda_text_analyst",
+    "m3_content_generator": "m3_content_generator",
+    "m3_questions_generator": "m3_content_generator",
+    "m3_notebook_generator": "m3_content_generator",
+    "m4_content_generator": "m4_content_generator",
+    "m4_chart_generator": "m4_content_generator",
+    "m4_questions_generator": "m4_content_generator",
+    "m5_content_generator": "m5_content_generator",
+    "m5_questions_generator": "m5_content_generator",
+    "teaching_note_part1": "teaching_note_part1",
+    "teaching_note_part2": "teaching_note_part1",
+    "processing": _FIRST_CANONICAL_STEP,
+}
+
+_PROGRESS_DEGRADATION_KEYS = (
+    "progress_degraded",
+    "progress_degraded_step",
+    "progress_degraded_reason",
+    "progress_degraded_retries",
+    "progress_degraded_at",
+    "progress_degraded_error",
+)
+
+
+def _to_canonical_progress_step(raw_step: str | None) -> str | None:
+    """Translate internal graph agent ids into the stable timeline step contract."""
+    if raw_step is None:
+        return None
+
+    normalized = raw_step.strip()
+    if not normalized:
+        return None
+
+    if normalized in TERMINAL_PROGRESS_STEPS:
+        return normalized
+
+    mapped = _GRAPH_AGENT_TO_CANONICAL_STEP.get(normalized)
+    if mapped:
+        return mapped
+
+    if normalized in CANONICAL_TIMELINE_STEP_IDS:
+        return normalized
+
+    return None
+
+
+def _clear_progress_degradation(payload: dict[str, Any]) -> None:
+    for key in _PROGRESS_DEGRADATION_KEYS:
+        payload.pop(key, None)
+
+
+def _persist_progress_degradation(
+    *,
+    job_id: str,
+    canonical_step: str,
+    max_attempts: int,
+    error_detail: str,
+) -> None:
+    """Persist a durable degraded marker when intermediate progress writes exhaust retries."""
+    db_degraded = SessionLocal()
+    try:
+        job_degraded = db_degraded.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
+        if job_degraded is None:
+            logger.error(
+                "AuthoringService: Could not mark degraded progress state because job %s was not found.",
+                job_id,
+            )
+            return
+
+        payload = dict(job_degraded.task_payload or {})
+        current_step = payload.get("current_step")
+        canonical_current_step = (
+            _to_canonical_progress_step(current_step)
+            if isinstance(current_step, str)
+            else None
+        ) or _FIRST_CANONICAL_STEP
+
+        payload = _next_progress_payload(
+            payload,
+            status="processing",
+            current_step=canonical_current_step,
+        )
+        payload["progress_degraded"] = True
+        payload["progress_degraded_step"] = canonical_step
+        payload["progress_degraded_reason"] = "intermediate_checkpoint_write_failed"
+        payload["progress_degraded_retries"] = max_attempts
+        payload["progress_degraded_at"] = datetime.now(timezone.utc).isoformat()
+        payload["progress_degraded_error"] = error_detail[:500]
+        job_degraded.task_payload = payload
+
+        db_degraded.commit()
+        logger.warning(
+            "AuthoringService: Progress stream degraded for job %s after %s failed attempts at step '%s'.",
+            job_id,
+            max_attempts,
+            canonical_step,
+        )
+    except Exception as exc:
+        logger.error(
+            "AuthoringService: Could not persist degraded progress state for job %s at step '%s': %s",
+            job_id,
+            canonical_step,
+            exc,
+        )
+        db_degraded.rollback()
+    finally:
+        db_degraded.close()
+
+
+async def _persist_intermediate_progress_step(
+    *,
+    job_id: str,
+    canonical_step: str,
+    max_attempts: int = 3,
+    retry_base_delay_seconds: float = 0.2,
+) -> bool:
+    """Persist a canonical intermediate step with bounded retries and degraded fallback."""
+    if canonical_step not in CANONICAL_TIMELINE_STEP_IDS:
+        logger.warning(
+            "AuthoringService: Skipping non-canonical progress step '%s' for job %s.",
+            canonical_step,
+            job_id,
+        )
+        return False
+
+    last_error = "unknown_error"
+
+    for attempt in range(1, max_attempts + 1):
+        db_step = SessionLocal()
+        try:
+            job_step = db_step.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
+            if job_step is None:
+                logger.error(
+                    "AuthoringService: Could not persist progress checkpoint because job %s was not found.",
+                    job_id,
+                )
+                return False
+
+            payload_step = _next_progress_payload(
+                job_step.task_payload,
+                status="processing",
+                current_step=canonical_step,
+            )
+            _clear_progress_degradation(payload_step)
+            job_step.task_payload = payload_step
+            db_step.commit()
+
+            if attempt > 1:
+                logger.warning(
+                    "AuthoringService: Progress checkpoint write recovered for job %s at step '%s' (attempt %s/%s).",
+                    job_id,
+                    canonical_step,
+                    attempt,
+                    max_attempts,
+                )
+            return True
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            logger.warning(
+                "AuthoringService: Progress checkpoint write failed for job %s at step '%s' (attempt %s/%s): %s",
+                job_id,
+                canonical_step,
+                attempt,
+                max_attempts,
+                exc,
+            )
+            db_step.rollback()
+            if attempt < max_attempts and retry_base_delay_seconds > 0:
+                await asyncio.sleep(retry_base_delay_seconds * (2 ** (attempt - 1)))
+        finally:
+            db_step.close()
+
+    _persist_progress_degradation(
+        job_id=job_id,
+        canonical_step=canonical_step,
+        max_attempts=max_attempts,
+        error_detail=last_error,
+    )
+    return False
+
 
 def _next_progress_payload(
     existing_payload: Mapping[str, Any] | None,
@@ -254,7 +458,7 @@ class AuthoringService:
             job.task_payload = _next_progress_payload(
                 job.task_payload,
                 status="processing",
-                current_step="processing",
+                current_step=_FIRST_CANONICAL_STEP,
             )
             payload = dict(job.task_payload or {})
             db.commit()
@@ -337,37 +541,31 @@ class AuthoringService:
 
             async def _run_graph_stream() -> dict[str, Any]:
                 final_state: dict[str, Any] = state_input.copy()
-                last_reported_step = "processing"
+                current_step = payload.get("current_step")
+                last_reported_step = (
+                    _to_canonical_progress_step(current_step)
+                    if isinstance(current_step, str)
+                    else None
+                ) or _FIRST_CANONICAL_STEP
                 stream_mode: Literal["values"] = "values"
                 stream = cast(Any, graph).astream(state_input, config=run_config, stream_mode=stream_mode)
 
                 async for event in stream:
                     final_state = dict(event)
                     current_agent = final_state.get("current_agent")
+                    canonical_step = (
+                        _to_canonical_progress_step(current_agent)
+                        if isinstance(current_agent, str)
+                        else None
+                    )
 
-                    if current_agent and current_agent != last_reported_step:
-                        try:
-                            db_step = SessionLocal()
-                            try:
-                                job_step = db_step.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
-                                if job_step is not None:
-                                    payload_step = _next_progress_payload(
-                                        job_step.task_payload,
-                                        status="processing",
-                                        current_step=str(current_agent),
-                                    )
-                                    job_step.task_payload = payload_step
-                                    db_step.commit()
-                                    last_reported_step = str(current_agent)
-                            finally:
-                                db_step.close()
-                        except Exception as exc:
-                            logger.error(
-                                "AuthoringService: Error updating current_step '%s' for job %s: %s",
-                                current_agent,
-                                job_id,
-                                exc,
-                            )
+                    if canonical_step and canonical_step != last_reported_step:
+                        persisted = await _persist_intermediate_progress_step(
+                            job_id=job_id,
+                            canonical_step=canonical_step,
+                        )
+                        if persisted:
+                            last_reported_step = canonical_step
 
                 return final_state
 

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -1,0 +1,147 @@
+import asyncio
+import uuid
+
+from sqlalchemy.orm import Session as OrmSession
+
+from case_generator.core.authoring import (
+    CANONICAL_TIMELINE_STEP_IDS,
+    _persist_intermediate_progress_step,
+    _to_canonical_progress_step,
+)
+from shared.models import Assignment, AuthoringJob
+
+
+def _seed_processing_job(db, teacher_id: str, initial_step: str = "case_architect") -> AuthoringJob:
+    assignment = Assignment(teacher_id=teacher_id, title="Progress Resilience", status="draft")
+    db.add(assignment)
+    db.flush()
+
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status="processing",
+        task_payload={
+            "current_step": initial_step,
+            "progress_seq": 1,
+            "progress_ts": "2026-01-01T00:00:00+00:00",
+            "progress_status": "processing",
+        },
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+def test_canonical_progress_step_mapping_is_stable() -> None:
+    expected = {
+        "case_architect": "case_architect",
+        "case_questions": "case_writer",
+        "eda_chart_generator": "eda_text_analyst",
+        "m3_questions_generator": "m3_content_generator",
+        "m4_chart_generator": "m4_content_generator",
+        "m5_questions_generator": "m5_content_generator",
+        "teaching_note_part2": "teaching_note_part1",
+        "processing": "case_architect",
+        "completed": "completed",
+        "failed": "failed",
+    }
+
+    for raw_step, canonical in expected.items():
+        assert _to_canonical_progress_step(raw_step) == canonical
+
+    assert _to_canonical_progress_step("unknown_internal_node") is None
+    assert _to_canonical_progress_step(" ") is None
+
+
+
+def test_intermediate_progress_write_recovers_after_transient_commit_failure(
+    db,
+    seed_identity,
+    monkeypatch,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-progress-retry@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    job = _seed_processing_job(db, teacher_id)
+
+    original_commit = OrmSession.commit
+    state = {"commit_calls": 0}
+
+    def flaky_commit(self, *args, **kwargs):
+        state["commit_calls"] += 1
+        if state["commit_calls"] == 1:
+            raise RuntimeError("transient commit failure")
+        return original_commit(self, *args, **kwargs)
+
+    monkeypatch.setattr(OrmSession, "commit", flaky_commit)
+
+    persisted = asyncio.run(
+        _persist_intermediate_progress_step(
+            job_id=job.id,
+            canonical_step="case_writer",
+            max_attempts=3,
+            retry_base_delay_seconds=0.0,
+        )
+    )
+
+    assert persisted is True
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+    payload = dict(refreshed.task_payload or {})
+
+    assert payload.get("current_step") == "case_writer"
+    assert payload.get("progress_status") == "processing"
+    assert payload.get("progress_degraded") is None
+
+
+
+def test_intermediate_progress_write_marks_degraded_state_after_retry_exhaustion(
+    db,
+    seed_identity,
+    monkeypatch,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-progress-degraded@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    job = _seed_processing_job(db, teacher_id, initial_step=CANONICAL_TIMELINE_STEP_IDS[0])
+
+    original_commit = OrmSession.commit
+    state = {"commit_calls": 0}
+
+    def fail_three_then_recover(self, *args, **kwargs):
+        state["commit_calls"] += 1
+        if state["commit_calls"] <= 3:
+            raise RuntimeError("commit timeout")
+        return original_commit(self, *args, **kwargs)
+
+    monkeypatch.setattr(OrmSession, "commit", fail_three_then_recover)
+
+    persisted = asyncio.run(
+        _persist_intermediate_progress_step(
+            job_id=job.id,
+            canonical_step="case_writer",
+            max_attempts=3,
+            retry_base_delay_seconds=0.0,
+        )
+    )
+
+    assert persisted is False
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+    payload = dict(refreshed.task_payload or {})
+
+    assert payload.get("current_step") == "case_architect"
+    assert payload.get("progress_status") == "processing"
+    assert payload.get("progress_degraded") is True
+    assert payload.get("progress_degraded_step") == "case_writer"
+    assert payload.get("progress_degraded_reason") == "intermediate_checkpoint_write_failed"
+    assert payload.get("progress_degraded_retries") == 3
+    assert isinstance(payload.get("progress_degraded_at"), str)
+    assert isinstance(payload.get("progress_degraded_error"), str)

--- a/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { AuthoringProgressTimeline } from "./AuthoringProgressTimeline";
+
+beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        value: vi.fn(),
+        writable: true,
+    });
+});
+
+describe("AuthoringProgressTimeline", () => {
+    it("shows progress from first step while processing", () => {
+        render(
+            <AuthoringProgressTimeline
+                activeAgent={undefined}
+                scope="technical"
+                jobStatus="processing"
+            />,
+        );
+
+        expect(screen.getByText("14%")).toBeTruthy();
+    });
+
+    it("uses step index + 1 for percentage", () => {
+        render(
+            <AuthoringProgressTimeline
+                activeAgent="m4_content_generator"
+                scope="technical"
+                jobStatus="processing"
+            />,
+        );
+
+        expect(screen.getByText("71%")).toBeTruthy();
+    });
+
+    it("shows 100 percent when job is completed", () => {
+        render(
+            <AuthoringProgressTimeline
+                activeAgent={undefined}
+                scope="narrative"
+                jobStatus="completed"
+            />,
+        );
+
+        expect(screen.getByText("100%")).toBeTruthy();
+    });
+});

--- a/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx
@@ -1,14 +1,20 @@
 /** AuthoringProgressTimeline: muestra progreso del pipeline */
 
 import { useEffect, useState, useRef } from "react";
+import type { AuthoringProgressStep } from "@/shared/adam-types";
 
 interface Props {
-  activeAgent?: string;
+  activeAgent?: AuthoringProgressStep;
   scope: "narrative" | "technical";
   jobStatus?: "pending" | "processing" | "completed" | "failed";
 }
 
-const PIPELINE_STEPS = [
+const PIPELINE_STEPS: Array<{
+  id: AuthoringProgressStep;
+  label: string;
+  detail: string;
+  scope: "both" | "technical";
+}> = [
   {
     id: "case_architect",
     label: "Diseñando arquitectura del caso",
@@ -66,8 +72,8 @@ function getStepStatus(
     if (stepIndex === effectiveIndex) return "active";
     return "pending";
   }
-  // Fallback: sin step conocido aún
-  if (jobStatus === "pending" || jobStatus === "processing") {
+  // Fallback: cuando estamos procesando pero aún sin step canónico conocido
+  if (jobStatus === "processing") {
     return stepIndex === 0 ? "active" : "pending";
   }
   return "pending";
@@ -95,10 +101,14 @@ export function AuthoringProgressTimeline({ activeAgent, scope, jobStatus }: Pro
   if (activeIndex >= 0) lastValidIndexRef.current = activeIndex;
   const effectiveIndex = activeIndex >= 0 ? activeIndex : lastValidIndexRef.current;
 
-  const currentProgressIndex = effectiveIndex >= 0
+  const inferredActiveIndex = effectiveIndex >= 0
     ? effectiveIndex
-    : (jobStatus === 'completed' ? visibleSteps.length : 0);
-  const progressPercent = Math.round((currentProgressIndex / visibleSteps.length) * 100);
+    : (jobStatus === "processing" ? 0 : -1);
+  const currentProgressIndex = jobStatus === "completed"
+    ? visibleSteps.length
+    : (inferredActiveIndex >= 0 ? inferredActiveIndex + 1 : 0);
+  const safeCurrentProgressIndex = Math.max(0, Math.min(currentProgressIndex, visibleSteps.length));
+  const progressPercent = Math.round((safeCurrentProgressIndex / visibleSteps.length) * 100);
 
   useEffect(() => {
     if (scrollContainerRef.current) {
@@ -155,7 +165,7 @@ export function AuthoringProgressTimeline({ activeAgent, scope, jobStatus }: Pro
           <div className="hidden md:flex flex-col gap-2 mt-8 w-full">
             <div className="flex items-center justify-between text-[10px] font-bold text-slate-400 uppercase tracking-widest">
               <span>Progreso del pipeline</span>
-              <span>{currentProgressIndex}/{visibleSteps.length}</span>
+              <span>{safeCurrentProgressIndex}/{visibleSteps.length}</span>
             </div>
             <div className="h-2 w-full bg-slate-100 rounded-full overflow-hidden">
               <div

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
@@ -41,6 +41,7 @@ describe("TeacherAuthoringPage", () => {
             submitJob: vi.fn(),
             reset: vi.fn(),
             isStreaming: false,
+            progressScope: null,
         });
 
         render(<TeacherAuthoringPage />);
@@ -60,6 +61,7 @@ describe("TeacherAuthoringPage", () => {
             submitJob: vi.fn(),
             reset: vi.fn(),
             isStreaming: false,
+            progressScope: null,
         });
 
         render(<TeacherAuthoringPage />);

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
@@ -41,10 +41,12 @@ export function TeacherAuthoringPage() {
     activeAgent,
     submitJob,
     reset: resetJob,
+    isStreaming,
+    progressScope,
   } = useAuthoringJobProgress();
 
   useEffect(() => {
-    if (jobStatus === "pending" || jobStatus === "processing") {
+    if (isStreaming || jobStatus === "pending" || jobStatus === "processing") {
       setAppState("generating");
       setErrorMessage("");
     } else if (jobStatus === "failed") {
@@ -54,7 +56,7 @@ export function TeacherAuthoringPage() {
       setCaseResult(jobResult);
       setAppState("success");
     }
-  }, [jobStatus, errorTrace, jobResult]);
+  }, [isStreaming, jobStatus, errorTrace, jobResult]);
 
   const handleGenerate = useCallback(
     async (data: CaseFormData) => {
@@ -89,7 +91,7 @@ export function TeacherAuthoringPage() {
         <AuthoringProgressTimeline
           activeAgent={activeAgent}
           jobStatus={jobStatus || undefined}
-          scope={formData.caseType === "harvard_only" ? "narrative" : "technical"}
+          scope={progressScope || (formData.caseType === "harvard_only" ? "narrative" : "technical")}
         />
       )}
 

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EMPTY_FORM } from "@/shared/adam-types";
+
+const {
+    submitJobMock,
+    streamProgressMock,
+} = vi.hoisted(() => {
+    return {
+        submitJobMock: vi.fn(),
+        streamProgressMock: vi.fn(),
+    };
+});
+
+vi.mock("@/shared/api", () => {
+    class MockApiError extends Error {
+        readonly status: number;
+        readonly retryAfterSeconds?: number;
+
+        constructor(status: number, message: string, retryAfterSeconds?: number) {
+            super(message);
+            this.status = status;
+            this.retryAfterSeconds = retryAfterSeconds;
+        }
+    }
+
+    return {
+        ApiError: MockApiError,
+        api: {
+            authoring: {
+                submitJob: submitJobMock,
+                streamProgress: streamProgressMock,
+            },
+        },
+    };
+});
+
+import { useAuthoringJobProgress } from "./useAuthoringJobProgress";
+
+describe("useAuthoringJobProgress rehydration", () => {
+    beforeEach(() => {
+        submitJobMock.mockReset();
+        streamProgressMock.mockReset();
+        sessionStorage.clear();
+    });
+
+    it("rehydrates persisted job and applies snapshot state immediately", async () => {
+        sessionStorage.setItem(
+            "adam_authoring_active_job",
+            JSON.stringify({ jobId: "job-42", scope: "technical" }),
+        );
+
+        streamProgressMock.mockImplementation(
+            async (_jobId: string, onEvent: (event: { event: string; data: string }) => void) => {
+                onEvent({ event: "metadata", data: JSON.stringify({ status: "processing" }) });
+                onEvent({ event: "message", data: JSON.stringify({ node: "m3_content_generator" }) });
+            },
+        );
+
+        const { result } = renderHook(() => useAuthoringJobProgress());
+
+        await waitFor(() => {
+            expect(streamProgressMock).toHaveBeenCalledWith(
+                "job-42",
+                expect.any(Function),
+                expect.any(AbortSignal),
+            );
+        });
+
+        expect(result.current.jobId).toBe("job-42");
+        expect(result.current.status).toBe("processing");
+        expect(result.current.activeAgent).toBe("m3_content_generator");
+        expect(result.current.progressScope).toBe("technical");
+    });
+
+    it("persists submitted job id and scope for refresh recovery", async () => {
+        submitJobMock.mockResolvedValue({ job_id: "job-99" });
+        streamProgressMock.mockResolvedValue(undefined);
+
+        const { result } = renderHook(() => useAuthoringJobProgress());
+
+        await act(async () => {
+            await result.current.submitJob({
+                ...EMPTY_FORM,
+                subject: "Caso",
+                caseType: "harvard_with_eda",
+            });
+        });
+
+        const persisted = sessionStorage.getItem("adam_authoring_active_job");
+        expect(persisted).toContain("job-99");
+        expect(persisted).toContain("technical");
+    });
+});

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
@@ -1,12 +1,68 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { ApiError, api } from "@/shared/api";
 import {
+    type AuthoringProgressStep,
     type AuthoringJobCreateRequest,
     type AuthoringJobStatusResponse,
     type CanonicalCaseOutput,
     type CaseFormData,
 } from "@/shared/adam-types";
+
+const ACTIVE_AUTHORING_JOB_STORAGE_KEY = "adam_authoring_active_job";
+
+type ProgressScope = "narrative" | "technical";
+
+interface PersistedActiveAuthoringJob {
+    jobId: string;
+    scope: ProgressScope;
+}
+
+function isProgressScope(value: unknown): value is ProgressScope {
+    return value === "narrative" || value === "technical";
+}
+
+function persistActiveAuthoringJob(state: PersistedActiveAuthoringJob): void {
+    if (typeof window === "undefined") {
+        return;
+    }
+    sessionStorage.setItem(ACTIVE_AUTHORING_JOB_STORAGE_KEY, JSON.stringify(state));
+}
+
+function clearPersistedActiveAuthoringJob(): void {
+    if (typeof window === "undefined") {
+        return;
+    }
+    sessionStorage.removeItem(ACTIVE_AUTHORING_JOB_STORAGE_KEY);
+}
+
+function readPersistedActiveAuthoringJob(): PersistedActiveAuthoringJob | null {
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    const raw = sessionStorage.getItem(ACTIVE_AUTHORING_JOB_STORAGE_KEY);
+    if (!raw) {
+        return null;
+    }
+
+    try {
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        if (typeof parsed.jobId !== "string" || parsed.jobId.trim() === "") {
+            clearPersistedActiveAuthoringJob();
+            return null;
+        }
+        if (!isProgressScope(parsed.scope)) {
+            clearPersistedActiveAuthoringJob();
+            return null;
+        }
+
+        return { jobId: parsed.jobId, scope: parsed.scope };
+    } catch {
+        clearPersistedActiveAuthoringJob();
+        return null;
+    }
+}
 
 function parseEventPayload(data: string) {
     return JSON.parse(data) as Record<string, unknown>;
@@ -47,10 +103,11 @@ export function buildAuthoringJobCreateRequest(formData: CaseFormData): Authorin
 export function useAuthoringJobProgress() {
     const [jobId, setJobId] = useState<string | null>(null);
     const [status, setStatus] = useState<AuthoringJobStatusResponse["status"] | null>(null);
-    const [activeAgent, setActiveAgent] = useState<string | undefined>(undefined);
+    const [activeAgent, setActiveAgent] = useState<AuthoringProgressStep | undefined>(undefined);
     const [errorTrace, setErrorTrace] = useState<string | null>(null);
     const [result, setResult] = useState<CanonicalCaseOutput | null>(null);
     const [isStreaming, setIsStreaming] = useState(false);
+    const [progressScope, setProgressScope] = useState<ProgressScope | null>(null);
 
     const streamAbortRef = useRef<AbortController | null>(null);
 
@@ -63,18 +120,24 @@ export function useAuthoringJobProgress() {
         setErrorTrace(null);
         setResult(null);
         setIsStreaming(false);
+        setProgressScope(null);
+        clearPersistedActiveAuthoringJob();
     }, []);
 
-    const startStreaming = useCallback((id: string) => {
+    const startStreaming = useCallback((id: string, scope: ProgressScope, opts?: { persist?: boolean }) => {
         streamAbortRef.current?.abort();
 
         const controller = new AbortController();
         streamAbortRef.current = controller;
 
         setJobId(id);
+        setProgressScope(scope);
         setIsStreaming(true);
-        setStatus("processing");
         setErrorTrace(null);
+
+        if (opts?.persist !== false) {
+            persistActiveAuthoringJob({ jobId: id, scope });
+        }
 
         void api.authoring
             .streamProgress(
@@ -94,7 +157,7 @@ export function useAuthoringJobProgress() {
                         if (event === "message") {
                             const node = payload.node;
                             if (typeof node === "string") {
-                                setActiveAgent(node);
+                                setActiveAgent(node as AuthoringProgressStep);
                             }
                             return;
                         }
@@ -110,6 +173,7 @@ export function useAuthoringJobProgress() {
 
                             setStatus("completed");
                             setIsStreaming(false);
+                            clearPersistedActiveAuthoringJob();
                             controller.abort();
                             return;
                         }
@@ -123,12 +187,14 @@ export function useAuthoringJobProgress() {
                             );
                             setStatus("failed");
                             setIsStreaming(false);
+                            clearPersistedActiveAuthoringJob();
                             controller.abort();
                         }
                     } catch {
                         setErrorTrace("Respuesta invalida del canal de progreso en tiempo real.");
                         setStatus("failed");
                         setIsStreaming(false);
+                        clearPersistedActiveAuthoringJob();
                         controller.abort();
                     }
                 },
@@ -142,6 +208,7 @@ export function useAuthoringJobProgress() {
                 setErrorTrace(getProgressStreamErrorMessage(error));
                 setStatus("failed");
                 setIsStreaming(false);
+                clearPersistedActiveAuthoringJob();
             })
             .finally(() => {
                 if (streamAbortRef.current === controller) {
@@ -149,6 +216,16 @@ export function useAuthoringJobProgress() {
                 }
             });
     }, []);
+
+    useEffect(() => {
+        const persisted = readPersistedActiveAuthoringJob();
+        if (!persisted) {
+            return;
+        }
+
+        setStatus("processing");
+        startStreaming(persisted.jobId, persisted.scope, { persist: false });
+    }, [startStreaming]);
 
     const submitJob = useCallback(
         async (formData: CaseFormData) => {
@@ -158,7 +235,8 @@ export function useAuthoringJobProgress() {
 
                 const data = await api.authoring.submitJob(buildAuthoringJobCreateRequest(formData));
                 if (data.job_id) {
-                    startStreaming(data.job_id);
+                    const scope: ProgressScope = formData.caseType === "harvard_only" ? "narrative" : "technical";
+                    startStreaming(data.job_id, scope);
                     return;
                 }
 
@@ -172,5 +250,5 @@ export function useAuthoringJobProgress() {
         [reset, startStreaming],
     );
 
-    return { jobId, status, errorTrace, result, activeAgent, submitJob, reset, isStreaming };
+    return { jobId, status, errorTrace, result, activeAgent, submitJob, reset, isStreaming, progressScope };
 }

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -185,6 +185,19 @@ export interface SuggestResponse {
 // API responses used by the teacher authoring flow.
 export type AuthoringJobStatus = "pending" | "processing" | "completed" | "failed";
 
+export const AUTHORING_PROGRESS_STEP_IDS = [
+    "case_architect",
+    "case_writer",
+    "eda_text_analyst",
+    "m3_content_generator",
+    "m4_content_generator",
+    "m5_content_generator",
+    "teaching_note_part1",
+] as const;
+
+export type AuthoringProgressStep = (typeof AUTHORING_PROGRESS_STEP_IDS)[number];
+export type AuthoringProgressCheckpoint = AuthoringProgressStep | "completed" | "failed";
+
 export interface AuthoringJobStatusResponse {
     job_id: string;
     status: AuthoringJobStatus;
@@ -197,7 +210,7 @@ export interface AuthoringJobStatusResponse {
 export interface AuthoringJobProgressSnapshotResponse {
     job_id: string;
     status: AuthoringJobStatus;
-    current_step?: string;
+    current_step?: AuthoringProgressCheckpoint;
     progress_seq?: number;
     progress_ts?: string;
     error_code?: string;

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -179,6 +179,77 @@ describe("api auth + stream glue", () => {
         expect(removeChannelMock).toHaveBeenCalledTimes(1);
     });
 
+    it("ignores stale post-subscribe snapshots after newer realtime progress", async () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+
+        const channel = {
+            on: vi.fn().mockReturnThis(),
+            subscribe: vi.fn((handler: (status: string) => void) => {
+                handler("SUBSCRIBED");
+                queueMicrotask(() => handler("CHANNEL_ERROR"));
+                return channel;
+            }),
+        };
+        const removeChannelMock = vi.fn().mockResolvedValue(undefined);
+
+        createClientMock.mockImplementationOnce(() => ({
+            auth: {
+                getSession: getSessionMock,
+            },
+            channel: vi.fn(() => channel),
+            removeChannel: removeChannelMock,
+        }));
+
+        const events: Array<{ event: string; data: string }> = [];
+
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    status: "processing",
+                    current_step: "m3_content_generator",
+                    progress_seq: 3,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    status: "processing",
+                    current_step: "case_writer",
+                    progress_seq: 2,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const streamPromise = api.authoring.streamProgress("job-1", (event) => events.push(event));
+
+        await expect(streamPromise).rejects.toMatchObject(
+            {
+                status: 502,
+                message: "No se pudo abrir el canal de progreso en tiempo real.",
+            } satisfies Pick<ApiError, "status" | "message">,
+        );
+
+        const statuses = events
+            .filter((event) => event.event === "metadata")
+            .map((event) => (JSON.parse(event.data) as { status: string }).status);
+        expect(statuses).toEqual(["processing"]);
+
+        const nodes = events
+            .filter((event) => event.event === "message")
+            .map((event) => (JSON.parse(event.data) as { node: string }).node);
+        expect(nodes).toEqual(["m3_content_generator"]);
+
+        expect(removeChannelMock).toHaveBeenCalledTimes(1);
+    });
+
     it("returns a non-generic auth error for forbidden streams", async () => {
         vi.stubGlobal(
             "fetch",

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -106,8 +106,7 @@ describe("api auth + stream glue", () => {
         await api.authoring.streamProgress("job-1", (event) => events.push(event));
 
         expect(events[0]).toEqual({ event: "metadata", data: "{\"status\":\"completed\"}" });
-        expect(events[1]).toEqual({ event: "message", data: "{\"node\":\"completed\"}" });
-        expect(events[2]).toEqual({ event: "result", data: "{\"canonical_output\":{\"title\":\"Case\"}}" });
+        expect(events[1]).toEqual({ event: "result", data: "{\"canonical_output\":{\"title\":\"Case\"}}" });
     });
 
     it("reconciles terminal state after subscribe when initial snapshot is stale", async () => {
@@ -137,7 +136,7 @@ describe("api auth + stream glue", () => {
                 new Response(JSON.stringify({
                     job_id: "job-1",
                     status: "processing",
-                    current_step: "writer",
+                    current_step: "case_writer",
                 }), {
                     status: 200,
                     headers: { "Content-Type": "application/json" },
@@ -206,7 +205,7 @@ describe("api auth + stream glue", () => {
                 new Response(JSON.stringify({
                     job_id: "job-1",
                     status: "processing",
-                    current_step: "writer",
+                    current_step: "case_writer",
                 }), {
                     status: 200,
                     headers: { "Content-Type": "application/json" },
@@ -220,6 +219,32 @@ describe("api auth + stream glue", () => {
                 message: "No se pudo conectar al canal de progreso en tiempo real.",
             } satisfies Pick<ApiError, "status" | "message">,
         );
+    });
+
+    it("ignores non-canonical current_step values", async () => {
+        const events: Array<{ event: string; data: string }> = [];
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({
+                job_id: "job-1",
+                status: "processing",
+                current_step: "unknown_internal_node",
+            }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(api.authoring.streamProgress("job-1", (event) => events.push(event))).rejects.toMatchObject(
+            {
+                status: 503,
+                message: "No se pudo conectar al canal de progreso en tiempo real.",
+            } satisfies Pick<ApiError, "status" | "message">,
+        );
+
+        expect(events).toEqual([
+            { event: "metadata", data: "{\"status\":\"processing\"}" },
+        ]);
     });
 
     it("surfaces retry-after metadata when progress snapshot receives 503 backpressure", async () => {

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -1,4 +1,5 @@
 import { getSupabaseClient, resetSupabaseClientForTests } from "@/shared/supabaseClient";
+import { AUTHORING_PROGRESS_STEP_IDS } from "@/shared/adam-types";
 
 import type {
     ActivateOAuthCompleteResponse,
@@ -18,6 +19,7 @@ import type {
     AdminTeacherOptionsResponse,
     AuthoringJobCreateRequest,
     AuthoringJobCreateResponse,
+    AuthoringProgressStep,
     AuthoringJobProgressSnapshotResponse,
     AuthoringJobResultResponse,
     AuthoringJobStatusResponse,
@@ -66,6 +68,8 @@ interface AuthoringJobRealtimeRow {
     status?: unknown;
     task_payload?: unknown;
 }
+
+const AUTHORING_PROGRESS_STEP_SET = new Set<string>(AUTHORING_PROGRESS_STEP_IDS);
 
 export interface ApiValidationErrorDetail {
     type: string;
@@ -263,11 +267,24 @@ function emitStatusEvent(onEvent: (event: ProgressEvent) => void, status: unknow
 }
 
 function emitStepEvent(onEvent: (event: ProgressEvent) => void, taskPayload: Record<string, unknown>): void {
-    const currentStep = taskPayload.current_step;
-    if (typeof currentStep !== "string" || currentStep.trim() === "") {
+    const currentStep = normalizeProgressStep(taskPayload.current_step);
+    if (!currentStep) {
         return;
     }
     onEvent({ event: "message", data: JSON.stringify({ node: currentStep }) });
+}
+
+function normalizeProgressStep(value: unknown): AuthoringProgressStep | null {
+    if (typeof value !== "string") {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed || !AUTHORING_PROGRESS_STEP_SET.has(trimmed)) {
+        return null;
+    }
+
+    return trimmed as AuthoringProgressStep;
 }
 
 async function emitTerminalEvent(
@@ -308,8 +325,9 @@ async function streamRealtimeProgress(
         `/authoring/jobs/${jobId}/progress`,
     );
     emitStatusEvent(onEvent, snapshot.status);
-    if (snapshot.current_step) {
-        onEvent({ event: "message", data: JSON.stringify({ node: snapshot.current_step }) });
+    const snapshotStep = normalizeProgressStep(snapshot.current_step);
+    if (snapshotStep) {
+        onEvent({ event: "message", data: JSON.stringify({ node: snapshotStep }) });
     }
 
     if (snapshot.status === "completed") {
@@ -369,6 +387,7 @@ async function streamRealtimeProgress(
                 }
 
                 if (subscriptionStatus === "SUBSCRIBED") {
+                    console.info("[authoring-progress] realtime subscribed", { jobId });
                     void parseJsonResponse<AuthoringJobProgressSnapshotResponse>(`/authoring/jobs/${jobId}/progress`)
                         .then((latestSnapshot) => {
                             if (settled) {
@@ -376,8 +395,9 @@ async function streamRealtimeProgress(
                             }
 
                             emitStatusEvent(onEvent, latestSnapshot.status);
-                            if (latestSnapshot.current_step) {
-                                onEvent({ event: "message", data: JSON.stringify({ node: latestSnapshot.current_step }) });
+                            const latestStep = normalizeProgressStep(latestSnapshot.current_step);
+                            if (latestStep) {
+                                onEvent({ event: "message", data: JSON.stringify({ node: latestStep }) });
                             }
 
                             if (latestSnapshot.status !== "completed" && latestSnapshot.status !== "failed") {
@@ -408,6 +428,10 @@ async function streamRealtimeProgress(
                 }
 
                 if (subscriptionStatus === "CHANNEL_ERROR" || subscriptionStatus === "TIMED_OUT") {
+                    console.error("[authoring-progress] realtime subscription failed", {
+                        jobId,
+                        subscriptionStatus,
+                    });
                     settled = true;
                     void client.removeChannel(channel).finally(() => {
                         reject(new ApiError(502, "No se pudo abrir el canal de progreso en tiempo real."));

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -266,14 +266,6 @@ function emitStatusEvent(onEvent: (event: ProgressEvent) => void, status: unknow
     onEvent({ event: "metadata", data: JSON.stringify({ status }) });
 }
 
-function emitStepEvent(onEvent: (event: ProgressEvent) => void, taskPayload: Record<string, unknown>): void {
-    const currentStep = normalizeProgressStep(taskPayload.current_step);
-    if (!currentStep) {
-        return;
-    }
-    onEvent({ event: "message", data: JSON.stringify({ node: currentStep }) });
-}
-
 function normalizeProgressStep(value: unknown): AuthoringProgressStep | null {
     if (typeof value !== "string") {
         return null;
@@ -285,6 +277,21 @@ function normalizeProgressStep(value: unknown): AuthoringProgressStep | null {
     }
 
     return trimmed as AuthoringProgressStep;
+}
+
+function normalizeProgressSeq(value: unknown): number | null {
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+        return null;
+    }
+
+    return value;
+}
+
+function getProgressStepIndex(step: AuthoringProgressStep | null): number {
+    if (!step) {
+        return -1;
+    }
+    return AUTHORING_PROGRESS_STEP_IDS.indexOf(step);
 }
 
 async function emitTerminalEvent(
@@ -324,11 +331,72 @@ async function streamRealtimeProgress(
     const snapshot = await parseJsonResponse<AuthoringJobProgressSnapshotResponse>(
         `/authoring/jobs/${jobId}/progress`,
     );
-    emitStatusEvent(onEvent, snapshot.status);
-    const snapshotStep = normalizeProgressStep(snapshot.current_step);
-    if (snapshotStep) {
-        onEvent({ event: "message", data: JSON.stringify({ node: snapshotStep }) });
-    }
+    let lastProgressSeq = normalizeProgressSeq(snapshot.progress_seq);
+    let lastEmittedStatus: string | null = null;
+    let lastEmittedStep: AuthoringProgressStep | null = null;
+
+    const emitMonotonicProgress = (
+        status: unknown,
+        step: unknown,
+        progressSeq: unknown,
+    ): void => {
+        if (typeof status !== "string") {
+            return;
+        }
+
+        const normalizedStep = normalizeProgressStep(step);
+        const normalizedSeq = normalizeProgressSeq(progressSeq);
+        const previousStepIndex = getProgressStepIndex(lastEmittedStep);
+        const nextStepIndex = getProgressStepIndex(normalizedStep);
+
+        if (normalizedSeq !== null && lastProgressSeq !== null && normalizedSeq < lastProgressSeq) {
+            return;
+        }
+
+        if (
+            normalizedSeq === null &&
+            lastProgressSeq !== null &&
+            previousStepIndex >= 0 &&
+            nextStepIndex >= 0 &&
+            nextStepIndex < previousStepIndex
+        ) {
+            return;
+        }
+
+        if (
+            normalizedSeq !== null &&
+            lastProgressSeq !== null &&
+            normalizedSeq === lastProgressSeq &&
+            status === lastEmittedStatus &&
+            (normalizedStep === null || normalizedStep === lastEmittedStep)
+        ) {
+            return;
+        }
+
+        if (
+            normalizedSeq === null &&
+            status === lastEmittedStatus &&
+            (normalizedStep === null || normalizedStep === lastEmittedStep)
+        ) {
+            return;
+        }
+
+        if (normalizedSeq !== null && (lastProgressSeq === null || normalizedSeq > lastProgressSeq)) {
+            lastProgressSeq = normalizedSeq;
+        }
+
+        if (status !== lastEmittedStatus) {
+            emitStatusEvent(onEvent, status);
+            lastEmittedStatus = status;
+        }
+
+        if (normalizedStep && normalizedStep !== lastEmittedStep) {
+            onEvent({ event: "message", data: JSON.stringify({ node: normalizedStep }) });
+            lastEmittedStep = normalizedStep;
+        }
+    };
+
+    emitMonotonicProgress(snapshot.status, snapshot.current_step, snapshot.progress_seq);
 
     if (snapshot.status === "completed") {
         await emitTerminalEvent(jobId, "completed", {}, onEvent);
@@ -368,8 +436,7 @@ async function streamRealtimeProgress(
                     }
 
                     const taskPayload = asObject(payload.new.task_payload);
-                    emitStatusEvent(onEvent, payload.new.status);
-                    emitStepEvent(onEvent, taskPayload);
+                    emitMonotonicProgress(payload.new.status, taskPayload.current_step, taskPayload.progress_seq);
 
                     const nextStatus = payload.new.status;
                     if (nextStatus === "completed" || nextStatus === "failed") {
@@ -394,11 +461,11 @@ async function streamRealtimeProgress(
                                 return;
                             }
 
-                            emitStatusEvent(onEvent, latestSnapshot.status);
-                            const latestStep = normalizeProgressStep(latestSnapshot.current_step);
-                            if (latestStep) {
-                                onEvent({ event: "message", data: JSON.stringify({ node: latestStep }) });
-                            }
+                            emitMonotonicProgress(
+                                latestSnapshot.status,
+                                latestSnapshot.current_step,
+                                latestSnapshot.progress_seq,
+                            );
 
                             if (latestSnapshot.status !== "completed" && latestSnapshot.status !== "failed") {
                                 return;


### PR DESCRIPTION
﻿## Root Cause Analysis (RCA)
The binary timeline behavior (`0%` for most of execution and sudden `100%` at completion) came from two issues acting together:

1. The backend emitted intermediate `current_agent` values that were not consistently aligned with the frontend timeline step IDs.
2. The frontend only advanced visible progress when it recognized canonical step IDs, so non-canonical/transitional values were effectively dropped from the UX path.

That mismatch made progress look stalled until terminal reconciliation arrived.

## Backend Phase 1: Canonical Contract + Resilient Persistence
### Canonical contract hardening
- Added a canonical step map and normalizer in `backend/src/case_generator/core/authoring.py`.
- Ensured persisted intermediate checkpoints resolve to the canonical timeline IDs consumed by the UI.

### Retry + degraded-state guardrail
- Added bounded retry for intermediate checkpoint persistence writes.
- Added degraded-state marker persistence when retries are exhausted, plus clear-on-recovery behavior.
- This prevents silent loss of intermediate progress updates and preserves operability semantics under transient DB commit issues.

### Backend regression coverage
- Added `backend/tests/test_authoring_progress_resilience.py` with coverage for:
  - canonical mapping stability,
  - transient commit recovery,
  - degraded-state marking on retry exhaustion.

## Frontend Phases 3/4: Rehydration + Smooth Progress UX
### Canonical step typing and normalization
- Added shared canonical progress types/constants in `frontend/src/shared/adam-types.ts`.
- Added normalization/filtering in `frontend/src/shared/api.ts` so stream emissions and snapshots only propagate canonical timeline steps.

### Stream rehydration after refresh
- Implemented session-backed active-job persistence in `useAuthoringJobProgress`.
- On mount, the hook now rehydrates the active job context, reconnects streaming, and restores timeline continuity.

### Timeline progress correctness
- Updated timeline percentage to use `(active_step_index + 1) / total_steps` while processing.
- This fixes the stuck-at-0% behavior when valid in-flight progress exists.

### Frontend observability
- Added realtime subscribe success/failure logging around subscription setup.

### Frontend test coverage
- Added/updated tests for canonical filtering, rehydration behavior, and timeline movement semantics.

## Validation Evidence
### Backend
- `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py`
- Result: `3 passed`

### Frontend
- `npm --prefix frontend run test -- src/shared/api.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts`
- Result: `22 passed`

- `npm --prefix frontend run lint`
- Result: pass

- `npm --prefix frontend run build`
- Result: pass

### Manual UX validation
- Browser manual refresh (`F5`) during generation confirmed timeline rehydration and continued incremental progress (validated by requester).

## Deferred Hardening (tracked in TODOS.md)
Added explicit follow-ups:
- `TODO-007`: frontend progress watchdog + controlled stream fallback/reconnect.
- `TODO-008`: stream health monitoring + alerting (subscription failures, reconnection rate, end-to-end progress latency).
