### PR TITLE
feat(issue-112): Stateful Recovery and Checkpointing — Phase 2 + Review Hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 help:
 	@echo "Available commands:"
 	@echo "  make dev-frontend    - Starts the frontend development server (Vite)"
-	@echo "  make dev-backend     - Starts the backend API server (runtime profile launcher)"
+	@echo "  make dev-backend     - Starts the backend API server pinned to localhost:5434"
 	@echo "  make dev-langgraph   - Starts the LangGraph development server"
 	@echo "  make dev             - Starts both frontend and backend API development servers"
 
@@ -14,7 +14,7 @@ dev-frontend:
 
 dev-backend:
 	@echo "Starting backend API development server..."
-	@cd backend && uv run python -m shared.app
+	@cd backend && DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres uv run python -m shared.app
 
 dev-langgraph:
 	@echo "Starting LangGraph development server..."

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Resumen corto:
 - plano `authoring/app DB local`: `docker compose up -d adam-edu-postgres` en `5434`
 - plano `auth local`: `supabase start` con API `54321`, DB `54322`, Studio `54323` y Mailpit `54324`
 - referencias remotas: `5432` para session mode y `6543` para transaction mode, nunca como default local del repo
+- el launcher local `uv run --directory backend python -m shared.app` ahora falla rapido si `ENVIRONMENT=development` apunta a un host remoto de Supabase; para local, usa siempre `localhost:5434`
 
 El error mas comun en esta fase es apuntar `DATABASE_URL` al Postgres de Supabase local.
 No lo hagas. `DATABASE_URL` local del repo sigue apuntando a `localhost:5434`.

--- a/TODOS.md
+++ b/TODOS.md
@@ -134,3 +134,51 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** Registrado como follow-up de hardening después de estabilizar el contrato canónico de pasos y la persistencia resiliente introducidos en esta entrega.
 
 **Depends on / blocked by:** Alineación con la estrategia de observabilidad de la plataforma (métricas, logs y alerting) y disponibilidad del destino de métricas en ambientes compartidos.
+
+---
+
+## TODO-009: Política de retención y purge de checkpoints LangGraph
+
+**What:** Definir e implementar una política explícita de retención para tablas de checkpoints (`checkpoints`, `checkpoint_blobs`, `checkpoint_writes`) con purge seguro por antigüedad/estado terminal y guardrails para no borrar sesiones activas.
+
+**Why:** La persistencia stateful de Issue #112 agrega crecimiento continuo de datos de checkpoint. Sin retención, la base acumula payloads JSONB/BYTEA y degrada costo/operación a mediano plazo.
+
+**Pros:** Control de crecimiento de almacenamiento, mejor performance operacional, y ciclo de vida claro de datos transitorios de ejecución.
+
+**Cons:** Requiere definir ventana de retención por entorno, estrategia de borrado incremental y observabilidad para evitar borrados agresivos.
+
+**Context:** Diferido en la planeación de Issue #112 para priorizar Fase 1 (persistencia + contrato) y Fase 2 (resume funcional) antes de hardening operacional.
+
+**Depends on / blocked by:** Estabilizar primero el flujo de resume en producción y acordar política de compliance para retención de trazas de ejecución.
+
+---
+
+## TODO-010: Utilidad de reconciliación de artefactos huérfanos legacy
+
+**What:** Crear una utilidad operativa para reconciliar artefactos huérfanos históricos (manifest en DB vs blob en storage) y aplicar remediación controlada (marcar, limpiar o re-vincular según reglas).
+
+**Why:** Aunque el pipeline actual maneja orphaning/publish por job, existen escenarios legacy y fallos previos donde pueden quedar inconsistencias entre DB y storage.
+
+**Pros:** Reduce deuda de datos históricos, mejora integridad de inventario de artifacts y simplifica troubleshooting de casos antiguos.
+
+**Cons:** Tiene riesgo de limpieza incorrecta si la heurística no es conservadora; requiere modo dry-run y auditoría de cambios.
+
+**Context:** Diferido en el plan de Issue #112 para no expandir alcance de la primera entrega de stateful recovery.
+
+**Depends on / blocked by:** Definir criterios de reconciliación por tipo de artifact y ventana temporal, más aprobación operativa para ejecutar limpieza en ambientes compartidos.
+
+---
+
+## TODO-011: Política de retry budget y circuit breaker para authoring
+
+**What:** Diseñar una política de presupuesto de reintentos por job/tenant y un circuit breaker para fallos transientes repetidos del proveedor LLM, con telemetría y mensajes de fallback consistentes.
+
+**Why:** El estado `failed_resumable` habilita reintentos manuales, pero sin límites puede generar loops costosos de reintento y mala experiencia bajo incidentes prolongados.
+
+**Pros:** Control de costo/estabilidad, prevención de tormentas de retry y comportamiento predecible durante degradaciones externas.
+
+**Cons:** Requiere calibración fina por tipo de error y coordinación entre backend, UX y métricas para no bloquear reintentos legítimos.
+
+**Context:** Registrado como deuda explícita al cerrar la planeación de Issue #112; no bloquea el arranque de Fase 1.
+
+**Depends on / blocked by:** Baseline de métricas de fallos transientes en producción y definición de política de producto sobre reintentos permitidos por usuario/curso.

--- a/TODOS.md
+++ b/TODOS.md
@@ -147,9 +147,9 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 **Cons:** Requiere definir ventana de retención por entorno, estrategia de borrado incremental y observabilidad para evitar borrados agresivos.
 
-**Context:** Diferido en la planeación de Issue #112 para priorizar Fase 1 (persistencia + contrato) y Fase 2 (resume funcional) antes de hardening operacional.
+**Context:** Reconfirmado en la corrección async de Issue #112. La decisión explícita es mantener Fase 2 enfocada en `AsyncPostgresSaver` + resume funcional y diferir la política de retención hasta que el flujo durable esté estable.
 
-**Depends on / blocked by:** Estabilizar primero el flujo de resume en producción y acordar política de compliance para retención de trazas de ejecución.
+**Depends on / blocked by:** Estabilizar primero el flujo de resume con el wiring async lazy/fail-closed y acordar política de compliance para retención de trazas de ejecución.
 
 ---
 
@@ -163,9 +163,9 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 **Cons:** Tiene riesgo de limpieza incorrecta si la heurística no es conservadora; requiere modo dry-run y auditoría de cambios.
 
-**Context:** Diferido en el plan de Issue #112 para no expandir alcance de la primera entrega de stateful recovery.
+**Context:** Reconfirmado en la revisión de corrección de Issue #112. La Fase 2 queda checkpoint-first; la reconciliación histórica sigue fuera de alcance para no mezclar cleanup legado con el fix del blocker async.
 
-**Depends on / blocked by:** Definir criterios de reconciliación por tipo de artifact y ventana temporal, más aprobación operativa para ejecutar limpieza en ambientes compartidos.
+**Depends on / blocked by:** Definir criterios de reconciliación por tipo de artifact y ventana temporal, más aprobación operativa para ejecutar limpieza en ambientes compartidos después de estabilizar el resume durable.
 
 ---
 
@@ -179,6 +179,22 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 **Cons:** Requiere calibración fina por tipo de error y coordinación entre backend, UX y métricas para no bloquear reintentos legítimos.
 
-**Context:** Registrado como deuda explícita al cerrar la planeación de Issue #112; no bloquea el arranque de Fase 1.
+**Context:** Reconfirmado durante la corrección async de Issue #112. La decisión explícita fue no diseñar budget/circuit breaker antes de tener baseline determinístico y `live_llm` del flujo de resume desde M4.
 
-**Depends on / blocked by:** Baseline de métricas de fallos transientes en producción y definición de política de producto sobre reintentos permitidos por usuario/curso.
+**Depends on / blocked by:** Baseline de métricas de fallos transientes en producción, validación del resume durable con `AsyncPostgresSaver`, y definición de política de producto sobre reintentos permitidos por usuario/curso.
+
+---
+
+## TODO-012: Lifecycle explícito para el singleton async de checkpoints
+
+**What:** Evaluar si el singleton async lazy de `AsyncConnectionPool` + `AsyncPostgresSaver` + grafo compilado debe migrarse a ownership explícito por `lifespan` en `shared.app` y `shared.worker_app`.
+
+**Why:** La Fase 2 de Issue #112 eligió el patrón lazy async por minimal diff. Si aparecen problemas de cleanup en shutdown, churn de event loops en tests o necesidad de teardown más predecible, conviene promover estos recursos a lifecycle explícito.
+
+**Pros:** Cierre determinístico de recursos, menos ambigüedad en tests/multi-loop, ownership operacional más obvio.
+
+**Cons:** Amplía scope a `shared.app` y `shared.worker_app`, añade más superficie sensible y no desbloquea el bug actual por sí mismo.
+
+**Context:** Esta fue la alternativa 1B considerada en la revisión de corrección de Issue #112. Se rechazó para el fix inicial por preferencia de diff mínimo, pero queda capturada como hardening posterior si el patrón lazy muestra límites reales.
+
+**Depends on / blocked by:** Observar primero el comportamiento del wiring async lazy en validación local, tests y worker real después de que el blocker quede resuelto.

--- a/backend/alembic/versions/a6fd55f56fbc_issue112_stateful_recovery_phase1.py
+++ b/backend/alembic/versions/a6fd55f56fbc_issue112_stateful_recovery_phase1.py
@@ -1,0 +1,108 @@
+"""issue112_stateful_recovery_phase1
+
+Revision ID: a6fd55f56fbc
+Revises: d4f4c2f9c1aa
+Create Date: 2026-04-14 21:09:27.685935
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a6fd55f56fbc'
+down_revision: Union[str, Sequence[str], None] = 'd4f4c2f9c1aa'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "checkpoint_migrations",
+        sa.Column("v", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("v"),
+    )
+
+    op.create_table(
+        "checkpoints",
+        sa.Column("thread_id", sa.Text(), nullable=False),
+        sa.Column("checkpoint_ns", sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.Column("checkpoint_id", sa.Text(), nullable=False),
+        sa.Column("parent_checkpoint_id", sa.Text(), nullable=True),
+        sa.Column("type", sa.Text(), nullable=True),
+        sa.Column("checkpoint", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.PrimaryKeyConstraint("thread_id", "checkpoint_ns", "checkpoint_id"),
+    )
+
+    op.create_table(
+        "checkpoint_blobs",
+        sa.Column("thread_id", sa.Text(), nullable=False),
+        sa.Column("checkpoint_ns", sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.Column("channel", sa.Text(), nullable=False),
+        sa.Column("version", sa.Text(), nullable=False),
+        sa.Column("type", sa.Text(), nullable=False),
+        sa.Column("blob", postgresql.BYTEA(), nullable=True),
+        sa.PrimaryKeyConstraint("thread_id", "checkpoint_ns", "channel", "version"),
+    )
+
+    op.create_table(
+        "checkpoint_writes",
+        sa.Column("thread_id", sa.Text(), nullable=False),
+        sa.Column("checkpoint_ns", sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.Column("checkpoint_id", sa.Text(), nullable=False),
+        sa.Column("task_id", sa.Text(), nullable=False),
+        sa.Column("idx", sa.Integer(), nullable=False),
+        sa.Column("channel", sa.Text(), nullable=False),
+        sa.Column("type", sa.Text(), nullable=True),
+        sa.Column("blob", postgresql.BYTEA(), nullable=False),
+        sa.Column("task_path", sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.PrimaryKeyConstraint("thread_id", "checkpoint_ns", "checkpoint_id", "task_id", "idx"),
+    )
+
+    op.create_index("ix_checkpoints_thread_id", "checkpoints", ["thread_id"], unique=False)
+    op.create_index("ix_checkpoint_blobs_thread_id", "checkpoint_blobs", ["thread_id"], unique=False)
+    op.create_index("ix_checkpoint_writes_thread_id", "checkpoint_writes", ["thread_id"], unique=False)
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_check_constraints = {
+        constraint.get("name")
+        for constraint in inspector.get_check_constraints("authoring_jobs")
+    }
+    if "ck_authoring_jobs_status" not in existing_check_constraints:
+        op.create_check_constraint(
+            "ck_authoring_jobs_status",
+            "authoring_jobs",
+            "status IN ('pending', 'processing', 'completed', 'failed', 'failed_resumable')",
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_check_constraints = {
+        constraint.get("name")
+        for constraint in inspector.get_check_constraints("authoring_jobs")
+    }
+    if "ck_authoring_jobs_status" in existing_check_constraints:
+        op.drop_constraint("ck_authoring_jobs_status", "authoring_jobs", type_="check")
+
+    op.drop_index("ix_checkpoint_writes_thread_id", table_name="checkpoint_writes")
+    op.drop_index("ix_checkpoint_blobs_thread_id", table_name="checkpoint_blobs")
+    op.drop_index("ix_checkpoints_thread_id", table_name="checkpoints")
+
+    op.drop_table("checkpoint_writes")
+    op.drop_table("checkpoint_blobs")
+    op.drop_table("checkpoints")
+    op.drop_table("checkpoint_migrations")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "supabase>=2.23.0",
     "cachetools>=5.0.0",
     "python-json-logger>=2.0.7",
+    "langgraph-checkpoint-postgres>=3.0.5",
 ]
 
 

--- a/backend/src/case_generator/core/artifact_manager.py
+++ b/backend/src/case_generator/core/artifact_manager.py
@@ -128,4 +128,61 @@ class ArtifactManager:
             logger.info(f"ArtifactManager: Promoted {len(manifests)} manifests to 'published_v5' for Job {job_id}")
             db.commit()
 
+    @classmethod
+    async def prefetch_resume_artifacts(
+        cls,
+        *,
+        db: Session,
+        storage_provider: IStorageProvider,
+        assignment_id: str,
+    ) -> dict[str, dict[str, str]]:
+        """
+        Load resumable artifacts in one query and map them into node->state payloads.
+
+        This avoids N+1 manifest reads when rehydrating state for resume attempts.
+        """
+        hydration_map = {
+            ("narrative_text", "case_writer"): ("case_writer", "doc1_narrativa"),
+            ("eda_report", "eda_text_analyst"): ("eda_text_analyst", "doc2_eda"),
+        }
+
+        manifests = (
+            db.query(ArtifactManifest)
+            .filter(
+                ArtifactManifest.assignment_id == assignment_id,
+                ArtifactManifest.status.in_(("published_v5", "unvalidated")),
+                ArtifactManifest.artifact_type.in_(("narrative_text", "eda_report")),
+            )
+            .order_by(ArtifactManifest.created_at.desc())
+            .all()
+        )
+
+        selected_by_kind: dict[tuple[str, str], ArtifactManifest] = {}
+        for manifest in manifests:
+            lookup_key = (manifest.artifact_type, manifest.producer_node)
+            if lookup_key in hydration_map and lookup_key not in selected_by_kind:
+                selected_by_kind[lookup_key] = manifest
+
+        cached_nodes: dict[str, dict[str, str]] = {}
+        for lookup_key, manifest in selected_by_kind.items():
+            node_name, state_key = hydration_map[lookup_key]
+            try:
+                artifact_text = await storage_provider.download_text(manifest.gcs_uri)
+            except Exception as exc:
+                logger.warning(
+                    "ArtifactManager: Could not hydrate %s/%s from %s: %s",
+                    manifest.artifact_type,
+                    manifest.producer_node,
+                    manifest.gcs_uri,
+                    exc,
+                )
+                continue
+
+            if not artifact_text.strip():
+                continue
+
+            cached_nodes.setdefault(node_name, {})[state_key] = artifact_text
+
+        return cached_nodes
+
 

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -763,30 +763,45 @@ class AuthoringService:
                 error_code = "checkpoint_unavailable"
                 error_msg = _DURABLE_CHECKPOINT_ERROR_MESSAGE
             else:
-                logger.error("AuthoringService: LangGraph raised exception for Job %s", job_id, exc_info=True)
-                error_trace = traceback.format_exc()
-                error_str = error_trace.lower()
-                if any(marker in error_str for marker in _TRANSIENT_TIMEOUT_MARKERS):
-                    error_code = "llm_timeout"
-                    error_msg = (
-                        "Nuestros servidores de IA estan a maxima capacidad y el tiempo de espera se agoto. "
-                        "Por favor, reintenta en unos minutos."
+                # Secondary guard: catch DB/pool errors wrapped by LangGraph retry
+                # machinery that escape the outer _is_durable_checkpoint_runtime_failure
+                # check (e.g. RuntimeError -> __cause__ = PoolTimeout).
+                if any(
+                    isinstance(e, _CHECKPOINT_INFRA_ERROR_TYPES)
+                    for e in _iter_exception_chain(exc)
+                ):
+                    logger.error(
+                        "AuthoringService: Infra error in exception chain for Job %s",
+                        job_id,
+                        exc_info=True,
                     )
-                elif any(marker in error_str for marker in _TRANSIENT_PROVIDER_UNAVAILABLE_MARKERS):
-                    error_code = "llm_provider_unavailable"
-                    error_msg = (
-                        "Nuestros servidores de IA estan experimentando un pico de trafico en este momento. "
-                        "Por favor, reintenta en un par de minutos."
-                    )
-                elif "429" in error_str or "quota" in error_str:
-                    error_code = "llm_rate_limited"
-                    error_msg = (
-                        "Hemos alcanzado el limite de operaciones de IA permitidas por minuto. "
-                        "Por favor, intenta generar el caso un poco mas tarde."
-                    )
+                    error_code = "checkpoint_unavailable"
+                    error_msg = _DURABLE_CHECKPOINT_ERROR_MESSAGE
                 else:
-                    error_code = "llm_unhandled_error"
-                    error_msg = error_trace
+                    logger.error("AuthoringService: LangGraph raised exception for Job %s", job_id, exc_info=True)
+                    error_trace = traceback.format_exc()
+                    error_str = error_trace.lower()
+                    if any(marker in error_str for marker in _TRANSIENT_TIMEOUT_MARKERS):
+                        error_code = "llm_timeout"
+                        error_msg = (
+                            "Nuestros servidores de IA estan a maxima capacidad y el tiempo de espera se agoto. "
+                            "Por favor, reintenta en unos minutos."
+                        )
+                    elif any(marker in error_str for marker in _TRANSIENT_PROVIDER_UNAVAILABLE_MARKERS):
+                        error_code = "llm_provider_unavailable"
+                        error_msg = (
+                            "Nuestros servidores de IA estan experimentando un pico de trafico en este momento. "
+                            "Por favor, reintenta en un par de minutos."
+                        )
+                    elif "429" in error_str or "quota" in error_str:
+                        error_code = "llm_rate_limited"
+                        error_msg = (
+                            "Hemos alcanzado el limite de operaciones de IA permitidas por minuto. "
+                            "Por favor, intenta generar el caso un poco mas tarde."
+                        )
+                    else:
+                        error_code = "llm_unhandled_error"
+                        error_msg = error_trace
 
         # --- MICRO-SESSION 2: Persist Results ---
         db = SessionLocal()

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 import logging
+from psycopg import Error as PsycopgError
+from psycopg_pool import PoolClosed, PoolTimeout
 import time
 import traceback
 import uuid
@@ -14,6 +16,8 @@ from case_generator.graph import DurableCheckpointUnavailableError, RESUME_CACHE
 from case_generator.orchestration.frontend_output_adapter import adapter_legacy_to_canonical_output
 from langchain_core.runnables import RunnableConfig
 from sqlalchemy import update
+from sqlalchemy.exc import DBAPIError, OperationalError
+from sqlalchemy.exc import TimeoutError as SATimeoutError
 from shared.blueprint_schema import (
     ArtifactManifestProjection,
     AssignmentBlueprint,
@@ -125,12 +129,47 @@ _TRANSIENT_PROVIDER_UNAVAILABLE_MARKERS = (
     "network is unreachable",
 )
 
+_DURABLE_CHECKPOINT_ERROR_MESSAGE = (
+    "No se pudo inicializar la persistencia durable del proceso de generacion. "
+    "Por favor, reintenta cuando el servicio de checkpoints este disponible."
+)
+_CHECKPOINT_INFRA_ERROR_TYPES = (
+    DBAPIError,
+    OperationalError,
+    SATimeoutError,
+    PsycopgError,
+    PoolClosed,
+    PoolTimeout,
+)
+
 
 def _classify_failure_status(error_code: str | None) -> str:
     """Map known transient failures to failed_resumable and default to failed."""
     if error_code in _RESUMABLE_FAILURE_CODES:
         return AUTHORING_JOB_STATUS_FAILED_RESUMABLE
     return AUTHORING_JOB_STATUS_FAILED
+
+
+def _iter_exception_chain(exc: BaseException) -> list[BaseException]:
+    """Return the causal chain for an exception without revisiting cycles."""
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+
+    while current is not None and id(current) not in seen:
+        chain.append(current)
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+
+    return chain
+
+
+def _is_durable_checkpoint_runtime_failure(exc: BaseException) -> bool:
+    """Return True when a graph stream error comes from checkpoint infra."""
+    return any(
+        isinstance(candidate, _CHECKPOINT_INFRA_ERROR_TYPES)
+        for candidate in _iter_exception_chain(exc)
+    )
 
 
 def _to_canonical_progress_step(raw_step: str | None) -> str | None:
@@ -706,10 +745,7 @@ class AuthoringService:
                 exc_info=True,
             )
             error_code = "checkpoint_unavailable"
-            error_msg = (
-                "No se pudo inicializar la persistencia durable del proceso de generacion. "
-                "Por favor, reintenta cuando el servicio de checkpoints este disponible."
-            )
+            error_msg = _DURABLE_CHECKPOINT_ERROR_MESSAGE
         except asyncio.TimeoutError:
             logger.error("AuthoringService: TIMEOUT — Job %s exceeded 900s", job_id)
             error_code = "llm_timeout"
@@ -717,31 +753,40 @@ class AuthoringService:
                 "Nuestros servidores de IA estan a maxima capacidad y el tiempo de espera se agoto. "
                 "Por favor, reintenta en unos minutos."
             )
-        except Exception:
-            logger.error("AuthoringService: LangGraph raised exception for Job %s", job_id, exc_info=True)
-            error_trace = traceback.format_exc()
-            error_str = error_trace.lower()
-            if any(marker in error_str for marker in _TRANSIENT_TIMEOUT_MARKERS):
-                error_code = "llm_timeout"
-                error_msg = (
-                    "Nuestros servidores de IA estan a maxima capacidad y el tiempo de espera se agoto. "
-                    "Por favor, reintenta en unos minutos."
+        except Exception as exc:
+            if _is_durable_checkpoint_runtime_failure(exc):
+                logger.error(
+                    "AuthoringService: Durable checkpoint runtime failed for Job %s",
+                    job_id,
+                    exc_info=True,
                 )
-            elif any(marker in error_str for marker in _TRANSIENT_PROVIDER_UNAVAILABLE_MARKERS):
-                error_code = "llm_provider_unavailable"
-                error_msg = (
-                    "Nuestros servidores de IA estan experimentando un pico de trafico en este momento. "
-                    "Por favor, reintenta en un par de minutos."
-                )
-            elif "429" in error_str or "quota" in error_str:
-                error_code = "llm_rate_limited"
-                error_msg = (
-                    "Hemos alcanzado el limite de operaciones de IA permitidas por minuto. "
-                    "Por favor, intenta generar el caso un poco mas tarde."
-                )
+                error_code = "checkpoint_unavailable"
+                error_msg = _DURABLE_CHECKPOINT_ERROR_MESSAGE
             else:
-                error_code = "llm_unhandled_error"
-                error_msg = error_trace
+                logger.error("AuthoringService: LangGraph raised exception for Job %s", job_id, exc_info=True)
+                error_trace = traceback.format_exc()
+                error_str = error_trace.lower()
+                if any(marker in error_str for marker in _TRANSIENT_TIMEOUT_MARKERS):
+                    error_code = "llm_timeout"
+                    error_msg = (
+                        "Nuestros servidores de IA estan a maxima capacidad y el tiempo de espera se agoto. "
+                        "Por favor, reintenta en unos minutos."
+                    )
+                elif any(marker in error_str for marker in _TRANSIENT_PROVIDER_UNAVAILABLE_MARKERS):
+                    error_code = "llm_provider_unavailable"
+                    error_msg = (
+                        "Nuestros servidores de IA estan experimentando un pico de trafico en este momento. "
+                        "Por favor, reintenta en un par de minutos."
+                    )
+                elif "429" in error_str or "quota" in error_str:
+                    error_code = "llm_rate_limited"
+                    error_msg = (
+                        "Hemos alcanzado el limite de operaciones de IA permitidas por minuto. "
+                        "Por favor, intenta generar el caso un poco mas tarde."
+                    )
+                else:
+                    error_code = "llm_unhandled_error"
+                    error_msg = error_trace
 
         # --- MICRO-SESSION 2: Persist Results ---
         db = SessionLocal()

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 import logging
+import time
 import traceback
 import uuid
 from typing import Any, Literal, Mapping, cast
@@ -97,6 +98,8 @@ _PROGRESS_DEGRADATION_KEYS = (
     "progress_degraded_at",
     "progress_degraded_error",
 )
+_RESUME_CACHE_STATE_KEY = "resume_cached_nodes"
+_RESUME_PREFETCH_WARN_MS = 25.0
 
 _RESUMABLE_FAILURE_CODES = {
     "llm_timeout",
@@ -460,6 +463,9 @@ class AuthoringService:
         owner_id = ""
         payload: dict[str, Any] = {}
         error_code: str | None = None
+        storage_provider = get_storage_provider()
+        resume_cached_nodes: dict[str, dict[str, str]] = {}
+        is_resume_retry = False
 
         # --- DB MICRO-SESSION 1: transition the job into processing ---
         # Winner-takes-lock CAS: only one concurrent retry may move status to processing.
@@ -469,6 +475,8 @@ class AuthoringService:
             if existing_job is None:
                 logger.error("AuthoringService: Job %s not found in DB.", job_id)
                 return
+
+            is_resume_retry = existing_job.status == AUTHORING_JOB_STATUS_FAILED_RESUMABLE
 
             if existing_job.status in [
                 AUTHORING_JOB_STATUS_COMPLETED,
@@ -543,6 +551,39 @@ class AuthoringService:
             logger.error("AuthoringService: Missing assignment_id for job %s after lock.", job_id)
             return
 
+        if is_resume_retry:
+            prefetch_started_at = time.perf_counter()
+            prefetch_db = SessionLocal()
+            try:
+                resume_cached_nodes = await ArtifactManager.prefetch_resume_artifacts(
+                    db=prefetch_db,
+                    storage_provider=storage_provider,
+                    assignment_id=assignment_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "AuthoringService: Resume artifact prefetch failed for job %s: %s",
+                    job_id,
+                    exc,
+                )
+            finally:
+                prefetch_db.close()
+
+            prefetch_latency_ms = round((time.perf_counter() - prefetch_started_at) * 1000, 3)
+            logger.info(
+                "AuthoringService: Resume prefetch for job %s loaded %s node payload(s) in %s ms.",
+                job_id,
+                len(resume_cached_nodes),
+                prefetch_latency_ms,
+            )
+            if prefetch_latency_ms > _RESUME_PREFETCH_WARN_MS:
+                logger.warning(
+                    "AuthoringService: Resume prefetch latency high for job %s: %s ms (threshold %s ms)",
+                    job_id,
+                    prefetch_latency_ms,
+                    _RESUME_PREFETCH_WARN_MS,
+                )
+
         # --- LANGGRAPH EXECUTION (no open DB session) ---
         graph_output: dict[str, Any] | None = None
         error_msg: str | None = None
@@ -590,7 +631,13 @@ class AuthoringService:
                 "urgency_frame": "48-96 horas",
                 "protected_columns": ["target", "id", "date"],
                 "industry_cagr_range": "5-8%",
+                _RESUME_CACHE_STATE_KEY: resume_cached_nodes,
             }
+
+            # Inject hydrated artifacts into initial graph state so downstream nodes
+            # keep context even when upstream generation is skipped.
+            for node_payload in resume_cached_nodes.values():
+                state_input.update(node_payload)
 
             run_config: RunnableConfig = {
                 "configurable": {
@@ -718,7 +765,6 @@ class AuthoringService:
             eda_full_text = _extract_text_field(graph_output, "doc2_eda", EDA_ARTIFACT_LIMIT)
             eda_summary = _build_eda_summary(eda_full_text)
 
-            storage_provider = get_storage_provider()
             artifact_ids: list[str] = []
             artifact_ids.append(
                 await ArtifactManager.save_artifact(

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -10,7 +10,7 @@ from typing import Any, Literal, Mapping, cast
 
 from case_generator.core.artifact_manager import ArtifactManager
 from case_generator.core.storage import get_storage_provider
-from case_generator.graph import graph
+from case_generator.graph import DurableCheckpointUnavailableError, RESUME_CACHE_STATE_KEY, get_graph
 from case_generator.orchestration.frontend_output_adapter import adapter_legacy_to_canonical_output
 from langchain_core.runnables import RunnableConfig
 from sqlalchemy import update
@@ -98,7 +98,6 @@ _PROGRESS_DEGRADATION_KEYS = (
     "progress_degraded_at",
     "progress_degraded_error",
 )
-_RESUME_CACHE_STATE_KEY = "resume_cached_nodes"
 _RESUME_PREFETCH_WARN_MS = 25.0
 
 _RESUMABLE_FAILURE_CODES = {
@@ -585,6 +584,12 @@ class AuthoringService:
                 )
 
         # --- LANGGRAPH EXECUTION (no open DB session) ---
+        # Retry/resume pipeline:
+        #   failed_resumable job
+        #     -> await get_graph()  [async lazy singleton, durable saver required]
+        #     -> graph.astream(thread_id=job_id)
+        #     -> checkpoint reload + explicit node skip/hydration
+        #     -> completed | failed_resumable | failed
         graph_output: dict[str, Any] | None = None
         error_msg: str | None = None
         try:
@@ -631,13 +636,15 @@ class AuthoringService:
                 "urgency_frame": "48-96 horas",
                 "protected_columns": ["target", "id", "date"],
                 "industry_cagr_range": "5-8%",
-                _RESUME_CACHE_STATE_KEY: resume_cached_nodes,
+                RESUME_CACHE_STATE_KEY: resume_cached_nodes,
             }
 
             # Inject hydrated artifacts into initial graph state so downstream nodes
             # keep context even when upstream generation is skipped.
             for node_payload in resume_cached_nodes.values():
                 state_input.update(node_payload)
+
+            compiled_graph = await get_graph()
 
             run_config: RunnableConfig = {
                 "configurable": {
@@ -665,7 +672,11 @@ class AuthoringService:
                     else None
                 ) or _FIRST_CANONICAL_STEP
                 stream_mode: Literal["values"] = "values"
-                stream = cast(Any, graph).astream(state_input, config=run_config, stream_mode=stream_mode)
+                stream = cast(Any, compiled_graph).astream(
+                    state_input,
+                    config=run_config,
+                    stream_mode=stream_mode,
+                )
 
                 async for event in stream:
                     final_state = dict(event)
@@ -688,6 +699,17 @@ class AuthoringService:
 
             graph_output = await asyncio.wait_for(_run_graph_stream(), timeout=900)
             logger.info("AuthoringService: LangGraph execution finished for Job %s.", job_id)
+        except DurableCheckpointUnavailableError:
+            logger.error(
+                "AuthoringService: Durable checkpoint wiring unavailable for Job %s",
+                job_id,
+                exc_info=True,
+            )
+            error_code = "checkpoint_unavailable"
+            error_msg = (
+                "No se pudo inicializar la persistencia durable del proceso de generacion. "
+                "Por favor, reintenta cuando el servicio de checkpoints este disponible."
+            )
         except asyncio.TimeoutError:
             logger.error("AuthoringService: TIMEOUT — Job %s exceeded 900s", job_id)
             error_code = "llm_timeout"

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -30,7 +30,7 @@ from shared.blueprint_schema import (
     StudentArtifacts,
     ValidationContract,
 )
-from shared.database import SessionLocal
+from shared.database import SessionLocal, register_active_authoring_job, unregister_active_authoring_job
 from shared.models import (
     AUTHORING_JOB_RETRYABLE_STATUSES,
     AUTHORING_JOB_STATUS_COMPLETED,
@@ -683,61 +683,66 @@ class AuthoringService:
             for node_payload in resume_cached_nodes.values():
                 state_input.update(node_payload)
 
-            compiled_graph = await get_graph()
+            register_active_authoring_job(job_id)
+            try:
+                compiled_graph = await get_graph()
 
-            run_config: RunnableConfig = {
-                "configurable": {
-                    "thread_id": job_id,
-                    "writer_model": "gemini-3-flash-preview",
-                    "architect_model": "gemini-3-flash-preview",
-                    "job_id": job_id,
-                    "assignment_id": assignment_id,
-                    "owner_id": owner_id,
+                run_config: RunnableConfig = {
+                    "configurable": {
+                        "thread_id": job_id,
+                        "writer_model": "gemini-3-flash-preview",
+                        "architect_model": "gemini-3-flash-preview",
+                        "job_id": job_id,
+                        "assignment_id": assignment_id,
+                        "owner_id": owner_id,
+                    }
                 }
-            }
 
-            logger.info(
-                "AuthoringService: Invoking LangGraph v8 for Job %s (case_id=%s)...",
-                job_id,
-                state_input["case_id"],
-            )
-
-            async def _run_graph_stream() -> dict[str, Any]:
-                final_state: dict[str, Any] = state_input.copy()
-                current_step = payload.get("current_step")
-                last_reported_step = (
-                    _to_canonical_progress_step(current_step)
-                    if isinstance(current_step, str)
-                    else None
-                ) or _FIRST_CANONICAL_STEP
-                stream_mode: Literal["values"] = "values"
-                stream = cast(Any, compiled_graph).astream(
-                    state_input,
-                    config=run_config,
-                    stream_mode=stream_mode,
+                logger.info(
+                    "AuthoringService: Invoking LangGraph v8 for Job %s (case_id=%s)...",
+                    job_id,
+                    state_input["case_id"],
                 )
 
-                async for event in stream:
-                    final_state = dict(event)
-                    current_agent = final_state.get("current_agent")
-                    canonical_step = (
-                        _to_canonical_progress_step(current_agent)
-                        if isinstance(current_agent, str)
+                async def _run_graph_stream() -> dict[str, Any]:
+                    final_state: dict[str, Any] = state_input.copy()
+                    current_step = payload.get("current_step")
+                    last_reported_step = (
+                        _to_canonical_progress_step(current_step)
+                        if isinstance(current_step, str)
                         else None
+                    ) or _FIRST_CANONICAL_STEP
+                    stream_mode: Literal["values"] = "values"
+                    stream = cast(Any, compiled_graph).astream(
+                        state_input,
+                        config=run_config,
+                        stream_mode=stream_mode,
                     )
 
-                    if canonical_step and canonical_step != last_reported_step:
-                        persisted = await _persist_intermediate_progress_step(
-                            job_id=job_id,
-                            canonical_step=canonical_step,
+                    async for event in stream:
+                        final_state = dict(event)
+                        current_agent = final_state.get("current_agent")
+                        canonical_step = (
+                            _to_canonical_progress_step(current_agent)
+                            if isinstance(current_agent, str)
+                            else None
                         )
-                        if persisted:
-                            last_reported_step = canonical_step
 
-                return final_state
+                        if canonical_step and canonical_step != last_reported_step:
+                            persisted = await _persist_intermediate_progress_step(
+                                job_id=job_id,
+                                canonical_step=canonical_step,
+                            )
+                            if persisted:
+                                last_reported_step = canonical_step
 
-            graph_output = await asyncio.wait_for(_run_graph_stream(), timeout=900)
-            logger.info("AuthoringService: LangGraph execution finished for Job %s.", job_id)
+                    return final_state
+
+                graph_task = asyncio.create_task(_run_graph_stream(), name=f"authoring-job-{job_id}")
+                graph_output = await asyncio.wait_for(graph_task, timeout=900)
+                logger.info("AuthoringService: LangGraph execution finished for Job %s.", job_id)
+            finally:
+                unregister_active_authoring_job(job_id)
         except DurableCheckpointUnavailableError:
             logger.error(
                 "AuthoringService: Durable checkpoint wiring unavailable for Job %s",

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -30,7 +30,7 @@ from shared.blueprint_schema import (
     StudentArtifacts,
     ValidationContract,
 )
-from shared.database import SessionLocal, register_active_authoring_job, unregister_active_authoring_job
+from shared.database import SessionLocal, register_active_authoring_job, settings, unregister_active_authoring_job
 from shared.models import (
     AUTHORING_JOB_RETRYABLE_STATUSES,
     AUTHORING_JOB_STATUS_COMPLETED,
@@ -63,6 +63,13 @@ CANONICAL_TIMELINE_STEP_IDS = (
     "case_writer",
     "eda_text_analyst",
     "m3_content_generator",
+    "m4_content_generator",
+    "m5_content_generator",
+    "teaching_note_part1",
+)
+NARRATIVE_TIMELINE_STEP_IDS = (
+    "case_architect",
+    "case_writer",
     "m4_content_generator",
     "m5_content_generator",
     "teaching_note_part1",
@@ -105,10 +112,23 @@ _PROGRESS_DEGRADATION_KEYS = (
 _RESUME_PREFETCH_WARN_MS = 25.0
 
 _RESUMABLE_FAILURE_CODES = {
+    "bootstrap_timeout",
+    "checkpoint_unavailable",
     "llm_timeout",
     "llm_provider_unavailable",
     "llm_rate_limited",
 }
+
+BOOTSTRAP_STATE_INITIALIZING = "initializing"
+_BOOTSTRAP_STATE_KEYS = (
+    "bootstrap_state",
+    "bootstrap_started_at",
+    "bootstrap_timeout_seconds",
+)
+
+
+class GraphBootstrapTimeoutError(RuntimeError):
+    """Raised when the graph bootstrap exceeds the configured timeout."""
 
 _TRANSIENT_TIMEOUT_MARKERS = (
     "timed out",
@@ -194,9 +214,87 @@ def _to_canonical_progress_step(raw_step: str | None) -> str | None:
     return None
 
 
+def _timeline_steps_for_payload(payload: Mapping[str, Any] | None) -> tuple[str, ...]:
+    case_type = payload.get("caseType", "harvard_only") if payload else "harvard_only"
+    return NARRATIVE_TIMELINE_STEP_IDS if case_type == "harvard_only" else CANONICAL_TIMELINE_STEP_IDS
+
+
+def derive_progress_percentage(
+    payload: Mapping[str, Any] | None,
+    *,
+    current_step: str | None,
+    status: str | None,
+) -> int | None:
+    """Match the frontend timeline percentage from the canonical persisted step."""
+    if status == AUTHORING_JOB_STATUS_COMPLETED or current_step == "completed":
+        return 100
+
+    canonical_step = _to_canonical_progress_step(current_step)
+    if canonical_step is None or canonical_step in TERMINAL_PROGRESS_STEPS:
+        return None
+
+    timeline_steps = _timeline_steps_for_payload(payload)
+    try:
+        step_index = timeline_steps.index(canonical_step)
+    except ValueError:
+        return None
+
+    return round(((step_index + 1) / len(timeline_steps)) * 100)
+
+
 def _clear_progress_degradation(payload: dict[str, Any]) -> None:
     for key in _PROGRESS_DEGRADATION_KEYS:
         payload.pop(key, None)
+
+
+def _bootstrap_timeout_seconds() -> float:
+    configured_timeout = settings.authoring_bootstrap_timeout_seconds
+    if configured_timeout is not None and configured_timeout > 0:
+        return float(configured_timeout)
+
+    normalized_environment = settings.environment.strip().lower()
+    return 120.0 if normalized_environment == "development" else 60.0
+
+
+def _clear_bootstrap_state(payload: dict[str, Any]) -> None:
+    for key in _BOOTSTRAP_STATE_KEYS:
+        payload.pop(key, None)
+
+
+def _mark_bootstrap_initializing(payload: dict[str, Any], *, timeout_seconds: float) -> None:
+    payload["bootstrap_state"] = BOOTSTRAP_STATE_INITIALIZING
+    payload["bootstrap_started_at"] = datetime.now(timezone.utc).isoformat()
+    payload["bootstrap_timeout_seconds"] = round(timeout_seconds, 3)
+
+
+def _remember_last_canonical_step(payload: dict[str, Any]) -> None:
+    current_step = payload.get("current_step")
+    if not isinstance(current_step, str):
+        return
+
+    canonical_step = _to_canonical_progress_step(current_step)
+    if canonical_step is None or canonical_step in TERMINAL_PROGRESS_STEPS:
+        return
+
+    payload["last_known_step"] = canonical_step
+
+
+def _processing_resume_step(payload: Mapping[str, Any] | None) -> str | None:
+    if not payload:
+        return None
+
+    for key in ("current_step", "last_known_step"):
+        raw_step = payload.get(key)
+        if not isinstance(raw_step, str):
+            continue
+
+        canonical_step = _to_canonical_progress_step(raw_step)
+        if canonical_step is None or canonical_step in TERMINAL_PROGRESS_STEPS:
+            continue
+
+        return canonical_step
+
+    return None
 
 
 def _persist_progress_degradation(
@@ -230,6 +328,7 @@ def _persist_progress_degradation(
             status="processing",
             current_step=canonical_current_step,
         )
+        _clear_bootstrap_state(payload)
         payload["progress_degraded"] = True
         payload["progress_degraded_step"] = canonical_step
         payload["progress_degraded_reason"] = "intermediate_checkpoint_write_failed"
@@ -291,6 +390,7 @@ async def _persist_intermediate_progress_step(
                 status="processing",
                 current_step=canonical_step,
             )
+            _clear_bootstrap_state(payload_step)
             _clear_progress_degradation(payload_step)
             job_step.task_payload = payload_step
             db_step.commit()
@@ -528,10 +628,20 @@ class AuthoringService:
                 )
                 return
 
+            bootstrap_timeout_seconds = _bootstrap_timeout_seconds()
+            processing_resume_step = _processing_resume_step(existing_job.task_payload)
             processing_payload = _next_progress_payload(
                 existing_job.task_payload,
                 status=AUTHORING_JOB_STATUS_PROCESSING,
-                current_step=_FIRST_CANONICAL_STEP,
+                current_step=processing_resume_step,
+            )
+            if processing_resume_step is None:
+                processing_payload.pop("current_step", None)
+            processing_payload.pop("error_code", None)
+            processing_payload.pop("error_trace", None)
+            _mark_bootstrap_initializing(
+                processing_payload,
+                timeout_seconds=bootstrap_timeout_seconds,
             )
             lock_stmt = (
                 update(AuthoringJob)
@@ -685,7 +795,25 @@ class AuthoringService:
 
             register_active_authoring_job(job_id)
             try:
-                compiled_graph = await get_graph()
+                bootstrap_started_at = time.perf_counter()
+                try:
+                    compiled_graph = await asyncio.wait_for(
+                        get_graph(),
+                        timeout=bootstrap_timeout_seconds,
+                    )
+                except asyncio.TimeoutError as exc:
+                    raise GraphBootstrapTimeoutError(
+                        f"Graph bootstrap exceeded {bootstrap_timeout_seconds} seconds"
+                    ) from exc
+
+                logger.info(
+                    "AuthoringService: Graph bootstrap ready for Job %s",
+                    job_id,
+                    extra={
+                        "bootstrap_latency_ms": round((time.perf_counter() - bootstrap_started_at) * 1000, 3),
+                        "bootstrap_timeout_seconds": bootstrap_timeout_seconds,
+                    },
+                )
 
                 run_config: RunnableConfig = {
                     "configurable": {
@@ -751,6 +879,17 @@ class AuthoringService:
             )
             error_code = "checkpoint_unavailable"
             error_msg = _DURABLE_CHECKPOINT_ERROR_MESSAGE
+        except GraphBootstrapTimeoutError:
+            logger.error(
+                "AuthoringService: Graph bootstrap timeout for Job %s",
+                job_id,
+                exc_info=True,
+            )
+            error_code = "bootstrap_timeout"
+            error_msg = (
+                "La infraestructura de generacion tardo demasiado en inicializarse. "
+                "Puedes reintentar sin perder el progreso ya completado."
+            )
         except asyncio.TimeoutError:
             logger.error("AuthoringService: TIMEOUT — Job %s exceeded 900s", job_id)
             error_code = "llm_timeout"
@@ -821,13 +960,16 @@ class AuthoringService:
             if error_msg:
                 failure_status = _classify_failure_status(error_code)
                 job.status = failure_status
+                existing_payload = dict(job.task_payload or {})
+                _remember_last_canonical_step(existing_payload)
                 current_payload = _next_progress_payload(
-                    job.task_payload,
+                    existing_payload,
                     status=failure_status,
                     current_step="failed",
                     error_code=error_code or "llm_failure",
                     error_trace=error_msg,
                 )
+                _clear_bootstrap_state(current_payload)
                 job.task_payload = current_payload
 
                 if failure_status == AUTHORING_JOB_STATUS_FAILED:
@@ -892,11 +1034,13 @@ class AuthoringService:
             assignment.canonical_output = canonical_result.get("canonical_output", {})
             assignment.status = "published"
             job.status = AUTHORING_JOB_STATUS_COMPLETED
-            job.task_payload = _next_progress_payload(
+            completed_payload = _next_progress_payload(
                 job.task_payload,
                 status=AUTHORING_JOB_STATUS_COMPLETED,
                 current_step="completed",
             )
+            _clear_bootstrap_state(completed_payload)
+            job.task_payload = completed_payload
 
             ArtifactManager.publish_job_artifacts(db, job_id)
             db.commit()

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -12,6 +12,7 @@ from case_generator.core.storage import get_storage_provider
 from case_generator.graph import graph
 from case_generator.orchestration.frontend_output_adapter import adapter_legacy_to_canonical_output
 from langchain_core.runnables import RunnableConfig
+from sqlalchemy import update
 from shared.blueprint_schema import (
     ArtifactManifestProjection,
     AssignmentBlueprint,
@@ -25,7 +26,15 @@ from shared.blueprint_schema import (
     ValidationContract,
 )
 from shared.database import SessionLocal
-from shared.models import Assignment, AuthoringJob
+from shared.models import (
+    AUTHORING_JOB_RETRYABLE_STATUSES,
+    AUTHORING_JOB_STATUS_COMPLETED,
+    AUTHORING_JOB_STATUS_FAILED,
+    AUTHORING_JOB_STATUS_FAILED_RESUMABLE,
+    AUTHORING_JOB_STATUS_PROCESSING,
+    Assignment,
+    AuthoringJob,
+)
 from shared.sanitization import sanitize_untrusted_text
 
 logger = logging.getLogger(__name__)
@@ -88,6 +97,38 @@ _PROGRESS_DEGRADATION_KEYS = (
     "progress_degraded_at",
     "progress_degraded_error",
 )
+
+_RESUMABLE_FAILURE_CODES = {
+    "llm_timeout",
+    "llm_provider_unavailable",
+    "llm_rate_limited",
+}
+
+_TRANSIENT_TIMEOUT_MARKERS = (
+    "timed out",
+    "read timeout",
+    "connect timeout",
+    "readtimeout",
+    "connecttimeout",
+    "deadline exceeded",
+)
+
+_TRANSIENT_PROVIDER_UNAVAILABLE_MARKERS = (
+    "503",
+    "service unavailable",
+    "temporarily unavailable",
+    "high demand",
+    "connection reset",
+    "connection aborted",
+    "network is unreachable",
+)
+
+
+def _classify_failure_status(error_code: str | None) -> str:
+    """Map known transient failures to failed_resumable and default to failed."""
+    if error_code in _RESUMABLE_FAILURE_CODES:
+        return AUTHORING_JOB_STATUS_FAILED_RESUMABLE
+    return AUTHORING_JOB_STATUS_FAILED
 
 
 def _to_canonical_progress_step(raw_step: str | None) -> str | None:
@@ -421,46 +462,75 @@ class AuthoringService:
         error_code: str | None = None
 
         # --- DB MICRO-SESSION 1: transition the job into processing ---
+        # Winner-takes-lock CAS: only one concurrent retry may move status to processing.
         db = SessionLocal()
         try:
-            job = db.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
-            if job is None:
+            existing_job = db.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
+            if existing_job is None:
                 logger.error("AuthoringService: Job %s not found in DB.", job_id)
                 return
 
-            if job.status in ["completed", "processing", "failed"]:
+            if existing_job.status in [
+                AUTHORING_JOB_STATUS_COMPLETED,
+                AUTHORING_JOB_STATUS_PROCESSING,
+                AUTHORING_JOB_STATUS_FAILED,
+            ]:
                 logger.warning(
                     "AuthoringService: Job %s is already in terminal/processing state '%s'. Aborting.",
                     job_id,
-                    job.status,
+                    existing_job.status,
                 )
                 return
 
-            assignment = db.query(Assignment).filter(Assignment.id == job.assignment_id).first()
+            processing_payload = _next_progress_payload(
+                existing_job.task_payload,
+                status=AUTHORING_JOB_STATUS_PROCESSING,
+                current_step=_FIRST_CANONICAL_STEP,
+            )
+            lock_stmt = (
+                update(AuthoringJob)
+                .where(
+                    AuthoringJob.id == job_id,
+                    AuthoringJob.status.in_(AUTHORING_JOB_RETRYABLE_STATUSES),
+                )
+                .values(
+                    status=AUTHORING_JOB_STATUS_PROCESSING,
+                    retry_count=AuthoringJob.retry_count + 1,
+                    task_payload=processing_payload,
+                )
+                .returning(AuthoringJob.assignment_id, AuthoringJob.task_payload)
+            )
+            locked_row = db.execute(lock_stmt).mappings().first()
+            if locked_row is None:
+                logger.info(
+                    "AuthoringService: retry_lost_race for job %s; another worker already claimed processing.",
+                    job_id,
+                )
+                db.rollback()
+                return
+
+            assignment_id = cast(str, locked_row["assignment_id"])
+            payload = dict(locked_row["task_payload"] or {})
+
+            assignment = db.query(Assignment).filter(Assignment.id == assignment_id).first()
             if assignment is None:
-                logger.error("AuthoringService: Assignment %s not found for job %s.", job.assignment_id, job_id)
-                job.status = "failed"
+                logger.error("AuthoringService: Assignment %s not found for job %s.", assignment_id, job_id)
                 payload_with_error = _next_progress_payload(
-                    job.task_payload,
-                    status="failed",
+                    payload,
+                    status=AUTHORING_JOB_STATUS_FAILED,
                     current_step="failed",
                     error_code="assignment_missing",
                     error_trace="Assignment not found for authoring job.",
                 )
-                job.task_payload = payload_with_error
+                db.execute(
+                    update(AuthoringJob)
+                    .where(AuthoringJob.id == job_id)
+                    .values(status=AUTHORING_JOB_STATUS_FAILED, task_payload=payload_with_error)
+                )
                 db.commit()
                 return
 
-            job.status = "processing"
-            job.retry_count += 1
-            assignment_id = assignment.id
             owner_id = assignment.teacher_id
-            job.task_payload = _next_progress_payload(
-                job.task_payload,
-                status="processing",
-                current_step=_FIRST_CANONICAL_STEP,
-            )
-            payload = dict(job.task_payload or {})
             db.commit()
         except Exception as exc:
             logger.error("AuthoringService: Failure locking job %s: %s", job_id, exc)
@@ -582,7 +652,13 @@ class AuthoringService:
             logger.error("AuthoringService: LangGraph raised exception for Job %s", job_id, exc_info=True)
             error_trace = traceback.format_exc()
             error_str = error_trace.lower()
-            if "503" in error_str or "high demand" in error_str or "unavailable" in error_str:
+            if any(marker in error_str for marker in _TRANSIENT_TIMEOUT_MARKERS):
+                error_code = "llm_timeout"
+                error_msg = (
+                    "Nuestros servidores de IA estan a maxima capacidad y el tiempo de espera se agoto. "
+                    "Por favor, reintenta en unos minutos."
+                )
+            elif any(marker in error_str for marker in _TRANSIENT_PROVIDER_UNAVAILABLE_MARKERS):
                 error_code = "llm_provider_unavailable"
                 error_msg = (
                     "Nuestros servidores de IA estan experimentando un pico de trafico en este momento. "
@@ -609,18 +685,26 @@ class AuthoringService:
                 return
 
             if error_msg:
-                job.status = "failed"
+                failure_status = _classify_failure_status(error_code)
+                job.status = failure_status
                 current_payload = _next_progress_payload(
                     job.task_payload,
-                    status="failed",
+                    status=failure_status,
                     current_step="failed",
                     error_code=error_code or "llm_failure",
                     error_trace=error_msg,
                 )
                 job.task_payload = current_payload
 
-                logger.error("AuthoringService: Job %s marked as FAILED. Cleaning up artifacts.", job_id)
-                ArtifactManager.orphan_job_artifacts(db, job_id)
+                if failure_status == AUTHORING_JOB_STATUS_FAILED:
+                    logger.error("AuthoringService: Job %s marked as FAILED. Cleaning up artifacts.", job_id)
+                    ArtifactManager.orphan_job_artifacts(db, job_id)
+                else:
+                    logger.warning(
+                        "AuthoringService: Job %s marked as FAILED_RESUMABLE after transient failure (%s).",
+                        job_id,
+                        error_code,
+                    )
                 db.commit()
                 return
 
@@ -674,10 +758,10 @@ class AuthoringService:
             canonical_result = adapter_legacy_to_canonical_output(graph_output)
             assignment.canonical_output = canonical_result.get("canonical_output", {})
             assignment.status = "published"
-            job.status = "completed"
+            job.status = AUTHORING_JOB_STATUS_COMPLETED
             job.task_payload = _next_progress_payload(
                 job.task_payload,
-                status="completed",
+                status=AUTHORING_JOB_STATUS_COMPLETED,
                 current_step="completed",
             )
 
@@ -694,11 +778,11 @@ class AuthoringService:
             db = SessionLocal()
             try:
                 job = db.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
-                if job is not None and job.status != "failed":
-                    job.status = "failed"
+                if job is not None and job.status != AUTHORING_JOB_STATUS_FAILED:
+                    job.status = AUTHORING_JOB_STATUS_FAILED
                     current_payload = _next_progress_payload(
                         job.task_payload,
-                        status="failed",
+                        status=AUTHORING_JOB_STATUS_FAILED,
                         current_step="failed",
                         error_code="finalization_error",
                         error_trace=traceback.format_exc(),

--- a/backend/src/case_generator/core/storage.py
+++ b/backend/src/case_generator/core/storage.py
@@ -9,6 +9,9 @@ class IStorageProvider(Protocol):
     async def upload_text(self, text_content: str, assignment_id: str, job_id: str, artifact_type: str, version: int) -> str:
         ...
 
+    async def download_text(self, uri: str) -> str:
+        ...
+
 class LocalStorageProvider:
     """
     Local storage provider used by development and test environments.
@@ -38,6 +41,14 @@ class LocalStorageProvider:
             
         # Return a local URI that mimics object-storage addressing.
         return f"local://{file_path}"
+
+    async def download_text(self, uri: str) -> str:
+        """
+        Load text content from a previously persisted local URI.
+        """
+        file_path = uri.removeprefix("local://") if uri.startswith("local://") else uri
+        with open(file_path, mode="r", encoding="utf-8") as f:
+            return f.read()
 
 # Swappable seam for future storage backends.
 def get_storage_provider() -> IStorageProvider:

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -45,6 +45,7 @@ import logging
 import os
 import random
 import re
+import threading
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
@@ -3146,14 +3147,19 @@ class DurableCheckpointUnavailableError(RuntimeError):
 _graph_singleton: Any | None = None
 _graph_singleton_loop: asyncio.AbstractEventLoop | None = None
 _graph_singleton_lock: asyncio.Lock | None = None
+_graph_singleton_lock_guard = threading.Lock()
 
 
 def _get_graph_lock(current_loop: asyncio.AbstractEventLoop) -> asyncio.Lock:
     """Return a loop-bound lock for async graph singleton initialization."""
     global _graph_singleton_lock, _graph_singleton_loop
 
-    if _graph_singleton_lock is None or _graph_singleton_loop is not current_loop:
-        _graph_singleton_lock = asyncio.Lock()
+    with _graph_singleton_lock_guard:
+        if _graph_singleton_lock is None or _graph_singleton_loop is not current_loop:
+            # Store the loop marker when the lock is created so concurrent first
+            # callers reuse a single initialization lock on that loop.
+            _graph_singleton_loop = current_loop
+            _graph_singleton_lock = asyncio.Lock()
     return _graph_singleton_lock
 
 

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -47,6 +47,7 @@ import os
 import random
 import re
 import threading
+import time
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
@@ -3183,10 +3184,14 @@ async def _build_async_postgres_checkpointer() -> AsyncPostgresSaver:
     try:
         pool = await get_langgraph_checkpointer_async_pool()
         logger.info("[graph] Initializing AsyncPostgresSaver", extra={"loop_id": id(asyncio.get_running_loop())})
+        setup_started_at = time.perf_counter()
         checkpointer = AsyncPostgresSaver(cast(Any, pool))
         # Idempotent bootstrap for local/tests where Alembic metadata may be recreated.
         await checkpointer.setup()
-        logger.info("[graph] AsyncPostgresSaver initialized")
+        logger.info(
+            "[graph] AsyncPostgresSaver initialized",
+            extra={"latency_ms": round((time.perf_counter() - setup_started_at) * 1000, 3)},
+        )
         return checkpointer
     except Exception as exc:
         logger.error("[graph] AsyncPostgresSaver initialization failed", exc_info=True)
@@ -3212,9 +3217,13 @@ async def get_graph() -> Any:
             return _graph_singleton
 
         checkpointer = await _build_async_postgres_checkpointer()
+        compile_started_at = time.perf_counter()
         compiled_graph = master_builder.compile(name="adam-agent", checkpointer=checkpointer)
         _graph_singleton = compiled_graph
         _graph_singleton_loop = current_loop
-        logger.info("[graph] Compiled master graph with AsyncPostgresSaver")
+        logger.info(
+            "[graph] Compiled master graph with AsyncPostgresSaver",
+            extra={"latency_ms": round((time.perf_counter() - compile_started_at) * 1000, 3)},
+        )
         return compiled_graph
 

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -3152,6 +3152,18 @@ _graph_singleton_lock_loop: asyncio.AbstractEventLoop | None = None
 _graph_singleton_lock_guard = threading.Lock()
 
 
+def reset_graph_singleton() -> None:
+    """Clear the cached compiled graph and its loop-bound initialization lock."""
+    global _graph_singleton, _graph_singleton_loop
+    global _graph_singleton_lock, _graph_singleton_lock_loop
+
+    _graph_singleton = None
+    _graph_singleton_loop = None
+    _graph_singleton_lock = None
+    _graph_singleton_lock_loop = None
+    logger.info("[graph] Reset compiled graph singleton")
+
+
 def _get_graph_lock(current_loop: asyncio.AbstractEventLoop) -> asyncio.Lock:
     """Return a loop-bound lock for async graph singleton initialization."""
     global _graph_singleton_lock, _graph_singleton_lock_loop
@@ -3170,12 +3182,14 @@ async def _build_async_postgres_checkpointer() -> AsyncPostgresSaver:
     """Build the durable async Postgres checkpointer inside an active event loop."""
     try:
         pool = await get_langgraph_checkpointer_async_pool()
+        logger.info("[graph] Initializing AsyncPostgresSaver", extra={"loop_id": id(asyncio.get_running_loop())})
         checkpointer = AsyncPostgresSaver(cast(Any, pool))
         # Idempotent bootstrap for local/tests where Alembic metadata may be recreated.
         await checkpointer.setup()
         logger.info("[graph] AsyncPostgresSaver initialized")
         return checkpointer
     except Exception as exc:
+        logger.error("[graph] AsyncPostgresSaver initialization failed", exc_info=True)
         raise DurableCheckpointUnavailableError(
             "Durable LangGraph checkpointing is unavailable."
         ) from exc

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -37,6 +37,7 @@ Resiliencia (v9):
   - RetryPolicy: backoff exponencial (1s → 2s → 4s, max 30s, jitter ON)
     - Timeout global: 900 segundos por job (authoring.py)
   - AsyncPostgresSaver: checkpointer para resume-from-failure
+    - get_graph(): singleton lazy por event loop para evitar reuse cruzado en tests/workers async
 """
 
 import asyncio
@@ -3147,18 +3148,20 @@ class DurableCheckpointUnavailableError(RuntimeError):
 _graph_singleton: Any | None = None
 _graph_singleton_loop: asyncio.AbstractEventLoop | None = None
 _graph_singleton_lock: asyncio.Lock | None = None
+_graph_singleton_lock_loop: asyncio.AbstractEventLoop | None = None
 _graph_singleton_lock_guard = threading.Lock()
 
 
 def _get_graph_lock(current_loop: asyncio.AbstractEventLoop) -> asyncio.Lock:
     """Return a loop-bound lock for async graph singleton initialization."""
-    global _graph_singleton_lock, _graph_singleton_loop
+    global _graph_singleton_lock, _graph_singleton_lock_loop
 
     with _graph_singleton_lock_guard:
-        if _graph_singleton_lock is None or _graph_singleton_loop is not current_loop:
-            # Store the loop marker when the lock is created so concurrent first
-            # callers reuse a single initialization lock on that loop.
-            _graph_singleton_loop = current_loop
+        if _graph_singleton_lock is None or _graph_singleton_lock_loop is not current_loop:
+            # Keep the lock loop separate from the compiled-graph loop marker so a
+            # new event loop cannot accidentally reuse a graph/checkpointer created
+            # for a previous loop.
+            _graph_singleton_lock_loop = current_loop
             _graph_singleton_lock = asyncio.Lock()
     return _graph_singleton_lock
 

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -55,6 +55,7 @@ from langchain_core.exceptions import OutputParserException
 from langchain_core.rate_limiters import InMemoryRateLimiter
 from langchain_core.runnables import RunnableConfig
 from langchain_google_genai import ChatGoogleGenerativeAI
+from langgraph.checkpoint.postgres import PostgresSaver
 from langgraph.graph import StateGraph, START, END
 from langgraph.types import RetryPolicy
 
@@ -93,6 +94,7 @@ from case_generator.tools_and_schemas import (
 )
 from case_generator.orchestration.frontend_adapter import adapter_canonical_to_legacy
 from case_generator.orchestration.frontend_output_adapter import adapter_legacy_to_canonical_output
+from shared.database import get_langgraph_checkpointer_pool
 from shared.sanitization import sanitize_untrusted_payload
 
 if TYPE_CHECKING:
@@ -2761,6 +2763,107 @@ def m5_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
 # CONSTRUCCIÓN DE SUBGRAFOS (FASE 4 - ARQUITECTURA MODULAR)
 # ─────────────────────────────────────────────────────────
 
+_RESUME_CACHE_STATE_KEY = "resume_cached_nodes"
+_PARALLEL_NODES_WITHOUT_AGENT = {"case_writer", "case_questions"}
+_RESUME_NODE_AGENT_OVERRIDES = {"eda_questions_generator": "doc3_generation"}
+_RESUME_NODE_REQUIRED_OUTPUTS: dict[str, tuple[str, ...]] = {
+    "case_architect": (
+        "titulo",
+        "industria",
+        "company_profile",
+        "dilema_brief",
+        "doc1_instrucciones",
+        "doc1_anexo_financiero",
+        "doc1_anexo_operativo",
+        "doc1_anexo_stakeholders",
+    ),
+    "case_writer": ("doc1_narrativa",),
+    "case_questions": ("doc1_preguntas",),
+    "eda_text_analyst": ("doc2_eda",),
+    "eda_chart_generator": ("doc2_eda_charts",),
+    "eda_questions_generator": ("doc2_preguntas_eda",),
+    "m3_content_generator": ("m3_content", "m3_mode"),
+    "m3_questions_generator": ("m3_questions",),
+    "m3_notebook_generator": ("m3_notebook_code",),
+    "m4_content_generator": ("m4_content",),
+    "m4_questions_generator": ("m4_questions",),
+    "m4_chart_generator": ("m4_charts",),
+    "m5_content_generator": ("m5_content",),
+    "m5_questions_generator": ("m5_questions",),
+    "teaching_note_part1": ("doc3_teaching_note_part1",),
+    "teaching_note_part2": ("doc3_teaching_note_part2",),
+}
+
+
+def _is_resumable_state_value(value: Any) -> bool:
+    """Return True when a state value is usable for resume skip decisions."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        normalized = value.strip()
+        if not normalized:
+            return False
+        # Sentinel placeholders indicate generation failures and should be recomputed.
+        if normalized.startswith("[") and ("_ERROR]" in normalized or "_NOT_EXECUTED]" in normalized):
+            return False
+        return True
+    if isinstance(value, (list, dict, tuple, set)):
+        return len(value) > 0
+    return True
+
+
+def _artifact_cached_output_for_node(node_name: str, state: ADAMState) -> dict[str, Any] | None:
+    cached_nodes = state.get(_RESUME_CACHE_STATE_KEY)
+    if not isinstance(cached_nodes, dict):
+        return None
+    node_payload = cached_nodes.get(node_name)
+    if not isinstance(node_payload, dict):
+        return None
+    hydrated_payload = {
+        key: value
+        for key, value in node_payload.items()
+        if _is_resumable_state_value(value)
+    }
+    return hydrated_payload or None
+
+
+def _checkpoint_has_node_output(node_name: str, state: ADAMState) -> bool:
+    required_keys = _RESUME_NODE_REQUIRED_OUTPUTS.get(node_name, ())
+    if not required_keys:
+        return False
+    return all(_is_resumable_state_value(state.get(key)) for key in required_keys)
+
+
+def _skip_payload_for_node(node_name: str) -> dict[str, Any]:
+    if node_name in _PARALLEL_NODES_WITHOUT_AGENT:
+        return {}
+    return {"current_agent": _RESUME_NODE_AGENT_OVERRIDES.get(node_name, node_name)}
+
+
+def _with_resume_skip(node_name: str, node_callable: Any) -> Any:
+    """Wrap a graph node to short-circuit when checkpoint/artifact state already exists."""
+
+    def _wrapped(state: ADAMState, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        cached_payload = _artifact_cached_output_for_node(node_name, state)
+        if cached_payload is not None:
+            payload = dict(cached_payload)
+            if node_name not in _PARALLEL_NODES_WITHOUT_AGENT:
+                payload.setdefault("current_agent", _RESUME_NODE_AGENT_OVERRIDES.get(node_name, node_name))
+            logger.info(
+                "[resume_skip] node=%s source=artifact_cache keys=%s",
+                node_name,
+                sorted(payload.keys()),
+            )
+            return payload
+
+        if _checkpoint_has_node_output(node_name, state):
+            logger.info("[resume_skip] node=%s source=checkpoint_state", node_name)
+            return _skip_payload_for_node(node_name)
+
+        return cast(dict[str, Any], node_callable(state, *args, **kwargs))
+
+    return _wrapped
+
 # Política de reintento estándar para manejar fallos de red / timeouts del LLM
 # Verificado contra Context7 docs (langchain-ai/langgraph): RetryPolicy soporta
 # backoff_factor (multiplica interval en cada intento), max_interval (techo en segundos),
@@ -2776,9 +2879,9 @@ standard_retry = RetryPolicy(
 
 # --- 1. SUBGRAFO: DOC 1 (Arquitecto, Redactor, Preguntas) ---
 doc1_builder = StateGraph(ADAMState)
-doc1_builder.add_node("case_architect", case_architect, retry_policy=standard_retry)
-doc1_builder.add_node("case_writer", case_writer, retry_policy=standard_retry)
-doc1_builder.add_node("case_questions", case_questions, retry_policy=standard_retry)
+doc1_builder.add_node("case_architect", _with_resume_skip("case_architect", case_architect), retry_policy=standard_retry)
+doc1_builder.add_node("case_writer", _with_resume_skip("case_writer", case_writer), retry_policy=standard_retry)
+doc1_builder.add_node("case_questions", _with_resume_skip("case_questions", case_questions), retry_policy=standard_retry)
 doc1_builder.add_node("doc1_complete", doc1_complete)
 
 doc1_builder.add_edge(START, "case_architect")
@@ -2810,9 +2913,21 @@ def m3_sync(state: ADAMState) -> dict:
 # ml_ds:    m3_content (Experiment Engineer) → [m3_questions ∥ m3_notebook] → m3_sync → END
 # m3_notebook_generator es noop para business.
 m3_builder = StateGraph(ADAMState)
-m3_builder.add_node("m3_content_generator", m3_content_generator, retry_policy=standard_retry)
-m3_builder.add_node("m3_questions_generator", m3_questions_generator, retry_policy=standard_retry)
-m3_builder.add_node("m3_notebook_generator", m3_notebook_generator, retry_policy=standard_retry)
+m3_builder.add_node(
+    "m3_content_generator",
+    _with_resume_skip("m3_content_generator", m3_content_generator),
+    retry_policy=standard_retry,
+)
+m3_builder.add_node(
+    "m3_questions_generator",
+    _with_resume_skip("m3_questions_generator", m3_questions_generator),
+    retry_policy=standard_retry,
+)
+m3_builder.add_node(
+    "m3_notebook_generator",
+    _with_resume_skip("m3_notebook_generator", m3_notebook_generator),
+    retry_policy=standard_retry,
+)
 m3_builder.add_node("m3_sync", m3_sync)
 
 m3_builder.add_edge(START, "m3_content_generator")
@@ -2835,9 +2950,21 @@ def m4_sync(state: ADAMState) -> dict:
 # --- 3. SUBGRAFO: M4 (Impacto y Valor) ---
 # m4_content → [m4_questions_generator ∥ m4_chart_generator] → m4_sync → END
 m4_builder = StateGraph(ADAMState)
-m4_builder.add_node("m4_content_generator", m4_content_generator, retry_policy=standard_retry)
-m4_builder.add_node("m4_questions_generator", m4_questions_generator, retry_policy=standard_retry)
-m4_builder.add_node("m4_chart_generator", m4_chart_generator, retry_policy=standard_retry)
+m4_builder.add_node(
+    "m4_content_generator",
+    _with_resume_skip("m4_content_generator", m4_content_generator),
+    retry_policy=standard_retry,
+)
+m4_builder.add_node(
+    "m4_questions_generator",
+    _with_resume_skip("m4_questions_generator", m4_questions_generator),
+    retry_policy=standard_retry,
+)
+m4_builder.add_node(
+    "m4_chart_generator",
+    _with_resume_skip("m4_chart_generator", m4_chart_generator),
+    retry_policy=standard_retry,
+)
 m4_builder.add_node("m4_sync", m4_sync)
 
 m4_builder.add_edge(START, "m4_content_generator")
@@ -2860,14 +2987,26 @@ m4_graph = m4_builder.compile()
 eda_builder = StateGraph(ADAMState)
 
 # ── Dataset pipeline (3 nodos) ───────────────────────────────────────────────
-eda_builder.add_node("schema_designer", schema_designer, retry_policy=standard_retry)
+eda_builder.add_node("schema_designer", _with_resume_skip("schema_designer", schema_designer), retry_policy=standard_retry)
 eda_builder.add_node("data_generator", data_generator)
 eda_builder.add_node("data_validator", data_validator)
 
 # ── Resto del flujo EDA ──────────────────────────────────────────────────────
-eda_builder.add_node("eda_text_analyst", eda_text_analyst, retry_policy=standard_retry)
-eda_builder.add_node("eda_chart_generator", eda_chart_generator, retry_policy=standard_retry)
-eda_builder.add_node("eda_questions_generator", eda_questions_generator, retry_policy=standard_retry)
+eda_builder.add_node(
+    "eda_text_analyst",
+    _with_resume_skip("eda_text_analyst", eda_text_analyst),
+    retry_policy=standard_retry,
+)
+eda_builder.add_node(
+    "eda_chart_generator",
+    _with_resume_skip("eda_chart_generator", eda_chart_generator),
+    retry_policy=standard_retry,
+)
+eda_builder.add_node(
+    "eda_questions_generator",
+    _with_resume_skip("eda_questions_generator", eda_questions_generator),
+    retry_policy=standard_retry,
+)
 eda_builder.add_node("eda_phase2_sync", eda_phase2_sync)
 
 # Dataset pipeline: schema_designer → data_serializer → data_validator
@@ -2908,15 +3047,27 @@ eda_graph = eda_builder.compile()
 # Post-sync1 es SECUENCIAL: m5_questions_generator → teaching_note_part2 → sync2.
 # Ventaja: teaching_note_part2 recibe m5_questions ya escritos en state.
 synthesis_builder = StateGraph(ADAMState)
-synthesis_builder.add_node("m5_content_generator", m5_content_generator,
-                            retry_policy=standard_retry)
-synthesis_builder.add_node("teaching_note_part1", teaching_note_part1,
-                            retry_policy=standard_retry)
+synthesis_builder.add_node(
+    "m5_content_generator",
+    _with_resume_skip("m5_content_generator", m5_content_generator),
+    retry_policy=standard_retry,
+)
+synthesis_builder.add_node(
+    "teaching_note_part1",
+    _with_resume_skip("teaching_note_part1", teaching_note_part1),
+    retry_policy=standard_retry,
+)
 synthesis_builder.add_node("synthesis_phase1_sync", synthesis_phase1_sync)
-synthesis_builder.add_node("m5_questions_generator", m5_questions_generator,
-                            retry_policy=standard_retry)
-synthesis_builder.add_node("teaching_note_part2", teaching_note_part2,
-                            retry_policy=standard_retry)
+synthesis_builder.add_node(
+    "m5_questions_generator",
+    _with_resume_skip("m5_questions_generator", m5_questions_generator),
+    retry_policy=standard_retry,
+)
+synthesis_builder.add_node(
+    "teaching_note_part2",
+    _with_resume_skip("teaching_note_part2", teaching_note_part2),
+    retry_policy=standard_retry,
+)
 synthesis_builder.add_node("synthesis_phase2_sync", synthesis_phase2_sync)
 
 # Fan-out paralelo desde START
@@ -2979,5 +3130,22 @@ master_builder.add_edge("synthesis_flow", "output_adapter_final")
 master_builder.add_edge("output_adapter_final", END)
 
 
-graph = master_builder.compile(name="adam-agent")
+def _build_postgres_checkpointer() -> PostgresSaver | None:
+    """Build a durable Postgres checkpointer using the shared DB pool."""
+    try:
+        checkpointer = PostgresSaver(cast(Any, get_langgraph_checkpointer_pool()))
+        # Idempotent bootstrap for local/tests where Alembic metadata may be recreated.
+        checkpointer.setup()
+        logger.info("[graph] Postgres checkpointer initialized")
+        return checkpointer
+    except Exception as exc:
+        logger.warning("[graph] Postgres checkpointer unavailable; falling back to in-memory run: %s", exc)
+        return None
+
+
+_checkpointer = _build_postgres_checkpointer()
+if _checkpointer is not None:
+    graph = master_builder.compile(name="adam-agent", checkpointer=_checkpointer)
+else:
+    graph = master_builder.compile(name="adam-agent")
 

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -35,10 +35,11 @@ Resiliencia (v9):
   - .with_fallbacks: primary → gemini-2.5-flash automático en caída de API
   - Fallback graceful: todos los nodos LLM retornan sentinel en vez de raise
   - RetryPolicy: backoff exponencial (1s → 2s → 4s, max 30s, jitter ON)
-  - Timeout global: 600 segundos por job (authoring.py)
+    - Timeout global: 900 segundos por job (authoring.py)
   - AsyncPostgresSaver: checkpointer para resume-from-failure
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -55,7 +56,7 @@ from langchain_core.exceptions import OutputParserException
 from langchain_core.rate_limiters import InMemoryRateLimiter
 from langchain_core.runnables import RunnableConfig
 from langchain_google_genai import ChatGoogleGenerativeAI
-from langgraph.checkpoint.postgres import PostgresSaver
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.graph import StateGraph, START, END
 from langgraph.types import RetryPolicy
 
@@ -94,7 +95,7 @@ from case_generator.tools_and_schemas import (
 )
 from case_generator.orchestration.frontend_adapter import adapter_canonical_to_legacy
 from case_generator.orchestration.frontend_output_adapter import adapter_legacy_to_canonical_output
-from shared.database import get_langgraph_checkpointer_pool
+from shared.database import get_langgraph_checkpointer_async_pool
 from shared.sanitization import sanitize_untrusted_payload
 
 if TYPE_CHECKING:
@@ -2763,7 +2764,7 @@ def m5_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
 # CONSTRUCCIÓN DE SUBGRAFOS (FASE 4 - ARQUITECTURA MODULAR)
 # ─────────────────────────────────────────────────────────
 
-_RESUME_CACHE_STATE_KEY = "resume_cached_nodes"
+RESUME_CACHE_STATE_KEY = "resume_cached_nodes"
 _PARALLEL_NODES_WITHOUT_AGENT = {"case_writer", "case_questions"}
 _RESUME_NODE_AGENT_OVERRIDES = {"eda_questions_generator": "doc3_generation"}
 _RESUME_NODE_REQUIRED_OUTPUTS: dict[str, tuple[str, ...]] = {
@@ -2813,7 +2814,7 @@ def _is_resumable_state_value(value: Any) -> bool:
 
 
 def _artifact_cached_output_for_node(node_name: str, state: ADAMState) -> dict[str, Any] | None:
-    cached_nodes = state.get(_RESUME_CACHE_STATE_KEY)
+    cached_nodes = state.get(RESUME_CACHE_STATE_KEY)
     if not isinstance(cached_nodes, dict):
         return None
     node_payload = cached_nodes.get(node_name)
@@ -3130,22 +3131,59 @@ master_builder.add_edge("synthesis_flow", "output_adapter_final")
 master_builder.add_edge("output_adapter_final", END)
 
 
-def _build_postgres_checkpointer() -> PostgresSaver | None:
-    """Build a durable Postgres checkpointer using the shared DB pool."""
+class DurableCheckpointUnavailableError(RuntimeError):
+    """Raised when the durable async LangGraph checkpoint path cannot initialize."""
+
+
+_graph_singleton: Any | None = None
+_graph_singleton_loop: asyncio.AbstractEventLoop | None = None
+_graph_singleton_lock: asyncio.Lock | None = None
+
+
+def _get_graph_lock(current_loop: asyncio.AbstractEventLoop) -> asyncio.Lock:
+    """Return a loop-bound lock for async graph singleton initialization."""
+    global _graph_singleton_lock, _graph_singleton_loop
+
+    if _graph_singleton_lock is None or _graph_singleton_loop is not current_loop:
+        _graph_singleton_lock = asyncio.Lock()
+    return _graph_singleton_lock
+
+
+async def _build_async_postgres_checkpointer() -> AsyncPostgresSaver:
+    """Build the durable async Postgres checkpointer inside an active event loop."""
     try:
-        checkpointer = PostgresSaver(cast(Any, get_langgraph_checkpointer_pool()))
+        pool = await get_langgraph_checkpointer_async_pool()
+        checkpointer = AsyncPostgresSaver(cast(Any, pool))
         # Idempotent bootstrap for local/tests where Alembic metadata may be recreated.
-        checkpointer.setup()
-        logger.info("[graph] Postgres checkpointer initialized")
+        await checkpointer.setup()
+        logger.info("[graph] AsyncPostgresSaver initialized")
         return checkpointer
     except Exception as exc:
-        logger.warning("[graph] Postgres checkpointer unavailable; falling back to in-memory run: %s", exc)
-        return None
+        raise DurableCheckpointUnavailableError(
+            "Durable LangGraph checkpointing is unavailable."
+        ) from exc
 
 
-_checkpointer = _build_postgres_checkpointer()
-if _checkpointer is not None:
-    graph = master_builder.compile(name="adam-agent", checkpointer=_checkpointer)
-else:
-    graph = master_builder.compile(name="adam-agent")
+async def get_graph() -> Any:
+    """Return the compiled master graph backed by a durable async checkpointer.
+
+    This is a lazy singleton per active event loop so the async saver is always
+    created under the loop that will later execute `graph.astream(...)`.
+    """
+    global _graph_singleton, _graph_singleton_loop
+
+    current_loop = asyncio.get_running_loop()
+    if _graph_singleton is not None and _graph_singleton_loop is current_loop:
+        return _graph_singleton
+
+    async with _get_graph_lock(current_loop):
+        if _graph_singleton is not None and _graph_singleton_loop is current_loop:
+            return _graph_singleton
+
+        checkpointer = await _build_async_postgres_checkpointer()
+        compiled_graph = master_builder.compile(name="adam-agent", checkpointer=checkpointer)
+        _graph_singleton = compiled_graph
+        _graph_singleton_loop = current_loop
+        logger.info("[graph] Compiled master graph with AsyncPostgresSaver")
+        return compiled_graph
 

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2844,7 +2844,12 @@ def _skip_payload_for_node(node_name: str) -> dict[str, Any]:
 def _with_resume_skip(node_name: str, node_callable: Any) -> Any:
     """Wrap a graph node to short-circuit when checkpoint/artifact state already exists."""
 
-    def _wrapped(state: ADAMState, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def _wrapped(
+        state: ADAMState,
+        config: RunnableConfig | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         cached_payload = _artifact_cached_output_for_node(node_name, state)
         if cached_payload is not None:
             payload = dict(cached_payload)
@@ -2861,7 +2866,10 @@ def _with_resume_skip(node_name: str, node_callable: Any) -> Any:
             logger.info("[resume_skip] node=%s source=checkpoint_state", node_name)
             return _skip_payload_for_node(node_name)
 
-        return cast(dict[str, Any], node_callable(state, *args, **kwargs))
+        if config is None:
+            return cast(dict[str, Any], node_callable(state, *args, **kwargs))
+
+        return cast(dict[str, Any], node_callable(state, config, *args, **kwargs))
 
     return _wrapped
 

--- a/backend/src/case_generator/state.py
+++ b/backend/src/case_generator/state.py
@@ -147,6 +147,10 @@ class ADAMState(CanonicalInputState):
     m5_content: NotRequired[str]
     # m5_questions: ya existe
 
+    # Optional node output cache hydrated from persisted artifacts before graph execution.
+    # Shape: {"node_name": {"state_key": "value"}}
+    resume_cached_nodes: NotRequired[dict[str, dict[str, str]]]
+
     # Derived helper fields built from the generated case context.
     nombre_empresa: NotRequired[str]      # extraído del título
     dilema_hypotheses: NotRequired[str]   # extraído del dilema_brief

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -61,6 +61,7 @@ from shared.database import (
     close_langgraph_checkpointer_pool,
     dispose_database_engine,
     get_db,
+    snapshot_active_authoring_jobs,
     validate_runtime_database_configuration,
 )
 from shared.db_resilience import (
@@ -451,7 +452,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     try:
         yield
     finally:
-        logger.info("Cleaning up resources...")
+        logger.info("Cleaning up resources... active_authoring_jobs=%s", snapshot_active_authoring_jobs())
         reset_graph_singleton()
         await close_langgraph_checkpointer_async_pool()
         close_langgraph_checkpointer_pool()

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -28,6 +28,7 @@ from sqlalchemy.exc import TimeoutError as SATimeoutError
 from sqlalchemy.orm import Session
 
 from case_generator.core.authoring import AuthoringService
+from case_generator.graph import reset_graph_singleton
 from case_generator.suggest_service import SuggestRequest, SuggestResponse, generate_suggestion
 from shared.admin_router import router as admin_router
 from shared.course_access_router import router as course_access_router
@@ -55,7 +56,13 @@ from shared.identity_activation import (
     upsert_membership as upsert_membership_impl,
     upsert_profile as upsert_profile_impl,
 )
-from shared.database import get_db
+from shared.database import (
+    close_langgraph_checkpointer_async_pool,
+    close_langgraph_checkpointer_pool,
+    dispose_database_engine,
+    get_db,
+    validate_runtime_database_configuration,
+)
 from shared.db_resilience import (
     AUTH_ME_ENDPOINT,
     AUTHORING_INTAKE_ENDPOINT,
@@ -205,6 +212,7 @@ def _run_uvicorn_profile(profile: UvicornRuntimeProfile) -> None:
 
 
 def main() -> None:
+    validate_runtime_database_configuration()
     runtime_profile = _build_uvicorn_runtime_profile()
     _run_uvicorn_profile(runtime_profile)
 
@@ -439,8 +447,15 @@ def require_teacher_actor_authoring_progress(
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    yield
-    logger.info("Cleaning up resources...")
+    validate_runtime_database_configuration()
+    try:
+        yield
+    finally:
+        logger.info("Cleaning up resources...")
+        reset_graph_singleton()
+        await close_langgraph_checkpointer_async_pool()
+        close_langgraph_checkpointer_pool()
+        dispose_database_engine()
 
 
 app = FastAPI(title="adam-v8.0 - Case Generation API", lifespan=lifespan)

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -27,7 +27,7 @@ from sqlalchemy.exc import DBAPIError, IntegrityError, OperationalError
 from sqlalchemy.exc import TimeoutError as SATimeoutError
 from sqlalchemy.orm import Session
 
-from case_generator.core.authoring import AuthoringService
+from case_generator.core.authoring import AuthoringService, derive_progress_percentage
 from case_generator.graph import reset_graph_singleton
 from case_generator.suggest_service import SuggestRequest, SuggestResponse, generate_suggestion
 from shared.admin_router import router as admin_router
@@ -692,6 +692,8 @@ class JobProgressResponse(BaseModel):
     job_id: str
     status: str
     current_step: str | None = None
+    progress_percentage: int | None = None
+    bootstrap_state: str | None = None
     progress_seq: int | None = None
     progress_ts: str | None = None
     error_code: str | None = None
@@ -768,12 +770,20 @@ def get_job_progress(
         progress_ts = payload.get("progress_ts")
         error_code = payload.get("error_code")
         error_trace = payload.get("error_trace")
+        bootstrap_state = payload.get("bootstrap_state")
+        current_step_value = current_step if isinstance(current_step, str) else None
 
         emit_metric("progress_snapshot_reads_total", 1, endpoint=AUTHORING_PROGRESS_ENDPOINT)
         return JobProgressResponse(
             job_id=job.id,
             status=job.status,
-            current_step=current_step if isinstance(current_step, str) else None,
+            current_step=current_step_value,
+            progress_percentage=derive_progress_percentage(
+                payload,
+                current_step=current_step_value,
+                status=job.status,
+            ),
+            bootstrap_state=bootstrap_state if isinstance(bootstrap_state, str) else None,
             progress_seq=progress_seq if isinstance(progress_seq, int) else None,
             progress_ts=progress_ts if isinstance(progress_ts, str) else None,
             error_code=error_code if isinstance(error_code, str) else None,

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -66,6 +66,11 @@ from shared.db_resilience import (
 )
 from shared.invite_status import invite_effective_status
 from shared.models import (
+    AUTHORING_JOB_RETRYABLE_STATUSES,
+    AUTHORING_JOB_STATUS_FAILED,
+    AUTHORING_JOB_STATUS_FAILED_RESUMABLE,
+    AUTHORING_JOB_STATUS_PENDING,
+    AUTHORING_JOB_STATUS_PROCESSING,
     Assignment,
     AuthoringJob,
     Course,
@@ -522,6 +527,12 @@ class JobCreatedResponse(BaseModel):
     message: str
 
 
+class RetryJobResponse(BaseModel):
+    job_id: str
+    status: str
+    message: str
+
+
 @app.post(
     "/api/authoring/jobs",
     response_model=JobCreatedResponse,
@@ -553,7 +564,7 @@ def create_authoring_job(
         job = AuthoringJob(
             assignment_id=assignment.id,
             idempotency_key=idempotency_key,
-            status="pending",
+            status=AUTHORING_JOB_STATUS_PENDING,
             task_payload={
                 "step": "authoring",
                 "asignatura": req.subject or req.assignment_title,
@@ -593,6 +604,46 @@ def create_authoring_job(
             round((time.monotonic() - started) * 1000, 3),
             endpoint=AUTHORING_INTAKE_ENDPOINT,
         )
+
+
+@app.post(
+    "/api/authoring/jobs/{job_id}/retry",
+    response_model=RetryJobResponse,
+    status_code=202,
+)
+def retry_authoring_job(
+    job_id: str,
+    background_tasks: BackgroundTasks,
+    actor: CurrentActor = Depends(require_teacher_actor_authoring_intake),
+    db: Session = Depends(get_db),
+) -> RetryJobResponse:
+    job = get_owned_job_or_404(db, job_id, actor)
+
+    if job.status == AUTHORING_JOB_STATUS_PROCESSING:
+        return RetryJobResponse(
+            job_id=job.id,
+            status="accepted",
+            message="Authoring job already in progress.",
+        )
+
+    if job.status not in AUTHORING_JOB_RETRYABLE_STATUSES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Job not retryable",
+            headers={"X-Job-Status": job.status},
+        )
+
+    logger.info(
+        "Authoring retry accepted for job %s (status=%s)",
+        job.id,
+        job.status,
+    )
+    background_tasks.add_task(AuthoringService.run_job, job.id)
+    return RetryJobResponse(
+        job_id=job.id,
+        status="accepted",
+        message="Authoring retry accepted and dispatched to queue.",
+    )
 
 
 # Cloud Tasks internal endpoint — handler lives in shared.internal_tasks
@@ -639,7 +690,7 @@ def get_job_status(
 ) -> JobStatusResponse:
     job = get_owned_job_or_404(db, job_id, actor)
     error_trace = None
-    if job.status == "failed" and job.task_payload:
+    if job.status in {AUTHORING_JOB_STATUS_FAILED, AUTHORING_JOB_STATUS_FAILED_RESUMABLE} and job.task_payload:
         error_trace = job.task_payload.get("error_trace")
 
     return JobStatusResponse(

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -212,11 +212,13 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
 
         if previous_pool is not None and previous_pool is not pool:
             try:
-                await previous_pool.close()
-            except Exception as exc:
-                logger.warning(
+                await asyncio.wait_for(previous_pool.close(), timeout=5.0)
+            except (asyncio.TimeoutError, Exception) as exc:
+                logger.error(
                     "Could not close previous LangGraph async checkpointer pool cleanly: %s",
                     exc,
                 )
+            finally:
+                previous_pool = None  # allow GC regardless
 
         return pool

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -14,6 +14,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 ENV_FILE = Path(__file__).resolve().parents[2] / ".env"
 logger = logging.getLogger(__name__)
+_LOCAL_DATABASE_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
 if sys.platform == "win32" and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
     # psycopg async connections are not compatible with the default Proactor loop
@@ -106,12 +107,38 @@ _langgraph_checkpointer_pool: ConnectionPool | None = None
 _langgraph_checkpointer_async_pool: AsyncConnectionPool | None = None
 _langgraph_checkpointer_async_pool_loop: asyncio.AbstractEventLoop | None = None
 _langgraph_checkpointer_async_pool_lock: asyncio.Lock | None = None
+_langgraph_checkpointer_async_pool_lock_loop: asyncio.AbstractEventLoop | None = None
 _langgraph_checkpointer_async_pool_lock_guard = threading.Lock()
 
 class Base(DeclarativeBase):
     """Base declarative class for SQLAlchemy models."""
 
     pass
+
+
+def validate_runtime_database_configuration(s: Settings | None = None) -> None:
+    """Reject the local runtime path when it points at remote Supabase.
+
+    The repo's documented development path is the Docker Postgres instance on
+    localhost:5434. Running `uv run python -m shared.app` against a remote
+    Supabase pooler keeps persistent dev pools alive against shared infra and
+    can starve the async checkpoint path.
+    """
+
+    active_settings = s or settings
+    if active_settings.environment.strip().lower() != "development":
+        return
+
+    parsed_url = make_url(active_settings.database_url)
+    host = (parsed_url.host or "").strip().lower()
+    if host in _LOCAL_DATABASE_HOSTS:
+        return
+
+    if host.endswith("supabase.com"):
+        raise RuntimeError(
+            "ENVIRONMENT=development must use the repo-local Postgres target on localhost:5434. "
+            "Remote Supabase DATABASE_URL values require the deployment runtime path, not `uv run python -m shared.app`."
+        )
 
 def get_db() -> Generator[Session, None, None]:
     """
@@ -162,16 +189,16 @@ def get_langgraph_checkpointer_pool() -> ConnectionPool:
 
 def _get_async_pool_lock(current_loop: asyncio.AbstractEventLoop) -> asyncio.Lock:
     """Return a loop-bound lock for async pool singleton initialization."""
-    global _langgraph_checkpointer_async_pool_lock, _langgraph_checkpointer_async_pool_loop
+    global _langgraph_checkpointer_async_pool_lock, _langgraph_checkpointer_async_pool_lock_loop
 
     with _langgraph_checkpointer_async_pool_lock_guard:
         if (
             _langgraph_checkpointer_async_pool_lock is None
-            or _langgraph_checkpointer_async_pool_loop is not current_loop
+            or _langgraph_checkpointer_async_pool_lock_loop is not current_loop
         ):
             # Bind the loop marker at lock creation time so concurrent first-use
             # callers on the same loop cannot mint different initialization locks.
-            _langgraph_checkpointer_async_pool_loop = current_loop
+            _langgraph_checkpointer_async_pool_lock_loop = current_loop
             _langgraph_checkpointer_async_pool_lock = asyncio.Lock()
     return _langgraph_checkpointer_async_pool_lock
 
@@ -196,6 +223,18 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
             return current_pool
 
         previous_pool = _langgraph_checkpointer_async_pool
+        parsed_url = make_url(settings.database_url)
+        logger.info(
+            "Opening LangGraph async checkpointer pool",
+            extra={
+                "pool_name": "langgraph-checkpointer-async",
+                "db_host": parsed_url.host,
+                "db_port": parsed_url.port,
+                "environment": settings.environment,
+                "max_size": max(1, settings.db_pool_size),
+                "loop_id": id(current_loop),
+            },
+        )
         pool = AsyncConnectionPool(
             conninfo=_to_psycopg_conninfo(settings.database_url),
             min_size=1,
@@ -212,6 +251,7 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
 
         if previous_pool is not None and previous_pool is not pool:
             try:
+                logger.info("Closing previous LangGraph async checkpointer pool", extra={"loop_id": id(current_loop)})
                 await asyncio.wait_for(previous_pool.close(), timeout=5.0)
             except (asyncio.TimeoutError, Exception) as exc:
                 logger.error(
@@ -222,3 +262,48 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
                 previous_pool = None  # allow GC regardless
 
         return pool
+
+
+async def close_langgraph_checkpointer_async_pool(timeout_seconds: float = 5.0) -> None:
+    """Close and clear the cached async LangGraph checkpointer pool."""
+    global _langgraph_checkpointer_async_pool
+    global _langgraph_checkpointer_async_pool_loop
+    global _langgraph_checkpointer_async_pool_lock
+    global _langgraph_checkpointer_async_pool_lock_loop
+
+    pool = _langgraph_checkpointer_async_pool
+    _langgraph_checkpointer_async_pool = None
+    _langgraph_checkpointer_async_pool_loop = None
+    _langgraph_checkpointer_async_pool_lock = None
+    _langgraph_checkpointer_async_pool_lock_loop = None
+
+    if pool is None:
+        return
+
+    try:
+        logger.info("Closing LangGraph async checkpointer pool")
+        await asyncio.wait_for(pool.close(), timeout=timeout_seconds)
+    except (asyncio.TimeoutError, Exception) as exc:
+        logger.error("Could not close LangGraph async checkpointer pool cleanly: %s", exc)
+
+
+def close_langgraph_checkpointer_pool() -> None:
+    """Close and clear the cached sync LangGraph checkpointer pool."""
+    global _langgraph_checkpointer_pool
+
+    pool = _langgraph_checkpointer_pool
+    _langgraph_checkpointer_pool = None
+    if pool is None:
+        return
+
+    try:
+        logger.info("Closing LangGraph sync checkpointer pool")
+        pool.close()
+    except Exception as exc:
+        logger.error("Could not close LangGraph sync checkpointer pool cleanly: %s", exc)
+
+
+def dispose_database_engine() -> None:
+    """Dispose the shared SQLAlchemy engine at process shutdown."""
+    logger.info("Disposing shared SQLAlchemy engine")
+    engine.dispose()

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -247,15 +247,12 @@ def _langgraph_checkpointer_pool_bounds() -> tuple[int, int]:
     return (1, max(1, settings.db_pool_size))
 
 
-def _langgraph_checkpointer_pool_tuning() -> dict[str, float]:
+def _langgraph_checkpointer_pool_tuning() -> tuple[float | None, float | None]:
     """Use short-lived checkpoint connections in production to avoid sticky sessions."""
     if settings.environment.strip().lower() != "production":
-        return {}
+        return (None, None)
 
-    return {
-        "max_idle": 5.0,
-        "max_lifetime": 60.0,
-    }
+    return (5.0, 60.0)
 
 
 def get_langgraph_checkpointer_pool() -> ConnectionPool:
@@ -264,16 +261,29 @@ def get_langgraph_checkpointer_pool() -> ConnectionPool:
 
     if _langgraph_checkpointer_pool is None:
         min_size, max_size = _langgraph_checkpointer_pool_bounds()
-        _langgraph_checkpointer_pool = ConnectionPool(
-            conninfo=_to_psycopg_conninfo(settings.database_url),
-            min_size=min_size,
-            max_size=max_size,
-            kwargs=_langgraph_pool_kwargs(),
-            timeout=float(settings.db_pool_timeout),
-            open=True,
-            name="langgraph-checkpointer",
-            **_langgraph_checkpointer_pool_tuning(),
-        )
+        max_idle, max_lifetime = _langgraph_checkpointer_pool_tuning()
+        if max_idle is None or max_lifetime is None:
+            _langgraph_checkpointer_pool = ConnectionPool(
+                conninfo=_to_psycopg_conninfo(settings.database_url),
+                min_size=min_size,
+                max_size=max_size,
+                kwargs=_langgraph_pool_kwargs(),
+                timeout=float(settings.db_pool_timeout),
+                open=True,
+                name="langgraph-checkpointer",
+            )
+        else:
+            _langgraph_checkpointer_pool = ConnectionPool(
+                conninfo=_to_psycopg_conninfo(settings.database_url),
+                min_size=min_size,
+                max_size=max_size,
+                kwargs=_langgraph_pool_kwargs(),
+                timeout=float(settings.db_pool_timeout),
+                open=True,
+                name="langgraph-checkpointer",
+                max_idle=max_idle,
+                max_lifetime=max_lifetime,
+            )
 
     return _langgraph_checkpointer_pool
 
@@ -329,16 +339,29 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
             },
         )
         pool_open_started_at = time.perf_counter()
-        pool = AsyncConnectionPool(
-            conninfo=_to_psycopg_conninfo(settings.database_url),
-            min_size=min_size,
-            max_size=max_size,
-            kwargs=_langgraph_pool_kwargs(),
-            timeout=float(settings.db_pool_timeout),
-            open=False,
-            name="langgraph-checkpointer-async",
-            **_langgraph_checkpointer_pool_tuning(),
-        )
+        max_idle, max_lifetime = _langgraph_checkpointer_pool_tuning()
+        if max_idle is None or max_lifetime is None:
+            pool = AsyncConnectionPool(
+                conninfo=_to_psycopg_conninfo(settings.database_url),
+                min_size=min_size,
+                max_size=max_size,
+                kwargs=_langgraph_pool_kwargs(),
+                timeout=float(settings.db_pool_timeout),
+                open=False,
+                name="langgraph-checkpointer-async",
+            )
+        else:
+            pool = AsyncConnectionPool(
+                conninfo=_to_psycopg_conninfo(settings.database_url),
+                min_size=min_size,
+                max_size=max_size,
+                kwargs=_langgraph_pool_kwargs(),
+                timeout=float(settings.db_pool_timeout),
+                open=False,
+                name="langgraph-checkpointer-async",
+                max_idle=max_idle,
+                max_lifetime=max_lifetime,
+            )
         await pool.open()
         logger.info(
             "LangGraph async checkpointer pool opened",

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 import sys
 import threading
+from typing import Any
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool, ConnectionPool
 from sqlalchemy import create_engine, Engine
@@ -109,11 +110,78 @@ _langgraph_checkpointer_async_pool_loop: asyncio.AbstractEventLoop | None = None
 _langgraph_checkpointer_async_pool_lock: asyncio.Lock | None = None
 _langgraph_checkpointer_async_pool_lock_loop: asyncio.AbstractEventLoop | None = None
 _langgraph_checkpointer_async_pool_lock_guard = threading.Lock()
+_active_authoring_jobs: set[str] = set()
+_active_authoring_jobs_guard = threading.Lock()
 
 class Base(DeclarativeBase):
     """Base declarative class for SQLAlchemy models."""
 
     pass
+
+
+def register_active_authoring_job(job_id: str) -> None:
+    """Track a job currently inside the durable authoring runtime path."""
+    with _active_authoring_jobs_guard:
+        _active_authoring_jobs.add(job_id)
+
+
+def unregister_active_authoring_job(job_id: str) -> None:
+    """Remove a job from the durable authoring runtime tracker."""
+    with _active_authoring_jobs_guard:
+        _active_authoring_jobs.discard(job_id)
+
+
+def snapshot_active_authoring_jobs() -> list[str]:
+    """Return the currently tracked durable authoring jobs."""
+    with _active_authoring_jobs_guard:
+        return sorted(_active_authoring_jobs)
+
+
+def _snapshot_authoring_task_names() -> list[str]:
+    """Return pending asyncio task names relevant to authoring shutdown."""
+    try:
+        current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return []
+
+    current_task = asyncio.current_task(current_loop)
+    task_names: list[str] = []
+    for task in asyncio.all_tasks(current_loop):
+        if task is current_task or task.done():
+            continue
+
+        task_name = task.get_name()
+        coro = task.get_coro()
+        coro_name = getattr(coro, "__qualname__", type(coro).__name__)
+        if task_name.startswith("authoring-job-") or "run_job" in coro_name or "_run_graph_stream" in coro_name:
+            task_names.append(f"{task_name}:{coro_name}")
+
+    return sorted(task_names)
+
+
+def _pool_stats_snapshot(pool: Any) -> dict[str, int]:
+    """Return stable pool telemetry fields even if the underlying API shifts."""
+    try:
+        stats = dict(pool.get_stats())
+    except Exception as exc:
+        logger.warning("Could not read LangGraph pool stats: %s", exc)
+        return {}
+
+    pool_size = int(stats.get("pool_size", 0))
+    available = int(stats.get("pool_available", 0))
+    return {
+        "pool_min": int(stats.get("pool_min", 0)),
+        "pool_max": int(stats.get("pool_max", 0)),
+        "pool_size": pool_size,
+        "pool_available": available,
+        "pool_busy": max(pool_size - available, 0),
+        "requests_waiting": int(stats.get("requests_waiting", 0)),
+        "requests_errors": int(stats.get("requests_errors", 0)),
+        "connections_num": int(stats.get("connections_num", 0)),
+        "connections_errors": int(stats.get("connections_errors", 0)),
+        "connections_lost": int(stats.get("connections_lost", 0)),
+        "returns_bad": int(stats.get("returns_bad", 0)),
+    }
 
 
 def validate_runtime_database_configuration(s: Settings | None = None) -> None:
@@ -280,11 +348,49 @@ async def close_langgraph_checkpointer_async_pool(timeout_seconds: float = 5.0) 
     if pool is None:
         return
 
+    active_jobs = snapshot_active_authoring_jobs()
+    pending_task_names = _snapshot_authoring_task_names()
+    initial_stats = _pool_stats_snapshot(pool)
+
     try:
-        logger.info("Closing LangGraph async checkpointer pool")
+        logger.info(
+            "Starting LangGraph async checkpointer pool shutdown. busy=%s available=%s waiting=%s active_jobs=%s pending_tasks=%s",
+            initial_stats.get("pool_busy", 0),
+            initial_stats.get("pool_available", 0),
+            initial_stats.get("requests_waiting", 0),
+            active_jobs,
+            pending_task_names,
+        )
         await asyncio.wait_for(pool.close(), timeout=timeout_seconds)
-    except (asyncio.TimeoutError, Exception) as exc:
-        logger.error("Could not close LangGraph async checkpointer pool cleanly: %s", exc)
+        closed_stats = _pool_stats_snapshot(pool)
+        logger.info(
+            "LangGraph async checkpointer pool closed successfully. busy=%s available=%s waiting=%s",
+            closed_stats.get("pool_busy", 0),
+            closed_stats.get("pool_available", 0),
+            closed_stats.get("requests_waiting", 0),
+        )
+    except asyncio.TimeoutError:
+        timed_out_stats = _pool_stats_snapshot(pool)
+        logger.error(
+            "LEAK DETECTED: LangGraph async checkpointer pool did not close in %ss. busy=%s available=%s waiting=%s active_jobs=%s pending_tasks=%s",
+            timeout_seconds,
+            timed_out_stats.get("pool_busy", 0),
+            timed_out_stats.get("pool_available", 0),
+            timed_out_stats.get("requests_waiting", 0),
+            active_jobs,
+            pending_task_names,
+        )
+    except Exception as exc:
+        failed_stats = _pool_stats_snapshot(pool)
+        logger.error(
+            "Could not close LangGraph async checkpointer pool cleanly: %s. busy=%s available=%s waiting=%s active_jobs=%s pending_tasks=%s",
+            exc,
+            failed_stats.get("pool_busy", 0),
+            failed_stats.get("pool_available", 0),
+            failed_stats.get("requests_waiting", 0),
+            active_jobs,
+            pending_task_names,
+        )
 
 
 def close_langgraph_checkpointer_pool() -> None:

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 import logging
 from pathlib import Path
 import sys
+import threading
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool, ConnectionPool
 from sqlalchemy import create_engine, Engine
@@ -105,6 +106,7 @@ _langgraph_checkpointer_pool: ConnectionPool | None = None
 _langgraph_checkpointer_async_pool: AsyncConnectionPool | None = None
 _langgraph_checkpointer_async_pool_loop: asyncio.AbstractEventLoop | None = None
 _langgraph_checkpointer_async_pool_lock: asyncio.Lock | None = None
+_langgraph_checkpointer_async_pool_lock_guard = threading.Lock()
 
 class Base(DeclarativeBase):
     """Base declarative class for SQLAlchemy models."""
@@ -162,11 +164,15 @@ def _get_async_pool_lock(current_loop: asyncio.AbstractEventLoop) -> asyncio.Loc
     """Return a loop-bound lock for async pool singleton initialization."""
     global _langgraph_checkpointer_async_pool_lock, _langgraph_checkpointer_async_pool_loop
 
-    if (
-        _langgraph_checkpointer_async_pool_lock is None
-        or _langgraph_checkpointer_async_pool_loop is not current_loop
-    ):
-        _langgraph_checkpointer_async_pool_lock = asyncio.Lock()
+    with _langgraph_checkpointer_async_pool_lock_guard:
+        if (
+            _langgraph_checkpointer_async_pool_lock is None
+            or _langgraph_checkpointer_async_pool_loop is not current_loop
+        ):
+            # Bind the loop marker at lock creation time so concurrent first-use
+            # callers on the same loop cannot mint different initialization locks.
+            _langgraph_checkpointer_async_pool_loop = current_loop
+            _langgraph_checkpointer_async_pool_lock = asyncio.Lock()
     return _langgraph_checkpointer_async_pool_lock
 
 

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -1,5 +1,7 @@
 from collections.abc import Generator
 from pathlib import Path
+from psycopg.rows import dict_row
+from psycopg_pool import ConnectionPool
 from sqlalchemy import create_engine, Engine
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
@@ -90,6 +92,7 @@ def _make_engine(s: Settings) -> Engine:
 settings = Settings()
 engine = _make_engine(settings)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+_langgraph_checkpointer_pool: ConnectionPool | None = None
 
 class Base(DeclarativeBase):
     """Base declarative class for SQLAlchemy models."""
@@ -106,3 +109,29 @@ def get_db() -> Generator[Session, None, None]:
         yield db
     finally:
         db.close()
+
+
+def _to_psycopg_conninfo(database_url: str) -> str:
+    """Normalize SQLAlchemy database URLs for psycopg connection pools."""
+    url = make_url(database_url)
+    if url.drivername == "postgresql+psycopg":
+        url = url.set(drivername="postgresql")
+    return url.render_as_string(hide_password=False)
+
+
+def get_langgraph_checkpointer_pool() -> ConnectionPool:
+    """Return a shared psycopg pool configured from existing DB settings."""
+    global _langgraph_checkpointer_pool
+
+    if _langgraph_checkpointer_pool is None:
+        _langgraph_checkpointer_pool = ConnectionPool(
+            conninfo=_to_psycopg_conninfo(settings.database_url),
+            min_size=1,
+            max_size=max(1, settings.db_pool_size),
+            kwargs={"autocommit": True, "row_factory": dict_row},
+            timeout=float(settings.db_pool_timeout),
+            open=True,
+            name="langgraph-checkpointer",
+        )
+
+    return _langgraph_checkpointer_pool

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -239,19 +239,40 @@ def _langgraph_pool_kwargs() -> dict[str, object]:
     }
 
 
+def _langgraph_checkpointer_pool_bounds() -> tuple[int, int]:
+    """Keep production checkpoint pools compatible with Supavisor transaction mode."""
+    if settings.environment.strip().lower() == "production":
+        return (1, 1)
+
+    return (1, max(1, settings.db_pool_size))
+
+
+def _langgraph_checkpointer_pool_tuning() -> dict[str, float]:
+    """Use short-lived checkpoint connections in production to avoid sticky sessions."""
+    if settings.environment.strip().lower() != "production":
+        return {}
+
+    return {
+        "max_idle": 5.0,
+        "max_lifetime": 60.0,
+    }
+
+
 def get_langgraph_checkpointer_pool() -> ConnectionPool:
     """Return a shared psycopg pool configured from existing DB settings."""
     global _langgraph_checkpointer_pool
 
     if _langgraph_checkpointer_pool is None:
+        min_size, max_size = _langgraph_checkpointer_pool_bounds()
         _langgraph_checkpointer_pool = ConnectionPool(
             conninfo=_to_psycopg_conninfo(settings.database_url),
-            min_size=1,
-            max_size=max(1, settings.db_pool_size),
+            min_size=min_size,
+            max_size=max_size,
             kwargs=_langgraph_pool_kwargs(),
             timeout=float(settings.db_pool_timeout),
             open=True,
             name="langgraph-checkpointer",
+            **_langgraph_checkpointer_pool_tuning(),
         )
 
     return _langgraph_checkpointer_pool
@@ -294,6 +315,7 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
 
         previous_pool = _langgraph_checkpointer_async_pool
         parsed_url = make_url(settings.database_url)
+        min_size, max_size = _langgraph_checkpointer_pool_bounds()
         logger.info(
             "Opening LangGraph async checkpointer pool",
             extra={
@@ -301,19 +323,21 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
                 "db_host": parsed_url.host,
                 "db_port": parsed_url.port,
                 "environment": settings.environment,
-                "max_size": max(1, settings.db_pool_size),
+                "min_size": min_size,
+                "max_size": max_size,
                 "loop_id": id(current_loop),
             },
         )
         pool_open_started_at = time.perf_counter()
         pool = AsyncConnectionPool(
             conninfo=_to_psycopg_conninfo(settings.database_url),
-            min_size=1,
-            max_size=max(1, settings.db_pool_size),
+            min_size=min_size,
+            max_size=max_size,
             kwargs=_langgraph_pool_kwargs(),
             timeout=float(settings.db_pool_timeout),
             open=False,
             name="langgraph-checkpointer-async",
+            **_langgraph_checkpointer_pool_tuning(),
         )
         await pool.open()
         logger.info(

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -1,7 +1,10 @@
+import asyncio
 from collections.abc import Generator
+import logging
 from pathlib import Path
+import sys
 from psycopg.rows import dict_row
-from psycopg_pool import ConnectionPool
+from psycopg_pool import AsyncConnectionPool, ConnectionPool
 from sqlalchemy import create_engine, Engine
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
@@ -9,6 +12,12 @@ from sqlalchemy.pool import NullPool
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 ENV_FILE = Path(__file__).resolve().parents[2] / ".env"
+logger = logging.getLogger(__name__)
+
+if sys.platform == "win32" and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
+    # psycopg async connections are not compatible with the default Proactor loop
+    # used by Python on Windows. Force the selector policy before any loop exists.
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
 class Settings(BaseSettings):
@@ -93,6 +102,9 @@ settings = Settings()
 engine = _make_engine(settings)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 _langgraph_checkpointer_pool: ConnectionPool | None = None
+_langgraph_checkpointer_async_pool: AsyncConnectionPool | None = None
+_langgraph_checkpointer_async_pool_loop: asyncio.AbstractEventLoop | None = None
+_langgraph_checkpointer_async_pool_lock: asyncio.Lock | None = None
 
 class Base(DeclarativeBase):
     """Base declarative class for SQLAlchemy models."""
@@ -119,6 +131,15 @@ def _to_psycopg_conninfo(database_url: str) -> str:
     return url.render_as_string(hide_password=False)
 
 
+def _langgraph_pool_kwargs() -> dict[str, object]:
+    """Return psycopg connect kwargs required by LangGraph Postgres savers."""
+    return {
+        "autocommit": True,
+        "row_factory": dict_row,
+        "prepare_threshold": 0,
+    }
+
+
 def get_langgraph_checkpointer_pool() -> ConnectionPool:
     """Return a shared psycopg pool configured from existing DB settings."""
     global _langgraph_checkpointer_pool
@@ -128,10 +149,68 @@ def get_langgraph_checkpointer_pool() -> ConnectionPool:
             conninfo=_to_psycopg_conninfo(settings.database_url),
             min_size=1,
             max_size=max(1, settings.db_pool_size),
-            kwargs={"autocommit": True, "row_factory": dict_row},
+            kwargs=_langgraph_pool_kwargs(),
             timeout=float(settings.db_pool_timeout),
             open=True,
             name="langgraph-checkpointer",
         )
 
     return _langgraph_checkpointer_pool
+
+
+def _get_async_pool_lock(current_loop: asyncio.AbstractEventLoop) -> asyncio.Lock:
+    """Return a loop-bound lock for async pool singleton initialization."""
+    global _langgraph_checkpointer_async_pool_lock, _langgraph_checkpointer_async_pool_loop
+
+    if (
+        _langgraph_checkpointer_async_pool_lock is None
+        or _langgraph_checkpointer_async_pool_loop is not current_loop
+    ):
+        _langgraph_checkpointer_async_pool_lock = asyncio.Lock()
+    return _langgraph_checkpointer_async_pool_lock
+
+
+async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
+    """Return a shared async psycopg pool for LangGraph durable checkpointing.
+
+    The pool is cached per active event loop to stay compatible with the async
+    saver implementation used by LangGraph during `graph.astream(...)`.
+    """
+
+    global _langgraph_checkpointer_async_pool, _langgraph_checkpointer_async_pool_loop
+
+    current_loop = asyncio.get_running_loop()
+    current_pool = _langgraph_checkpointer_async_pool
+    if current_pool is not None and _langgraph_checkpointer_async_pool_loop is current_loop:
+        return current_pool
+
+    async with _get_async_pool_lock(current_loop):
+        current_pool = _langgraph_checkpointer_async_pool
+        if current_pool is not None and _langgraph_checkpointer_async_pool_loop is current_loop:
+            return current_pool
+
+        previous_pool = _langgraph_checkpointer_async_pool
+        pool = AsyncConnectionPool(
+            conninfo=_to_psycopg_conninfo(settings.database_url),
+            min_size=1,
+            max_size=max(1, settings.db_pool_size),
+            kwargs=_langgraph_pool_kwargs(),
+            timeout=float(settings.db_pool_timeout),
+            open=False,
+            name="langgraph-checkpointer-async",
+        )
+        await pool.open()
+
+        _langgraph_checkpointer_async_pool = pool
+        _langgraph_checkpointer_async_pool_loop = current_loop
+
+        if previous_pool is not None and previous_pool is not pool:
+            try:
+                await previous_pool.close()
+            except Exception as exc:
+                logger.warning(
+                    "Could not close previous LangGraph async checkpointer pool cleanly: %s",
+                    exc,
+                )
+
+        return pool

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 import sys
 import threading
+import time
 from typing import Any
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool, ConnectionPool
@@ -43,6 +44,7 @@ class Settings(BaseSettings):
     db_lock_timeout_ms: int = 5000
     db_retry_after_seconds: int = 3
     db_critical_endpoint_budget: int = 64
+    authoring_bootstrap_timeout_seconds: int | None = None
 
     model_config = SettingsConfigDict(env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 
@@ -303,6 +305,7 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
                 "loop_id": id(current_loop),
             },
         )
+        pool_open_started_at = time.perf_counter()
         pool = AsyncConnectionPool(
             conninfo=_to_psycopg_conninfo(settings.database_url),
             min_size=1,
@@ -313,6 +316,15 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
             name="langgraph-checkpointer-async",
         )
         await pool.open()
+        logger.info(
+            "LangGraph async checkpointer pool opened",
+            extra={
+                "pool_name": "langgraph-checkpointer-async",
+                "environment": settings.environment,
+                "loop_id": id(current_loop),
+                "latency_ms": round((time.perf_counter() - pool_open_started_at) * 1000, 3),
+            },
+        )
 
         _langgraph_checkpointer_async_pool = pool
         _langgraph_checkpointer_async_pool_loop = current_loop

--- a/backend/src/shared/internal_tasks.py
+++ b/backend/src/shared/internal_tasks.py
@@ -33,7 +33,12 @@ from sqlalchemy.orm import Session
 
 from case_generator.core.authoring import AuthoringService
 from shared.database import get_db
-from shared.models import AuthoringJob
+from shared.models import (
+    AUTHORING_JOB_STATUS_COMPLETED,
+    AUTHORING_JOB_STATUS_FAILED,
+    AUTHORING_JOB_STATUS_PROCESSING,
+    AuthoringJob,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +137,11 @@ async def process_authoring_job_task(
         logger.error("cloud_task_job_not_found", extra={"job_id": payload.job_id})
         raise HTTPException(status_code=404, detail="Job not found")
 
-    if job.status in ["completed", "failed", "processing"]:
+    if job.status in [
+        AUTHORING_JOB_STATUS_COMPLETED,
+        AUTHORING_JOB_STATUS_FAILED,
+        AUTHORING_JOB_STATUS_PROCESSING,
+    ]:
         logger.warning(
             "cloud_task_idempotency_barrier",
             extra={"job_id": job.id, "status": job.status},

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -347,6 +347,18 @@ class Assignment(Base):
     artifacts: Mapped[list["ArtifactManifest"]] = relationship(back_populates="assignment")
 
 
+AUTHORING_JOB_STATUS_PENDING = "pending"
+AUTHORING_JOB_STATUS_PROCESSING = "processing"
+AUTHORING_JOB_STATUS_COMPLETED = "completed"
+AUTHORING_JOB_STATUS_FAILED = "failed"
+AUTHORING_JOB_STATUS_FAILED_RESUMABLE = "failed_resumable"
+
+AUTHORING_JOB_RETRYABLE_STATUSES = (
+    AUTHORING_JOB_STATUS_PENDING,
+    AUTHORING_JOB_STATUS_FAILED_RESUMABLE,
+)
+
+
 class AuthoringJob(Base):
     """
     Tracks asynchronous authoring execution.
@@ -354,6 +366,12 @@ class AuthoringJob(Base):
     """
 
     __tablename__ = "authoring_jobs"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('pending', 'processing', 'completed', 'failed', 'failed_resumable')",
+            name="ck_authoring_jobs_status",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
     assignment_id: Mapped[str] = mapped_column(String(36), ForeignKey("assignments.id"), nullable=False)
@@ -362,7 +380,7 @@ class AuthoringJob(Base):
     idempotency_key: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
 
     # State tracking for the authoring job lifecycle.
-    status: Mapped[str] = mapped_column(String(50), default="pending")
+    status: Mapped[str] = mapped_column(String(50), default=AUTHORING_JOB_STATUS_PENDING)
     retry_count: Mapped[int] = mapped_column(Integer, default=0)
 
     # Normalized intake payload that drives the authoring run.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Generator
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 import os
+import subprocess
 import uuid
 
 import jwt
@@ -40,17 +41,20 @@ def _assert_local_schema_reset_target() -> None:
             f"got {db_url.host}:{db_url.port}/{db_url.database})."
         )
 
-
 @pytest.fixture(scope="session", autouse=True)
 def ensure_db_schema() -> None:
-    """Recreate the ORM schema once so metadata changes are reflected in the test DB."""
+    """Recreate the local test schema from Alembic so checkpoint tables exist."""
     _assert_local_schema_reset_target()
     close_all_sessions()
     with engine.begin() as connection:
         connection.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
         connection.execute(text("CREATE SCHEMA public"))
-    Base.metadata.create_all(bind=engine)
 
+    # The runtime schema is Alembic-driven, and LangGraph checkpoint tables are
+    # not created by ORM metadata alone.
+    # Get absolute path to backend directory. conftest.py is in backend/tests/
+    backend_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    subprocess.run(["uv", "run", "alembic", "upgrade", "head"], cwd=backend_dir, check=True)
 
 @pytest.fixture(autouse=True)
 def configure_auth_env(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,9 +4,10 @@ from collections.abc import Callable, Generator
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 import os
-import subprocess
 import uuid
 
+from alembic import command
+from alembic.config import Config
 import jwt
 import pytest
 from fastapi.testclient import TestClient
@@ -19,6 +20,13 @@ from shared.app import app
 from shared.auth import get_auth_settings, get_jwt_verifier, get_supabase_admin_auth_client
 from shared.database import SessionLocal, engine, settings
 from shared.models import Base, Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, Tenant, User
+
+
+_CHECKPOINT_TABLES = (
+    "checkpoint_writes",
+    "checkpoint_blobs",
+    "checkpoints",
+)
 
 
 def _assert_local_schema_reset_target() -> None:
@@ -50,11 +58,18 @@ def ensure_db_schema() -> None:
         connection.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
         connection.execute(text("CREATE SCHEMA public"))
 
-    # The runtime schema is Alembic-driven, and LangGraph checkpoint tables are
-    # not created by ORM metadata alone.
-    # Get absolute path to backend directory. conftest.py is in backend/tests/
+    _run_alembic_upgrade_head()
+
+
+def _run_alembic_upgrade_head() -> None:
+    """Run Alembic migrations in-process so tests reuse the active virtualenv."""
     backend_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    subprocess.run(["uv", "run", "alembic", "upgrade", "head"], cwd=backend_dir, check=True)
+    alembic_config = Config()
+    alembic_config.set_main_option("path_separator", "os")
+    alembic_config.set_main_option("script_location", os.path.join(backend_dir, "alembic"))
+    alembic_config.set_main_option("prepend_sys_path", backend_dir)
+    alembic_config.set_main_option("sqlalchemy.url", settings.database_url)
+    command.upgrade(alembic_config, "head")
 
 @pytest.fixture(autouse=True)
 def configure_auth_env(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
@@ -103,10 +118,13 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 def _truncate_all_tables() -> None:
-    table_names = ", ".join(table.name for table in Base.metadata.sorted_tables)
-    if not table_names:
+    table_names = [table.name for table in Base.metadata.sorted_tables]
+    table_names.extend(_CHECKPOINT_TABLES)
+    ordered_table_names = list(dict.fromkeys(table_names))
+    table_names_csv = ", ".join(ordered_table_names)
+    if not table_names_csv:
         return
-    truncate_sql = text(f"TRUNCATE TABLE {table_names} RESTART IDENTITY CASCADE")
+    truncate_sql = text(f"TRUNCATE TABLE {table_names_csv} RESTART IDENTITY CASCADE")
     close_all_sessions()
     # The backend suite assumes exclusive ownership of the local test DB while it runs.
     with engine.begin() as connection:

--- a/backend/tests/integration/test_t1_smoke.py
+++ b/backend/tests/integration/test_t1_smoke.py
@@ -1,10 +1,11 @@
 """T1 smoke test live ejecutable con pytest."""
 
 import json
+import uuid
 
 import pytest
 
-pytestmark = pytest.mark.live_llm
+pytestmark = [pytest.mark.live_llm, pytest.mark.asyncio]
 
 T1_PAYLOAD = {
     "messages": [("user", "Generar caso Harvard T1 smoke test")],
@@ -47,8 +48,11 @@ def _record_generation_errors(errors: list[str], field_name: str, value: object)
         errors.append(f"[FAIL] {field_name} contiene sentinel {sentinel}")
 
 
-def test_t1_smoke() -> None:
-    from case_generator.graph import graph
+async def test_t1_smoke() -> None:
+    from case_generator.graph import get_graph
+
+    graph = await get_graph()
+    config = {"configurable": {"thread_id": f"test_t1_smoke-{uuid.uuid4()}"}}
 
     print("\n" + "=" * 60)
     print("T1 SMOKE TEST - business + harvard_only")
@@ -60,7 +64,7 @@ def test_t1_smoke() -> None:
     executed_nodes: list[str] = []
     final_state: dict = {}
 
-    for event in graph.stream(T1_PAYLOAD, stream_mode="updates"):
+    async for event in graph.astream(T1_PAYLOAD, config=config, stream_mode="updates"):
         for node_name, node_output in event.items():
             executed_nodes.append(node_name)
             print(f"  [OK] Nodo completado: {node_name}")

--- a/backend/tests/integration/test_t2_smoke.py
+++ b/backend/tests/integration/test_t2_smoke.py
@@ -1,10 +1,11 @@
 """T2 smoke test live ejecutable con pytest."""
 
 import json
+import uuid
 
 import pytest
 
-pytestmark = pytest.mark.live_llm
+pytestmark = [pytest.mark.live_llm, pytest.mark.asyncio]
 
 T2_PAYLOAD = {
     "messages": [("user", "Generar caso Harvard T2 smoke test")],
@@ -65,8 +66,11 @@ def _record_generation_errors(errors: list[str], field_name: str, value: object)
         errors.append(f"[FAIL] {field_name} contiene sentinel {sentinel}")
 
 
-def test_t2_smoke() -> None:
-    from case_generator.graph import graph
+async def test_t2_smoke() -> None:
+    from case_generator.graph import get_graph
+
+    graph = await get_graph()
+    config = {"configurable": {"thread_id": f"test_t2_smoke-{uuid.uuid4()}"}}
 
     print("\n" + "=" * 60)
     print("T2 SMOKE TEST -- business + harvard_with_eda")
@@ -77,7 +81,7 @@ def test_t2_smoke() -> None:
     executed_nodes: list[str] = []
     final_state: dict = {}
 
-    for event in graph.stream(T2_PAYLOAD, stream_mode="updates"):
+    async for event in graph.astream(T2_PAYLOAD, config=config, stream_mode="updates"):
         for node_name, node_output in event.items():
             executed_nodes.append(node_name)
             print(f"  [OK] Nodo completado: {node_name}")

--- a/backend/tests/integration/test_t3_smoke.py
+++ b/backend/tests/integration/test_t3_smoke.py
@@ -1,10 +1,11 @@
 """T3 smoke test live ejecutable con pytest."""
 
 import json
+import uuid
 
 import pytest
 
-pytestmark = pytest.mark.live_llm
+pytestmark = [pytest.mark.live_llm, pytest.mark.asyncio]
 
 T3_PAYLOAD = {
     "messages": [("user", "Generar caso Harvard T3 smoke test")],
@@ -57,8 +58,11 @@ def _record_generation_errors(errors: list[str], field_name: str, value: object)
         errors.append(f"[FAIL] {field_name} contiene sentinel {sentinel}")
 
 
-def test_t3_smoke() -> None:
-    from case_generator.graph import graph
+async def test_t3_smoke() -> None:
+    from case_generator.graph import get_graph
+
+    graph = await get_graph()
+    config = {"configurable": {"thread_id": f"test_t3_smoke-{uuid.uuid4()}"}}
 
     print("\n" + "=" * 60)
     print("T3 SMOKE TEST -- ml_ds + harvard_only")
@@ -69,7 +73,7 @@ def test_t3_smoke() -> None:
     executed_nodes: list[str] = []
     final_state: dict = {}
 
-    for event in graph.stream(T3_PAYLOAD, stream_mode="updates"):
+    async for event in graph.astream(T3_PAYLOAD, config=config, stream_mode="updates"):
         for node_name, node_output in event.items():
             executed_nodes.append(node_name)
             print(f"  [OK] Nodo completado: {node_name}")

--- a/backend/tests/integration/test_t4_smoke.py
+++ b/backend/tests/integration/test_t4_smoke.py
@@ -5,10 +5,11 @@ campo legacy obsoleto que debe permanecer ausente.
 """
 
 import json
+import uuid
 
 import pytest
 
-pytestmark = pytest.mark.live_llm
+pytestmark = [pytest.mark.live_llm, pytest.mark.asyncio]
 
 T4_PAYLOAD = {
     "messages": [("user", "Generar caso Harvard T4 smoke test")],
@@ -69,8 +70,11 @@ def _record_generation_errors(errors: list[str], field_name: str, value: object)
         errors.append(f"[FAIL] {field_name} contiene sentinel {sentinel}")
 
 
-def test_t4_smoke() -> None:
-    from case_generator.graph import graph
+async def test_t4_smoke() -> None:
+    from case_generator.graph import get_graph
+
+    graph = await get_graph()
+    config = {"configurable": {"thread_id": f"test_t4_smoke-{uuid.uuid4()}"}}
 
     print("\n" + "=" * 60)
     print("T4 SMOKE TEST -- ml_ds + harvard_with_eda + notebook")
@@ -82,7 +86,7 @@ def test_t4_smoke() -> None:
     executed_nodes: list[str] = []
     final_state: dict = {}
 
-    for event in graph.stream(T4_PAYLOAD, stream_mode="updates"):
+    async for event in graph.astream(T4_PAYLOAD, config=config, stream_mode="updates"):
         for node_name, node_output in event.items():
             executed_nodes.append(node_name)
             print(f"  [OK] Nodo completado: {node_name}")

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -442,6 +442,69 @@ def test_validate_runtime_database_configuration_rejects_remote_supabase_in_deve
             raise AssertionError("Expected development runtime validation to reject remote Supabase")
 
 
+def test_langgraph_checkpointer_sync_pool_caps_size_in_production(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeConnectionPool:
+        def __init__(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    production_settings = database_module.Settings(
+        database_url="postgresql+psycopg://user:pass@aws-1-us-west-2.pooler.supabase.com:6543/postgres",
+        environment="production",
+        db_pool_size=8,
+    )
+
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_pool", None)
+    monkeypatch.setattr(database_module, "ConnectionPool", FakeConnectionPool)
+    monkeypatch.setattr(database_module, "settings", production_settings)
+
+    database_module.get_langgraph_checkpointer_pool()
+
+    kwargs = captured["kwargs"]
+    assert kwargs["min_size"] == 1
+    assert kwargs["max_size"] == 1
+    assert kwargs["max_idle"] == 5.0
+    assert kwargs["max_lifetime"] == 60.0
+
+
+async def test_langgraph_checkpointer_async_pool_caps_size_in_production(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeAsyncConnectionPool:
+        def __init__(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+        async def open(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    production_settings = database_module.Settings(
+        database_url="postgresql+psycopg://user:pass@aws-1-us-west-2.pooler.supabase.com:6543/postgres",
+        environment="production",
+        db_pool_size=8,
+    )
+
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock_loop", None)
+    monkeypatch.setattr(database_module, "AsyncConnectionPool", FakeAsyncConnectionPool)
+    monkeypatch.setattr(database_module, "settings", production_settings)
+
+    await database_module.get_langgraph_checkpointer_async_pool()
+
+    kwargs = captured["kwargs"]
+    assert kwargs["min_size"] == 1
+    assert kwargs["max_size"] == 1
+    assert kwargs["max_idle"] == 5.0
+    assert kwargs["max_lifetime"] == 60.0
+
+
 async def test_graph_singleton_initializes_once_per_loop(monkeypatch) -> None:
     state = {"checkpointer_calls": 0, "compile_calls": 0}
 

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -266,6 +266,7 @@ async def test_graph_singleton_initializes_once_per_loop(monkeypatch) -> None:
     monkeypatch.setattr(graph_module, "_graph_singleton", None)
     monkeypatch.setattr(graph_module, "_graph_singleton_loop", None)
     monkeypatch.setattr(graph_module, "_graph_singleton_lock", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton_lock_loop", None)
     monkeypatch.setattr(graph_module, "_build_async_postgres_checkpointer", fake_build_async_postgres_checkpointer)
     monkeypatch.setattr(graph_module.master_builder, "compile", fake_compile)
 
@@ -277,6 +278,39 @@ async def test_graph_singleton_initializes_once_per_loop(monkeypatch) -> None:
     assert first is second
     assert state["checkpointer_calls"] == 1
     assert state["compile_calls"] == 1
+
+
+def test_graph_singleton_rebuilds_when_event_loop_changes(monkeypatch) -> None:
+    state = {"checkpointer_calls": 0, "compile_calls": 0}
+
+    async def fake_build_async_postgres_checkpointer():
+        state["checkpointer_calls"] += 1
+        await asyncio.sleep(0)
+        return {"checkpointer_calls": state["checkpointer_calls"]}
+
+    def fake_compile(*, name: str, checkpointer: object):
+        state["compile_calls"] += 1
+        return {
+            "name": name,
+            "checkpointer": checkpointer,
+            "compile_calls": state["compile_calls"],
+        }
+
+    monkeypatch.setattr(graph_module, "_graph_singleton", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton_loop", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton_lock", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton_lock_loop", None)
+    monkeypatch.setattr(graph_module, "_build_async_postgres_checkpointer", fake_build_async_postgres_checkpointer)
+    monkeypatch.setattr(graph_module.master_builder, "compile", fake_compile)
+
+    first = asyncio.run(graph_module.get_graph())
+    second = asyncio.run(graph_module.get_graph())
+
+    assert first is not second
+    assert first["compile_calls"] == 1
+    assert second["compile_calls"] == 2
+    assert state["checkpointer_calls"] == 2
+    assert state["compile_calls"] == 2
 
 
 def test_run_job_fail_closed_when_checkpoint_runtime_fails_mid_stream(

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -1,4 +1,6 @@
+import contextlib
 import asyncio
+import logging
 import uuid
 from unittest.mock import AsyncMock, patch
 
@@ -300,6 +302,41 @@ async def test_close_async_checkpointer_pool_clears_singleton(monkeypatch) -> No
     assert database_module._langgraph_checkpointer_async_pool_loop is None
     assert database_module._langgraph_checkpointer_async_pool_lock is None
     assert database_module._langgraph_checkpointer_async_pool_lock_loop is None
+
+
+async def test_close_async_checkpointer_pool_logs_timeout_telemetry(monkeypatch, caplog) -> None:
+    class HangingAsyncConnectionPool:
+        def get_stats(self) -> dict[str, int]:
+            return {
+                "pool_min": 1,
+                "pool_max": 5,
+                "pool_size": 3,
+                "pool_available": 1,
+                "requests_waiting": 2,
+            }
+
+        async def close(self) -> None:
+            await asyncio.Future()
+
+    leaked_task = asyncio.create_task(asyncio.Event().wait(), name="authoring-job-job-timeout")
+    database_module.register_active_authoring_job("job-timeout")
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", HangingAsyncConnectionPool())
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", asyncio.get_running_loop())
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", asyncio.Lock())
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock_loop", asyncio.get_running_loop())
+
+    caplog.set_level(logging.INFO)
+    try:
+        await database_module.close_langgraph_checkpointer_async_pool(timeout_seconds=0.01)
+    finally:
+        database_module.unregister_active_authoring_job("job-timeout")
+        leaked_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await leaked_task
+
+    assert "LEAK DETECTED" in caplog.text
+    assert "job-timeout" in caplog.text
+    assert "authoring-job-job-timeout" in caplog.text
 
 
 def test_validate_runtime_database_configuration_rejects_remote_supabase_in_development() -> None:

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -235,6 +235,7 @@ async def test_async_checkpointer_pool_initializes_once_per_loop(monkeypatch) ->
     monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", None)
     monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", None)
     monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock_loop", None)
     monkeypatch.setattr(database_module, "AsyncConnectionPool", FakeAsyncConnectionPool)
 
     first, second = await asyncio.gather(
@@ -245,6 +246,75 @@ async def test_async_checkpointer_pool_initializes_once_per_loop(monkeypatch) ->
     assert first is second
     assert len(created_pools) == 1
     assert state["open_calls"] == 1
+
+
+def test_async_checkpointer_pool_rebuilds_when_event_loop_changes(monkeypatch) -> None:
+    created_pools: list[object] = []
+    state = {"open_calls": 0}
+
+    class FakeAsyncConnectionPool:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            created_pools.append(self)
+
+        async def open(self) -> None:
+            state["open_calls"] += 1
+            await asyncio.sleep(0)
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock_loop", None)
+    monkeypatch.setattr(database_module, "AsyncConnectionPool", FakeAsyncConnectionPool)
+
+    first = asyncio.run(database_module.get_langgraph_checkpointer_async_pool())
+    second = asyncio.run(database_module.get_langgraph_checkpointer_async_pool())
+
+    assert first is not second
+    assert len(created_pools) == 2
+    assert state["open_calls"] == 2
+
+
+async def test_close_async_checkpointer_pool_clears_singleton(monkeypatch) -> None:
+    state = {"close_calls": 0}
+
+    class FakeAsyncConnectionPool:
+        async def close(self) -> None:
+            state["close_calls"] += 1
+
+    fake_pool = FakeAsyncConnectionPool()
+
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", fake_pool)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", asyncio.get_running_loop())
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", asyncio.Lock())
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock_loop", asyncio.get_running_loop())
+
+    await database_module.close_langgraph_checkpointer_async_pool()
+
+    assert state["close_calls"] == 1
+    assert database_module._langgraph_checkpointer_async_pool is None
+    assert database_module._langgraph_checkpointer_async_pool_loop is None
+    assert database_module._langgraph_checkpointer_async_pool_lock is None
+    assert database_module._langgraph_checkpointer_async_pool_lock_loop is None
+
+
+def test_validate_runtime_database_configuration_rejects_remote_supabase_in_development() -> None:
+    settings = database_module.Settings(
+        database_url="postgresql+psycopg://user:pass@aws-1-us-west-2.pooler.supabase.com:5432/postgres",
+        environment="development",
+    )
+
+    with patch.object(database_module, "settings", settings):
+        try:
+            database_module.validate_runtime_database_configuration(settings)
+        except RuntimeError as exc:
+            assert "localhost:5434" in str(exc)
+        else:
+            raise AssertionError("Expected development runtime validation to reject remote Supabase")
 
 
 async def test_graph_singleton_initializes_once_per_loop(monkeypatch) -> None:

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -1,13 +1,16 @@
 import asyncio
 import uuid
+from unittest.mock import AsyncMock, patch
 
 from sqlalchemy.orm import Session as OrmSession
 
 from case_generator.core.authoring import (
     CANONICAL_TIMELINE_STEP_IDS,
+    AuthoringService,
     _persist_intermediate_progress_step,
     _to_canonical_progress_step,
 )
+from case_generator.graph import DurableCheckpointUnavailableError
 from shared.models import Assignment, AuthoringJob
 
 
@@ -26,6 +29,30 @@ def _seed_processing_job(db, teacher_id: str, initial_step: str = "case_architec
             "progress_ts": "2026-01-01T00:00:00+00:00",
             "progress_status": "processing",
         },
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+def _seed_authoring_job(
+    db,
+    teacher_id: str,
+    *,
+    status: str,
+    task_payload: dict[str, object] | None = None,
+) -> AuthoringJob:
+    assignment = Assignment(teacher_id=teacher_id, title="Issue 112 Resilience", status="draft")
+    db.add(assignment)
+    db.flush()
+
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status=status,
+        retry_count=0,
+        task_payload=dict(task_payload or {}),
     )
     db.add(job)
     db.commit()
@@ -145,3 +172,96 @@ def test_intermediate_progress_write_marks_degraded_state_after_retry_exhaustion
     assert payload.get("progress_degraded_retries") == 3
     assert isinstance(payload.get("progress_degraded_at"), str)
     assert isinstance(payload.get("progress_degraded_error"), str)
+
+
+def test_run_job_fail_closed_when_checkpointer_is_unavailable(
+    db,
+    seed_identity,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-checkpointer-down@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    job = _seed_authoring_job(
+        db,
+        teacher_id,
+        status="pending",
+        task_payload={"current_step": "case_architect", "progress_seq": 1},
+    )
+
+    async def fail_get_graph():
+        raise DurableCheckpointUnavailableError("checkpoint bootstrap failed")
+
+    with (
+        patch("case_generator.core.authoring.get_storage_provider", return_value=object()),
+        patch("case_generator.core.authoring.get_graph", new=fail_get_graph),
+        patch("case_generator.core.authoring.ArtifactManager.orphan_job_artifacts") as orphan_mock,
+    ):
+        asyncio.run(AuthoringService.run_job(job.id))
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+
+    payload = dict(refreshed.task_payload or {})
+    assert refreshed.status == "failed"
+    assert refreshed.retry_count == 1
+    assert payload.get("current_step") == "failed"
+    assert payload.get("error_code") == "checkpoint_unavailable"
+    assert "persistencia durable" in str(payload.get("error_trace", ""))
+    orphan_mock.assert_called_once()
+
+
+def test_run_job_duplicate_retry_race_allows_only_one_checkpoint_attempt(
+    db,
+    seed_identity,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-double-retry@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    job = _seed_authoring_job(
+        db,
+        teacher_id,
+        status="failed_resumable",
+        task_payload={
+            "current_step": "case_writer",
+            "progress_seq": 4,
+            "error_code": "llm_timeout",
+        },
+    )
+
+    state = {"get_graph_calls": 0}
+
+    async def fail_get_graph_once_locked():
+        state["get_graph_calls"] += 1
+        await asyncio.sleep(0.05)
+        raise DurableCheckpointUnavailableError("checkpoint bootstrap failed")
+
+    prefetch_mock = AsyncMock(return_value={})
+
+    with (
+        patch("case_generator.core.authoring.get_storage_provider", return_value=object()),
+        patch("case_generator.core.authoring.ArtifactManager.prefetch_resume_artifacts", new=prefetch_mock),
+        patch("case_generator.core.authoring.get_graph", new=fail_get_graph_once_locked),
+        patch("case_generator.core.authoring.ArtifactManager.orphan_job_artifacts") as orphan_mock,
+    ):
+        async def run_twice() -> None:
+            await asyncio.gather(
+                AuthoringService.run_job(job.id),
+                AuthoringService.run_job(job.id),
+            )
+
+        asyncio.run(run_twice())
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+
+    payload = dict(refreshed.task_payload or {})
+    assert state["get_graph_calls"] == 1
+    assert prefetch_mock.await_count == 1
+    assert refreshed.retry_count == 1
+    assert refreshed.status == "failed"
+    assert payload.get("error_code") == "checkpoint_unavailable"
+    orphan_mock.assert_called_once()

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session as OrmSession
 import case_generator.graph as graph_module
 import shared.database as database_module
 from case_generator.core.authoring import (
+    BOOTSTRAP_STATE_INITIALIZING,
     CANONICAL_TIMELINE_STEP_IDS,
     AuthoringService,
     _persist_intermediate_progress_step,
@@ -209,12 +210,99 @@ def test_run_job_fail_closed_when_checkpointer_is_unavailable(
     assert refreshed is not None
 
     payload = dict(refreshed.task_payload or {})
-    assert refreshed.status == "failed"
+    assert refreshed.status == "failed_resumable"
     assert refreshed.retry_count == 1
     assert payload.get("current_step") == "failed"
     assert payload.get("error_code") == "checkpoint_unavailable"
+    assert payload.get("last_known_step") == "case_architect"
+    assert payload.get("bootstrap_state") is None
     assert "persistencia durable" in str(payload.get("error_trace", ""))
-    orphan_mock.assert_called_once()
+    orphan_mock.assert_not_called()
+
+
+def test_run_job_marks_bootstrap_initializing_before_graph_start(
+    db,
+    seed_identity,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-bootstrap-state@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    job = _seed_authoring_job(
+        db,
+        teacher_id,
+        status="pending",
+        task_payload={},
+    )
+
+    gate = asyncio.Event()
+
+    async def block_get_graph():
+        processing_db = database_module.SessionLocal()
+        try:
+            processing_job = processing_db.get(AuthoringJob, job.id)
+            assert processing_job is not None
+            payload = dict(processing_job.task_payload or {})
+            assert payload.get("bootstrap_state") == BOOTSTRAP_STATE_INITIALIZING
+            assert payload.get("current_step") is None
+            assert payload.get("error_code") is None
+            assert isinstance(payload.get("bootstrap_started_at"), str)
+            assert payload.get("bootstrap_timeout_seconds") is not None
+        finally:
+            processing_db.close()
+            gate.set()
+
+        raise DurableCheckpointUnavailableError("checkpoint bootstrap failed")
+
+    with (
+        patch("case_generator.core.authoring.get_storage_provider", return_value=object()),
+        patch("case_generator.core.authoring.get_graph", new=block_get_graph),
+    ):
+        asyncio.run(AuthoringService.run_job(job.id))
+
+    assert gate.is_set()
+
+
+def test_run_job_classifies_bootstrap_timeout_as_resumable(
+    db,
+    seed_identity,
+    monkeypatch,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-bootstrap-timeout@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    job = _seed_authoring_job(
+        db,
+        teacher_id,
+        status="pending",
+        task_payload={},
+    )
+
+    async def get_graph_success() -> object:
+        return object()
+
+    async def fake_wait_for(awaitable, timeout):
+        await awaitable
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr("case_generator.core.authoring._bootstrap_timeout_seconds", lambda: 1.0)
+
+    with (
+        patch("case_generator.core.authoring.get_storage_provider", return_value=object()),
+        patch("case_generator.core.authoring.get_graph", new=get_graph_success),
+        patch("case_generator.core.authoring.asyncio.wait_for", new=fake_wait_for),
+    ):
+        asyncio.run(AuthoringService.run_job(job.id))
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+
+    payload = dict(refreshed.task_payload or {})
+    assert refreshed.status == "failed_resumable"
+    assert payload.get("error_code") == "bootstrap_timeout"
+    assert payload.get("bootstrap_state") is None
 
 
 async def test_async_checkpointer_pool_initializes_once_per_loop(monkeypatch) -> None:
@@ -458,12 +546,13 @@ def test_run_job_fail_closed_when_checkpoint_runtime_fails_mid_stream(
     assert refreshed is not None
 
     payload = dict(refreshed.task_payload or {})
-    assert refreshed.status == "failed"
+    assert refreshed.status == "failed_resumable"
     assert refreshed.retry_count == 1
     assert payload.get("current_step") == "failed"
     assert payload.get("error_code") == "checkpoint_unavailable"
+    assert payload.get("last_known_step") == "case_architect"
     assert "persistencia durable" in str(payload.get("error_trace", ""))
-    orphan_mock.assert_called_once()
+    orphan_mock.assert_not_called()
 
 
 def test_run_job_duplicate_retry_race_allows_only_one_checkpoint_attempt(
@@ -516,6 +605,7 @@ def test_run_job_duplicate_retry_race_allows_only_one_checkpoint_attempt(
     assert state["get_graph_calls"] == 1
     assert prefetch_mock.await_count == 1
     assert refreshed.retry_count == 1
-    assert refreshed.status == "failed"
+    assert refreshed.status == "failed_resumable"
     assert payload.get("error_code") == "checkpoint_unavailable"
-    orphan_mock.assert_called_once()
+    assert payload.get("last_known_step") == "case_writer"
+    orphan_mock.assert_not_called()

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -2,8 +2,11 @@ import asyncio
 import uuid
 from unittest.mock import AsyncMock, patch
 
+from psycopg_pool import PoolClosed
 from sqlalchemy.orm import Session as OrmSession
 
+import case_generator.graph as graph_module
+import shared.database as database_module
 from case_generator.core.authoring import (
     CANONICAL_TIMELINE_STEP_IDS,
     AuthoringService,
@@ -195,6 +198,116 @@ def test_run_job_fail_closed_when_checkpointer_is_unavailable(
     with (
         patch("case_generator.core.authoring.get_storage_provider", return_value=object()),
         patch("case_generator.core.authoring.get_graph", new=fail_get_graph),
+        patch("case_generator.core.authoring.ArtifactManager.orphan_job_artifacts") as orphan_mock,
+    ):
+        asyncio.run(AuthoringService.run_job(job.id))
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+
+    payload = dict(refreshed.task_payload or {})
+    assert refreshed.status == "failed"
+    assert refreshed.retry_count == 1
+    assert payload.get("current_step") == "failed"
+    assert payload.get("error_code") == "checkpoint_unavailable"
+    assert "persistencia durable" in str(payload.get("error_trace", ""))
+    orphan_mock.assert_called_once()
+
+
+async def test_async_checkpointer_pool_initializes_once_per_loop(monkeypatch) -> None:
+    created_pools: list[object] = []
+    state = {"open_calls": 0}
+
+    class FakeAsyncConnectionPool:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            created_pools.append(self)
+
+        async def open(self) -> None:
+            state["open_calls"] += 1
+            await asyncio.sleep(0)
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", None)
+    monkeypatch.setattr(database_module, "AsyncConnectionPool", FakeAsyncConnectionPool)
+
+    first, second = await asyncio.gather(
+        database_module.get_langgraph_checkpointer_async_pool(),
+        database_module.get_langgraph_checkpointer_async_pool(),
+    )
+
+    assert first is second
+    assert len(created_pools) == 1
+    assert state["open_calls"] == 1
+
+
+async def test_graph_singleton_initializes_once_per_loop(monkeypatch) -> None:
+    state = {"checkpointer_calls": 0, "compile_calls": 0}
+
+    async def fake_build_async_postgres_checkpointer():
+        state["checkpointer_calls"] += 1
+        await asyncio.sleep(0)
+        return object()
+
+    def fake_compile(*, name: str, checkpointer: object):
+        state["compile_calls"] += 1
+        return {
+            "name": name,
+            "checkpointer": checkpointer,
+            "compile_calls": state["compile_calls"],
+        }
+
+    monkeypatch.setattr(graph_module, "_graph_singleton", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton_loop", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton_lock", None)
+    monkeypatch.setattr(graph_module, "_build_async_postgres_checkpointer", fake_build_async_postgres_checkpointer)
+    monkeypatch.setattr(graph_module.master_builder, "compile", fake_compile)
+
+    first, second = await asyncio.gather(
+        graph_module.get_graph(),
+        graph_module.get_graph(),
+    )
+
+    assert first is second
+    assert state["checkpointer_calls"] == 1
+    assert state["compile_calls"] == 1
+
+
+def test_run_job_fail_closed_when_checkpoint_runtime_fails_mid_stream(
+    db,
+    seed_identity,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-checkpoint-runtime@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    job = _seed_authoring_job(
+        db,
+        teacher_id,
+        status="pending",
+        task_payload={"current_step": "case_architect", "progress_seq": 1},
+    )
+
+    class FailingGraph:
+        def astream(self, *args, **kwargs):
+            async def _stream():
+                raise PoolClosed("checkpoint pool closed")
+                yield {}
+
+            return _stream()
+
+    async def get_failing_graph():
+        return FailingGraph()
+
+    with (
+        patch("case_generator.core.authoring.get_storage_provider", return_value=object()),
+        patch("case_generator.core.authoring.get_graph", new=get_failing_graph),
         patch("case_generator.core.authoring.ArtifactManager.orphan_job_artifacts") as orphan_mock,
     ):
         asyncio.run(AuthoringService.run_job(job.id))

--- a/backend/tests/test_phase1b_integration.py
+++ b/backend/tests/test_phase1b_integration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from shared.database import SessionLocal
 from shared.models import Assignment, AuthoringJob
@@ -22,6 +22,14 @@ async def _failing_astream(*args, **kwargs):
     yield {}
 
 
+class _StubGraph:
+    def __init__(self, stream_impl):
+        self._stream_impl = stream_impl
+
+    def astream(self, *args, **kwargs):
+        return self._stream_impl(*args, **kwargs)
+
+
 def test_phase1b_intake_and_authoring_stubbed(client, auth_headers_factory, seed_identity) -> None:
     teacher_email = "teacher102@example.edu"
     seed_identity(user_id=TEACHER_ID, email=teacher_email, role="teacher")
@@ -30,12 +38,13 @@ def test_phase1b_intake_and_authoring_stubbed(client, auth_headers_factory, seed
         "assignment_title": "Phase 1B Integration Test Title",
     }
 
-    with patch("case_generator.core.authoring.graph.astream") as mock_astream:
-        mock_astream.side_effect = _successful_astream
+    graph_getter = AsyncMock(return_value=_StubGraph(_successful_astream))
+
+    with patch("case_generator.core.authoring.get_graph", new=graph_getter):
         response = client.post("/api/authoring/jobs", json=payload, headers=headers)
         assert response.status_code == 202
         job_id = response.json()["job_id"]
-        mock_astream.assert_called_once()
+        graph_getter.assert_awaited_once()
 
     db = SessionLocal()
     try:
@@ -67,11 +76,14 @@ def test_phase1b_authoring_service_failure(client, auth_headers_factory, seed_id
         "assignment_title": "Phase 1B Error Test Title",
     }
 
-    with patch("case_generator.core.authoring.graph.astream") as mock_astream:
-        mock_astream.side_effect = _failing_astream
+    graph_getter = AsyncMock(return_value=_StubGraph(_failing_astream))
+
+    with patch("case_generator.core.authoring.get_graph", new=graph_getter):
         response = client.post("/api/authoring/jobs", json=payload, headers=headers)
         assert response.status_code == 202
         job_id = response.json()["job_id"]
+
+    graph_getter.assert_awaited_once()
 
     db = SessionLocal()
     try:

--- a/backend/tests/test_phase1b_real.py
+++ b/backend/tests/test_phase1b_real.py
@@ -115,7 +115,7 @@ def test_legacy_suggest(client):
         "industry": "Technology",
         "studentProfile": "business",
         "caseType": "harvard_only",
-        "edaDepth": "charts_only",
+        "edaDepth": "charts_plus_explanation",
         "includePythonCode": False,
         "intent": "both",
         "scenarioDescription": "Write a short 1-paragraph story about a business.",

--- a/backend/tests/test_phase2_fragmentation.py
+++ b/backend/tests/test_phase2_fragmentation.py
@@ -268,13 +268,15 @@ async def test_retry_idempotency():
 
 async def test_legacy_compatibility():
     print("\n--- Test 4: Legacy /suggest Compatibility ---")
-    from case_generator.graph import graph as legacy_graph
+    from case_generator.graph import get_graph
     from case_generator.suggest_service import generate_suggestion
 
-    assert legacy_graph is not None, "Legacy graph must remain importable"
+    compiled_graph = await get_graph()
+
+    assert compiled_graph is not None, "Graph getter must return a compiled graph"
     assert callable(generate_suggestion), "generate_suggestion must remain callable"
 
-    print("  [OK] Legacy graph imported successfully")
+    print("  [OK] Async graph getter resolved successfully")
     print("  [OK] generate_suggestion callable")
     print("  [OK] Legacy Compatibility PASSED")
 

--- a/backend/tests/test_phase3_status_api.py
+++ b/backend/tests/test_phase3_status_api.py
@@ -170,6 +170,8 @@ def test_progress_snapshot_returns_durable_fields(client, db, auth_headers_facto
         idempotency_key=f"job-{uuid.uuid4()}",
         status="processing",
         task_payload={
+            "caseType": "harvard_only",
+            "bootstrap_state": "initializing",
             "current_step": "case_writer",
             "progress_seq": 3,
             "progress_ts": "2026-01-01T00:00:00+00:00",
@@ -187,8 +189,88 @@ def test_progress_snapshot_returns_durable_fields(client, db, auth_headers_facto
     assert payload["job_id"] == job.id
     assert payload["status"] == "processing"
     assert payload["current_step"] == "case_writer"
+    assert payload["progress_percentage"] == 40
+    assert payload["bootstrap_state"] == "initializing"
     assert payload["progress_seq"] == 3
     assert payload["progress_ts"] == "2026-01-01T00:00:00+00:00"
+
+
+def test_progress_snapshot_surfaces_bootstrap_without_visible_step(
+    client,
+    db,
+    auth_headers_factory,
+    seed_identity,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-bootstrap-progress@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+
+    assignment = Assignment(teacher_id=teacher_id, title="Bootstrap Progress", status="draft")
+    db.add(assignment)
+    db.flush()
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status="processing",
+        task_payload={
+            "caseType": "charts_plus_solution",
+            "bootstrap_state": "initializing",
+            "progress_seq": 1,
+            "progress_ts": "2026-01-01T00:00:00+00:00",
+        },
+    )
+    db.add(job)
+    db.commit()
+
+    response = client.get(f"/api/authoring/jobs/{job.id}/progress", headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["job_id"] == job.id
+    assert payload["status"] == "processing"
+    assert payload["current_step"] is None
+    assert payload["progress_percentage"] is None
+    assert payload["bootstrap_state"] == "initializing"
+
+
+def test_progress_snapshot_derives_percentage_for_technical_jobs(
+    client,
+    db,
+    auth_headers_factory,
+    seed_identity,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-progress-technical@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+
+    assignment = Assignment(teacher_id=teacher_id, title="Progress Percentage", status="draft")
+    db.add(assignment)
+    db.flush()
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status="processing",
+        task_payload={
+            "caseType": "charts_plus_solution",
+            "current_step": "m4_content_generator",
+            "progress_seq": 5,
+            "progress_ts": "2026-01-01T00:00:00+00:00",
+        },
+    )
+    db.add(job)
+    db.commit()
+
+    response = client.get(f"/api/authoring/jobs/{job.id}/progress", headers=headers)
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["job_id"] == job.id
+    assert payload["status"] == "processing"
+    assert payload["current_step"] == "m4_content_generator"
+    assert payload["progress_percentage"] == 71
+    assert payload["progress_seq"] == 5
 
 
 def test_authoring_owner_isolated(client, db, auth_headers_factory, seed_identity) -> None:

--- a/backend/tests/test_phase3_status_api.py
+++ b/backend/tests/test_phase3_status_api.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest.mock import AsyncMock, patch
 
 from shared.models import Assignment, AuthoringJob
 
@@ -179,3 +180,99 @@ def test_authoring_owner_isolated(client, db, auth_headers_factory, seed_identit
 
     assert client.get(f"/api/authoring/jobs/{job.id}", headers=other_headers).status_code == 404
     assert client.get(f"/api/authoring/jobs/{job.id}/result", headers=other_headers).status_code == 404
+
+
+def test_retry_authoring_job_accepts_failed_resumable(
+    client,
+    db,
+    auth_headers_factory,
+    seed_identity,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-retry-ok@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+
+    assignment = Assignment(teacher_id=teacher_id, title="Retryable Job", status="draft")
+    db.add(assignment)
+    db.flush()
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status="failed_resumable",
+        task_payload={"error_code": "llm_timeout", "error_trace": "timeout"},
+    )
+    db.add(job)
+    db.commit()
+
+    with patch("shared.app.AuthoringService.run_job", new=AsyncMock()) as run_job_mock:
+        response = client.post(f"/api/authoring/jobs/{job.id}/retry", headers=headers)
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["job_id"] == job.id
+    assert payload["status"] == "accepted"
+    assert payload["message"] == "Authoring retry accepted and dispatched to queue."
+    run_job_mock.assert_awaited_once_with(job.id)
+
+
+def test_retry_authoring_job_reports_already_in_progress(
+    client,
+    db,
+    auth_headers_factory,
+    seed_identity,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-retry-processing@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+
+    assignment = Assignment(teacher_id=teacher_id, title="Processing Job", status="draft")
+    db.add(assignment)
+    db.flush()
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status="processing",
+        task_payload={"current_step": "case_architect", "progress_seq": 2},
+    )
+    db.add(job)
+    db.commit()
+
+    response = client.post(f"/api/authoring/jobs/{job.id}/retry", headers=headers)
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["job_id"] == job.id
+    assert payload["status"] == "accepted"
+    assert payload["message"] == "Authoring job already in progress."
+
+
+def test_retry_authoring_job_rejects_non_retryable_status(
+    client,
+    db,
+    auth_headers_factory,
+    seed_identity,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-retry-reject@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+
+    assignment = Assignment(teacher_id=teacher_id, title="Completed Job", status="published")
+    db.add(assignment)
+    db.flush()
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status="completed",
+        task_payload={"current_step": "completed", "progress_seq": 9},
+    )
+    db.add(job)
+    db.commit()
+
+    response = client.post(f"/api/authoring/jobs/{job.id}/retry", headers=headers)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Job not retryable"
+    assert response.headers["X-Job-Status"] == "completed"

--- a/backend/tests/test_phase3_status_api.py
+++ b/backend/tests/test_phase3_status_api.py
@@ -1,7 +1,41 @@
+import asyncio
 import uuid
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
+from case_generator.graph import reset_graph_singleton
+import shared.database as database_module
+from shared.database import close_langgraph_checkpointer_async_pool, snapshot_active_authoring_jobs
 from shared.models import Assignment, AuthoringJob
+
+
+_teardown_verification_state = {"close_calls": 0}
+
+
+@pytest.fixture(autouse=True)
+def ensure_no_authoring_runtime_leaks() -> None:
+    yield
+    assert snapshot_active_authoring_jobs() == []
+    reset_graph_singleton()
+    asyncio.run(close_langgraph_checkpointer_async_pool(timeout_seconds=0.1))
+
+
+def test_phase3_status_api_teardown_primes_pool_cleanup() -> None:
+    class FakeAsyncConnectionPool:
+        async def close(self) -> None:
+            _teardown_verification_state["close_calls"] += 1
+
+    database_module._langgraph_checkpointer_async_pool = FakeAsyncConnectionPool()
+    database_module._langgraph_checkpointer_async_pool_loop = None
+    database_module._langgraph_checkpointer_async_pool_lock = None
+    database_module._langgraph_checkpointer_async_pool_lock_loop = None
+
+
+def test_phase3_status_api_teardown_cleans_pool_before_next_test() -> None:
+    assert database_module._langgraph_checkpointer_async_pool is None
+    assert database_module._langgraph_checkpointer_async_pool_loop is None
+    assert _teardown_verification_state["close_calls"] == 1
 
 
 def test_polling_happy_path(client, db, auth_headers_factory, seed_identity) -> None:

--- a/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
+++ b/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
@@ -31,6 +31,10 @@ Step 0 outcome: user chose BIG CHANGE.
 - `backend/src/case_generator/graph.py` now separates the compiled-graph loop marker from the graph-init lock loop marker. This fixes the real live-LLM bug where `get_graph()` could return a compiled graph/checkpointer created on a previous pytest event loop, which then failed with `asyncio.Lock ... is bound to a different event loop` on the next `aget_tuple()`.
 - `backend/tests/test_authoring_progress_resilience.py` now includes a cross-loop regression test proving the graph singleton recompiles when the event loop changes.
 - `backend/tests/test_phase1b_real.py` now uses the current `edaDepth` enum (`charts_plus_explanation`) instead of the removed `charts_only` value.
+- Post-closure runtime hardening landed after a real remote incident on `job_id` `edba8d63-23f4-47b6-babc-939e5dfb07ec`: `/progress` still returned `200`, but Realtime subscription failed while the backend raised `psycopg_pool.PoolTimeout` and then failed closed with `checkpoint_unavailable` before any durable rows were written.
+- `backend/src/shared/database.py` now rejects the local `uv run python -m shared.app` path when `ENVIRONMENT=development` points at a remote Supabase host instead of `localhost:5434`, logs async pool open/close events, and exposes explicit close helpers for both LangGraph checkpointer pools.
+- `backend/src/shared/app.py` now validates the runtime DB target at startup and closes the async checkpointer pool, sync checkpointer pool, compiled graph singleton, and SQLAlchemy engine during FastAPI lifespan shutdown.
+- `frontend/src/shared/api.ts` now reconciles `/progress` one more time after `CHANNEL_ERROR` or `TIMED_OUT` so terminal backend failures like `checkpoint_unavailable` surface to the teacher instead of collapsing into a generic Realtime error.
 - Targeted backend contract validation is green against the repo-local Postgres target:
   - `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py` -> `15 passed`
 - Manual local checkpoint smoke is green against `localhost:5434` using the real `AuthoringService.run_job()` path:
@@ -49,8 +53,11 @@ Step 0 outcome: user chose BIG CHANGE.
   - observed token savings vs baseline: `20,370` total tokens
 - Post-fix backend validation is green:
   - `uv run --directory backend mypy src` -> clean
-  - `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `9 passed`
+  - `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `12 passed`
   - `uv run --directory backend pytest -q` -> `227 passed, 4 skipped`
+  - `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py tests/test_authoring_progress_resilience.py` -> `27 passed`
+  - `npm --prefix frontend run test -- src/shared/api.test.ts` -> `20 passed`
+  - `npm --prefix frontend run lint -- src/shared/api.ts src/shared/api.test.ts` -> clean
 - Focused live validation after the singleton fix is improved but still noisy under upstream Gemini availability:
   - `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q` -> `6 passed, 2 failed`
   - the previous cross-loop checkpoint failure did not reproduce after the graph singleton fix
@@ -370,10 +377,10 @@ Phase 3, UX and contract continuity, complete
 13. Done: add session storage reconciliation on `404` during rehydration, non-retryable stale recovery UX, retry CTA gating, and duplicate retry click guard.
 
 Phase 4, tests and evals
-14. In progress: backend contract tests in `test_phase3_status_api.py` and `test_internal_tasks.py` still need to run or expand.
+14. Done: backend contract tests in `test_phase3_status_api.py` and `test_internal_tasks.py` still need to run or expand.
 15. Done: dedicated concurrency tests for duplicate retry race and first-use singleton initialization (8 tests).
 16. Done: add frontend tests for retry UX, rehydration, and timeline continuity.
-17. Next: run the remaining deterministic backend suites and manual checkpoint verification first, then focused `live_llm` baseline plus resume comparisons.
+17. Done: run the remaining deterministic backend suites and manual checkpoint verification first, then focused `live_llm` baseline plus resume comparisons.
 
 ### Verification plan
 Completed in this pass:

--- a/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
+++ b/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
@@ -4,89 +4,221 @@ Build a resilient stateful orchestration path for authoring jobs so generation c
 
 Step 0 outcome: user chose BIG CHANGE.
 
+### Current status after correction review
+- Phase 1 is already landed: schema, failed_resumable contract, retry endpoint, and CAS retry transition exist.
+- Phase 2 is partially landed but blocked by a critical async mismatch.
+- Root cause confirmed: `graph.astream()` runs through LangGraph's async checkpoint path, but `backend/src/case_generator/graph.py` currently instantiates the sync `PostgresSaver` instead of `AsyncPostgresSaver`.
+- Local validation target for this issue remains the repo app database on `localhost:5434`.
+
 ### What already exists
-- Job lifecycle orchestration exists in backend/src/case_generator/core/authoring.py at run_job transitions pending to processing to completed/failed.
-- Thread identity already exists via thread_id=job_id in backend/src/case_generator/core/authoring.py.
-- Durable progress contract exists with progress_seq/current_step in backend/src/case_generator/core/authoring.py, backend/src/shared/app.py, frontend/src/shared/api.ts.
-- Frontend rehydration exists in frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts.
-- Artifact idempotency and uniqueness exist in backend/src/case_generator/core/artifact_manager.py and backend/src/shared/models.py.
+- Job lifecycle orchestration exists in `backend/src/case_generator/core/authoring.py` at `run_job`, including transitions `pending -> processing -> completed/failed`.
+- Thread identity already exists via `thread_id = job_id` in `backend/src/case_generator/core/authoring.py`.
+- Durable progress contract exists with `progress_seq/current_step` in `backend/src/case_generator/core/authoring.py`, `backend/src/shared/app.py`, and `frontend/src/shared/api.ts`.
+- Frontend rehydration already exists in `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts`.
+- Retry contract already exists: `POST /api/authoring/jobs/{job_id}/retry` plus CAS retry claiming in `AuthoringService.run_job`.
+- Explicit skip wrappers already exist in `backend/src/case_generator/graph.py`.
+- Artifact idempotency and uniqueness already exist in `backend/src/case_generator/core/artifact_manager.py` and `backend/src/shared/models.py`.
 
 ### NOT in scope
-- Distributed lock infrastructure external to Postgres (deferred, overbuilt for first release).
-- Legacy orphan artifact reconciliation utility for old jobs (deferred to TODO).
-- Checkpoint retention and purge automation (deferred to TODO).
-- Retry budget/circuit-breaker policy automation (deferred to TODO).
-- Full DB enum/check constraints refactor for all statuses (deferred, can follow after first stable rollout).
+- Distributed lock infrastructure external to Postgres.
+  Rationale: current CAS in `authoring_jobs` is already the right first release boundary.
+- Legacy orphan artifact reconciliation utility for old jobs.
+  Rationale: historical cleanup is real but does not unblock the async checkpoint failure.
+- Checkpoint retention and purge automation.
+  Rationale: needs a stable resume path before operational lifecycle policy.
+- Retry budget/circuit-breaker policy automation.
+  Rationale: needs baseline metrics after resume is working correctly.
+- Full DB enum/check constraints refactor for all statuses.
+  Rationale: no need to reopen Phase 1 schema scope for the async blocker.
+- Broad artifact persistence for every graph node.
+  Rationale: Phase 2 should remain checkpoint-first; manifests stay a supplemental hydration source.
+- Frontend visual polish beyond retry continuity and stable timeline behavior.
+  Rationale: not needed to unblock the backend async correction.
+
+### Root cause diagnosis
+Observed failure:
+
+```text
+NotImplementedError
+  at langgraph.checkpoint.base.__init__.py:aget_tuple
+```
+
+Confirmed mechanism:
+
+```text
+AuthoringService.run_job
+  -> graph.astream(...)
+  -> AsyncPregelLoop.__aenter__
+  -> await checkpointer.aget_tuple(...)
+  -> current checkpointer is sync PostgresSaver
+  -> aget_tuple not implemented on sync saver
+  -> NotImplementedError
+```
+
+The installed LangGraph package exposes the correct async implementation at:
+
+```python
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+```
+
+The async saver expects an async psycopg pool:
+
+```python
+from psycopg_pool import AsyncConnectionPool
+```
+
+Pool requirements for LangGraph compatibility:
+- `autocommit=True`
+- `row_factory=dict_row`
+- `prepare_threshold=0`
+
+Windows local development note:
+- `psycopg` async is not compatible with the default `ProactorEventLoop` on Windows.
+- The backend must force `WindowsSelectorEventLoopPolicy` before the first loop is created so local async checkpoint validation works on the repo's Windows development environment.
 
 ### Architecture decisions fixed
-1. Use official PostgresSaver for LangGraph checkpoint persistence (not custom checkpointer).
-2. Add dedicated retry endpoint POST /api/authoring/jobs/{job_id}/retry.
-3. Introduce explicit failed_resumable status in backend and frontend contracts.
-4. Implement explicit skip/hydration helper per node (no magic decorator abstraction).
-5. Classify failures: transient to failed_resumable, permanent to failed.
+1. Use the official `AsyncPostgresSaver` from `langgraph.checkpoint.postgres.aio` with `AsyncConnectionPool`.
+2. Replace import-time graph/checkpointer construction with a process-scoped lazy async singleton initialized inside an active event loop.
+3. Fail closed when durable checkpointing cannot be initialized or read. No silent downgrade to a graph compiled without a checkpointer.
+4. Keep the dedicated retry endpoint `POST /api/authoring/jobs/{job_id}/retry`.
+5. Keep explicit skip/hydration helper per node. No decorator framework or implicit magic.
+6. Treat checkpoint state as the primary resume truth. Artifact prefetch remains supplemental hydration only.
+7. Classify transient provider failures as `failed_resumable`, but classify checkpoint wiring failures as hard `failed`.
 
 ### Code quality decisions fixed
-6. Extract small private helper(s) for failure transition/payload construction in AuthoringService to reduce duplication.
-7. Centralize backend job status constants to avoid string drift.
-8. Update ASCII diagrams in touched orchestration files and add retry-flow diagram in AuthoringService comments.
-9. Define explicit fail-closed behavior for corrupt/missing checkpoints.
+8. Extract and keep the async wiring in small helpers instead of adding new services.
+9. Remove string drift for the resume cache key by centralizing it in `graph.py` and importing it from `authoring.py`.
+10. Update stale ASCII diagrams/comments in touched orchestration files as part of the same change.
+11. Add an inline retry/resume flow comment near the `AuthoringService.run_job` execution path.
+12. Keep the diff minimal: Phase 2 async correction starts in `backend/src/shared/database.py`, `backend/src/case_generator/graph.py`, and `backend/src/case_generator/core/authoring.py`.
 
 ### Test decisions fixed
-10. Add backend integration resilience test with injected failure in M4 and retry from checkpoint with skip verification.
-11. Extend API/worker contract tests for failed_resumable and retry endpoint behavior.
-12. Extend frontend tests for failed_resumable retry UX and timeline jump on resume.
-13. Run deterministic plus live_llm focused eval scope with baseline comparison.
+13. Add backend resilience coverage for the async checkpoint path and retry-from-checkpoint behavior.
+14. Add a focused regression check for the exact blocker: `astream()` must not raise `NotImplementedError` on `aget_tuple`.
+15. Extend API/worker contract tests for `failed_resumable` and retry endpoint behavior.
+16. Extend frontend tests for `failed_resumable` retry UX and timeline continuity after resume.
+17. Validate in layers: deterministic suites first, then one `live_llm` baseline and one `live_llm` resume scenario with injected M4 transient failure.
 
 ### Performance decisions fixed
-14. Avoid N+1 skip checks by prefetching artifact manifests once per run.
-15. Keep checkpoint state lean (resume-critical fields plus artifact references), avoid storing full heavy payload each step.
-16. Use atomic compare-and-set transition for retry status changes to prevent concurrent duplicate resumes.
+18. Keep one eager artifact manifest prefetch per retry to avoid N+1 storage lookups.
+19. Keep checkpoint state lean and let LangGraph persist only the state it already owns.
+20. Keep a single async pool/checkpointer/compiled-graph singleton per active process loop to avoid per-job recompilation overhead.
+21. Preserve the existing atomic compare-and-set retry transition to prevent duplicate resumes.
 
-### Impact analysis (files)
-- backend/pyproject.toml
-- backend/alembic/versions/*issue112*.py
-- backend/src/shared/models.py
-- backend/src/case_generator/graph.py
-- backend/src/case_generator/core/authoring.py
-- backend/src/shared/app.py
-- backend/src/shared/internal_tasks.py
-- frontend/src/shared/adam-types.ts
-- frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
-- frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
-- backend/tests/test_authoring_progress_resilience.py
-- backend/tests/test_phase3_status_api.py
-- backend/tests/test_internal_tasks.py
-- frontend/src/shared/api.test.ts
-- frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
-- frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+### Impact analysis
+Immediate Phase 2 correction files:
+- `backend/src/shared/database.py`
+- `backend/src/case_generator/graph.py`
+- `backend/src/case_generator/core/authoring.py`
+- `docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md`
+- `TODOS.md`
+
+Later validation/continuity files after the wiring is green:
+- `backend/tests/test_authoring_progress_resilience.py`
+- `backend/tests/test_phase3_status_api.py`
+- `backend/tests/test_internal_tasks.py`
+- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts`
+- `frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx`
+- `frontend/src/shared/api.test.ts`
+- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts`
+- `frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx`
+
+### Async wiring design
+
+#### 1. Database pool
+Add a new async pool getter in `backend/src/shared/database.py`.
+
+```text
+get_langgraph_checkpointer_async_pool()
+  -> normalize DATABASE_URL
+  -> create AsyncConnectionPool lazily
+  -> open pool inside active event loop
+  -> reuse pool on subsequent calls from the same process loop
+```
+
+The local DB remains `localhost:5434`.
+
+#### 2. Graph singleton
+Stop compiling the master graph with a durable checkpointer at import time.
+
+```text
+module import
+  -> define subgraphs and master_builder only
+
+await get_graph()
+  -> await get async pool
+  -> construct AsyncPostgresSaver
+  -> await checkpointer.setup()
+  -> compile master_builder with durable saver
+  -> cache graph/checkpointer for later runs on the same loop
+```
+
+#### 3. Authoring execution path
+Change `AuthoringService.run_job` to await `get_graph()` before starting `astream()`.
+
+```text
+run_job
+  -> acquire retry CAS
+  -> optional manifest prefetch
+  -> await get_graph()
+  -> graph.astream(...)
+  -> checkpoint reload by thread_id = job_id
+  -> explicit node skip/hydration
+  -> final status persistence
+```
 
 ### Checkpoint state design (Postgres)
-Use official LangGraph PostgresSaver tables created via Alembic integration, with this logical model:
-- Identity: thread_id equals job_id.
-- Ordering: checkpoint_id plus created_at monotonic timeline.
-- Payload: serialized checkpoint state and metadata fields for resume diagnostics.
-- Query shape used by app: fetch latest checkpoint by thread_id/job_id.
-- App-level contract remains in authoring_jobs for operational status, progress_seq, current_step, retry_count, error classification.
+Use the official LangGraph Postgres checkpoint tables created via Alembic integration, with this logical model:
+- Identity: `thread_id == job_id`.
+- Ordering: `checkpoint_id` provides the latest durable point for the thread namespace.
+- Payload: serialized LangGraph checkpoint state plus metadata.
+- Query shape used by the app: fetch latest checkpoint by `thread_id = job_id`.
+- App-level operational contract remains in `authoring_jobs` for `status`, `progress_seq`, `current_step`, `retry_count`, and error classification.
+
+### Hydration and skip strategy
+The resume path is intentionally two-layered:
+
+```text
+Layer 1: checkpoint state (primary)
+  -> full prior graph state restored by LangGraph
+
+Layer 2: artifact prefetch (supplemental)
+  -> hydrate published artifacts already available in storage
+  -> merge into initial state_input before astream
+```
+
+Rules:
+- A node may skip when required outputs are already present in restored checkpoint state.
+- If artifact hydration exists, it supplements the checkpoint state; it does not replace it.
+- If checkpoint state is missing/corrupt for a resume path, the job fails closed.
+- Phase 2 does not expand artifact persistence to every node. Checkpoint state remains the primary correctness mechanism for M3/M4/M5 continuity.
 
 ### Recovery flow diagram (Retry click)
+
+```text
 Teacher retries failed_resumable job
   -> API validates ownership and status
   -> enqueue retry command (no direct graph execution at endpoint)
   -> worker/service acquires atomic DB transition
-  -> load latest checkpoint by thread_id=job_id
+  -> await get_graph()  [async lazy singleton + durable saver required]
+  -> load latest checkpoint by thread_id = job_id
   -> prefetch artifact manifests once
   -> resume graph
       -> for each module node
-         -> valid artifact exists? hydrate and skip heavy LLM
-         -> else run node and persist artifact/checkpoint
+         -> checkpoint has required state? skip
+         -> else valid artifact exists? hydrate and skip
+         -> else execute heavy node
   -> terminal outcome
-      -> completed with monotonic progress_seq continuity
+      -> completed with monotonic progress continuity
       -> or failed_resumable/failed with classified error
+```
 
 ### Duplicate retry race mitigation (atomic transition)
 Goal: if the teacher double-clicks Retry, only one execution can start.
 
 Atomic lock in DB at execution start (winner-takes-lock):
+
+```sql
 UPDATE authoring_jobs
 SET status = 'processing',
     retry_count = retry_count + 1,
@@ -94,94 +226,120 @@ SET status = 'processing',
 WHERE id = :job_id
   AND status IN ('pending', 'failed_resumable')
 RETURNING id, assignment_id, task_payload, retry_count;
+```
 
 Behavior:
-- Winner path: UPDATE returns one row, process continues with checkpoint resume.
-- Loser path: UPDATE returns zero rows, process exits as no-op with structured log retry_lost_race.
-- Endpoint response policy (fixed):
-  - First click: 202 accepted (retry scheduled).
-  - Rapid second click: idempotent 202 already_in_progress, but never starts another AI run.
+- Winner path: `UPDATE` returns one row, process continues with checkpoint resume.
+- Loser path: `UPDATE` returns zero rows, process exits as no-op with structured log `retry_lost_race`.
+- Endpoint response policy:
+  - first click: `202 accepted`
+  - rapid second click: idempotent `202 already_in_progress`, but never starts another AI run
 
-Implementation notes:
-- Keep graph start out of the HTTP handler; only enqueue retry work.
-- Move lock acquisition into the worker/service path so even duplicated queued tasks cannot run in parallel.
-- Preserve task_payload.current_step and progress_seq; lock transition must not reset progress.
+Implementation note:
+- The lock transition must not silently discard retry metadata.
+- The graph still starts only from the worker/service path, not from the HTTP handler.
 
 ### Test diagram (new codepaths and branches)
+
+```text
+Fresh async checkpoint path
+  -> async pool opens correctly
+  -> AsyncPostgresSaver setup succeeds
+  -> astream enters without NotImplementedError
+
 Retry endpoint path
   -> valid owner and status failed_resumable -> resume
   -> invalid owner/status -> reject
+
 Checkpoint path
   -> checkpoint exists and valid -> resume from module boundary
   -> checkpoint missing/corrupt -> fail closed classification
+
 Skip path per node
-  -> artifact valid -> skip
-  -> artifact missing/invalid -> execute heavy node
+  -> checkpoint state valid -> skip
+  -> artifact valid -> hydrate and skip
+  -> neither valid -> execute heavy node
+
 Concurrency path
   -> duplicate retry requests -> single winner via atomic transition
+
 Progress path
-  -> resumed run continues progress_seq monotonic and frontend jump remains stable
+  -> resumed run continues progress_seq/current_step continuity
+  -> frontend timeline jump remains stable
+```
 
 ### Failure modes and coverage intent
+- Async checkpoint unavailable:
+  test required yes, error handling required yes (fail closed), silent failure allowed no.
 - Duplicate retry race:
-  test required yes (concurrent double-click simulation + dual queued-task simulation), error handling required yes (winner-takes-lock CAS + loser no-op), silent failure allowed no.
-- Corrupt checkpoint:
+  test required yes, error handling required yes (winner-takes-lock CAS + loser no-op), silent failure allowed no.
+- Corrupt/missing checkpoint:
   test required yes, error handling required yes (fail closed classification), silent failure allowed no.
 - Invalid artifact hydration:
-  test required yes, error handling required yes (fallback execute), silent failure allowed no.
+  test required yes, error handling required yes (fallback execute or ignore bad hydration), silent failure allowed no.
 - Resumed progress regression:
-  test required yes, error handling required yes (monotonic gating plus backend seq continuity), silent failure allowed no.
+  test required yes, error handling required yes (monotonic gating plus backend continuity), silent failure allowed no.
 
-Critical gaps flagged during review: 4 (all addressed by decisions 10 to 16 in this plan).
+Critical gaps flagged during review: 4.
 
 ### Implementation phases
 Phase 1, persistence and status contract
-1. Add PostgresSaver dependency and migration wiring.
-2. Add failed_resumable status contract backend and frontend.
-3. Add retry endpoint with ownership/status validation and queue semantics; execute atomic DB transition in worker/service lock step.
+1. Keep landed schema and contract work as-is unless an implementation mismatch is found.
 
-Phase 2, resume orchestration
-4. Add checkpoint load/resume path in AuthoringService based on thread_id=job_id.
-5. Add per-run manifest prefetch and explicit skip/hydration helper.
-6. Add failure classifier and stop orphaning successful artifacts on resumable failures.
+Phase 2, async correction and resume orchestration
+2. Add async pool wiring in `backend/src/shared/database.py`.
+3. Replace sync saver wiring with async lazy graph/checkpointer wiring in `backend/src/case_generator/graph.py`.
+4. Update `AuthoringService.run_job` to await the async graph getter in `backend/src/case_generator/core/authoring.py`.
+5. Preserve explicit manifest prefetch and node skip helpers.
+6. Fail closed when durable checkpointing cannot initialize or be read.
 
 Phase 3, UX and contract continuity
-7. Update frontend state handling for failed_resumable and retry UX path.
-8. Preserve progress_seq/current_step continuity on resumed stream.
+7. Keep frontend `failed_resumable` retry handling and persisted-job rehydration stable.
+8. Preserve `progress_seq/current_step` continuity on resumed stream.
 
 Phase 4, tests and evals
-9. Add backend integration and contract tests for resume/checkpoint/atomic retry.
-10. Add dedicated concurrency tests for Duplicate retry race (double-click API + duplicate queued-task simulation) and assert single winner lock acquisition.
+9. Add backend integration and contract tests for async checkpoint resume/checkpoint failure/atomic retry.
+10. Add dedicated concurrency tests for duplicate retry race.
 11. Add frontend retry/rehydration/timeline continuity tests.
-12. Run deterministic suites and focused live_llm suites with baseline comparison.
+12. Run deterministic suites first, then focused `live_llm` baseline + resume comparisons.
 
 ### Verification plan
-1. uv run --directory backend pytest -q backend/tests/test_authoring_progress_resilience.py backend/tests/test_phase3_status_api.py backend/tests/test_internal_tasks.py
-2. npm --prefix frontend run test -- src/shared/api.test.ts src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
-3. uv run --directory backend mypy src
-4. npm --prefix frontend run lint
-5. npm --prefix frontend run build
-6. RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q
+Immediate async wiring validation:
+1. Run a local reproduction against `localhost:5434` and confirm `graph.astream()` no longer raises `NotImplementedError` on `aget_tuple`.
+2. Confirm LangGraph checkpoint tables (`checkpoints`, `checkpoint_blobs`, `checkpoint_writes`) receive rows for the run thread/job.
+
+Deterministic validation:
+3. `uv run --directory backend pytest -q backend/tests/test_authoring_progress_resilience.py backend/tests/test_phase3_status_api.py backend/tests/test_internal_tasks.py`
+4. `uv run --directory backend mypy src`
+
+Frontend validation after Phase 3 continuity updates:
+5. `npm --prefix frontend run test -- src/shared/api.test.ts src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx`
+6. `npm --prefix frontend run lint`
+7. `npm --prefix frontend run build`
+
+Focused live evals only after deterministic green:
+8. `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q`
 
 Live_llm baseline comparisons:
 - successful full run token/call profile before and after
-- resumed run from injected M4 failure, assert lower token/call footprint than full rerun
+- resumed run from injected M4 transient failure, assert lower token/call footprint than full rerun
 
 ### TODO decisions captured
-- Add to TODOS.md: checkpoint retention and purge policy.
-- Add to TODOS.md: legacy orphan artifact reconciliation utility.
-- Add to TODOS.md: retry budget and circuit breaker policy.
+- Add to `TODOS.md`: checkpoint retention and purge policy.
+- Add to `TODOS.md`: legacy orphan artifact reconciliation utility.
+- Add to `TODOS.md`: retry budget and circuit breaker policy.
+- Add to `TODOS.md`: explicit lifespan-managed cleanup for the lazy async checkpoint singleton if runtime/test loop churn makes it necessary later.
 
 ### Unresolved decisions that may bite later
-- None. All Architecture, Code Quality, Test, and Performance section decisions were explicitly resolved.
+- None. The async lazy singleton model, fail-closed policy, and focused validation scope were explicitly resolved during the correction review.
 
 ### Completion summary
 - Step 0: Scope Challenge (user chose: BIG CHANGE)
-- Architecture Review: 5 issues found
-- Code Quality Review: 4 issues found
+- Architecture Review: 2 implementation-shaping issues resolved
+- Code Quality Review: 4 direct fixes identified
 - Test Review: diagram produced, 4 gaps identified
-- Performance Review: 3 issues found
+- Performance Review: 4 decisions fixed
 - NOT in scope: written
 - What already exists: written
-- TODOS.md updates: 3 items proposed to user
+- TODOS.md updates: 4 deferred items captured
 - Failure modes: 4 critical gaps flagged

--- a/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
+++ b/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
@@ -1,0 +1,187 @@
+## Plan: Issue 112 Stateful Recovery and Checkpointing
+
+Build a resilient stateful orchestration path for authoring jobs so generation can resume from the last successful module after transient failures, without redoing completed expensive LLM work. Keep changes engineered enough, explicit, and minimal-diff.
+
+Step 0 outcome: user chose BIG CHANGE.
+
+### What already exists
+- Job lifecycle orchestration exists in backend/src/case_generator/core/authoring.py at run_job transitions pending to processing to completed/failed.
+- Thread identity already exists via thread_id=job_id in backend/src/case_generator/core/authoring.py.
+- Durable progress contract exists with progress_seq/current_step in backend/src/case_generator/core/authoring.py, backend/src/shared/app.py, frontend/src/shared/api.ts.
+- Frontend rehydration exists in frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts.
+- Artifact idempotency and uniqueness exist in backend/src/case_generator/core/artifact_manager.py and backend/src/shared/models.py.
+
+### NOT in scope
+- Distributed lock infrastructure external to Postgres (deferred, overbuilt for first release).
+- Legacy orphan artifact reconciliation utility for old jobs (deferred to TODO).
+- Checkpoint retention and purge automation (deferred to TODO).
+- Retry budget/circuit-breaker policy automation (deferred to TODO).
+- Full DB enum/check constraints refactor for all statuses (deferred, can follow after first stable rollout).
+
+### Architecture decisions fixed
+1. Use official PostgresSaver for LangGraph checkpoint persistence (not custom checkpointer).
+2. Add dedicated retry endpoint POST /api/authoring/jobs/{job_id}/retry.
+3. Introduce explicit failed_resumable status in backend and frontend contracts.
+4. Implement explicit skip/hydration helper per node (no magic decorator abstraction).
+5. Classify failures: transient to failed_resumable, permanent to failed.
+
+### Code quality decisions fixed
+6. Extract small private helper(s) for failure transition/payload construction in AuthoringService to reduce duplication.
+7. Centralize backend job status constants to avoid string drift.
+8. Update ASCII diagrams in touched orchestration files and add retry-flow diagram in AuthoringService comments.
+9. Define explicit fail-closed behavior for corrupt/missing checkpoints.
+
+### Test decisions fixed
+10. Add backend integration resilience test with injected failure in M4 and retry from checkpoint with skip verification.
+11. Extend API/worker contract tests for failed_resumable and retry endpoint behavior.
+12. Extend frontend tests for failed_resumable retry UX and timeline jump on resume.
+13. Run deterministic plus live_llm focused eval scope with baseline comparison.
+
+### Performance decisions fixed
+14. Avoid N+1 skip checks by prefetching artifact manifests once per run.
+15. Keep checkpoint state lean (resume-critical fields plus artifact references), avoid storing full heavy payload each step.
+16. Use atomic compare-and-set transition for retry status changes to prevent concurrent duplicate resumes.
+
+### Impact analysis (files)
+- backend/pyproject.toml
+- backend/alembic/versions/*issue112*.py
+- backend/src/shared/models.py
+- backend/src/case_generator/graph.py
+- backend/src/case_generator/core/authoring.py
+- backend/src/shared/app.py
+- backend/src/shared/internal_tasks.py
+- frontend/src/shared/adam-types.ts
+- frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
+- frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
+- backend/tests/test_authoring_progress_resilience.py
+- backend/tests/test_phase3_status_api.py
+- backend/tests/test_internal_tasks.py
+- frontend/src/shared/api.test.ts
+- frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
+- frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+
+### Checkpoint state design (Postgres)
+Use official LangGraph PostgresSaver tables created via Alembic integration, with this logical model:
+- Identity: thread_id equals job_id.
+- Ordering: checkpoint_id plus created_at monotonic timeline.
+- Payload: serialized checkpoint state and metadata fields for resume diagnostics.
+- Query shape used by app: fetch latest checkpoint by thread_id/job_id.
+- App-level contract remains in authoring_jobs for operational status, progress_seq, current_step, retry_count, error classification.
+
+### Recovery flow diagram (Retry click)
+Teacher retries failed_resumable job
+  -> API validates ownership and status
+  -> enqueue retry command (no direct graph execution at endpoint)
+  -> worker/service acquires atomic DB transition
+  -> load latest checkpoint by thread_id=job_id
+  -> prefetch artifact manifests once
+  -> resume graph
+      -> for each module node
+         -> valid artifact exists? hydrate and skip heavy LLM
+         -> else run node and persist artifact/checkpoint
+  -> terminal outcome
+      -> completed with monotonic progress_seq continuity
+      -> or failed_resumable/failed with classified error
+
+### Duplicate retry race mitigation (atomic transition)
+Goal: if the teacher double-clicks Retry, only one execution can start.
+
+Atomic lock in DB at execution start (winner-takes-lock):
+UPDATE authoring_jobs
+SET status = 'processing',
+    retry_count = retry_count + 1,
+    updated_at = NOW()
+WHERE id = :job_id
+  AND status IN ('pending', 'failed_resumable')
+RETURNING id, assignment_id, task_payload, retry_count;
+
+Behavior:
+- Winner path: UPDATE returns one row, process continues with checkpoint resume.
+- Loser path: UPDATE returns zero rows, process exits as no-op with structured log retry_lost_race.
+- Endpoint response policy (fixed):
+  - First click: 202 accepted (retry scheduled).
+  - Rapid second click: idempotent 202 already_in_progress, but never starts another AI run.
+
+Implementation notes:
+- Keep graph start out of the HTTP handler; only enqueue retry work.
+- Move lock acquisition into the worker/service path so even duplicated queued tasks cannot run in parallel.
+- Preserve task_payload.current_step and progress_seq; lock transition must not reset progress.
+
+### Test diagram (new codepaths and branches)
+Retry endpoint path
+  -> valid owner and status failed_resumable -> resume
+  -> invalid owner/status -> reject
+Checkpoint path
+  -> checkpoint exists and valid -> resume from module boundary
+  -> checkpoint missing/corrupt -> fail closed classification
+Skip path per node
+  -> artifact valid -> skip
+  -> artifact missing/invalid -> execute heavy node
+Concurrency path
+  -> duplicate retry requests -> single winner via atomic transition
+Progress path
+  -> resumed run continues progress_seq monotonic and frontend jump remains stable
+
+### Failure modes and coverage intent
+- Duplicate retry race:
+  test required yes (concurrent double-click simulation + dual queued-task simulation), error handling required yes (winner-takes-lock CAS + loser no-op), silent failure allowed no.
+- Corrupt checkpoint:
+  test required yes, error handling required yes (fail closed classification), silent failure allowed no.
+- Invalid artifact hydration:
+  test required yes, error handling required yes (fallback execute), silent failure allowed no.
+- Resumed progress regression:
+  test required yes, error handling required yes (monotonic gating plus backend seq continuity), silent failure allowed no.
+
+Critical gaps flagged during review: 4 (all addressed by decisions 10 to 16 in this plan).
+
+### Implementation phases
+Phase 1, persistence and status contract
+1. Add PostgresSaver dependency and migration wiring.
+2. Add failed_resumable status contract backend and frontend.
+3. Add retry endpoint with ownership/status validation and queue semantics; execute atomic DB transition in worker/service lock step.
+
+Phase 2, resume orchestration
+4. Add checkpoint load/resume path in AuthoringService based on thread_id=job_id.
+5. Add per-run manifest prefetch and explicit skip/hydration helper.
+6. Add failure classifier and stop orphaning successful artifacts on resumable failures.
+
+Phase 3, UX and contract continuity
+7. Update frontend state handling for failed_resumable and retry UX path.
+8. Preserve progress_seq/current_step continuity on resumed stream.
+
+Phase 4, tests and evals
+9. Add backend integration and contract tests for resume/checkpoint/atomic retry.
+10. Add dedicated concurrency tests for Duplicate retry race (double-click API + duplicate queued-task simulation) and assert single winner lock acquisition.
+11. Add frontend retry/rehydration/timeline continuity tests.
+12. Run deterministic suites and focused live_llm suites with baseline comparison.
+
+### Verification plan
+1. uv run --directory backend pytest -q backend/tests/test_authoring_progress_resilience.py backend/tests/test_phase3_status_api.py backend/tests/test_internal_tasks.py
+2. npm --prefix frontend run test -- src/shared/api.test.ts src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+3. uv run --directory backend mypy src
+4. npm --prefix frontend run lint
+5. npm --prefix frontend run build
+6. RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q
+
+Live_llm baseline comparisons:
+- successful full run token/call profile before and after
+- resumed run from injected M4 failure, assert lower token/call footprint than full rerun
+
+### TODO decisions captured
+- Add to TODOS.md: checkpoint retention and purge policy.
+- Add to TODOS.md: legacy orphan artifact reconciliation utility.
+- Add to TODOS.md: retry budget and circuit breaker policy.
+
+### Unresolved decisions that may bite later
+- None. All Architecture, Code Quality, Test, and Performance section decisions were explicitly resolved.
+
+### Completion summary
+- Step 0: Scope Challenge (user chose: BIG CHANGE)
+- Architecture Review: 5 issues found
+- Code Quality Review: 4 issues found
+- Test Review: diagram produced, 4 gaps identified
+- Performance Review: 3 issues found
+- NOT in scope: written
+- What already exists: written
+- TODOS.md updates: 3 items proposed to user
+- Failure modes: 4 critical gaps flagged

--- a/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
+++ b/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
@@ -4,17 +4,37 @@ Build a resilient stateful orchestration path for authoring jobs so generation c
 
 Step 0 outcome: user chose BIG CHANGE.
 
-### Current status after backend hardening pass (2026-04-15)
+### Current status after code review hardening pass (2026-04-15)
 - Phase 1 is already landed: schema, `failed_resumable` contract, retry endpoint, and CAS retry transition exist.
-- Phase 2 backend wiring is now landed on branch `feat/issue112-stateful-recovery` in commit `790947d`.
-- `backend/src/shared/database.py` now creates the LangGraph `AsyncConnectionPool` lazily inside an active event loop, keeps the Windows selector policy fix for local async psycopg, and hardens first-use singleton lock creation against same-loop races.
+- Phase 2 backend wiring landed on branch `feat/issue112-stateful-recovery` in commit `790947d`.
+- Code review pass landed in commit `df82309` with 4 hardening fixes (see review findings below).
+- `backend/src/shared/database.py` now creates the LangGraph `AsyncConnectionPool` lazily inside an active event loop, keeps the Windows selector policy fix for local async psycopg, hardens first-use singleton lock creation against same-loop races, and wraps pool cleanup in `asyncio.wait_for` with a 5s timeout plus `finally` GC dereference to prevent connection leaks under loop churn.
 - `backend/src/case_generator/graph.py` now compiles the master graph lazily with `AsyncPostgresSaver` and includes the same first-use singleton race fix for graph initialization.
-- `backend/src/case_generator/core/authoring.py` now awaits `get_graph()`, preserves the retry CAS plus artifact prefetch flow, and hard-fails checkpoint infrastructure failures both at bootstrap and mid-stream with `checkpoint_unavailable` instead of misclassifying them as resumable provider failures.
+- `backend/src/case_generator/core/authoring.py` now awaits `get_graph()`, preserves the retry CAS plus artifact prefetch flow, hard-fails checkpoint infrastructure failures both at bootstrap and mid-stream, and has a secondary `_CHECKPOINT_INFRA_ERROR_TYPES` chain walk before string matching to prevent DB infrastructure errors from being misclassified as `failed_resumable`.
 - `backend/tests/test_authoring_progress_resilience.py` now covers duplicate retry race, bootstrap checkpointer failure, async pool first-use concurrency, graph singleton first-use concurrency, and mid-stream checkpoint fail-closed behavior.
+- `frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx` now wraps `retryJob()` in try/catch so a failed retry resets state to `error` instead of leaving the UI stuck on `generating`.
+- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts` now validates `retryResponse.job_id` is a non-null string before passing to `startStreaming`, preventing silent 404 streaming.
 - Deterministic validation completed in this pass:
-  - `uv run --directory backend mypy src`
-  - `DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `8 passed`
-- Remaining work for the next developer or agent: frontend Phase 3 continuity, backend contract coverage in `backend/tests/test_phase3_status_api.py` and `backend/tests/test_internal_tasks.py`, and a manual local checkpoint-table verification on a real authoring run.
+  - `uv run --directory backend mypy src` -> clean
+  - `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `8 passed`
+  - `npm --prefix frontend run test` -> `25 passed`
+  - `npx tsc --noEmit` -> clean
+- Remaining work for the next developer or agent: see "Handoff for next agent" section below.
+
+### Review findings applied in commit `df82309`
+| ID   | Severity | File | Fix |
+|------|----------|------|-----|
+| C-1  | CRITICAL | `backend/src/case_generator/core/authoring.py` | Added secondary `_CHECKPOINT_INFRA_ERROR_TYPES` chain walk before string matching. DB infra errors (PoolTimeout, connection reset) were matching LLM transient string markers → misclassified as `failed_resumable` → retry storm against exhausted DB pool. |
+| C-2  | CRITICAL | `frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx` | Wrapped `retryJob()` in try/catch inside `handleRetry`. `setAppState("generating")` before `await retryJob()` meant a throw left the UI stuck in generating state with no error feedback. |
+| H-1  | HIGH     | `backend/src/shared/database.py` | Added `asyncio.wait_for(..., timeout=5.0)` around `previous_pool.close()` with `finally: previous_pool = None` for GC. Prevents connection leak when pool close hangs during loop churn. |
+| H-2  | HIGH     | `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts` | Added guard `if (!retryResponse.job_id \|\| typeof retryResponse.job_id !== "string")` before `startStreaming`. Prevents silent 404 streaming from an undefined job_id. |
+
+### Dismissed false positives from review
+- **RunnableConfig loss in `_with_resume_skip`**: LangGraph injects `RunnableConfig` into each node independently via the graph executor — it is not propagated through state. No fix needed.
+- **asyncio.Lock event loop binding race**: Cloud Run runs a single event loop per process. The lazy singleton pattern with `threading.Lock` outer guard and `asyncio.Lock` inner guard is safe in this deployment model. No fix needed.
+
+### Deferred finding (INFO)
+- **I-1**: Session storage reconciliation — if a `failed_resumable` job is cleaned up server-side, the frontend session storage retains a stale entry and may attempt to rehydrate a non-existent job. Low priority; add a server-side existence check or clear session storage on 404 during rehydration in a future pass.
 
 ### What already exists
 - Job lifecycle orchestration exists in `backend/src/case_generator/core/authoring.py` at `run_job`, including transitions `pending -> processing -> completed/failed`.
@@ -299,15 +319,22 @@ Phase 2, async correction and resume orchestration, backend complete
 5. Done: preserve explicit manifest prefetch and node skip helpers.
 6. Done: fail closed when durable checkpointing cannot initialize or be read, including mid-stream checkpoint infrastructure failures after graph start.
 
+Phase 2.5, code review hardening, complete
+7. Done: hardened exception classification in `authoring.py` (C-1).
+8. Done: hardened pool cleanup timeout in `database.py` (H-1).
+9. Done: hardened frontend retry error handling in `TeacherAuthoringPage.tsx` (C-2).
+10. Done: hardened retry response validation in `useAuthoringJobProgress.ts` (H-2).
+
 Phase 3, UX and contract continuity, next active phase
-7. Next: keep frontend `failed_resumable` retry handling and persisted-job rehydration stable.
-8. Next: preserve `progress_seq/current_step` continuity on resumed stream.
+11. Next: add frontend retry/rehydration/timeline continuity tests.
+12. Next: preserve `progress_seq/current_step` continuity on resumed stream.
+13. Next: add session storage reconciliation (clear stale entries on 404 during rehydration).
 
 Phase 4, tests and evals
-9. In progress: add backend integration and contract tests for async checkpoint resume/checkpoint failure/atomic retry. Focused resilience coverage is landed; `test_phase3_status_api.py` and `test_internal_tasks.py` still need to run or expand as needed.
-10. Done in focused coverage: add dedicated concurrency tests for duplicate retry race and first-use singleton initialization.
-11. Next: add frontend retry or rehydration or timeline continuity tests.
-12. Next: run deterministic suites first, then focused `live_llm` baseline plus resume comparisons.
+14. In progress: backend contract tests in `test_phase3_status_api.py` and `test_internal_tasks.py` still need to run or expand.
+15. Done: dedicated concurrency tests for duplicate retry race and first-use singleton initialization (8 tests).
+16. Next: add frontend tests for retry UX, rehydration, and timeline continuity.
+17. Next: run deterministic suites first, then focused `live_llm` baseline plus resume comparisons.
 
 ### Verification plan
 Completed in this pass:
@@ -344,10 +371,76 @@ Live_llm baseline comparisons:
 - Step 0: Scope Challenge (user chose: BIG CHANGE)
 - Architecture Review: 2 implementation-shaping issues resolved
 - Code Quality Review: 4 direct fixes identified, backend hardening landed
+- Code Review Hardening: 4 review findings (2 CRITICAL, 2 HIGH) fixed in commit `df82309`
 - Test Review: focused backend regressions added for concurrency and fail-closed behavior
 - Performance Review: single async pool and compiled-graph singleton path preserved, with same-loop init race fixed
 - Backend Phase 2 implementation complete and pushed in commit `790947d`
+- Review hardening complete and pushed in commit `df82309`
 - Validated in this pass:
-  - `uv run --directory backend mypy src`
-  - `DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `8 passed`
-- Remaining for next phase: frontend Phase 3 continuity, backend contract tests in `test_phase3_status_api.py` and `test_internal_tasks.py`, manual checkpoint-table verification on a real run, and optional `live_llm` comparisons after deterministic green
+  - `uv run --directory backend mypy src` -> clean
+  - `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `8 passed`
+  - `npm --prefix frontend run test` -> `25 passed`
+  - `npx tsc --noEmit` -> clean
+- Remaining for next phase: see handoff section below
+
+### Handoff for next agent
+
+#### What is done
+1. **Phase 1** (schema + contract): Landed on `main`. `failed_resumable` status, retry endpoint, CAS retry transition all exist.
+2. **Phase 2** (async correction + resume orchestration): Landed on `feat/issue112-stateful-recovery` in commit `790947d`. `AsyncPostgresSaver`, lazy async singleton pool+graph, fail-closed checkpoint wiring.
+3. **Phase 2.5** (code review hardening): Landed on `feat/issue112-stateful-recovery` in commit `df82309`. 4 fixes: exception classification guard, pool cleanup timeout, retry error handling, retry response validation.
+4. **Backend tests**: 8 resilience tests passing (`test_authoring_progress_resilience.py`). mypy clean.
+5. **Frontend hardening**: retry try/catch and job_id validation applied. 25 tests passing. tsc clean.
+
+#### What to do next (in priority order)
+
+**1. Backend contract test gap**
+- Run `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py` and verify they pass.
+- If they need updates for the new async graph initialization path, update them.
+
+**2. Manual local checkpoint-table verification**
+- Run a real authoring job against `localhost:5434` and confirm:
+  - `graph.astream()` does NOT raise `NotImplementedError` on `aget_tuple`.
+  - LangGraph checkpoint tables (`checkpoints`, `checkpoint_blobs`, `checkpoint_writes`) receive rows for the run thread/job.
+
+**3. Frontend Phase 3 tests**
+- Add or update tests in:
+  - `frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx` — test `handleRetry` error path shows error state
+  - `frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts` — test rehydration with stale session storage entry
+  - `frontend/src/shared/api.test.ts` — test retry endpoint response validation
+- Run: `npm --prefix frontend run test`, `npm --prefix frontend run lint`, `npm --prefix frontend run build`
+
+**4. Session storage reconciliation (deferred I-1)**
+- When rehydrating from session storage, check server-side job existence before resuming streaming.
+- If the job returns 404, clear the session storage entry and reset to initial state.
+- File: `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts`
+
+**5. Live LLM validation (only after all deterministic suites green)**
+- `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q`
+- Baseline: successful full run token/call profile
+- Resume: injected M4 transient failure resume, assert lower token/call footprint than full rerun
+
+#### Key files for context
+| File | Role |
+|------|------|
+| `backend/src/case_generator/core/authoring.py` | Job lifecycle orchestration, exception classification, retry CAS |
+| `backend/src/case_generator/graph.py` | Lazy async graph/checkpointer singleton, skip wrappers |
+| `backend/src/shared/database.py` | Lazy async pool singleton, pool lifecycle |
+| `backend/tests/test_authoring_progress_resilience.py` | 8 resilience tests for concurrency and fail-closed |
+| `frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx` | Authoring page, retry handler |
+| `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts` | Job progress hook, streaming, rehydration |
+
+#### Validation commands
+```powershell
+# Backend
+uv run --directory backend mypy src
+uv run --directory backend pytest -q
+
+# Frontend
+npm --prefix frontend run lint
+npm --prefix frontend run test
+npm --prefix frontend run build
+
+# Live LLM (only after deterministic green)
+RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q
+```

--- a/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
+++ b/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
@@ -4,11 +4,17 @@ Build a resilient stateful orchestration path for authoring jobs so generation c
 
 Step 0 outcome: user chose BIG CHANGE.
 
-### Current status after correction review
-- Phase 1 is already landed: schema, failed_resumable contract, retry endpoint, and CAS retry transition exist.
-- Phase 2 is partially landed but blocked by a critical async mismatch.
-- Root cause confirmed: `graph.astream()` runs through LangGraph's async checkpoint path, but `backend/src/case_generator/graph.py` currently instantiates the sync `PostgresSaver` instead of `AsyncPostgresSaver`.
-- Local validation target for this issue remains the repo app database on `localhost:5434`.
+### Current status after backend hardening pass (2026-04-15)
+- Phase 1 is already landed: schema, `failed_resumable` contract, retry endpoint, and CAS retry transition exist.
+- Phase 2 backend wiring is now landed on branch `feat/issue112-stateful-recovery` in commit `790947d`.
+- `backend/src/shared/database.py` now creates the LangGraph `AsyncConnectionPool` lazily inside an active event loop, keeps the Windows selector policy fix for local async psycopg, and hardens first-use singleton lock creation against same-loop races.
+- `backend/src/case_generator/graph.py` now compiles the master graph lazily with `AsyncPostgresSaver` and includes the same first-use singleton race fix for graph initialization.
+- `backend/src/case_generator/core/authoring.py` now awaits `get_graph()`, preserves the retry CAS plus artifact prefetch flow, and hard-fails checkpoint infrastructure failures both at bootstrap and mid-stream with `checkpoint_unavailable` instead of misclassifying them as resumable provider failures.
+- `backend/tests/test_authoring_progress_resilience.py` now covers duplicate retry race, bootstrap checkpointer failure, async pool first-use concurrency, graph singleton first-use concurrency, and mid-stream checkpoint fail-closed behavior.
+- Deterministic validation completed in this pass:
+  - `uv run --directory backend mypy src`
+  - `DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `8 passed`
+- Remaining work for the next developer or agent: frontend Phase 3 continuity, backend contract coverage in `backend/tests/test_phase3_status_api.py` and `backend/tests/test_internal_tasks.py`, and a manual local checkpoint-table verification on a real authoring run.
 
 ### What already exists
 - Job lifecycle orchestration exists in `backend/src/case_generator/core/authoring.py` at `run_job`, including transitions `pending -> processing -> completed/failed`.
@@ -106,14 +112,14 @@ Windows local development note:
 21. Preserve the existing atomic compare-and-set retry transition to prevent duplicate resumes.
 
 ### Impact analysis
-Immediate Phase 2 correction files:
+Completed in this pass:
 - `backend/src/shared/database.py`
 - `backend/src/case_generator/graph.py`
 - `backend/src/case_generator/core/authoring.py`
+- `backend/tests/test_authoring_progress_resilience.py`
 - `docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md`
-- `TODOS.md`
 
-Later validation/continuity files after the wiring is green:
+Still pending for later validation or continuity work:
 - `backend/tests/test_authoring_progress_resilience.py`
 - `backend/tests/test_phase3_status_api.py`
 - `backend/tests/test_internal_tasks.py`
@@ -280,45 +286,46 @@ Progress path
 - Resumed progress regression:
   test required yes, error handling required yes (monotonic gating plus backend continuity), silent failure allowed no.
 
-Critical gaps flagged during review: 4.
+Critical gaps flagged during review: 4. The backend hardening gaps are resolved in this pass; the remaining work is now Phase 3 continuity plus broader contract validation.
 
 ### Implementation phases
 Phase 1, persistence and status contract
 1. Keep landed schema and contract work as-is unless an implementation mismatch is found.
 
-Phase 2, async correction and resume orchestration
-2. Add async pool wiring in `backend/src/shared/database.py`.
-3. Replace sync saver wiring with async lazy graph/checkpointer wiring in `backend/src/case_generator/graph.py`.
-4. Update `AuthoringService.run_job` to await the async graph getter in `backend/src/case_generator/core/authoring.py`.
-5. Preserve explicit manifest prefetch and node skip helpers.
-6. Fail closed when durable checkpointing cannot initialize or be read.
+Phase 2, async correction and resume orchestration, backend complete
+2. Done: add async pool wiring in `backend/src/shared/database.py`.
+3. Done: replace sync saver wiring with async lazy graph/checkpointer wiring in `backend/src/case_generator/graph.py`.
+4. Done: update `AuthoringService.run_job` to await the async graph getter in `backend/src/case_generator/core/authoring.py`.
+5. Done: preserve explicit manifest prefetch and node skip helpers.
+6. Done: fail closed when durable checkpointing cannot initialize or be read, including mid-stream checkpoint infrastructure failures after graph start.
 
-Phase 3, UX and contract continuity
-7. Keep frontend `failed_resumable` retry handling and persisted-job rehydration stable.
-8. Preserve `progress_seq/current_step` continuity on resumed stream.
+Phase 3, UX and contract continuity, next active phase
+7. Next: keep frontend `failed_resumable` retry handling and persisted-job rehydration stable.
+8. Next: preserve `progress_seq/current_step` continuity on resumed stream.
 
 Phase 4, tests and evals
-9. Add backend integration and contract tests for async checkpoint resume/checkpoint failure/atomic retry.
-10. Add dedicated concurrency tests for duplicate retry race.
-11. Add frontend retry/rehydration/timeline continuity tests.
-12. Run deterministic suites first, then focused `live_llm` baseline + resume comparisons.
+9. In progress: add backend integration and contract tests for async checkpoint resume/checkpoint failure/atomic retry. Focused resilience coverage is landed; `test_phase3_status_api.py` and `test_internal_tasks.py` still need to run or expand as needed.
+10. Done in focused coverage: add dedicated concurrency tests for duplicate retry race and first-use singleton initialization.
+11. Next: add frontend retry or rehydration or timeline continuity tests.
+12. Next: run deterministic suites first, then focused `live_llm` baseline plus resume comparisons.
 
 ### Verification plan
-Immediate async wiring validation:
-1. Run a local reproduction against `localhost:5434` and confirm `graph.astream()` no longer raises `NotImplementedError` on `aget_tuple`.
-2. Confirm LangGraph checkpoint tables (`checkpoints`, `checkpoint_blobs`, `checkpoint_writes`) receive rows for the run thread/job.
+Completed in this pass:
+1. `uv run --directory backend mypy src`
+2. `DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py`
 
-Deterministic validation:
-3. `uv run --directory backend pytest -q backend/tests/test_authoring_progress_resilience.py backend/tests/test_phase3_status_api.py backend/tests/test_internal_tasks.py`
-4. `uv run --directory backend mypy src`
+Still pending before the backend track is considered fully closed:
+3. Run a local reproduction against `localhost:5434` and confirm `graph.astream()` no longer raises `NotImplementedError` on `aget_tuple` during a real authoring execution.
+4. Confirm LangGraph checkpoint tables (`checkpoints`, `checkpoint_blobs`, `checkpoint_writes`) receive rows for the run thread/job.
+5. `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py`
 
 Frontend validation after Phase 3 continuity updates:
-5. `npm --prefix frontend run test -- src/shared/api.test.ts src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx`
-6. `npm --prefix frontend run lint`
-7. `npm --prefix frontend run build`
+6. `npm --prefix frontend run test -- src/shared/api.test.ts src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx`
+7. `npm --prefix frontend run lint`
+8. `npm --prefix frontend run build`
 
 Focused live evals only after deterministic green:
-8. `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q`
+9. `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q`
 
 Live_llm baseline comparisons:
 - successful full run token/call profile before and after
@@ -336,10 +343,11 @@ Live_llm baseline comparisons:
 ### Completion summary
 - Step 0: Scope Challenge (user chose: BIG CHANGE)
 - Architecture Review: 2 implementation-shaping issues resolved
-- Code Quality Review: 4 direct fixes identified
-- Test Review: diagram produced, 4 gaps identified
-- Performance Review: 4 decisions fixed
-- NOT in scope: written
-- What already exists: written
-- TODOS.md updates: 4 deferred items captured
-- Failure modes: 4 critical gaps flagged
+- Code Quality Review: 4 direct fixes identified, backend hardening landed
+- Test Review: focused backend regressions added for concurrency and fail-closed behavior
+- Performance Review: single async pool and compiled-graph singleton path preserved, with same-loop init race fixed
+- Backend Phase 2 implementation complete and pushed in commit `790947d`
+- Validated in this pass:
+  - `uv run --directory backend mypy src`
+  - `DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `8 passed`
+- Remaining for next phase: frontend Phase 3 continuity, backend contract tests in `test_phase3_status_api.py` and `test_internal_tasks.py`, manual checkpoint-table verification on a real run, and optional `live_llm` comparisons after deterministic green

--- a/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
+++ b/docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md
@@ -4,22 +4,57 @@ Build a resilient stateful orchestration path for authoring jobs so generation c
 
 Step 0 outcome: user chose BIG CHANGE.
 
-### Current status after code review hardening pass (2026-04-15)
+### Current status after Phase 3 frontend completion (2026-04-15)
 - Phase 1 is already landed: schema, `failed_resumable` contract, retry endpoint, and CAS retry transition exist.
 - Phase 2 backend wiring landed on branch `feat/issue112-stateful-recovery` in commit `790947d`.
 - Code review pass landed in commit `df82309` with 4 hardening fixes (see review findings below).
+- Phase 3 frontend UX + contract continuity landed on branch `feat/issue112-stateful-recovery` in commit `eba18da`.
 - `backend/src/shared/database.py` now creates the LangGraph `AsyncConnectionPool` lazily inside an active event loop, keeps the Windows selector policy fix for local async psycopg, hardens first-use singleton lock creation against same-loop races, and wraps pool cleanup in `asyncio.wait_for` with a 5s timeout plus `finally` GC dereference to prevent connection leaks under loop churn.
 - `backend/src/case_generator/graph.py` now compiles the master graph lazily with `AsyncPostgresSaver` and includes the same first-use singleton race fix for graph initialization.
 - `backend/src/case_generator/core/authoring.py` now awaits `get_graph()`, preserves the retry CAS plus artifact prefetch flow, hard-fails checkpoint infrastructure failures both at bootstrap and mid-stream, and has a secondary `_CHECKPOINT_INFRA_ERROR_TYPES` chain walk before string matching to prevent DB infrastructure errors from being misclassified as `failed_resumable`.
 - `backend/tests/test_authoring_progress_resilience.py` now covers duplicate retry race, bootstrap checkpointer failure, async pool first-use concurrency, graph singleton first-use concurrency, and mid-stream checkpoint fail-closed behavior.
-- `frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx` now wraps `retryJob()` in try/catch so a failed retry resets state to `error` instead of leaving the UI stuck on `generating`.
-- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts` now validates `retryResponse.job_id` is a non-null string before passing to `startStreaming`, preventing silent 404 streaming.
+- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts` now bootstraps resumed jobs from `GET /api/authoring/jobs/{job_id}/progress`, preserves the last known `current_step` during realtime reconnect, clears stale session storage on `404`, and keeps retry payload handling fail-closed.
+- `frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx` now wraps `retryJob()` in try/catch, ignores duplicate retry clicks while one attempt is in flight, and only exposes `Reintentar` for `failed_resumable`.
+- `frontend/src/features/teacher-authoring/AuthoringErrorState.tsx` now supports non-retryable recovery failures without rendering a misleading retry CTA.
+- `frontend/src/shared/api.ts` now exposes `getProgress(jobId)` so resumed flows can bootstrap from the durable progress snapshot before reconnecting Supabase Realtime.
+- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts`, `frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx`, `frontend/src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx`, and `frontend/src/shared/api.test.ts` now cover stale rehydration cleanup, retry fail-closed behavior, duplicate retry clicks, durable progress bootstrap, and sticky timeline continuity.
 - Deterministic validation completed in this pass:
   - `uv run --directory backend mypy src` -> clean
   - `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `8 passed`
-  - `npm --prefix frontend run test` -> `25 passed`
-  - `npx tsc --noEmit` -> clean
-- Remaining work for the next developer or agent: see "Handoff for next agent" section below.
+  - `npm --prefix frontend run test -- src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx src/shared/api.test.ts src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx` -> `35 passed`
+  - `npm --prefix frontend run test` -> `224 passed`
+  - `npm --prefix frontend run lint` -> clean
+  - `npm --prefix frontend run build` -> clean
+- Phase 4 backend closure evidence is recorded below. The only residual merge concern is upstream `live_llm` provider noise, not a remaining checkpoint/runtime defect.
+
+### Phase 4 execution results (2026-04-16)
+- `backend/src/case_generator/graph.py` now separates the compiled-graph loop marker from the graph-init lock loop marker. This fixes the real live-LLM bug where `get_graph()` could return a compiled graph/checkpointer created on a previous pytest event loop, which then failed with `asyncio.Lock ... is bound to a different event loop` on the next `aget_tuple()`.
+- `backend/tests/test_authoring_progress_resilience.py` now includes a cross-loop regression test proving the graph singleton recompiles when the event loop changes.
+- `backend/tests/test_phase1b_real.py` now uses the current `edaDepth` enum (`charts_plus_explanation`) instead of the removed `charts_only` value.
+- Targeted backend contract validation is green against the repo-local Postgres target:
+  - `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py` -> `15 passed`
+- Manual local checkpoint smoke is green against `localhost:5434` using the real `AuthoringService.run_job()` path:
+  - smoke `job_id/thread_id`: `2042784e-76a7-4dfb-873c-43105bca5b80`
+  - final job status: `completed`
+  - raw SQL evidence from `adam-edu-postgres`:
+    - `checkpoints`: `25`
+    - `checkpoint_blobs`: `67`
+    - `checkpoint_writes`: `317`
+- Manual durable resume proof is green using the real durable graph with LangChain callback token accounting:
+  - baseline thread: `issue112-baseline-ab4796b7-6582-4a8f-8329-3b73bf0065eb`
+  - interrupted/resume thread: `issue112-resume-dbcc4e93-6731-4d1b-a209-67c26ef1c9e8`
+  - baseline full run: `61,951` total tokens across `6` LLM calls
+  - interrupted first attempt: stopped after `m3_flow` at the M4 boundary with checkpoint rows already persisted
+  - resumed second attempt on the same thread: `41,581` total tokens across `4` LLM calls
+  - observed token savings vs baseline: `20,370` total tokens
+- Post-fix backend validation is green:
+  - `uv run --directory backend mypy src` -> clean
+  - `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `9 passed`
+  - `uv run --directory backend pytest -q` -> `227 passed, 4 skipped`
+- Focused live validation after the singleton fix is improved but still noisy under upstream Gemini availability:
+  - `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q` -> `6 passed, 2 failed`
+  - the previous cross-loop checkpoint failure did not reproduce after the graph singleton fix
+  - residual failures were observed during provider-side `503 UNAVAILABLE / high demand` conditions and should be treated as live-provider noise, not as a deterministic checkpoint/runtime regression
 
 ### Review findings applied in commit `df82309`
 | ID   | Severity | File | Fix |
@@ -33,8 +68,8 @@ Step 0 outcome: user chose BIG CHANGE.
 - **RunnableConfig loss in `_with_resume_skip`**: LangGraph injects `RunnableConfig` into each node independently via the graph executor — it is not propagated through state. No fix needed.
 - **asyncio.Lock event loop binding race**: Cloud Run runs a single event loop per process. The lazy singleton pattern with `threading.Lock` outer guard and `asyncio.Lock` inner guard is safe in this deployment model. No fix needed.
 
-### Deferred finding (INFO)
-- **I-1**: Session storage reconciliation — if a `failed_resumable` job is cleaned up server-side, the frontend session storage retains a stale entry and may attempt to rehydrate a non-existent job. Low priority; add a server-side existence check or clear session storage on 404 during rehydration in a future pass.
+### Former deferred finding (INFO, resolved in Phase 3)
+- **I-1**: Session storage reconciliation was closed in commit `eba18da`. Rehydration now bootstraps against `GET /progress` before reconnecting realtime, clears the persisted session entry on `404`, and fails closed with a non-retryable recovery error instead of looping on an orphaned job.
 
 ### What already exists
 - Job lifecycle orchestration exists in `backend/src/case_generator/core/authoring.py` at `run_job`, including transitions `pending -> processing -> completed/failed`.
@@ -137,17 +172,21 @@ Completed in this pass:
 - `backend/src/case_generator/graph.py`
 - `backend/src/case_generator/core/authoring.py`
 - `backend/tests/test_authoring_progress_resilience.py`
+- `frontend/src/features/teacher-authoring/AuthoringErrorState.tsx`
+- `frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx`
+- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts`
+- `frontend/src/shared/api.ts`
+- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts`
+- `frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx`
+- `frontend/src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx`
+- `frontend/src/shared/api.test.ts`
 - `docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md`
 
 Still pending for later validation or continuity work:
-- `backend/tests/test_authoring_progress_resilience.py`
 - `backend/tests/test_phase3_status_api.py`
 - `backend/tests/test_internal_tasks.py`
-- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts`
-- `frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx`
-- `frontend/src/shared/api.test.ts`
-- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts`
-- `frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx`
+- manual local checkpoint-table verification against `localhost:5434`
+- focused `live_llm` baseline + resume comparison after deterministic backend green
 
 ### Async wiring design
 
@@ -325,34 +364,33 @@ Phase 2.5, code review hardening, complete
 9. Done: hardened frontend retry error handling in `TeacherAuthoringPage.tsx` (C-2).
 10. Done: hardened retry response validation in `useAuthoringJobProgress.ts` (H-2).
 
-Phase 3, UX and contract continuity, next active phase
-11. Next: add frontend retry/rehydration/timeline continuity tests.
-12. Next: preserve `progress_seq/current_step` continuity on resumed stream.
-13. Next: add session storage reconciliation (clear stale entries on 404 during rehydration).
+Phase 3, UX and contract continuity, complete
+11. Done: add frontend retry/rehydration/timeline continuity tests.
+12. Done: preserve `progress_seq/current_step` continuity on resumed stream by bootstrapping the durable progress snapshot before realtime reconnect.
+13. Done: add session storage reconciliation on `404` during rehydration, non-retryable stale recovery UX, retry CTA gating, and duplicate retry click guard.
 
 Phase 4, tests and evals
 14. In progress: backend contract tests in `test_phase3_status_api.py` and `test_internal_tasks.py` still need to run or expand.
 15. Done: dedicated concurrency tests for duplicate retry race and first-use singleton initialization (8 tests).
-16. Next: add frontend tests for retry UX, rehydration, and timeline continuity.
-17. Next: run deterministic suites first, then focused `live_llm` baseline plus resume comparisons.
+16. Done: add frontend tests for retry UX, rehydration, and timeline continuity.
+17. Next: run the remaining deterministic backend suites and manual checkpoint verification first, then focused `live_llm` baseline plus resume comparisons.
 
 ### Verification plan
 Completed in this pass:
 1. `uv run --directory backend mypy src`
 2. `DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py`
+3. `npm --prefix frontend run test -- src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx src/shared/api.test.ts src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx`
+4. `npm --prefix frontend run test`
+5. `npm --prefix frontend run lint`
+6. `npm --prefix frontend run build`
 
 Still pending before the backend track is considered fully closed:
-3. Run a local reproduction against `localhost:5434` and confirm `graph.astream()` no longer raises `NotImplementedError` on `aget_tuple` during a real authoring execution.
-4. Confirm LangGraph checkpoint tables (`checkpoints`, `checkpoint_blobs`, `checkpoint_writes`) receive rows for the run thread/job.
-5. `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py`
-
-Frontend validation after Phase 3 continuity updates:
-6. `npm --prefix frontend run test -- src/shared/api.test.ts src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx`
-7. `npm --prefix frontend run lint`
-8. `npm --prefix frontend run build`
+7. Run a local reproduction against `localhost:5434` and confirm `graph.astream()` no longer raises `NotImplementedError` on `aget_tuple` during a real authoring execution.
+8. Confirm LangGraph checkpoint tables (`checkpoints`, `checkpoint_blobs`, `checkpoint_writes`) receive rows for the run thread/job.
+9. `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py`
 
 Focused live evals only after deterministic green:
-9. `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q`
+10. `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q`
 
 Live_llm baseline comparisons:
 - successful full run token/call profile before and after
@@ -372,16 +410,20 @@ Live_llm baseline comparisons:
 - Architecture Review: 2 implementation-shaping issues resolved
 - Code Quality Review: 4 direct fixes identified, backend hardening landed
 - Code Review Hardening: 4 review findings (2 CRITICAL, 2 HIGH) fixed in commit `df82309`
-- Test Review: focused backend regressions added for concurrency and fail-closed behavior
+- Phase 3 frontend continuity: complete in commit `eba18da`
+- Test Review: focused backend regressions plus frontend continuity regressions are now landed
 - Performance Review: single async pool and compiled-graph singleton path preserved, with same-loop init race fixed
 - Backend Phase 2 implementation complete and pushed in commit `790947d`
 - Review hardening complete and pushed in commit `df82309`
+- Frontend Phase 3 implementation complete and pushed in commit `eba18da`
 - Validated in this pass:
   - `uv run --directory backend mypy src` -> clean
   - `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `8 passed`
-  - `npm --prefix frontend run test` -> `25 passed`
-  - `npx tsc --noEmit` -> clean
-- Remaining for next phase: see handoff section below
+  - `npm --prefix frontend run test -- src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx src/shared/api.test.ts src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx` -> `35 passed`
+  - `npm --prefix frontend run test` -> `224 passed`
+  - `npm --prefix frontend run lint` -> clean
+  - `npm --prefix frontend run build` -> clean
+- Phase 4 backend closure is complete locally. Remaining merge-time caution is limited to provider-side `live_llm` noise during reruns.
 
 ### Handoff for next agent
 
@@ -390,35 +432,36 @@ Live_llm baseline comparisons:
 2. **Phase 2** (async correction + resume orchestration): Landed on `feat/issue112-stateful-recovery` in commit `790947d`. `AsyncPostgresSaver`, lazy async singleton pool+graph, fail-closed checkpoint wiring.
 3. **Phase 2.5** (code review hardening): Landed on `feat/issue112-stateful-recovery` in commit `df82309`. 4 fixes: exception classification guard, pool cleanup timeout, retry error handling, retry response validation.
 4. **Backend tests**: 8 resilience tests passing (`test_authoring_progress_resilience.py`). mypy clean.
-5. **Frontend hardening**: retry try/catch and job_id validation applied. 25 tests passing. tsc clean.
+5. **Frontend hardening**: retry try/catch and job_id validation landed in `df82309`.
+6. **Phase 3** (UX + contract continuity): Landed on `feat/issue112-stateful-recovery` in commit `eba18da`. Resume bootstrap now starts from the durable progress snapshot, stale session storage is cleared on `404`, retry clicks are locally deduplicated, non-retryable failures no longer show `Reintentar`, and frontend regressions are covered.
+7. **Frontend validation**: targeted continuity suite `35 passed`, full frontend suite `224 passed`, lint clean, build clean.
+8. **Phase 4** (backend closure + live proof): Local contract tests green (`15 passed`), manual checkpoint SQL evidence captured for real `job_id/thread_id` `2042784e-76a7-4dfb-873c-43105bca5b80`, graph singleton cross-loop bug fixed, deterministic backend suite green post-fix (`227 passed, 4 skipped`), and manual resume proof captured `20,370` token savings versus a full rerun.
 
-#### What to do next (in priority order)
+#### Phase 4 closure evidence
 
-**1. Backend contract test gap**
-- Run `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py` and verify they pass.
-- If they need updates for the new async graph initialization path, update them.
+**1. Backend contract validation**
+- `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py` -> `15 passed`
 
 **2. Manual local checkpoint-table verification**
-- Run a real authoring job against `localhost:5434` and confirm:
-  - `graph.astream()` does NOT raise `NotImplementedError` on `aget_tuple`.
-  - LangGraph checkpoint tables (`checkpoints`, `checkpoint_blobs`, `checkpoint_writes`) receive rows for the run thread/job.
+- Real authoring job against `localhost:5434` completed with `job_id/thread_id` `2042784e-76a7-4dfb-873c-43105bca5b80`.
+- Raw SQL counts captured from `adam-edu-postgres`:
+  - `checkpoints = 25`
+  - `checkpoint_blobs = 67`
+  - `checkpoint_writes = 317`
 
-**3. Frontend Phase 3 tests**
-- Add or update tests in:
-  - `frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx` — test `handleRetry` error path shows error state
-  - `frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts` — test rehydration with stale session storage entry
-  - `frontend/src/shared/api.test.ts` — test retry endpoint response validation
-- Run: `npm --prefix frontend run test`, `npm --prefix frontend run lint`, `npm --prefix frontend run build`
+**3. Full backend deterministic suite**
+- `uv run --directory backend mypy src` -> clean
+- `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `9 passed`
+- `uv run --directory backend pytest -q` -> `227 passed, 4 skipped`
 
-**4. Session storage reconciliation (deferred I-1)**
-- When rehydrating from session storage, check server-side job existence before resuming streaming.
-- If the job returns 404, clear the session storage entry and reset to initial state.
-- File: `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts`
-
-**5. Live LLM validation (only after all deterministic suites green)**
-- `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q`
-- Baseline: successful full run token/call profile
-- Resume: injected M4 transient failure resume, assert lower token/call footprint than full rerun
+**4. Live LLM validation and manual token proof**
+- `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q` -> `6 passed, 2 failed`
+- The loop-bound `AsyncPostgresSaver` bug is fixed; the rerun no longer reproduces the previous `asyncio.Lock ... bound to a different event loop` failure.
+- Residual live failures coincided with upstream Gemini `503 UNAVAILABLE / high demand` responses and should be documented as provider noise.
+- Manual baseline vs resume proof on the durable graph:
+  - baseline: `61,951` total tokens / `6` LLM calls
+  - resumed second attempt on same thread after interruption at the M4 boundary: `41,581` total tokens / `4` LLM calls
+  - observed savings: `20,370` tokens
 
 #### Key files for context
 | File | Role |
@@ -427,8 +470,10 @@ Live_llm baseline comparisons:
 | `backend/src/case_generator/graph.py` | Lazy async graph/checkpointer singleton, skip wrappers |
 | `backend/src/shared/database.py` | Lazy async pool singleton, pool lifecycle |
 | `backend/tests/test_authoring_progress_resilience.py` | 8 resilience tests for concurrency and fail-closed |
+| `frontend/src/features/teacher-authoring/AuthoringErrorState.tsx` | Error CTA gating for retryable vs non-retryable failures |
 | `frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx` | Authoring page, retry handler |
 | `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts` | Job progress hook, streaming, rehydration |
+| `frontend/src/shared/api.ts` | Durable progress snapshot bootstrap client |
 
 #### Validation commands
 ```powershell

--- a/docs/runbooks/local-dev-auth.md
+++ b/docs/runbooks/local-dev-auth.md
@@ -27,6 +27,7 @@ Este repo mantiene su base principal local fuera de Supabase CLI.
 
 `DATABASE_URL` siempre apunta a este Postgres del repo cuando trabajas localmente.
 No lo apuntes al Postgres interno de Supabase CLI.
+El launcher `uv run --directory backend python -m shared.app` ahora valida esto en startup y rechaza hosts remotos de Supabase cuando corres en `development`.
 
 ## Plano 2: auth local y tooling de Supabase
 
@@ -79,6 +80,8 @@ Los prerrequisitos anteriores no cuentan dentro de este flujo.
 7. `uv run --directory backend python -m shared.app`
 8. `npm --prefix frontend install`
 9. `npm --prefix frontend run dev`
+
+Si usas el atajo opcional del root en entornos Unix-like, `make dev-backend` ya fuerza `DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres` para evitar arrancar accidentalmente contra un pooler remoto.
 
 ## Traduccion de `supabase status -o env`
 

--- a/frontend/src/features/teacher-authoring/AuthoringErrorState.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringErrorState.tsx
@@ -2,7 +2,7 @@
 
 interface AuthoringErrorStateProps {
     message: string;
-    onRetry: () => void;
+    onRetry?: () => void;
     onBack: () => void;
 }
 
@@ -28,12 +28,14 @@ export function AuthoringErrorState({ message, onRetry, onBack }: AuthoringError
                     >
                         ← Volver al formulario
                     </button>
-                    <button
-                        onClick={onRetry}
-                        className="rounded-input bg-adam-accent px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-adam-accent/90 focus-visible:outline-2 focus-visible:outline-adam-accent"
-                    >
-                        Reintentar
-                    </button>
+                    {onRetry ? (
+                        <button
+                            onClick={onRetry}
+                            className="rounded-input bg-adam-accent px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-adam-accent/90 focus-visible:outline-2 focus-visible:outline-adam-accent"
+                        >
+                            Reintentar
+                        </button>
+                    ) : null}
                 </div>
             </div>
         </div>

--- a/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx
@@ -23,6 +23,20 @@ describe("AuthoringProgressTimeline", () => {
         expect(screen.getByText("14%")).toBeTruthy();
     });
 
+    it("keeps the visible timeline at zero while bootstrap is still initializing", () => {
+        render(
+            <AuthoringProgressTimeline
+                activeAgent={undefined}
+                bootstrapState="initializing"
+                scope="technical"
+                jobStatus="processing"
+            />,
+        );
+
+        expect(screen.getByText("0%")).toBeTruthy();
+        expect(screen.getByText("Preparando generador")).toBeTruthy();
+    });
+
     it("uses step index + 1 for percentage", () => {
         render(
             <AuthoringProgressTimeline

--- a/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx
@@ -46,4 +46,26 @@ describe("AuthoringProgressTimeline", () => {
 
         expect(screen.getByText("100%")).toBeTruthy();
     });
+
+    it("keeps the last known step when the active agent temporarily disappears", () => {
+        const { rerender } = render(
+            <AuthoringProgressTimeline
+                activeAgent="m4_content_generator"
+                scope="technical"
+                jobStatus="processing"
+            />,
+        );
+
+        expect(screen.getByText("71%")).toBeTruthy();
+
+        rerender(
+            <AuthoringProgressTimeline
+                activeAgent={undefined}
+                scope="technical"
+                jobStatus="processing"
+            />,
+        );
+
+        expect(screen.getByText("71%")).toBeTruthy();
+    });
 });

--- a/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx
@@ -1,10 +1,11 @@
 /** AuthoringProgressTimeline: muestra progreso del pipeline */
 
 import { useEffect, useState, useRef } from "react";
-import type { AuthoringProgressStep } from "@/shared/adam-types";
+import type { AuthoringBootstrapState, AuthoringProgressStep } from "@/shared/adam-types";
 
 interface Props {
   activeAgent?: AuthoringProgressStep;
+  bootstrapState?: AuthoringBootstrapState;
   scope: "narrative" | "technical";
   jobStatus?: "pending" | "processing" | "completed" | "failed" | "failed_resumable";
 }
@@ -79,7 +80,7 @@ function getStepStatus(
   return "pending";
 }
 
-export function AuthoringProgressTimeline({ activeAgent, scope, jobStatus }: Props) {
+export function AuthoringProgressTimeline({ activeAgent, bootstrapState, scope, jobStatus }: Props) {
   const [dots, setDots] = useState("");
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const lastValidIndexRef = useRef<number>(-1);
@@ -100,10 +101,11 @@ export function AuthoringProgressTimeline({ activeAgent, scope, jobStatus }: Pro
   // nos quedamos en el último paso conocido en lugar de resetear el progreso a 0.
   if (activeIndex >= 0) lastValidIndexRef.current = activeIndex;
   const effectiveIndex = activeIndex >= 0 ? activeIndex : lastValidIndexRef.current;
+  const isBootstrapInitializing = bootstrapState === "initializing";
 
   const inferredActiveIndex = effectiveIndex >= 0
     ? effectiveIndex
-    : (jobStatus === "processing" ? 0 : -1);
+    : (jobStatus === "processing" && !isBootstrapInitializing ? 0 : -1);
   const currentProgressIndex = jobStatus === "completed"
     ? visibleSteps.length
     : (inferredActiveIndex >= 0 ? inferredActiveIndex + 1 : 0);
@@ -153,11 +155,13 @@ export function AuthoringProgressTimeline({ activeAgent, scope, jobStatus }: Pro
             <div className="space-y-2 w-full">
               {/* Textos escalados de 3xl a 2xl, y base a sm */}
               <h2 className="text-2xl font-extrabold text-slate-800 tracking-tight leading-tight flex items-end justify-center md:justify-start">
-                Generando caso
+                {isBootstrapInitializing ? "Preparando generador" : "Generando caso"}
                 <span className="inline-block w-4 text-left text-[#0144a0] animate-pulse">{dots}</span>
               </h2>
               <p className="text-sm text-slate-500 leading-relaxed max-w-[240px] mx-auto md:mx-0 text-center md:text-left">
-                Los agentes de ADAM están analizando y construyendo tu caso de forma orquestada.
+                {isBootstrapInitializing
+                  ? "Inicializando la persistencia durable y compilando el flujo antes de arrancar el primer paso visible."
+                  : "Los agentes de ADAM están analizando y construyendo tu caso de forma orquestada."}
               </p>
             </div>
           </div>

--- a/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx
@@ -6,7 +6,7 @@ import type { AuthoringProgressStep } from "@/shared/adam-types";
 interface Props {
   activeAgent?: AuthoringProgressStep;
   scope: "narrative" | "technical";
-  jobStatus?: "pending" | "processing" | "completed" | "failed";
+  jobStatus?: "pending" | "processing" | "completed" | "failed" | "failed_resumable";
 }
 
 const PIPELINE_STEPS: Array<{

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
@@ -57,6 +57,7 @@ describe("TeacherAuthoringPage", () => {
             reset: vi.fn(),
             isStreaming: false,
             progressScope: null,
+            bootstrapState: undefined,
         });
 
         render(<TeacherAuthoringPage />);
@@ -78,6 +79,7 @@ describe("TeacherAuthoringPage", () => {
             reset: vi.fn(),
             isStreaming: false,
             progressScope: null,
+            bootstrapState: undefined,
         });
 
         render(<TeacherAuthoringPage />);
@@ -102,6 +104,7 @@ describe("TeacherAuthoringPage", () => {
             reset,
             isStreaming: false,
             progressScope: "technical",
+            bootstrapState: undefined,
         });
 
         render(<TeacherAuthoringPage />);
@@ -129,6 +132,7 @@ describe("TeacherAuthoringPage", () => {
             reset: vi.fn(),
             isStreaming: false,
             progressScope: null,
+            bootstrapState: undefined,
         });
 
         render(<TeacherAuthoringPage />);
@@ -150,6 +154,7 @@ describe("TeacherAuthoringPage", () => {
             reset: vi.fn(),
             isStreaming: false,
             progressScope: "technical",
+            bootstrapState: undefined,
         });
 
         render(<TeacherAuthoringPage />);
@@ -176,6 +181,7 @@ describe("TeacherAuthoringPage", () => {
             reset: vi.fn(),
             isStreaming: false,
             progressScope: "technical",
+            bootstrapState: undefined,
         });
 
         render(<TeacherAuthoringPage />);

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
@@ -9,7 +9,13 @@ vi.mock("./AuthoringProgressTimeline", () => ({
     AuthoringProgressTimeline: () => <div data-testid="authoring-progress">Progress</div>,
 }));
 vi.mock("./AuthoringErrorState", () => ({
-    AuthoringErrorState: () => <div data-testid="authoring-error">Error</div>,
+    AuthoringErrorState: (props: { message: string; onRetry: () => void; onBack: () => void }) => (
+        <div data-testid="authoring-error">
+            <p>{props.message}</p>
+            <button onClick={props.onRetry}>Reintentar</button>
+            <button onClick={props.onBack}>Volver</button>
+        </div>
+    ),
 }));
 vi.mock("@/features/teacher-layout/TeacherLayout", () => ({
     TeacherLayout: (props: { children: ReactNode; testId?: string }) => (
@@ -39,6 +45,7 @@ describe("TeacherAuthoringPage", () => {
             result: null,
             activeAgent: undefined,
             submitJob: vi.fn(),
+            retryJob: vi.fn(),
             reset: vi.fn(),
             isStreaming: false,
             progressScope: null,
@@ -59,6 +66,7 @@ describe("TeacherAuthoringPage", () => {
             result: {} as never,
             activeAgent: undefined,
             submitJob: vi.fn(),
+            retryJob: vi.fn(),
             reset: vi.fn(),
             isStreaming: false,
             progressScope: null,
@@ -69,5 +77,35 @@ describe("TeacherAuthoringPage", () => {
         expect(screen.getByText(/cargando vista previa/i)).toBeTruthy();
         expect(await screen.findByTestId("case-preview")).toBeTruthy();
         expect(screen.queryByTestId("authoring-form")).toBeNull();
+    });
+
+    it("shows resumable error state and retries without resetting context", async () => {
+        const retryJob = vi.fn().mockResolvedValue(undefined);
+        const reset = vi.fn();
+
+        vi.mocked(useAuthoringJobProgress).mockReturnValue({
+            jobId: "job-77",
+            status: "failed_resumable",
+            errorTrace: "timeout upstream",
+            result: null,
+            activeAgent: undefined,
+            submitJob: vi.fn(),
+            retryJob,
+            reset,
+            isStreaming: false,
+            progressScope: "technical",
+        });
+
+        render(<TeacherAuthoringPage />);
+
+        expect(screen.getByTestId("authoring-error")).toBeTruthy();
+        expect(screen.getByText(/timeout upstream/i)).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: /reintentar/i }));
+
+        await waitFor(() => {
+            expect(retryJob).toHaveBeenCalledTimes(1);
+        });
+        expect(reset).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
@@ -9,10 +9,18 @@ vi.mock("./AuthoringProgressTimeline", () => ({
     AuthoringProgressTimeline: () => <div data-testid="authoring-progress">Progress</div>,
 }));
 vi.mock("./AuthoringErrorState", () => ({
-    AuthoringErrorState: (props: { message: string; onRetry: () => void; onBack: () => void }) => (
+    AuthoringErrorState: (props: { message: string; onRetry?: () => void; onBack: () => void }) => (
         <div data-testid="authoring-error">
             <p>{props.message}</p>
-            <button onClick={props.onRetry}>Reintentar</button>
+            {props.onRetry ? <button onClick={props.onRetry}>Reintentar</button> : null}
+            {props.onRetry ? (
+                <button onClick={() => {
+                    props.onRetry?.();
+                    props.onRetry?.();
+                }}>
+                    Reintentar dos veces
+                </button>
+            ) : null}
             <button onClick={props.onBack}>Volver</button>
         </div>
     ),
@@ -101,11 +109,81 @@ describe("TeacherAuthoringPage", () => {
         expect(screen.getByTestId("authoring-error")).toBeTruthy();
         expect(screen.getByText(/timeout upstream/i)).toBeTruthy();
 
-        fireEvent.click(screen.getByRole("button", { name: /reintentar/i }));
+        fireEvent.click(screen.getByRole("button", { name: /^reintentar$/i }));
 
         await waitFor(() => {
             expect(retryJob).toHaveBeenCalledTimes(1);
         });
         expect(reset).not.toHaveBeenCalled();
+    });
+
+    it("hides the retry action for non-resumable failures", () => {
+        vi.mocked(useAuthoringJobProgress).mockReturnValue({
+            jobId: null,
+            status: "failed",
+            errorTrace: "La sesion de recuperacion ya no esta disponible.",
+            result: null,
+            activeAgent: undefined,
+            submitJob: vi.fn(),
+            retryJob: vi.fn(),
+            reset: vi.fn(),
+            isStreaming: false,
+            progressScope: null,
+        });
+
+        render(<TeacherAuthoringPage />);
+
+        expect(screen.getByTestId("authoring-error")).toBeTruthy();
+        expect(screen.queryByRole("button", { name: /reintentar/i })).toBeNull();
+        expect(screen.getByRole("button", { name: /volver/i })).toBeTruthy();
+    });
+
+    it("returns to the error state if retry throws", async () => {
+        vi.mocked(useAuthoringJobProgress).mockReturnValue({
+            jobId: "job-77",
+            status: "failed_resumable",
+            errorTrace: "timeout upstream",
+            result: null,
+            activeAgent: undefined,
+            submitJob: vi.fn(),
+            retryJob: vi.fn().mockRejectedValue(new Error("Retry exploded")),
+            reset: vi.fn(),
+            isStreaming: false,
+            progressScope: "technical",
+        });
+
+        render(<TeacherAuthoringPage />);
+
+        fireEvent.click(screen.getByRole("button", { name: /^reintentar$/i }));
+
+        expect(await screen.findByText(/retry exploded/i)).toBeTruthy();
+        expect(screen.getByTestId("authoring-error")).toBeTruthy();
+    });
+
+    it("ignores duplicate retry invocations while one is already in flight", async () => {
+        const retryJob = vi.fn().mockImplementation(async () => {
+            await new Promise(() => undefined);
+        });
+
+        vi.mocked(useAuthoringJobProgress).mockReturnValue({
+            jobId: "job-77",
+            status: "failed_resumable",
+            errorTrace: "timeout upstream",
+            result: null,
+            activeAgent: undefined,
+            submitJob: vi.fn(),
+            retryJob,
+            reset: vi.fn(),
+            isStreaming: false,
+            progressScope: "technical",
+        });
+
+        render(<TeacherAuthoringPage />);
+
+        fireEvent.click(screen.getByRole("button", { name: /reintentar dos veces/i }));
+
+        await waitFor(() => {
+            expect(retryJob).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
@@ -81,8 +81,13 @@ export function TeacherAuthoringPage() {
   const handleRetry = useCallback(async () => {
     if (jobStatus === "failed_resumable") {
       setErrorMessage("");
-      setAppState("generating");
-      await retryJob();
+      try {
+        setAppState("generating");
+        await retryJob();
+      } catch (err) {
+        setErrorMessage(err instanceof Error ? err.message : "Error al reintentar.");
+        setAppState("error");
+      }
       return;
     }
 

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
@@ -40,6 +40,7 @@ export function TeacherAuthoringPage() {
     result: jobResult,
     activeAgent,
     submitJob,
+    retryJob,
     reset: resetJob,
     isStreaming,
     progressScope,
@@ -49,9 +50,15 @@ export function TeacherAuthoringPage() {
     if (isStreaming || jobStatus === "pending" || jobStatus === "processing") {
       setAppState("generating");
       setErrorMessage("");
-    } else if (jobStatus === "failed") {
+    } else if (jobStatus === "failed" || jobStatus === "failed_resumable") {
       setAppState("error");
-      setErrorMessage(errorTrace || "Error desconocido durante la generacion.");
+      if (errorTrace && errorTrace.trim() !== "") {
+        setErrorMessage(errorTrace);
+      } else if (jobStatus === "failed_resumable") {
+        setErrorMessage("La generacion se interrumpio por un error transitorio. Puedes reintentar sin perder el progreso ya completado.");
+      } else {
+        setErrorMessage("Error desconocido durante la generacion.");
+      }
     } else if (jobStatus === "completed" && jobResult) {
       setCaseResult(jobResult);
       setAppState("success");
@@ -71,10 +78,17 @@ export function TeacherAuthoringPage() {
     // Placeholder para un futuro flujo HITL.
   }, []);
 
-  const handleRetry = () => {
+  const handleRetry = useCallback(async () => {
+    if (jobStatus === "failed_resumable") {
+      setErrorMessage("");
+      setAppState("generating");
+      await retryJob();
+      return;
+    }
+
     resetJob();
     setAppState("idle");
-  };
+  }, [jobStatus, resetJob, retryJob]);
 
   return (
     <TeacherLayout testId="teacher-authoring-page" contentClassName="mx-auto w-full max-w-6xl">

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
@@ -1,6 +1,6 @@
 /** ADAM v8 - Portal Profesor: Builder Mode (Supabase Realtime Flow) */
 
-import { Suspense, lazy, useCallback, useEffect, useState } from "react";
+import { Suspense, lazy, useCallback, useEffect, useRef, useState } from "react";
 import type { CaseFormData, CanonicalCaseOutput } from "@/shared/adam-types";
 import { EMPTY_FORM } from "@/shared/adam-types";
 import { TeacherLayout } from "@/features/teacher-layout/TeacherLayout";
@@ -33,6 +33,7 @@ export function TeacherAuthoringPage() {
   const [formData, setFormData] = useState<CaseFormData>(EMPTY_FORM);
   const [caseResult, setCaseResult] = useState<CanonicalCaseOutput | null>(null);
   const [errorMessage, setErrorMessage] = useState("");
+  const retryInFlightRef = useRef(false);
 
   const {
     status: jobStatus,
@@ -80,6 +81,11 @@ export function TeacherAuthoringPage() {
 
   const handleRetry = useCallback(async () => {
     if (jobStatus === "failed_resumable") {
+      if (retryInFlightRef.current) {
+        return;
+      }
+
+      retryInFlightRef.current = true;
       setErrorMessage("");
       try {
         setAppState("generating");
@@ -87,6 +93,8 @@ export function TeacherAuthoringPage() {
       } catch (err) {
         setErrorMessage(err instanceof Error ? err.message : "Error al reintentar.");
         setAppState("error");
+      } finally {
+        retryInFlightRef.current = false;
       }
       return;
     }
@@ -128,7 +136,7 @@ export function TeacherAuthoringPage() {
       {appState === "error" && (
         <AuthoringErrorState
           message={errorMessage}
-          onRetry={handleRetry}
+          onRetry={jobStatus === "failed_resumable" ? handleRetry : undefined}
           onBack={() => setAppState("idle")}
         />
       )}

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
@@ -45,6 +45,7 @@ export function TeacherAuthoringPage() {
     reset: resetJob,
     isStreaming,
     progressScope,
+    bootstrapState,
   } = useAuthoringJobProgress();
 
   useEffect(() => {
@@ -117,6 +118,7 @@ export function TeacherAuthoringPage() {
       {appState === "generating" && (
         <AuthoringProgressTimeline
           activeAgent={activeAgent}
+          bootstrapState={bootstrapState}
           jobStatus={jobStatus || undefined}
           scope={progressScope || (formData.caseType === "harvard_only" ? "narrative" : "technical")}
         />

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
@@ -5,10 +5,12 @@ import { EMPTY_FORM } from "@/shared/adam-types";
 
 const {
     submitJobMock,
+    retryJobMock,
     streamProgressMock,
 } = vi.hoisted(() => {
     return {
         submitJobMock: vi.fn(),
+        retryJobMock: vi.fn(),
         streamProgressMock: vi.fn(),
     };
 });
@@ -30,6 +32,7 @@ vi.mock("@/shared/api", () => {
         api: {
             authoring: {
                 submitJob: submitJobMock,
+                retryJob: retryJobMock,
                 streamProgress: streamProgressMock,
             },
         },
@@ -41,6 +44,7 @@ import { useAuthoringJobProgress } from "./useAuthoringJobProgress";
 describe("useAuthoringJobProgress rehydration", () => {
     beforeEach(() => {
         submitJobMock.mockReset();
+        retryJobMock.mockReset();
         streamProgressMock.mockReset();
         sessionStorage.clear();
     });
@@ -91,5 +95,89 @@ describe("useAuthoringJobProgress rehydration", () => {
         const persisted = sessionStorage.getItem("adam_authoring_active_job");
         expect(persisted).toContain("job-99");
         expect(persisted).toContain("technical");
+    });
+
+    it("keeps sessionStorage state when stream ends in failed_resumable", async () => {
+        submitJobMock.mockResolvedValue({ job_id: "job-77" });
+        streamProgressMock.mockImplementation(
+            async (_jobId: string, onEvent: (event: { event: string; data: string }) => void) => {
+                onEvent({ event: "metadata", data: JSON.stringify({ status: "processing" }) });
+                onEvent({
+                    event: "error",
+                    data: JSON.stringify({ status: "failed_resumable", detail: "timeout" }),
+                });
+            },
+        );
+
+        const { result } = renderHook(() => useAuthoringJobProgress());
+
+        await act(async () => {
+            await result.current.submitJob({
+                ...EMPTY_FORM,
+                subject: "Caso",
+                caseType: "harvard_with_eda",
+            });
+        });
+
+        await waitFor(() => {
+            expect(result.current.status).toBe("failed_resumable");
+        });
+        expect(result.current.errorTrace).toBe("timeout");
+
+        const persisted = sessionStorage.getItem("adam_authoring_active_job");
+        expect(persisted).toContain("job-77");
+    });
+
+    it("calls retry endpoint and reconnects progress stream", async () => {
+        submitJobMock.mockResolvedValue({ job_id: "job-88" });
+        retryJobMock.mockResolvedValue({
+            job_id: "job-88",
+            status: "accepted",
+            message: "Authoring retry accepted and dispatched to queue.",
+        });
+
+        let streamInvocation = 0;
+        streamProgressMock.mockImplementation(
+            async (_jobId: string, onEvent: (event: { event: string; data: string }) => void) => {
+                streamInvocation += 1;
+
+                if (streamInvocation === 1) {
+                    onEvent({ event: "metadata", data: JSON.stringify({ status: "processing" }) });
+                    onEvent({
+                        event: "error",
+                        data: JSON.stringify({ status: "failed_resumable", detail: "timeout" }),
+                    });
+                    return;
+                }
+
+                onEvent({ event: "metadata", data: JSON.stringify({ status: "processing" }) });
+                onEvent({ event: "message", data: JSON.stringify({ node: "m4_content_generator" }) });
+            },
+        );
+
+        const { result } = renderHook(() => useAuthoringJobProgress());
+
+        await act(async () => {
+            await result.current.submitJob({
+                ...EMPTY_FORM,
+                subject: "Caso",
+                caseType: "harvard_with_eda",
+            });
+        });
+
+        await waitFor(() => {
+            expect(result.current.status).toBe("failed_resumable");
+        });
+
+        await act(async () => {
+            await result.current.retryJob();
+        });
+
+        expect(retryJobMock).toHaveBeenCalledWith("job-88");
+        await waitFor(() => {
+            expect(result.current.status).toBe("processing");
+            expect(result.current.activeAgent).toBe("m4_content_generator");
+        });
+        expect(streamProgressMock).toHaveBeenCalledTimes(2);
     });
 });

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
@@ -4,19 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_FORM } from "@/shared/adam-types";
 
 const {
+    MockApiError,
+    getProgressMock,
     submitJobMock,
     retryJobMock,
     streamProgressMock,
 } = vi.hoisted(() => {
-    return {
-        submitJobMock: vi.fn(),
-        retryJobMock: vi.fn(),
-        streamProgressMock: vi.fn(),
-    };
-});
-
-vi.mock("@/shared/api", () => {
-    class MockApiError extends Error {
+    class LocalMockApiError extends Error {
         readonly status: number;
         readonly retryAfterSeconds?: number;
 
@@ -28,12 +22,24 @@ vi.mock("@/shared/api", () => {
     }
 
     return {
+        MockApiError: LocalMockApiError,
+        getProgressMock: vi.fn(),
+        submitJobMock: vi.fn(),
+        retryJobMock: vi.fn(),
+        streamProgressMock: vi.fn(),
+    };
+});
+
+vi.mock("@/shared/api", () => {
+    return {
         ApiError: MockApiError,
         api: {
             authoring: {
+                getProgress: getProgressMock,
                 submitJob: submitJobMock,
                 retryJob: retryJobMock,
                 streamProgress: streamProgressMock,
+                getResult: vi.fn(),
             },
         },
     };
@@ -43,6 +49,7 @@ import { useAuthoringJobProgress } from "./useAuthoringJobProgress";
 
 describe("useAuthoringJobProgress rehydration", () => {
     beforeEach(() => {
+        getProgressMock.mockReset();
         submitJobMock.mockReset();
         retryJobMock.mockReset();
         streamProgressMock.mockReset();
@@ -55,12 +62,13 @@ describe("useAuthoringJobProgress rehydration", () => {
             JSON.stringify({ jobId: "job-42", scope: "technical" }),
         );
 
-        streamProgressMock.mockImplementation(
-            async (_jobId: string, onEvent: (event: { event: string; data: string }) => void) => {
-                onEvent({ event: "metadata", data: JSON.stringify({ status: "processing" }) });
-                onEvent({ event: "message", data: JSON.stringify({ node: "m3_content_generator" }) });
-            },
-        );
+        getProgressMock.mockResolvedValue({
+            job_id: "job-42",
+            status: "processing",
+            current_step: "m3_content_generator",
+            progress_seq: 3,
+        });
+        streamProgressMock.mockResolvedValue(undefined);
 
         const { result } = renderHook(() => useAuthoringJobProgress());
 
@@ -76,6 +84,25 @@ describe("useAuthoringJobProgress rehydration", () => {
         expect(result.current.status).toBe("processing");
         expect(result.current.activeAgent).toBe("m3_content_generator");
         expect(result.current.progressScope).toBe("technical");
+    });
+
+    it("clears stale persisted job state when bootstrap progress returns 404", async () => {
+        sessionStorage.setItem(
+            "adam_authoring_active_job",
+            JSON.stringify({ jobId: "job-404", scope: "technical" }),
+        );
+        getProgressMock.mockRejectedValue(new MockApiError(404, "missing"));
+
+        const { result } = renderHook(() => useAuthoringJobProgress());
+
+        await waitFor(() => {
+            expect(result.current.status).toBe("failed");
+        });
+
+        expect(result.current.jobId).toBeNull();
+        expect(result.current.errorTrace).toContain("sesion de recuperacion");
+        expect(sessionStorage.getItem("adam_authoring_active_job")).toBeNull();
+        expect(streamProgressMock).not.toHaveBeenCalled();
     });
 
     it("persists submitted job id and scope for refresh recovery", async () => {
@@ -135,6 +162,12 @@ describe("useAuthoringJobProgress rehydration", () => {
             status: "accepted",
             message: "Authoring retry accepted and dispatched to queue.",
         });
+        getProgressMock.mockResolvedValue({
+            job_id: "job-88",
+            status: "processing",
+            current_step: "m4_content_generator",
+            progress_seq: 4,
+        });
 
         let streamInvocation = 0;
         streamProgressMock.mockImplementation(
@@ -143,6 +176,7 @@ describe("useAuthoringJobProgress rehydration", () => {
 
                 if (streamInvocation === 1) {
                     onEvent({ event: "metadata", data: JSON.stringify({ status: "processing" }) });
+                    onEvent({ event: "message", data: JSON.stringify({ node: "m4_content_generator" }) });
                     onEvent({
                         event: "error",
                         data: JSON.stringify({ status: "failed_resumable", detail: "timeout" }),
@@ -150,8 +184,7 @@ describe("useAuthoringJobProgress rehydration", () => {
                     return;
                 }
 
-                onEvent({ event: "metadata", data: JSON.stringify({ status: "processing" }) });
-                onEvent({ event: "message", data: JSON.stringify({ node: "m4_content_generator" }) });
+                await new Promise(() => undefined);
             },
         );
 
@@ -178,6 +211,47 @@ describe("useAuthoringJobProgress rehydration", () => {
             expect(result.current.status).toBe("processing");
             expect(result.current.activeAgent).toBe("m4_content_generator");
         });
+        expect(getProgressMock).toHaveBeenCalledWith("job-88");
         expect(streamProgressMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("fails closed when retry returns an invalid payload", async () => {
+        submitJobMock.mockResolvedValue({ job_id: "job-91" });
+        retryJobMock.mockResolvedValue({
+            status: "accepted",
+            message: "Authoring retry accepted and dispatched to queue.",
+        } as never);
+        streamProgressMock.mockImplementation(
+            async (_jobId: string, onEvent: (event: { event: string; data: string }) => void) => {
+                onEvent({ event: "metadata", data: JSON.stringify({ status: "processing" }) });
+                onEvent({ event: "message", data: JSON.stringify({ node: "m4_content_generator" }) });
+                onEvent({
+                    event: "error",
+                    data: JSON.stringify({ status: "failed_resumable", detail: "timeout" }),
+                });
+            },
+        );
+
+        const { result } = renderHook(() => useAuthoringJobProgress());
+
+        await act(async () => {
+            await result.current.submitJob({
+                ...EMPTY_FORM,
+                subject: "Caso",
+                caseType: "harvard_with_eda",
+            });
+        });
+
+        await waitFor(() => {
+            expect(result.current.status).toBe("failed_resumable");
+        });
+
+        await act(async () => {
+            await result.current.retryJob();
+        });
+
+        expect(result.current.status).toBe("failed");
+        expect(result.current.errorTrace).toContain("respuesta de reintento invalida");
+        expect(getProgressMock).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
@@ -66,6 +66,7 @@ describe("useAuthoringJobProgress rehydration", () => {
             job_id: "job-42",
             status: "processing",
             current_step: "m3_content_generator",
+            bootstrap_state: "initializing",
             progress_seq: 3,
         });
         streamProgressMock.mockResolvedValue(undefined);
@@ -83,7 +84,32 @@ describe("useAuthoringJobProgress rehydration", () => {
         expect(result.current.jobId).toBe("job-42");
         expect(result.current.status).toBe("processing");
         expect(result.current.activeAgent).toBe("m3_content_generator");
+        expect(result.current.bootstrapState).toBe("initializing");
         expect(result.current.progressScope).toBe("technical");
+    });
+
+    it("tracks bootstrap metadata before the first canonical step is available", async () => {
+        sessionStorage.setItem(
+            "adam_authoring_active_job",
+            JSON.stringify({ jobId: "job-bootstrap", scope: "technical" }),
+        );
+
+        getProgressMock.mockResolvedValue({
+            job_id: "job-bootstrap",
+            status: "processing",
+            bootstrap_state: "initializing",
+            progress_seq: 1,
+        });
+        streamProgressMock.mockResolvedValue(undefined);
+
+        const { result } = renderHook(() => useAuthoringJobProgress());
+
+        await waitFor(() => {
+            expect(result.current.status).toBe("processing");
+            expect(result.current.bootstrapState).toBe("initializing");
+        });
+
+        expect(result.current.activeAgent).toBeUndefined();
     });
 
     it("clears stale persisted job state when bootstrap progress returns 404", async () => {

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiError, api } from "@/shared/api";
 import {
     AUTHORING_PROGRESS_STEP_IDS,
+    type AuthoringBootstrapState,
     type AuthoringProgressStep,
     type AuthoringJobCreateRequest,
     type AuthoringJobStatusResponse,
@@ -87,6 +88,10 @@ function isAuthoringProgressStep(value: unknown): value is AuthoringProgressStep
     return typeof value === "string" && AUTHORING_PROGRESS_STEP_SET.has(value);
 }
 
+function isAuthoringBootstrapState(value: unknown): value is AuthoringBootstrapState {
+    return value === "initializing";
+}
+
 function getProgressStreamErrorMessage(error: unknown) {
     if (error instanceof ApiError) {
         if (error.status === 503 && error.retryAfterSeconds) {
@@ -147,6 +152,7 @@ export function useAuthoringJobProgress() {
     const [result, setResult] = useState<CanonicalCaseOutput | null>(null);
     const [isStreaming, setIsStreaming] = useState(false);
     const [progressScope, setProgressScope] = useState<ProgressScope | null>(null);
+    const [bootstrapState, setBootstrapState] = useState<AuthoringBootstrapState | undefined>(undefined);
 
     const streamAbortRef = useRef<AbortController | null>(null);
 
@@ -160,13 +166,14 @@ export function useAuthoringJobProgress() {
         setResult(null);
         setIsStreaming(false);
         setProgressScope(null);
+        setBootstrapState(undefined);
         clearPersistedActiveAuthoringJob();
     }, []);
 
     const startStreaming = useCallback((
         id: string,
         scope: ProgressScope,
-        opts?: { persist?: boolean; preserveActiveAgent?: boolean },
+        opts?: { persist?: boolean; preserveActiveAgent?: boolean; preserveActiveBootstrapState?: boolean },
     ) => {
         streamAbortRef.current?.abort();
 
@@ -180,6 +187,9 @@ export function useAuthoringJobProgress() {
         setResult(null);
         if (!opts?.preserveActiveAgent) {
             setActiveAgent(undefined);
+        }
+        if (!opts?.preserveActiveBootstrapState) {
+            setBootstrapState(undefined);
         }
 
         if (opts?.persist !== false) {
@@ -198,6 +208,12 @@ export function useAuthoringJobProgress() {
                             if (isAuthoringJobStatus(nextStatus)) {
                                 setStatus(nextStatus);
                             }
+                            const nextBootstrapState = payload.bootstrap_state;
+                            setBootstrapState(
+                                isAuthoringBootstrapState(nextBootstrapState)
+                                    ? nextBootstrapState
+                                    : undefined,
+                            );
                             return;
                         }
 
@@ -205,6 +221,7 @@ export function useAuthoringJobProgress() {
                             const node = payload.node;
                             if (typeof node === "string") {
                                 setActiveAgent(node as AuthoringProgressStep);
+                                setBootstrapState(undefined);
                             }
                             return;
                         }
@@ -220,6 +237,7 @@ export function useAuthoringJobProgress() {
 
                             setStatus("completed");
                             setIsStreaming(false);
+                            setBootstrapState(undefined);
                             clearPersistedActiveAuthoringJob();
                             controller.abort();
                             return;
@@ -238,6 +256,7 @@ export function useAuthoringJobProgress() {
                             );
                             setStatus(nextStatus);
                             setIsStreaming(false);
+                            setBootstrapState(undefined);
                             if (nextStatus !== "failed_resumable") {
                                 clearPersistedActiveAuthoringJob();
                             }
@@ -261,6 +280,7 @@ export function useAuthoringJobProgress() {
                 setErrorTrace(getProgressStreamErrorMessage(error));
                 setStatus("failed");
                 setIsStreaming(false);
+                setBootstrapState(undefined);
                 clearPersistedActiveAuthoringJob();
             })
             .finally(() => {
@@ -286,12 +306,16 @@ export function useAuthoringJobProgress() {
                 const checkpointStep = isAuthoringProgressStep(snapshot.current_step)
                     ? snapshot.current_step
                     : undefined;
+                const nextBootstrapState = isAuthoringBootstrapState(snapshot.bootstrap_state)
+                    ? snapshot.bootstrap_state
+                    : undefined;
 
                 if (snapshot.status === "completed") {
                     const resultResponse = await api.authoring.getResult(id);
                     setResult(toCanonicalCaseOutput(resultResponse));
                     setStatus("completed");
                     setIsStreaming(false);
+                    setBootstrapState(undefined);
                     clearPersistedActiveAuthoringJob();
                     return;
                 }
@@ -300,6 +324,7 @@ export function useAuthoringJobProgress() {
                     setStatus(snapshot.status);
                     setErrorTrace(getTerminalErrorMessage(snapshot.status, snapshot.error_trace));
                     setIsStreaming(false);
+                    setBootstrapState(undefined);
                     if (snapshot.status !== "failed_resumable") {
                         clearPersistedActiveAuthoringJob();
                     }
@@ -307,6 +332,7 @@ export function useAuthoringJobProgress() {
                 }
 
                 setStatus(snapshot.status);
+                setBootstrapState(nextBootstrapState);
                 if (checkpointStep) {
                     setActiveAgent(checkpointStep);
                 }
@@ -314,6 +340,7 @@ export function useAuthoringJobProgress() {
                 startStreaming(id, scope, {
                     persist: opts.persist,
                     preserveActiveAgent: true,
+                    preserveActiveBootstrapState: true,
                 });
             } catch (error) {
                 if (error instanceof ApiError && error.status === 404) {
@@ -321,6 +348,7 @@ export function useAuthoringJobProgress() {
                     setJobId(null);
                     setProgressScope(null);
                     setActiveAgent(undefined);
+                    setBootstrapState(undefined);
                     setErrorTrace(STALE_RECOVERY_MESSAGE);
                     setStatus("failed");
                     setIsStreaming(false);
@@ -330,6 +358,7 @@ export function useAuthoringJobProgress() {
                 setErrorTrace(getProgressStreamErrorMessage(error));
                 setStatus("failed");
                 setIsStreaming(false);
+                setBootstrapState(undefined);
             }
         },
         [startStreaming],
@@ -408,5 +437,6 @@ export function useAuthoringJobProgress() {
         reset,
         isStreaming,
         progressScope,
+        bootstrapState,
     };
 }

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
@@ -288,6 +288,9 @@ export function useAuthoringJobProgress() {
             setErrorTrace(null);
             setStatus("pending");
             const retryResponse = await api.authoring.retryJob(retryTargetJobId);
+            if (!retryResponse.job_id || typeof retryResponse.job_id !== "string") {
+                throw new Error("El servidor devolvio una respuesta de reintento invalida.");
+            }
             startStreaming(retryResponse.job_id, scope);
         } catch (error) {
             setErrorTrace(error instanceof Error ? error.message : "Error de red");

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
@@ -2,16 +2,21 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { ApiError, api } from "@/shared/api";
 import {
+    AUTHORING_PROGRESS_STEP_IDS,
     type AuthoringProgressStep,
     type AuthoringJobCreateRequest,
     type AuthoringJobStatusResponse,
+    type AuthoringJobResultResponse,
     type CanonicalCaseOutput,
     type CaseFormData,
 } from "@/shared/adam-types";
 
 const ACTIVE_AUTHORING_JOB_STORAGE_KEY = "adam_authoring_active_job";
+const STALE_RECOVERY_MESSAGE = "La sesion de recuperacion ya no esta disponible. Vuelve al formulario para iniciar una nueva generacion.";
 
 type ProgressScope = "narrative" | "technical";
+
+const AUTHORING_PROGRESS_STEP_SET = new Set<string>(AUTHORING_PROGRESS_STEP_IDS);
 
 interface PersistedActiveAuthoringJob {
     jobId: string;
@@ -78,6 +83,10 @@ function isAuthoringJobStatus(value: unknown): value is AuthoringJobStatusRespon
     );
 }
 
+function isAuthoringProgressStep(value: unknown): value is AuthoringProgressStep {
+    return typeof value === "string" && AUTHORING_PROGRESS_STEP_SET.has(value);
+}
+
 function getProgressStreamErrorMessage(error: unknown) {
     if (error instanceof ApiError) {
         if (error.status === 503 && error.retryAfterSeconds) {
@@ -87,6 +96,26 @@ function getProgressStreamErrorMessage(error: unknown) {
     }
 
     return "No se pudo conectar al canal de progreso en tiempo real.";
+}
+
+function getTerminalErrorMessage(status: AuthoringJobStatusResponse["status"], detail?: unknown) {
+    if (typeof detail === "string" && detail.trim() !== "") {
+        return detail;
+    }
+
+    if (status === "failed_resumable") {
+        return "La generacion se interrumpio por un error transitorio. Puedes reintentar sin perder el progreso ya completado.";
+    }
+
+    return "Error del servidor durante la generacion.";
+}
+
+function toCanonicalCaseOutput(response: AuthoringJobResultResponse): CanonicalCaseOutput {
+    if (response.canonical_output && typeof response.canonical_output === "object") {
+        return response.canonical_output as CanonicalCaseOutput;
+    }
+
+    return response as unknown as CanonicalCaseOutput;
 }
 
 export function buildAuthoringJobCreateRequest(formData: CaseFormData): AuthoringJobCreateRequest {
@@ -134,7 +163,11 @@ export function useAuthoringJobProgress() {
         clearPersistedActiveAuthoringJob();
     }, []);
 
-    const startStreaming = useCallback((id: string, scope: ProgressScope, opts?: { persist?: boolean }) => {
+    const startStreaming = useCallback((
+        id: string,
+        scope: ProgressScope,
+        opts?: { persist?: boolean; preserveActiveAgent?: boolean },
+    ) => {
         streamAbortRef.current?.abort();
 
         const controller = new AbortController();
@@ -145,7 +178,9 @@ export function useAuthoringJobProgress() {
         setIsStreaming(true);
         setErrorTrace(null);
         setResult(null);
-        setActiveAgent(undefined);
+        if (!opts?.preserveActiveAgent) {
+            setActiveAgent(undefined);
+        }
 
         if (opts?.persist !== false) {
             persistActiveAuthoringJob({ jobId: id, scope });
@@ -235,15 +270,79 @@ export function useAuthoringJobProgress() {
             });
     }, []);
 
+    const bootstrapResumedJob = useCallback(
+        async (
+            id: string,
+            scope: ProgressScope,
+            opts: { persist?: boolean },
+        ) => {
+            setJobId(id);
+            setProgressScope(scope);
+            setResult(null);
+            setErrorTrace(null);
+
+            try {
+                const snapshot = await api.authoring.getProgress(id);
+                const checkpointStep = isAuthoringProgressStep(snapshot.current_step)
+                    ? snapshot.current_step
+                    : undefined;
+
+                if (snapshot.status === "completed") {
+                    const resultResponse = await api.authoring.getResult(id);
+                    setResult(toCanonicalCaseOutput(resultResponse));
+                    setStatus("completed");
+                    setIsStreaming(false);
+                    clearPersistedActiveAuthoringJob();
+                    return;
+                }
+
+                if (snapshot.status === "failed" || snapshot.status === "failed_resumable") {
+                    setStatus(snapshot.status);
+                    setErrorTrace(getTerminalErrorMessage(snapshot.status, snapshot.error_trace));
+                    setIsStreaming(false);
+                    if (snapshot.status !== "failed_resumable") {
+                        clearPersistedActiveAuthoringJob();
+                    }
+                    return;
+                }
+
+                setStatus(snapshot.status);
+                if (checkpointStep) {
+                    setActiveAgent(checkpointStep);
+                }
+
+                startStreaming(id, scope, {
+                    persist: opts.persist,
+                    preserveActiveAgent: true,
+                });
+            } catch (error) {
+                if (error instanceof ApiError && error.status === 404) {
+                    clearPersistedActiveAuthoringJob();
+                    setJobId(null);
+                    setProgressScope(null);
+                    setActiveAgent(undefined);
+                    setErrorTrace(STALE_RECOVERY_MESSAGE);
+                    setStatus("failed");
+                    setIsStreaming(false);
+                    return;
+                }
+
+                setErrorTrace(getProgressStreamErrorMessage(error));
+                setStatus("failed");
+                setIsStreaming(false);
+            }
+        },
+        [startStreaming],
+    );
+
     useEffect(() => {
         const persisted = readPersistedActiveAuthoringJob();
         if (!persisted) {
             return;
         }
 
-        setStatus("processing");
-        startStreaming(persisted.jobId, persisted.scope, { persist: false });
-    }, [startStreaming]);
+        void bootstrapResumedJob(persisted.jobId, persisted.scope, { persist: false });
+    }, [bootstrapResumedJob]);
 
     const submitJob = useCallback(
         async (formData: CaseFormData) => {
@@ -291,12 +390,12 @@ export function useAuthoringJobProgress() {
             if (!retryResponse.job_id || typeof retryResponse.job_id !== "string") {
                 throw new Error("El servidor devolvio una respuesta de reintento invalida.");
             }
-            startStreaming(retryResponse.job_id, scope);
+            await bootstrapResumedJob(retryResponse.job_id, scope, { persist: true });
         } catch (error) {
             setErrorTrace(error instanceof Error ? error.message : "Error de red");
             setStatus("failed");
         }
-    }, [jobId, progressScope, startStreaming]);
+    }, [bootstrapResumedJob, jobId, progressScope]);
 
     return {
         jobId,

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
@@ -68,6 +68,16 @@ function parseEventPayload(data: string) {
     return JSON.parse(data) as Record<string, unknown>;
 }
 
+function isAuthoringJobStatus(value: unknown): value is AuthoringJobStatusResponse["status"] {
+    return (
+        value === "pending"
+        || value === "processing"
+        || value === "completed"
+        || value === "failed"
+        || value === "failed_resumable"
+    );
+}
+
 function getProgressStreamErrorMessage(error: unknown) {
     if (error instanceof ApiError) {
         if (error.status === 503 && error.retryAfterSeconds) {
@@ -134,6 +144,8 @@ export function useAuthoringJobProgress() {
         setProgressScope(scope);
         setIsStreaming(true);
         setErrorTrace(null);
+        setResult(null);
+        setActiveAgent(undefined);
 
         if (opts?.persist !== false) {
             persistActiveAuthoringJob({ jobId: id, scope });
@@ -148,8 +160,8 @@ export function useAuthoringJobProgress() {
 
                         if (event === "metadata") {
                             const nextStatus = payload.status;
-                            if (typeof nextStatus === "string") {
-                                setStatus(nextStatus as AuthoringJobStatusResponse["status"]);
+                            if (isAuthoringJobStatus(nextStatus)) {
+                                setStatus(nextStatus);
                             }
                             return;
                         }
@@ -179,15 +191,21 @@ export function useAuthoringJobProgress() {
                         }
 
                         if (event === "error") {
+                            const payloadStatus = payload.status;
+                            const nextStatus = isAuthoringJobStatus(payloadStatus)
+                                ? payloadStatus
+                                : "failed";
                             const detail = payload.detail;
                             setErrorTrace(
                                 typeof detail === "string"
                                     ? detail
                                     : "Error del servidor durante la generacion.",
                             );
-                            setStatus("failed");
+                            setStatus(nextStatus);
                             setIsStreaming(false);
-                            clearPersistedActiveAuthoringJob();
+                            if (nextStatus !== "failed_resumable") {
+                                clearPersistedActiveAuthoringJob();
+                            }
                             controller.abort();
                         }
                     } catch {
@@ -250,5 +268,43 @@ export function useAuthoringJobProgress() {
         [reset, startStreaming],
     );
 
-    return { jobId, status, errorTrace, result, activeAgent, submitJob, reset, isStreaming, progressScope };
+    const retryJob = useCallback(async () => {
+        const retryTargetJobId = jobId;
+        if (!retryTargetJobId) {
+            setErrorTrace("No se encontro un job para reintentar.");
+            setStatus("failed");
+            return;
+        }
+
+        const persisted = readPersistedActiveAuthoringJob();
+        const scope = progressScope ?? persisted?.scope;
+        if (!scope) {
+            setErrorTrace("No se pudo recuperar el contexto del progreso para reintentar.");
+            setStatus("failed");
+            return;
+        }
+
+        try {
+            setErrorTrace(null);
+            setStatus("pending");
+            const retryResponse = await api.authoring.retryJob(retryTargetJobId);
+            startStreaming(retryResponse.job_id, scope);
+        } catch (error) {
+            setErrorTrace(error instanceof Error ? error.message : "Error de red");
+            setStatus("failed");
+        }
+    }, [jobId, progressScope, startStreaming]);
+
+    return {
+        jobId,
+        status,
+        errorTrace,
+        result,
+        activeAgent,
+        submitJob,
+        retryJob,
+        reset,
+        isStreaming,
+        progressScope,
+    };
 }

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -183,7 +183,12 @@ export interface SuggestResponse {
 
 
 // API responses used by the teacher authoring flow.
-export type AuthoringJobStatus = "pending" | "processing" | "completed" | "failed";
+export type AuthoringJobStatus =
+    | "pending"
+    | "processing"
+    | "completed"
+    | "failed"
+    | "failed_resumable";
 
 export const AUTHORING_PROGRESS_STEP_IDS = [
     "case_architect",
@@ -225,6 +230,12 @@ export interface AuthoringJobResultResponse {
         student_artifacts?: Record<string, unknown>;
     };
     canonical_output?: CanonicalCaseOutput;    // v5.0 — Option D
+}
+
+export interface AuthoringJobRetryResponse {
+    job_id: string;
+    status: "accepted";
+    message: string;
 }
 
 export type AppState = "idle" | "generating" | "success" | "editing" | "error";

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -202,6 +202,7 @@ export const AUTHORING_PROGRESS_STEP_IDS = [
 
 export type AuthoringProgressStep = (typeof AUTHORING_PROGRESS_STEP_IDS)[number];
 export type AuthoringProgressCheckpoint = AuthoringProgressStep | "completed" | "failed";
+export type AuthoringBootstrapState = "initializing";
 
 export interface AuthoringJobStatusResponse {
     job_id: string;
@@ -216,6 +217,8 @@ export interface AuthoringJobProgressSnapshotResponse {
     job_id: string;
     status: AuthoringJobStatus;
     current_step?: AuthoringProgressCheckpoint;
+    progress_percentage?: number;
+    bootstrap_state?: AuthoringBootstrapState;
     progress_seq?: number;
     progress_ts?: string;
     error_code?: string;

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -290,6 +290,17 @@ describe("api auth + stream glue", () => {
                     status: 200,
                     headers: { "Content-Type": "application/json" },
                 }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    status: "processing",
+                    current_step: "case_writer",
+                    progress_seq: 2,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
             );
         vi.stubGlobal("fetch", fetchMock);
 
@@ -312,6 +323,76 @@ describe("api auth + stream glue", () => {
             .map((event) => (JSON.parse(event.data) as { node: string }).node);
         expect(nodes).toEqual(["m3_content_generator"]);
 
+        expect(removeChannelMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("reconciles a terminal backend failure after realtime channel error", async () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+
+        const channel = {
+            on: vi.fn().mockReturnThis(),
+            subscribe: vi.fn((handler: (status: string) => void) => {
+                handler("SUBSCRIBED");
+                queueMicrotask(() => handler("CHANNEL_ERROR"));
+                return channel;
+            }),
+        };
+        const removeChannelMock = vi.fn().mockResolvedValue(undefined);
+
+        createClientMock.mockImplementationOnce(() => ({
+            auth: {
+                getSession: getSessionMock,
+            },
+            channel: vi.fn(() => channel),
+            removeChannel: removeChannelMock,
+        }));
+
+        const events: Array<{ event: string; data: string }> = [];
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    status: "processing",
+                    current_step: "case_architect",
+                    progress_seq: 1,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    status: "processing",
+                    current_step: "case_architect",
+                    progress_seq: 1,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    status: "failed",
+                    current_step: "failed",
+                    progress_seq: 2,
+                    error_trace: "checkpoint unavailable",
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await api.authoring.streamProgress("job-1", (event) => events.push(event));
+
+        expect(events).toContainEqual({ event: "metadata", data: "{\"status\":\"failed\"}" });
+        expect(events).toContainEqual({
+            event: "error",
+            data: "{\"status\":\"failed\",\"detail\":\"checkpoint unavailable\"}",
+        });
         expect(removeChannelMock).toHaveBeenCalledTimes(1);
     });
 

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -20,6 +20,21 @@ vi.mock("@supabase/supabase-js", () => ({
 
 import { ApiError, api, formatHttpError, resetApiClientForTests } from "./api";
 
+async function flushAsyncWork() {
+    for (let tick = 0; tick < 10; tick += 1) {
+        await Promise.resolve();
+    }
+}
+
+async function flushAsyncWorkUntil(check: () => boolean, maxTicks = 50) {
+    for (let tick = 0; tick < maxTicks; tick += 1) {
+        if (check()) {
+            return;
+        }
+        await Promise.resolve();
+    }
+}
+
 describe("api auth + stream glue", () => {
     beforeEach(() => {
         resetApiClientForTests();
@@ -35,6 +50,7 @@ describe("api auth + stream glue", () => {
     });
 
     afterEach(() => {
+        vi.useRealTimers();
         vi.restoreAllMocks();
     });
 
@@ -245,6 +261,7 @@ describe("api auth + stream glue", () => {
     });
 
     it("ignores stale post-subscribe snapshots after newer realtime progress", async () => {
+        vi.useFakeTimers();
         vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
         vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
 
@@ -267,6 +284,7 @@ describe("api auth + stream glue", () => {
         }));
 
         const events: Array<{ event: string; data: string }> = [];
+        const controller = new AbortController();
 
         const fetchMock = vi.fn()
             .mockResolvedValueOnce(
@@ -304,14 +322,15 @@ describe("api auth + stream glue", () => {
             );
         vi.stubGlobal("fetch", fetchMock);
 
-        const streamPromise = api.authoring.streamProgress("job-1", (event) => events.push(event));
-
-        await expect(streamPromise).rejects.toMatchObject(
-            {
-                status: 502,
-                message: "No se pudo abrir el canal de progreso en tiempo real.",
-            } satisfies Pick<ApiError, "status" | "message">,
+        const streamPromise = api.authoring.streamProgress(
+            "job-1",
+            (event) => events.push(event),
+            controller.signal,
         );
+
+        await flushAsyncWork();
+        controller.abort();
+        await streamPromise;
 
         const statuses = events
             .filter((event) => event.event === "metadata")
@@ -324,6 +343,7 @@ describe("api auth + stream glue", () => {
         expect(nodes).toEqual(["m3_content_generator"]);
 
         expect(removeChannelMock).toHaveBeenCalledTimes(1);
+        expect(vi.getTimerCount()).toBe(0);
     });
 
     it("reconciles a terminal backend failure after realtime channel error", async () => {
@@ -415,30 +435,79 @@ describe("api auth + stream glue", () => {
         );
     });
 
-    it("fails with explicit realtime channel error when client is unavailable", async () => {
-        vi.stubGlobal(
-            "fetch",
-            vi.fn().mockResolvedValue(
+    it("falls back to polling when realtime client is unavailable and stops on completed", async () => {
+        vi.useFakeTimers();
+
+        const events: Array<{ event: string; data: string }> = [];
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(
                 new Response(JSON.stringify({
                     job_id: "job-1",
                     status: "processing",
                     current_step: "case_writer",
+                    progress_seq: 2,
                 }), {
                     status: 200,
                     headers: { "Content-Type": "application/json" },
                 }),
-            ),
-        );
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    status: "processing",
+                    current_step: "m4_content_generator",
+                    progress_seq: 4,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    status: "completed",
+                    current_step: "completed",
+                    progress_seq: 5,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    assignment_id: "assignment-1",
+                    blueprint: {},
+                    canonical_output: { title: "Case" },
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
 
-        await expect(api.authoring.streamProgress("job-1", () => undefined)).rejects.toMatchObject(
-            {
-                status: 503,
-                message: "No se pudo conectar al canal de progreso en tiempo real.",
-            } satisfies Pick<ApiError, "status" | "message">,
-        );
+        const streamPromise = api.authoring.streamProgress("job-1", (event) => events.push(event));
+
+        await flushAsyncWork();
+        await vi.advanceTimersByTimeAsync(3000);
+        await streamPromise;
+
+        const nodes = events
+            .filter((event) => event.event === "message")
+            .map((event) => (JSON.parse(event.data) as { node: string }).node);
+        expect(nodes).toEqual(["case_writer", "m4_content_generator"]);
+        expect(events).toContainEqual({ event: "metadata", data: "{\"status\":\"completed\"}" });
+        expect(events[events.length - 1]).toEqual({
+            event: "result",
+            data: "{\"canonical_output\":{\"title\":\"Case\"}}",
+        });
+        expect(vi.getTimerCount()).toBe(0);
     });
 
-    it("ignores non-canonical current_step values", async () => {
+    it("ignores non-canonical current_step values while polling fallback stays active", async () => {
+        vi.useFakeTimers();
+
+        const controller = new AbortController();
         const events: Array<{ event: string; data: string }> = [];
         const fetchMock = vi.fn().mockResolvedValue(
             new Response(JSON.stringify({
@@ -452,16 +521,95 @@ describe("api auth + stream glue", () => {
         );
         vi.stubGlobal("fetch", fetchMock);
 
-        await expect(api.authoring.streamProgress("job-1", (event) => events.push(event))).rejects.toMatchObject(
-            {
-                status: 503,
-                message: "No se pudo conectar al canal de progreso en tiempo real.",
-            } satisfies Pick<ApiError, "status" | "message">,
+        const streamPromise = api.authoring.streamProgress(
+            "job-1",
+            (event) => events.push(event),
+            controller.signal,
         );
+
+        await flushAsyncWork();
+        controller.abort();
+        await streamPromise;
 
         expect(events).toEqual([
             { event: "metadata", data: "{\"status\":\"processing\"}" },
         ]);
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("does not overlap HTTP polling requests during realtime fallback", async () => {
+        vi.useFakeTimers();
+
+        let resolvePendingPoll: ((value: Response) => void) | undefined;
+        const pendingPollResponse = new Promise<Response>((resolve) => {
+            resolvePendingPoll = resolve;
+        });
+
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    status: "processing",
+                    current_step: "case_writer",
+                    progress_seq: 1,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    status: "processing",
+                    current_step: "case_writer",
+                    progress_seq: 1,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockImplementationOnce(() => pendingPollResponse)
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-1",
+                    assignment_id: "assignment-1",
+                    blueprint: {},
+                    canonical_output: { title: "Case" },
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const streamPromise = api.authoring.streamProgress("job-1", () => undefined);
+
+        await flushAsyncWorkUntil(() => fetchMock.mock.calls.length >= 2);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(3000);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+
+        await vi.advanceTimersByTimeAsync(3000);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+
+        resolvePendingPoll?.(
+            new Response(JSON.stringify({
+                job_id: "job-1",
+                status: "completed",
+                current_step: "completed",
+                progress_seq: 2,
+            }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+
+        await flushAsyncWorkUntil(() => fetchMock.mock.calls.length >= 4);
+        await streamPromise;
+
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+        expect(vi.getTimerCount()).toBe(0);
     });
 
     it("surfaces retry-after metadata when progress snapshot receives 503 backpressure", async () => {

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -153,6 +153,27 @@ describe("api auth + stream glue", () => {
         expect(response.status).toBe("accepted");
     });
 
+    it("fetches the durable progress snapshot from the authoring progress endpoint", async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({
+                job_id: "job-1",
+                status: "processing",
+                current_step: "m4_content_generator",
+                progress_seq: 4,
+            }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await api.authoring.getProgress("job-1");
+
+        expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/authoring/jobs/job-1/progress");
+        expect(response.current_step).toBe("m4_content_generator");
+        expect(response.progress_seq).toBe(4);
+    });
+
     it("reconciles terminal state after subscribe when initial snapshot is stale", async () => {
         vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
         vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -109,6 +109,50 @@ describe("api auth + stream glue", () => {
         expect(events[1]).toEqual({ event: "result", data: "{\"canonical_output\":{\"title\":\"Case\"}}" });
     });
 
+    it("emits resumable terminal error when snapshot is already failed_resumable", async () => {
+        const events: Array<{ event: string; data: string }> = [];
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({
+                job_id: "job-1",
+                status: "failed_resumable",
+                current_step: "m4_content_generator",
+                error_trace: "timeout",
+            }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await api.authoring.streamProgress("job-1", (event) => events.push(event));
+
+        expect(events[0]).toEqual({ event: "metadata", data: "{\"status\":\"failed_resumable\"}" });
+        expect(events).toContainEqual({
+            event: "error",
+            data: "{\"status\":\"failed_resumable\",\"detail\":\"timeout\"}",
+        });
+    });
+
+    it("posts retry requests to the authoring retry endpoint", async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({
+                job_id: "job-1",
+                status: "accepted",
+                message: "Authoring retry accepted and dispatched to queue.",
+            }), {
+                status: 202,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await api.authoring.retryJob("job-1");
+
+        expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/authoring/jobs/job-1/retry");
+        expect((fetchMock.mock.calls[0]?.[1] as RequestInit).method).toBe("POST");
+        expect(response.status).toBe("accepted");
+    });
+
     it("reconciles terminal state after subscribe when initial snapshot is stale", async () => {
         vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
         vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -19,6 +19,7 @@ import type {
     AdminTeacherOptionsResponse,
     AuthoringJobCreateRequest,
     AuthoringJobCreateResponse,
+    AuthoringJobRetryResponse,
     AuthoringProgressStep,
     AuthoringJobProgressSnapshotResponse,
     AuthoringJobResultResponse,
@@ -309,11 +310,12 @@ async function emitTerminalEvent(
         return;
     }
 
-    if (status === "failed") {
+    if (status === "failed" || status === "failed_resumable") {
         const detail = taskPayload.error_trace;
         onEvent({
             event: "error",
             data: JSON.stringify({
+                status,
                 detail:
                     typeof detail === "string" && detail.trim() !== ""
                         ? detail
@@ -403,10 +405,10 @@ async function streamRealtimeProgress(
         return;
     }
 
-    if (snapshot.status === "failed") {
+    if (snapshot.status === "failed" || snapshot.status === "failed_resumable") {
         await emitTerminalEvent(
             jobId,
-            "failed",
+            snapshot.status,
             { error_trace: snapshot.error_trace ?? "Error del servidor durante la generacion." },
             onEvent,
         );
@@ -439,7 +441,11 @@ async function streamRealtimeProgress(
                     emitMonotonicProgress(payload.new.status, taskPayload.current_step, taskPayload.progress_seq);
 
                     const nextStatus = payload.new.status;
-                    if (nextStatus === "completed" || nextStatus === "failed") {
+                    if (
+                        nextStatus === "completed"
+                        || nextStatus === "failed"
+                        || nextStatus === "failed_resumable"
+                    ) {
                         settled = true;
                         void emitTerminalEvent(jobId, nextStatus, taskPayload, onEvent)
                             .then(() => client.removeChannel(channel))
@@ -467,13 +473,17 @@ async function streamRealtimeProgress(
                                 latestSnapshot.progress_seq,
                             );
 
-                            if (latestSnapshot.status !== "completed" && latestSnapshot.status !== "failed") {
+                            if (
+                                latestSnapshot.status !== "completed"
+                                && latestSnapshot.status !== "failed"
+                                && latestSnapshot.status !== "failed_resumable"
+                            ) {
                                 return;
                             }
 
                             settled = true;
                             const terminalPayload =
-                                latestSnapshot.status === "failed"
+                                latestSnapshot.status === "failed" || latestSnapshot.status === "failed_resumable"
                                     ? {
                                           error_trace:
                                               latestSnapshot.error_trace ?? "Error del servidor durante la generacion.",
@@ -531,6 +541,11 @@ export const api = {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(reqBody),
+            });
+        },
+        async retryJob(jobId: string): Promise<AuthoringJobRetryResponse> {
+            return parseJsonResponse<AuthoringJobRetryResponse>(`/authoring/jobs/${jobId}/retry`, {
+                method: "POST",
             });
         },
         async getStatus(jobId: string): Promise<AuthoringJobStatusResponse> {

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -548,6 +548,9 @@ export const api = {
                 method: "POST",
             });
         },
+        async getProgress(jobId: string): Promise<AuthoringJobProgressSnapshotResponse> {
+            return parseJsonResponse<AuthoringJobProgressSnapshotResponse>(`/authoring/jobs/${jobId}/progress`);
+        },
         async getStatus(jobId: string): Promise<AuthoringJobStatusResponse> {
             return parseJsonResponse<AuthoringJobStatusResponse>(`/authoring/jobs/${jobId}`);
         },

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -17,6 +17,7 @@ import type {
     AdminTeacherInviteRequest,
     AdminTeacherInviteResponse,
     AdminTeacherOptionsResponse,
+    AuthoringBootstrapState,
     AuthoringJobCreateRequest,
     AuthoringJobCreateResponse,
     AuthoringJobRetryResponse,
@@ -71,6 +72,14 @@ interface AuthoringJobRealtimeRow {
 }
 
 const AUTHORING_PROGRESS_STEP_SET = new Set<string>(AUTHORING_PROGRESS_STEP_IDS);
+const AUTHORING_PROGRESS_POLL_INTERVAL_MS = 3000;
+
+class ProgressPollingFallbackError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "ProgressPollingFallbackError";
+    }
+}
 
 export interface ApiValidationErrorDetail {
     type: string;
@@ -260,11 +269,30 @@ function asObject(value: unknown): Record<string, unknown> {
     return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
 }
 
-function emitStatusEvent(onEvent: (event: ProgressEvent) => void, status: unknown): void {
+function normalizeBootstrapState(value: unknown): AuthoringBootstrapState | null {
+    if (value !== "initializing") {
+        return null;
+    }
+
+    return value;
+}
+
+function emitMetadataEvent(
+    onEvent: (event: ProgressEvent) => void,
+    status: unknown,
+    bootstrapState?: unknown,
+): void {
     if (typeof status !== "string") {
         return;
     }
-    onEvent({ event: "metadata", data: JSON.stringify({ status }) });
+
+    const normalizedBootstrapState = normalizeBootstrapState(bootstrapState);
+    const payload: { status: string; bootstrap_state?: AuthoringBootstrapState } = { status };
+    if (normalizedBootstrapState) {
+        payload.bootstrap_state = normalizedBootstrapState;
+    }
+
+    onEvent({ event: "metadata", data: JSON.stringify(payload) });
 }
 
 function normalizeProgressStep(value: unknown): AuthoringProgressStep | null {
@@ -332,15 +360,18 @@ async function streamRealtimeProgress(
 ): Promise<void> {
     const snapshot = await parseJsonResponse<AuthoringJobProgressSnapshotResponse>(
         `/authoring/jobs/${jobId}/progress`,
+        { signal },
     );
     let lastProgressSeq = normalizeProgressSeq(snapshot.progress_seq);
     let lastEmittedStatus: string | null = null;
     let lastEmittedStep: AuthoringProgressStep | null = null;
+    let lastBootstrapState: AuthoringBootstrapState | null = null;
 
     const emitMonotonicProgress = (
         status: unknown,
         step: unknown,
         progressSeq: unknown,
+        bootstrapState?: unknown,
     ): void => {
         if (typeof status !== "string") {
             return;
@@ -348,6 +379,7 @@ async function streamRealtimeProgress(
 
         const normalizedStep = normalizeProgressStep(step);
         const normalizedSeq = normalizeProgressSeq(progressSeq);
+        const normalizedBootstrapState = normalizeBootstrapState(bootstrapState);
         const previousStepIndex = getProgressStepIndex(lastEmittedStep);
         const nextStepIndex = getProgressStepIndex(normalizedStep);
 
@@ -387,9 +419,10 @@ async function streamRealtimeProgress(
             lastProgressSeq = normalizedSeq;
         }
 
-        if (status !== lastEmittedStatus) {
-            emitStatusEvent(onEvent, status);
+        if (status !== lastEmittedStatus || normalizedBootstrapState !== lastBootstrapState) {
+            emitMetadataEvent(onEvent, status, normalizedBootstrapState);
             lastEmittedStatus = status;
+            lastBootstrapState = normalizedBootstrapState;
         }
 
         if (normalizedStep && normalizedStep !== lastEmittedStep) {
@@ -398,17 +431,24 @@ async function streamRealtimeProgress(
         }
     };
 
-    emitMonotonicProgress(snapshot.status, snapshot.current_step, snapshot.progress_seq);
+    emitMonotonicProgress(
+        snapshot.status,
+        snapshot.current_step,
+        snapshot.progress_seq,
+        snapshot.bootstrap_state,
+    );
 
     const reconcileLatestSnapshot = async (): Promise<boolean> => {
         const latestSnapshot = await parseJsonResponse<AuthoringJobProgressSnapshotResponse>(
             `/authoring/jobs/${jobId}/progress`,
+            { signal },
         );
 
         emitMonotonicProgress(
             latestSnapshot.status,
             latestSnapshot.current_step,
             latestSnapshot.progress_seq,
+            latestSnapshot.bootstrap_state,
         );
 
         if (latestSnapshot.status === "completed") {
@@ -429,6 +469,86 @@ async function streamRealtimeProgress(
         return false;
     };
 
+    // Realtime is the preferred path. Polling is the durable fallback when the
+    // channel cannot be established or later degrades with CHANNEL_ERROR/TIMED_OUT.
+    const pollProgressUntilTerminal = async (): Promise<void> => {
+        await new Promise<void>((resolve, reject) => {
+            let settled = false;
+            let timer: ReturnType<typeof setInterval> | null = null;
+            let pollInFlight = false;
+
+            const clearTimer = () => {
+                if (timer !== null) {
+                    clearInterval(timer);
+                    timer = null;
+                }
+            };
+
+            const onAbort = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimer();
+                resolve();
+            };
+
+            const fail = (error: unknown) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimer();
+                reject(error);
+            };
+
+            const finish = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimer();
+                resolve();
+            };
+
+            const pollOnce = async () => {
+                if (settled || pollInFlight) {
+                    return;
+                }
+
+                pollInFlight = true;
+                try {
+                    const isTerminal = await reconcileLatestSnapshot();
+                    if (isTerminal) {
+                        finish();
+                    }
+                } catch (error) {
+                    fail(error);
+                } finally {
+                    pollInFlight = false;
+                }
+            };
+
+            if (signal) {
+                if (signal.aborted) {
+                    finish();
+                    return;
+                }
+                signal.addEventListener("abort", onAbort, { once: true });
+            }
+
+            void pollOnce().then(() => {
+                if (settled) {
+                    return;
+                }
+
+                timer = setInterval(() => {
+                    void pollOnce();
+                }, AUTHORING_PROGRESS_POLL_INTERVAL_MS);
+            });
+        });
+    };
+
     if (snapshot.status === "completed") {
         await emitTerminalEvent(jobId, "completed", {}, onEvent);
         return;
@@ -446,108 +566,111 @@ async function streamRealtimeProgress(
 
     const client = getSupabaseClient();
     if (!client || typeof client.channel !== "function" || typeof client.removeChannel !== "function") {
-        throw new ApiError(503, "No se pudo conectar al canal de progreso en tiempo real.");
+        await pollProgressUntilTerminal();
+        return;
     }
 
-    await new Promise<void>((resolve, reject) => {
-        let settled = false;
-        const channel = client
-            .channel(`authoring-job-${jobId}`)
-            .on(
-                "postgres_changes",
-                {
-                    event: "UPDATE",
-                    schema: "public",
-                    table: "authoring_jobs",
-                    filter: `id=eq.${jobId}`,
-                },
-                (payload: { new: AuthoringJobRealtimeRow | null }) => {
-                    if (settled || !payload.new) {
+    try {
+        await new Promise<void>((resolve, reject) => {
+            let settled = false;
+
+            const channel = client
+                .channel(`authoring-job-${jobId}`)
+                .on(
+                    "postgres_changes",
+                    {
+                        event: "UPDATE",
+                        schema: "public",
+                        table: "authoring_jobs",
+                        filter: `id=eq.${jobId}`,
+                    },
+                    (payload: { new: AuthoringJobRealtimeRow | null }) => {
+                        if (settled || !payload.new) {
+                            return;
+                        }
+
+                        const taskPayload = asObject(payload.new.task_payload);
+                        emitMonotonicProgress(payload.new.status, taskPayload.current_step, taskPayload.progress_seq);
+
+                        const nextStatus = payload.new.status;
+                        if (
+                            nextStatus === "completed"
+                            || nextStatus === "failed"
+                            || nextStatus === "failed_resumable"
+                        ) {
+                            settled = true;
+                            void emitTerminalEvent(jobId, nextStatus, taskPayload, onEvent)
+                                .then(() => client.removeChannel(channel))
+                                .then(() => resolve())
+                                .catch((error) => reject(error));
+                        }
+                    },
+                )
+                .subscribe((subscriptionStatus) => {
+                    if (settled) {
                         return;
                     }
 
-                    const taskPayload = asObject(payload.new.task_payload);
-                    emitMonotonicProgress(payload.new.status, taskPayload.current_step, taskPayload.progress_seq);
+                    if (subscriptionStatus === "SUBSCRIBED") {
+                        console.info("[authoring-progress] realtime subscribed", { jobId });
+                        void reconcileLatestSnapshot()
+                            .then((reconciledTerminalState) => {
+                                if (settled) {
+                                    return;
+                                }
 
-                    const nextStatus = payload.new.status;
-                    if (
-                        nextStatus === "completed"
-                        || nextStatus === "failed"
-                        || nextStatus === "failed_resumable"
-                    ) {
-                        settled = true;
-                        void emitTerminalEvent(jobId, nextStatus, taskPayload, onEvent)
-                            .then(() => client.removeChannel(channel))
-                            .then(() => resolve())
-                            .catch((error) => reject(error));
+                                if (!reconciledTerminalState) {
+                                    return;
+                                }
+
+                                settled = true;
+                                void client.removeChannel(channel).then(() => resolve()).catch((error) => reject(error));
+                            })
+                            .catch((error) => {
+                                if (settled) {
+                                    return;
+                                }
+                                settled = true;
+                                void client.removeChannel(channel).finally(() => reject(error));
+                            });
+                        return;
                     }
-                },
-            )
-            .subscribe((subscriptionStatus) => {
+
+                    if (subscriptionStatus === "CHANNEL_ERROR" || subscriptionStatus === "TIMED_OUT") {
+                        console.error("[authoring-progress] realtime subscription failed", {
+                            jobId,
+                            subscriptionStatus,
+                        });
+                        settled = true;
+                        void client.removeChannel(channel)
+                            .catch(() => undefined)
+                            .then(() => reject(new ProgressPollingFallbackError(subscriptionStatus)));
+                    }
+                });
+
+            const onAbort = () => {
                 if (settled) {
                     return;
                 }
+                settled = true;
+                void client.removeChannel(channel).finally(() => resolve());
+            };
 
-                if (subscriptionStatus === "SUBSCRIBED") {
-                    console.info("[authoring-progress] realtime subscribed", { jobId });
-                    void reconcileLatestSnapshot()
-                        .then((reconciledTerminalState) => {
-                            if (settled) {
-                                return;
-                            }
-
-                            if (!reconciledTerminalState) {
-                                return;
-                            }
-
-                            settled = true;
-                            void client.removeChannel(channel).then(() => resolve()).catch((error) => reject(error));
-                        })
-                        .catch((error) => {
-                            if (settled) {
-                                return;
-                            }
-                            settled = true;
-                            void client.removeChannel(channel).finally(() => reject(error));
-                        });
+            if (signal) {
+                if (signal.aborted) {
+                    onAbort();
                     return;
                 }
-
-                if (subscriptionStatus === "CHANNEL_ERROR" || subscriptionStatus === "TIMED_OUT") {
-                    console.error("[authoring-progress] realtime subscription failed", {
-                        jobId,
-                        subscriptionStatus,
-                    });
-                    settled = true;
-                    void client.removeChannel(channel)
-                        .catch(() => undefined)
-                        .then(async () => {
-                            const reconciledTerminalState = await reconcileLatestSnapshot();
-                            if (!reconciledTerminalState) {
-                                throw new ApiError(502, "No se pudo abrir el canal de progreso en tiempo real.");
-                            }
-                        })
-                        .then(() => resolve())
-                        .catch((error) => reject(error));
-                }
-            });
-
-        const onAbort = () => {
-            if (settled) {
-                return;
+                signal.addEventListener("abort", onAbort, { once: true });
             }
-            settled = true;
-            void client.removeChannel(channel).finally(() => resolve());
-        };
-
-        if (signal) {
-            if (signal.aborted) {
-                onAbort();
-                return;
-            }
-            signal.addEventListener("abort", onAbort, { once: true });
+        });
+    } catch (error) {
+        if (error instanceof ProgressPollingFallbackError) {
+            await pollProgressUntilTerminal();
+            return;
         }
-    });
+        throw error;
+    }
 }
 
 export const api = {

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -400,6 +400,35 @@ async function streamRealtimeProgress(
 
     emitMonotonicProgress(snapshot.status, snapshot.current_step, snapshot.progress_seq);
 
+    const reconcileLatestSnapshot = async (): Promise<boolean> => {
+        const latestSnapshot = await parseJsonResponse<AuthoringJobProgressSnapshotResponse>(
+            `/authoring/jobs/${jobId}/progress`,
+        );
+
+        emitMonotonicProgress(
+            latestSnapshot.status,
+            latestSnapshot.current_step,
+            latestSnapshot.progress_seq,
+        );
+
+        if (latestSnapshot.status === "completed") {
+            await emitTerminalEvent(jobId, "completed", {}, onEvent);
+            return true;
+        }
+
+        if (latestSnapshot.status === "failed" || latestSnapshot.status === "failed_resumable") {
+            await emitTerminalEvent(
+                jobId,
+                latestSnapshot.status,
+                { error_trace: latestSnapshot.error_trace ?? "Error del servidor durante la generacion." },
+                onEvent,
+            );
+            return true;
+        }
+
+        return false;
+    };
+
     if (snapshot.status === "completed") {
         await emitTerminalEvent(jobId, "completed", {}, onEvent);
         return;
@@ -461,38 +490,18 @@ async function streamRealtimeProgress(
 
                 if (subscriptionStatus === "SUBSCRIBED") {
                     console.info("[authoring-progress] realtime subscribed", { jobId });
-                    void parseJsonResponse<AuthoringJobProgressSnapshotResponse>(`/authoring/jobs/${jobId}/progress`)
-                        .then((latestSnapshot) => {
+                    void reconcileLatestSnapshot()
+                        .then((reconciledTerminalState) => {
                             if (settled) {
                                 return;
                             }
 
-                            emitMonotonicProgress(
-                                latestSnapshot.status,
-                                latestSnapshot.current_step,
-                                latestSnapshot.progress_seq,
-                            );
-
-                            if (
-                                latestSnapshot.status !== "completed"
-                                && latestSnapshot.status !== "failed"
-                                && latestSnapshot.status !== "failed_resumable"
-                            ) {
+                            if (!reconciledTerminalState) {
                                 return;
                             }
 
                             settled = true;
-                            const terminalPayload =
-                                latestSnapshot.status === "failed" || latestSnapshot.status === "failed_resumable"
-                                    ? {
-                                          error_trace:
-                                              latestSnapshot.error_trace ?? "Error del servidor durante la generacion.",
-                                      }
-                                    : {};
-                            void emitTerminalEvent(jobId, latestSnapshot.status, terminalPayload, onEvent)
-                                .then(() => client.removeChannel(channel))
-                                .then(() => resolve())
-                                .catch((error) => reject(error));
+                            void client.removeChannel(channel).then(() => resolve()).catch((error) => reject(error));
                         })
                         .catch((error) => {
                             if (settled) {
@@ -510,9 +519,16 @@ async function streamRealtimeProgress(
                         subscriptionStatus,
                     });
                     settled = true;
-                    void client.removeChannel(channel).finally(() => {
-                        reject(new ApiError(502, "No se pudo abrir el canal de progreso en tiempo real."));
-                    });
+                    void client.removeChannel(channel)
+                        .catch(() => undefined)
+                        .then(async () => {
+                            const reconciledTerminalState = await reconcileLatestSnapshot();
+                            if (!reconciledTerminalState) {
+                                throw new ApiError(502, "No se pudo abrir el canal de progreso en tiempo real.");
+                            }
+                        })
+                        .then(() => resolve())
+                        .catch((error) => reject(error));
                 }
             });
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,7 +6,6 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable","dom"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
﻿## Summary

Issue #112 closes on branch `feat/issue112-stateful-recovery` with the full Phase 4 validation pass plus follow-up hardening patches driven by real runtime incidents.

This PR now includes the complete stateful recovery path for authoring jobs: durable LangGraph checkpoints, retry/resume continuity, stale-session cleanup on the frontend, cross-loop graph/checkpointer safety, runtime cleanup for the async checkpoint pool, connection leak self-diagnostics, and black-box evidence that resume avoids redoing expensive LLM work.

### Final closure commits
- `21ac465` `chore(qa): final phase 4 validation, cross-loop lock fix and token savings evidence.`
- `1eed943` `fix(runtime): harden checkpoint pool cleanup and stream fallback`
- `0924e71` `docs(runtime): align local backend launcher with localhost postgres`
- `83978da` `fix(backend): implement resilient pool shutdown and leak telemetry (unblock CI).`

## What Changed

### Phase 2, Async checkpoint correction and resume orchestration
- `backend/src/shared/database.py`: lazy async `AsyncConnectionPool`, Windows selector policy guard, pool lifecycle hardening
- `backend/src/case_generator/graph.py`: lazy async `AsyncPostgresSaver`, loop-bound compiled graph singleton, resume skip wrappers
- `backend/src/case_generator/core/authoring.py`: async graph invocation, retry CAS preservation, fail-closed checkpoint infrastructure classification
- `backend/tests/test_authoring_progress_resilience.py`: resilience coverage for concurrency, duplicate retry race, bootstrap failure, and fail-closed checkpoint runtime behavior

### Phase 2.5, Review hardening
| ID | Severity | File | Fix |
|----|----------|------|-----|
| C-1 | CRITICAL | `backend/src/case_generator/core/authoring.py` | Secondary `_CHECKPOINT_INFRA_ERROR_TYPES` chain walk prevents DB infra failures from being misclassified as `failed_resumable` |
| C-2 | CRITICAL | `frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx` | Retry handler try/catch prevents stuck generating state after retry failure |
| H-1 | HIGH | `backend/src/shared/database.py` | Timeout plus dereference on async pool cleanup avoids leaked pools under loop churn |
| H-2 | HIGH | `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts` | `retryResponse.job_id` validation prevents silent bad reconnects |

### Phase 3, Frontend continuity
- Resume bootstrap now starts from `GET /api/authoring/jobs/{job_id}/progress` before realtime reconnect
- Stale `sessionStorage` recovery is cleared on `404`
- Retry clicks are locally deduplicated
- Non-retryable recovery failures no longer render a misleading retry CTA
- Timeline continuity remains stable while realtime catches back up

### Phase 4, Final QA and closure
- `backend/src/case_generator/graph.py`: fixed the live-runtime bug where the graph singleton could reuse a compiled graph/checkpointer from a previous pytest event loop. The compiled graph loop marker is now separate from the init-lock loop marker.
- `backend/tests/test_authoring_progress_resilience.py`: added cross-loop regression coverage proving the graph is rebuilt when the event loop changes.
- `backend/tests/test_phase1b_real.py`: updated the stale `edaDepth` fixture value to the current enum.
- `docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md`: updated with the complete Phase 4 evidence and closure handoff.

### Post-closure runtime hardening
A real remote incident exposed one more operational gap after the Phase 4 landing:
- `job_id` `edba8d63-23f4-47b6-babc-939e5dfb07ec`
- `/api/authoring/jobs/{job_id}/progress` still returned `200` with `status=processing`
- Realtime subscription failed in the browser
- the backend then raised `psycopg_pool.PoolTimeout` while initializing the durable saver and failed closed as `checkpoint_unavailable`
- no durable rows were written for that thread

The hardening patch in `1eed943` addresses that path directly:
- `backend/src/shared/database.py`: rejects the local `uv run python -m shared.app` path when `ENVIRONMENT=development` points at a remote Supabase host instead of `localhost:5434`
- `backend/src/shared/database.py`: logs async pool open/close events and exposes explicit close helpers for both LangGraph checkpointer pools
- `backend/src/shared/app.py`: validates the runtime DB target at startup and closes the async checkpointer pool, sync checkpointer pool, compiled graph singleton, and SQLAlchemy engine during FastAPI lifespan shutdown
- `frontend/src/shared/api.ts`: re-reads `/progress` after `CHANNEL_ERROR` or `TIMED_OUT` so terminal backend failures like `checkpoint_unavailable` surface to the teacher instead of collapsing into a generic Realtime error

The follow-up alignment in `0924e71` makes the local path explicit instead of surprising:
- `Makefile`: `make dev-backend` now pins `DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres`
- `README.md` and `docs/runbooks/local-dev-auth.md`: local startup docs now state that the development launcher fails fast if it points at a remote Supabase host

### Post-closure pool leak diagnostics
Commit `83978da` adds connection leak self-diagnostics for CI stability:
- `backend/src/shared/database.py`: pool stats telemetry (`_log_pool_stats`) emits connection counts before and after shutdown, enabling CI to detect leaks without manual inspection
- `backend/src/case_generator/core/authoring.py`: authoring tasks now use named task identifiers to correlate pool activity with specific graph invocations
- `backend/tests/test_phase3_status_api.py`: explicit teardown assertions prove the async pool is fully closed before the next test runs, preventing cross-test connection bleed
- `backend/tests/test_authoring_progress_resilience.py`: updated fixtures to align with the new pool shutdown contract

## Why This Was Necessary
- The original async checkpoint migration fixed `NotImplementedError` on `aget_tuple`, but live async tests still exposed a second defect: `get_graph()` could hand a new loop a graph/checkpointer created on an older loop, which then failed with `asyncio.Lock ... is bound to a different event loop`.
- Resume correctness is not proved by deterministic tests alone. We needed black-box evidence that:
  - checkpoint rows are actually written for the real `thread_id = job_id` path
  - resume on the same durable thread uses fewer LLM tokens than a full rerun
- A follow-up production-like incident then showed a different class of failure: the backend could still starve the durable saver on connection acquisition and leave the UI with a misleading Realtime-only error.
- CI flakiness due to connection pool leaks required explicit pool telemetry and teardown assertions to diagnose and prevent cross-test contamination.

## Validation

### Deterministic
- [x] `uv run --directory backend mypy src` -> clean
- [x] `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py` -> `15 passed`
- [x] `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py` -> `12 passed`
- [x] `uv run --directory backend pytest -q tests/test_phase3_status_api.py tests/test_internal_tasks.py tests/test_authoring_progress_resilience.py` -> `27 passed`
- [x] `uv run --directory backend pytest -q` -> `227 passed, 4 skipped`
- [x] `uv run --directory backend mypy src/shared/database.py src/shared/app.py src/case_generator/graph.py` -> clean
- [x] `npm --prefix frontend run test -- src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts src/features/teacher-authoring/TeacherAuthoringPage.test.tsx src/shared/api.test.ts src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx` -> `35 passed`
- [x] `npm --prefix frontend run test -- src/shared/api.test.ts` -> `20 passed`
- [x] `npm --prefix frontend run test` -> `224 passed`
- [x] `npm --prefix frontend run lint`
- [x] `npm --prefix frontend run lint -- src/shared/api.ts src/shared/api.test.ts`
- [x] `npm --prefix frontend run build`

### Latest local reruns (post `83978da`)
- [x] `uv run --directory backend pytest tests/test_phase3_status_api.py -q -s` -> `10 passed`
- [x] `uv run --directory backend pytest tests/test_authoring_progress_resilience.py -q` -> `13 passed`
- [x] `uv run --directory backend pytest tests/test_phase3_status_api.py tests/test_authoring_progress_resilience.py tests/test_internal_tasks.py -q` -> `28 passed`
- [x] `uv run --directory backend pytest -q` -> `225 passed, 12 skipped`

### SQL Evidence, The Black Box
Real local authoring smoke against `localhost:5434`, through `AuthoringService.run_job()` using durable checkpoints.

| Evidence | Value |
|----|----|
| Smoke `job_id/thread_id` | `2042784e-76a7-4dfb-873c-43105bca5b80` |
| Final job status | `completed` |
| Assignment status | `published` |
| `checkpoints` rows | `25` |
| `checkpoint_blobs` rows | `67` |
| `checkpoint_writes` rows | `317` |

Raw SQL source used in local Postgres:

```sql
select 'checkpoints' as table_name, count(*) as row_count
from checkpoints where thread_id = '2042784e-76a7-4dfb-873c-43105bca5b80'
union all
select 'checkpoint_blobs' as table_name, count(*) as row_count
from checkpoint_blobs where thread_id = '2042784e-76a7-4dfb-873c-43105bca5b80'
union all
select 'checkpoint_writes' as table_name, count(*) as row_count
from checkpoint_writes where thread_id = '2042784e-76a7-4dfb-873c-43105bca5b80';
```

### Token Savings Evidence, Resume vs Full Rerun
Manual durable-graph proof using the same checkpointed thread and LangChain callback accounting.

| Run | Thread ID | Status | LLM Calls | Total Tokens |
|----|----|----|----:|----:|
| Baseline full run | `issue112-baseline-ab4796b7-6582-4a8f-8329-3b73bf0065eb` | completed | 6 | 61,951 |
| Interrupted first attempt | `issue112-resume-dbcc4e93-6731-4d1b-a209-67c26ef1c9e8` | interrupted after `m3_flow` | 2 | 20,377 |
| Resumed second attempt | `issue112-resume-dbcc4e93-6731-4d1b-a209-67c26ef1c9e8` | completed | 4 | 41,581 |

| Comparison | Value |
|----|----:|
| Baseline total tokens | 61,951 |
| Resumed second-attempt total tokens | 41,581 |
| Observed savings | 20,370 |

This is the black-box success criterion for Issue #112: resume on the same durable thread avoids redoing the full expensive path.

## Live LLM Caveat
- `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q` improved to `6 passed, 2 failed` after the cross-loop fix.
- The previous checkpoint/runtime failure did not reproduce.
- The remaining two failures happened under upstream Gemini `503 UNAVAILABLE / high demand` conditions, so they are being treated as live-provider noise, not deterministic checkpoint/runtime regressions in this branch.

## Checklist
- [x] Single-purpose PR
- [x] No secrets added
- [x] Docs updated with Phase 4 evidence and runtime hardening follow-up
- [x] Frontend continuity complete
- [x] Backend deterministic validation green after final fix
- [x] SQL checkpoint evidence captured
- [x] Token savings evidence captured
- [x] Runtime cleanup added for graph/checkpointer resources
- [x] Final runtime hardening commit pushed
- [x] Local launcher docs aligned with localhost Postgres guard
- [x] Pool leak telemetry and teardown assertions added
- [ ] Optional: rerun `live_llm` suite during a calmer Gemini window for a fully green external-provider signal

## Reference
- Full closure record: `docs/planPlataforma/PlanesFases/issue_112_stateful_recovery.md`
