### PR TITLE
Fix bootstrap resilience and synchronize timeouts for issue #120

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -100,6 +100,7 @@ from case_generator.tools_and_schemas import (
 from case_generator.orchestration.frontend_adapter import adapter_canonical_to_legacy
 from case_generator.orchestration.frontend_output_adapter import adapter_legacy_to_canonical_output
 from shared.database import (
+    close_langgraph_checkpointer_async_pool,
     collect_langgraph_bootstrap_diagnostics,
     get_checkpoint_migrations_version,
     get_langgraph_checkpointer_async_pool,
@@ -3315,46 +3316,74 @@ async def _build_async_postgres_checkpointer(*, is_first_init: bool) -> AsyncPos
     """Build the durable async Postgres checkpointer inside an active event loop."""
     current_loop = asyncio.get_running_loop()
     loop_id = id(current_loop)
-    pool = await get_langgraph_checkpointer_async_pool()
-    checkpoint_migrations_version = await get_checkpoint_migrations_version(pool)
-    logger.debug(
-        "[graph] Initializing AsyncPostgresSaver",
-        extra={
-            "loop_id": loop_id,
-            "checkpoint_migrations_version": checkpoint_migrations_version,
-            "bootstrap_is_first_init": is_first_init,
-        },
-    )
+    pool: Any | None = None
+    checkpoint_migrations_version: int | None = None
     setup_started_at = time.perf_counter()
-    checkpointer = AsyncPostgresSaver(cast(Any, pool))
 
     try:
+        pool = await get_langgraph_checkpointer_async_pool()
+        checkpoint_migrations_version = await get_checkpoint_migrations_version(pool)
+        logger.debug(
+            "[graph] Initializing AsyncPostgresSaver",
+            extra={
+                "loop_id": loop_id,
+                "checkpoint_migrations_version": checkpoint_migrations_version,
+                "bootstrap_is_first_init": is_first_init,
+            },
+        )
+        checkpointer = AsyncPostgresSaver(cast(Any, pool))
         # Idempotent bootstrap for local/tests where Alembic metadata may be recreated.
         await checkpointer.setup()
     except asyncio.CancelledError as exc:
         setup_ms = round((time.perf_counter() - setup_started_at) * 1000, 3)
-        await _log_checkpointer_setup_failure(
-            pool=pool,
-            exc=exc,
-            setup_ms=setup_ms,
-            checkpoint_migrations_version=checkpoint_migrations_version,
-            is_first_init=is_first_init,
-            loop_id=loop_id,
-        )
+        if pool is not None:
+            await _log_checkpointer_setup_failure(
+                pool=pool,
+                exc=exc,
+                setup_ms=setup_ms,
+                checkpoint_migrations_version=checkpoint_migrations_version,
+                is_first_init=is_first_init,
+                loop_id=loop_id,
+            )
+        else:
+            logger.error(
+                "[graph] AsyncPostgresSaver setup cancelled before pool bootstrap finished",
+                exc_info=(type(exc), exc, exc.__traceback__),
+                extra={
+                    "loop_id": loop_id,
+                    "bootstrap_setup_ms": setup_ms,
+                    "checkpoint_migrations_version": checkpoint_migrations_version,
+                    "bootstrap_is_first_init": is_first_init,
+                },
+            )
+        await close_langgraph_checkpointer_async_pool()
+        reset_graph_singleton()
         raise
     except Exception as exc:
         setup_ms = round((time.perf_counter() - setup_started_at) * 1000, 3)
-        await _log_checkpointer_setup_failure(
-            pool=pool,
-            exc=exc,
-            setup_ms=setup_ms,
-            checkpoint_migrations_version=checkpoint_migrations_version,
-            is_first_init=is_first_init,
-            loop_id=loop_id,
-        )
-        raise DurableCheckpointUnavailableError(
-            "Durable LangGraph checkpointing is unavailable."
-        ) from exc
+        if pool is not None:
+            await _log_checkpointer_setup_failure(
+                pool=pool,
+                exc=exc,
+                setup_ms=setup_ms,
+                checkpoint_migrations_version=checkpoint_migrations_version,
+                is_first_init=is_first_init,
+                loop_id=loop_id,
+            )
+        else:
+            logger.error(
+                "[graph] AsyncPostgresSaver setup failed before pool bootstrap finished",
+                exc_info=(type(exc), exc, exc.__traceback__),
+                extra={
+                    "loop_id": loop_id,
+                    "bootstrap_setup_ms": setup_ms,
+                    "checkpoint_migrations_version": checkpoint_migrations_version,
+                    "bootstrap_is_first_init": is_first_init,
+                },
+            )
+        await close_langgraph_checkpointer_async_pool()
+        reset_graph_singleton()
+        raise
 
     setup_ms = round((time.perf_counter() - setup_started_at) * 1000, 3)
     logger.info(

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -3318,7 +3318,7 @@ async def _build_async_postgres_checkpointer(*, is_first_init: bool) -> AsyncPos
     loop_id = id(current_loop)
     pool: Any | None = None
     checkpoint_migrations_version: int | None = None
-    setup_started_at = time.perf_counter()
+    setup_started_at: float | None = None
 
     try:
         pool = await get_langgraph_checkpointer_async_pool()
@@ -3332,10 +3332,11 @@ async def _build_async_postgres_checkpointer(*, is_first_init: bool) -> AsyncPos
             },
         )
         checkpointer = AsyncPostgresSaver(cast(Any, pool))
+        setup_started_at = time.perf_counter()
         # Idempotent bootstrap for local/tests where Alembic metadata may be recreated.
         await checkpointer.setup()
     except asyncio.CancelledError as exc:
-        setup_ms = round((time.perf_counter() - setup_started_at) * 1000, 3)
+        setup_ms = 0.0 if setup_started_at is None else round((time.perf_counter() - setup_started_at) * 1000, 3)
         if pool is not None:
             await _log_checkpointer_setup_failure(
                 pool=pool,
@@ -3360,7 +3361,7 @@ async def _build_async_postgres_checkpointer(*, is_first_init: bool) -> AsyncPos
         reset_graph_singleton()
         raise
     except Exception as exc:
-        setup_ms = round((time.perf_counter() - setup_started_at) * 1000, 3)
+        setup_ms = 0.0 if setup_started_at is None else round((time.perf_counter() - setup_started_at) * 1000, 3)
         if pool is not None:
             await _log_checkpointer_setup_failure(
                 pool=pool,
@@ -3385,7 +3386,7 @@ async def _build_async_postgres_checkpointer(*, is_first_init: bool) -> AsyncPos
         reset_graph_singleton()
         raise
 
-    setup_ms = round((time.perf_counter() - setup_started_at) * 1000, 3)
+    setup_ms = 0.0 if setup_started_at is None else round((time.perf_counter() - setup_started_at) * 1000, 3)
     logger.info(
         "[graph] AsyncPostgresSaver initialized",
         extra={

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -61,14 +61,19 @@ def _validate_production_database_url(s: Settings) -> None:
         )
 
 
+def _build_postgres_timeout_options(s: Settings) -> str:
+    """Return the libpq options string for Postgres session-level timeouts."""
+    statement_timeout_ms = max(1, s.db_statement_timeout_ms)
+    lock_timeout_ms = max(1, s.db_lock_timeout_ms)
+    return (
+        f"-c statement_timeout={statement_timeout_ms} "
+        f"-c lock_timeout={lock_timeout_ms}"
+    )
+
+
 def _build_connect_args(s: Settings) -> dict[str, str]:
     """Set session-level statement and lock timeout for every DB connection."""
-    return {
-        "options": (
-            f"-c statement_timeout={max(1, s.db_statement_timeout_ms)} "
-            f"-c lock_timeout={max(1, s.db_lock_timeout_ms)}"
-        )
-    }
+    return {"options": _build_postgres_timeout_options(s)}
 
 
 def _make_engine(s: Settings) -> Engine:
@@ -343,6 +348,7 @@ def _langgraph_pool_kwargs() -> dict[str, object]:
         "autocommit": True,
         "row_factory": dict_row,
         "prepare_threshold": 0,
+        "options": _build_postgres_timeout_options(settings),
     }
 
 

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from unittest.mock import AsyncMock, patch
 
-from psycopg_pool import PoolClosed
+from psycopg_pool import PoolClosed, PoolTimeout
 import pytest
 from sqlalchemy import text
 from sqlalchemy.orm import Session as OrmSession
@@ -486,6 +486,53 @@ async def test_async_checkpointer_pool_logs_stable_pool_open_key_and_warning(mon
     await database_module.close_langgraph_checkpointer_async_pool()
 
 
+async def test_langgraph_async_pool_propagates_statement_timeout_to_real_connection() -> None:
+    await database_module.close_langgraph_checkpointer_async_pool()
+
+    try:
+        pool = await database_module.get_langgraph_checkpointer_async_pool()
+        async with pool.connection() as conn:
+            result = await conn.execute("SHOW statement_timeout")
+            row = await result.fetchone()
+    finally:
+        await database_module.close_langgraph_checkpointer_async_pool()
+
+    statement_timeout = database_module._extract_row_value(row, "statement_timeout")
+    if statement_timeout is None:
+        statement_timeout = row[0]
+
+    assert str(statement_timeout).strip().lower() not in {"0", "0ms", "0s"}
+
+
+async def test_langgraph_async_pool_passes_timeout_options_in_pool_kwargs(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeAsyncConnectionPool:
+        def __init__(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+        async def open(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock_loop", None)
+    monkeypatch.setattr(database_module, "AsyncConnectionPool", FakeAsyncConnectionPool)
+
+    await database_module.get_langgraph_checkpointer_async_pool()
+
+    pool_kwargs = captured["kwargs"]
+    connect_kwargs = pool_kwargs["kwargs"]
+    timeout_options = connect_kwargs["options"]
+    assert f"statement_timeout={database_module.settings.db_statement_timeout_ms}" in timeout_options
+    assert f"lock_timeout={database_module.settings.db_lock_timeout_ms}" in timeout_options
+
+
 def test_validate_runtime_database_configuration_rejects_remote_supabase_in_development() -> None:
     settings = database_module.Settings(
         database_url="postgresql+psycopg://user:pass@aws-1-us-west-2.pooler.supabase.com:5432/postgres",
@@ -650,12 +697,14 @@ async def test_build_async_postgres_checkpointer_preserves_failure_when_diagnost
 ) -> None:
     fake_pool = object()
 
+    original_error = PoolTimeout("setup timed out")
+
     class FailingAsyncPostgresSaver:
         def __init__(self, pool):
             self.pool = pool
 
         async def setup(self) -> None:
-            raise RuntimeError("setup failed")
+            raise original_error
 
     perf_counter_values = iter((0.0, 10.2))
 
@@ -681,8 +730,10 @@ async def test_build_async_postgres_checkpointer_preserves_failure_when_diagnost
 
     caplog.set_level(logging.WARNING, logger="adam.graph")
 
-    with pytest.raises(DurableCheckpointUnavailableError):
+    with pytest.raises(PoolTimeout) as exc_info:
         await graph_module._build_async_postgres_checkpointer(is_first_init=False)
+
+    assert exc_info.value is original_error
 
     warning_record = next(
         record
@@ -700,6 +751,64 @@ async def test_build_async_postgres_checkpointer_preserves_failure_when_diagnost
     assert error_record.checkpoint_migrations_version == 3
     assert error_record.pool_busy == 1
     assert error_record.requests_waiting == 2
+
+
+async def test_build_async_postgres_checkpointer_cleans_up_and_retries_with_fresh_pool(monkeypatch) -> None:
+    created_pools: list[object] = []
+    setup_calls = {"count": 0}
+
+    class FakeAsyncConnectionPool:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            created_pools.append(self)
+
+        async def open(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    class FlakyAsyncPostgresSaver:
+        def __init__(self, pool):
+            self.pool = pool
+
+        async def setup(self) -> None:
+            setup_calls["count"] += 1
+            if setup_calls["count"] == 1:
+                raise PoolTimeout("setup timed out")
+
+    async def fake_get_checkpoint_migrations_version(_pool):
+        return 9
+
+    async def wrapped_close(*args, **kwargs):
+        await database_module.close_langgraph_checkpointer_async_pool(*args, **kwargs)
+
+    reset_mock = patch.object(graph_module, "reset_graph_singleton", wraps=graph_module.reset_graph_singleton)
+
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock_loop", None)
+    monkeypatch.setattr(database_module, "AsyncConnectionPool", FakeAsyncConnectionPool)
+    monkeypatch.setattr(graph_module, "get_langgraph_checkpointer_async_pool", database_module.get_langgraph_checkpointer_async_pool)
+    monkeypatch.setattr(graph_module, "get_checkpoint_migrations_version", fake_get_checkpoint_migrations_version)
+    monkeypatch.setattr(graph_module, "AsyncPostgresSaver", FlakyAsyncPostgresSaver)
+
+    with reset_mock as reset_graph_singleton_mock:
+        close_mock = AsyncMock(side_effect=wrapped_close)
+        monkeypatch.setattr(graph_module, "close_langgraph_checkpointer_async_pool", close_mock)
+
+        with pytest.raises(PoolTimeout):
+            await graph_module._build_async_postgres_checkpointer(is_first_init=True)
+
+        retry_checkpointer = await graph_module._build_async_postgres_checkpointer(is_first_init=True)
+
+    assert close_mock.await_count == 1
+    assert reset_graph_singleton_mock.call_count == 1
+    assert len(created_pools) == 2
+    assert created_pools[0] is not created_pools[1]
+    assert retry_checkpointer.pool is created_pools[1]
 
 
 def test_alembic_upgrade_head_seeds_checkpoint_migrations_to_latest_version(db) -> None:

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -655,12 +655,14 @@ async def test_build_async_postgres_checkpointer_logs_stable_setup_keys_and_warn
         async def setup(self) -> None:
             await asyncio.sleep(0)
 
-    perf_counter_values = iter((0.0, 10.5))
+    perf_counter_values = iter((1.0, 4.0, 10.0, 20.5))
 
     async def fake_get_pool():
+        graph_module.time.perf_counter()
         return fake_pool
 
     async def fake_get_checkpoint_migrations_version(_pool):
+        graph_module.time.perf_counter()
         return 9
 
     monkeypatch.setattr(graph_module, "get_langgraph_checkpointer_async_pool", fake_get_pool)
@@ -706,12 +708,14 @@ async def test_build_async_postgres_checkpointer_preserves_failure_when_diagnost
         async def setup(self) -> None:
             raise original_error
 
-    perf_counter_values = iter((0.0, 10.2))
+    perf_counter_values = iter((1.0, 3.0, 10.0, 20.2))
 
     async def fake_get_pool():
+        graph_module.time.perf_counter()
         return fake_pool
 
     async def fake_get_checkpoint_migrations_version(_pool):
+        graph_module.time.perf_counter()
         return 3
 
     async def fake_collect_diagnostics(_pool):


### PR DESCRIPTION
## Summary
This PR addresses bootstrap resilience and connection timeout synchronization issues identified in #120.

## Validation
- Verified that bootstrap failures now clean up cached LangGraph pool and graph state before re-raising exceptions.
- Confirmed that statement_timeout and lock_timeout are consistently applied across both SQLAlchemy and LangGraph pool connections.
- Added/Updated tests in ackend/tests/test_authoring_progress_resilience.py to ensure stability.

## Why it matters
Ensuring that the application can gracefully recover from bootstrap failures and maintaining consistent timeouts prevents orphaned connections and resource exhaustion in the database pool.

Closes #120