### PR TITLE
fix: harden authoring progress sync and Plotly bootstrap

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -121,7 +121,39 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
-## TODO-008: Monitoreo y alertas de salud del stream de authoring
+## TODO-008: Pool sizing de LangGraph checkpointer para concurrencia bajo Supavisor
+
+**What:** Evaluar y ajustar el pool sizing `(1,1)` del `AsyncConnectionPool` de LangGraph cuando corre sobre Supavisor transaction mode, para soportar 2-5 teachers concurrentes sin serialización innecesaria.
+
+**Why:** Con `max_size=1`, jobs concurrentes de authoring compiten por la misma conexión del checkpointer. Bajo carga, esto serializa operaciones que podrían ser paralelas.
+
+**Pros:** Desbloquea concurrencia real en authoring sin cambiar arquitectura. Mejora latencia percibida cuando múltiples teachers generan casos simultáneamente.
+
+**Cons:** Requiere entender los límites de conexión de Supavisor y el comportamiento de transaction mode con pools más grandes. Riesgo de agotar connection slots si se sobredimensiona.
+
+**Context:** Identificado en la revisión de eng-review de Issues #117-#120. La configuración actual en `_langgraph_checkpointer_pool_bounds()` (database.py:242-246) fue correcta para MVP single-teacher. Ver Issue #121.
+
+**Depends on / blocked by:** Issues #118/#120 (alineación de schema y hardening de pool). Puede implementarse después o en paralelo.
+
+---
+
+## TODO-009: Ceremonia de upgrade de `langgraph-checkpoint-postgres`
+
+**What:** Documentar y seguir una ceremonia explícita cada vez que se actualice la versión de `langgraph-checkpoint-postgres` en `pyproject.toml`: verificar nuevas migraciones en `MIGRATIONS`, crear migración Alembic que siembre versiones adicionales en `checkpoint_migrations`, alinear DDL nuevo con nombres de LangGraph.
+
+**Why:** El root cause del bootstrap timeout (#117) fue la desalineación entre Alembic y el ledger de migraciones de LangGraph. Si se actualiza la dependencia sin verificar migraciones nuevas, el mismo problema puede reaparecer.
+
+**Pros:** Previene regresión del bootstrap timeout en futuras actualizaciones. Formaliza un proceso que hoy es implícito.
+
+**Cons:** Añade un paso manual al upgrade de dependencias. Requiere que quien actualice la dependencia conozca la estructura de `MIGRATIONS` en el paquete.
+
+**Context:** Identificado en la revisión de eng-review de Issue #118. La ceremonia debe incluir: (1) diff de `MIGRATIONS` list, (2) nueva migración Alembic si hay versiones nuevas, (3) alineación de nombres DDL, (4) actualización del pin exacto en `pyproject.toml`.
+
+**Depends on / blocked by:** Issue #118 (establece la línea base de alineación Alembic/LangGraph). No bloquea nada inmediato.
+
+---
+
+## TODO-010: Monitoreo y alertas de salud del stream de authoring
 
 **What:** Agregar telemetría estructurada y tableros/alertas para el flujo realtime de authoring: tasa de suscripción fallida, reconexiones por job, latencia entre persistencia backend y render frontend, y porcentaje de jobs que llegan a `completed` sin eventos intermedios.
 
@@ -137,7 +169,7 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
-## TODO-009: Política de retención y purge de checkpoints LangGraph
+## TODO-011: Política de retención y purge de checkpoints LangGraph
 
 **What:** Definir e implementar una política explícita de retención para tablas de checkpoints (`checkpoints`, `checkpoint_blobs`, `checkpoint_writes`) con purge seguro por antigüedad/estado terminal y guardrails para no borrar sesiones activas.
 
@@ -153,7 +185,7 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
-## TODO-010: Utilidad de reconciliación de artefactos huérfanos legacy
+## TODO-012: Utilidad de reconciliación de artefactos huérfanos legacy
 
 **What:** Crear una utilidad operativa para reconciliar artefactos huérfanos históricos (manifest en DB vs blob en storage) y aplicar remediación controlada (marcar, limpiar o re-vincular según reglas).
 
@@ -169,7 +201,7 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
-## TODO-011: Política de retry budget y circuit breaker para authoring
+## TODO-013: Política de retry budget y circuit breaker para authoring
 
 **What:** Diseñar una política de presupuesto de reintentos por job/tenant y un circuit breaker para fallos transientes repetidos del proveedor LLM, con telemetría y mensajes de fallback consistentes.
 
@@ -185,7 +217,7 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
-## TODO-012: Lifecycle explícito para el singleton async de checkpoints
+## TODO-014: Lifecycle explícito para el singleton async de checkpoints
 
 **What:** Evaluar si el singleton async lazy de `AsyncConnectionPool` + `AsyncPostgresSaver` + grafo compilado debe migrarse a ownership explícito por `lifespan` en `shared.app` y `shared.worker_app`.
 

--- a/frontend/src/app/main.tsx
+++ b/frontend/src/app/main.tsx
@@ -8,6 +8,10 @@ import "./global.css";
 import App from "./App.tsx";
 import { AuthProvider } from "./auth/AuthContext.tsx";
 
+// Plotly dependencies still expect a Node-style global in some browser bundles.
+// Mirror window onto global before importing any charting code at runtime.
+(window as typeof window & { global?: Window }).global = window;
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter basename="/app/">

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.rehydration.test.ts
@@ -5,6 +5,7 @@ import { EMPTY_FORM } from "@/shared/adam-types";
 
 const {
     MockApiError,
+    MockProgressTransportDegradedError,
     getProgressMock,
     submitJobMock,
     retryJobMock,
@@ -21,8 +22,16 @@ const {
         }
     }
 
+    class LocalMockProgressTransportDegradedError extends Error {
+        constructor(message: string) {
+            super(message);
+            this.name = "ProgressTransportDegradedError";
+        }
+    }
+
     return {
         MockApiError: LocalMockApiError,
+        MockProgressTransportDegradedError: LocalMockProgressTransportDegradedError,
         getProgressMock: vi.fn(),
         submitJobMock: vi.fn(),
         retryJobMock: vi.fn(),
@@ -33,6 +42,7 @@ const {
 vi.mock("@/shared/api", () => {
     return {
         ApiError: MockApiError,
+        ProgressTransportDegradedError: MockProgressTransportDegradedError,
         api: {
             authoring: {
                 getProgress: getProgressMock,
@@ -239,6 +249,48 @@ describe("useAuthoringJobProgress rehydration", () => {
         });
         expect(getProgressMock).toHaveBeenCalledWith("job-88");
         expect(streamProgressMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("self-heals a recoverable transport degradation without requiring refresh", async () => {
+        submitJobMock.mockResolvedValue({ job_id: "job-125" });
+        getProgressMock.mockResolvedValue({
+            job_id: "job-125",
+            status: "processing",
+            current_step: "case_writer",
+            bootstrap_state: "initializing",
+            progress_seq: 1,
+        });
+
+        let streamInvocation = 0;
+        streamProgressMock.mockImplementation(async () => {
+            streamInvocation += 1;
+
+            if (streamInvocation === 1) {
+                throw new MockProgressTransportDegradedError("SUBSCRIBE_TIMEOUT");
+            }
+
+            await new Promise(() => undefined);
+        });
+
+        const { result } = renderHook(() => useAuthoringJobProgress());
+
+        await act(async () => {
+            await result.current.submitJob({
+                ...EMPTY_FORM,
+                subject: "Caso",
+                caseType: "harvard_with_eda",
+            });
+        });
+
+        await waitFor(() => {
+            expect(streamProgressMock).toHaveBeenCalledTimes(2);
+        });
+
+        expect(getProgressMock).toHaveBeenCalledWith("job-125");
+        expect(result.current.status).toBe("processing");
+        expect(result.current.activeAgent).toBe("case_writer");
+        expect(result.current.bootstrapState).toBe("initializing");
+        expect(sessionStorage.getItem("adam_authoring_active_job")).toContain("job-125");
     });
 
     it("fails closed when retry returns an invalid payload", async () => {

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { ApiError, api } from "@/shared/api";
+import { ApiError, api, ProgressTransportDegradedError } from "@/shared/api";
 import {
     AUTHORING_PROGRESS_STEP_IDS,
     type AuthoringBootstrapState,
@@ -155,6 +155,10 @@ export function useAuthoringJobProgress() {
     const [bootstrapState, setBootstrapState] = useState<AuthoringBootstrapState | undefined>(undefined);
 
     const streamAbortRef = useRef<AbortController | null>(null);
+    const bootstrapResumedJobRef = useRef<
+        ((id: string, scope: ProgressScope, opts: { persist?: boolean; recoveryAttempt?: number }) => Promise<void>)
+        | null
+    >(null);
 
     const reset = useCallback(() => {
         streamAbortRef.current?.abort();
@@ -173,7 +177,12 @@ export function useAuthoringJobProgress() {
     const startStreaming = useCallback((
         id: string,
         scope: ProgressScope,
-        opts?: { persist?: boolean; preserveActiveAgent?: boolean; preserveActiveBootstrapState?: boolean },
+        opts?: {
+            persist?: boolean;
+            preserveActiveAgent?: boolean;
+            preserveActiveBootstrapState?: boolean;
+            recoveryAttempt?: number;
+        },
     ) => {
         streamAbortRef.current?.abort();
 
@@ -277,6 +286,14 @@ export function useAuthoringJobProgress() {
                     return;
                 }
 
+                if (error instanceof ProgressTransportDegradedError && (opts?.recoveryAttempt ?? 0) < 1) {
+                    void bootstrapResumedJobRef.current?.(id, scope, {
+                        persist: opts?.persist,
+                        recoveryAttempt: (opts?.recoveryAttempt ?? 0) + 1,
+                    });
+                    return;
+                }
+
                 setErrorTrace(getProgressStreamErrorMessage(error));
                 setStatus("failed");
                 setIsStreaming(false);
@@ -294,7 +311,7 @@ export function useAuthoringJobProgress() {
         async (
             id: string,
             scope: ProgressScope,
-            opts: { persist?: boolean },
+            opts: { persist?: boolean; recoveryAttempt?: number },
         ) => {
             setJobId(id);
             setProgressScope(scope);
@@ -341,6 +358,7 @@ export function useAuthoringJobProgress() {
                     persist: opts.persist,
                     preserveActiveAgent: true,
                     preserveActiveBootstrapState: true,
+                    recoveryAttempt: opts.recoveryAttempt,
                 });
             } catch (error) {
                 if (error instanceof ApiError && error.status === 404) {
@@ -363,6 +381,8 @@ export function useAuthoringJobProgress() {
         },
         [startStreaming],
     );
+
+    bootstrapResumedJobRef.current = bootstrapResumedJob;
 
     useEffect(() => {
         const persisted = readPersistedActiveAuthoringJob();

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -260,6 +260,80 @@ describe("api auth + stream glue", () => {
         expect(removeChannelMock).toHaveBeenCalledTimes(1);
     });
 
+    it("reconciles an ultra-fast job that completes before realtime subscribes", async () => {
+        vi.useFakeTimers();
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+
+        const channel = {
+            on: vi.fn().mockReturnThis(),
+            subscribe: vi.fn(() => channel),
+        };
+        const removeChannelMock = vi.fn().mockResolvedValue(undefined);
+
+        createClientMock.mockImplementationOnce(() => ({
+            auth: {
+                getSession: getSessionMock,
+            },
+            channel: vi.fn(() => channel),
+            removeChannel: removeChannelMock,
+        }));
+
+        const events: Array<{ event: string; data: string }> = [];
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-fast",
+                    status: "processing",
+                    bootstrap_state: "initializing",
+                    progress_seq: 1,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-fast",
+                    status: "completed",
+                    current_step: "completed",
+                    progress_seq: 2,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-fast",
+                    assignment_id: "assignment-1",
+                    blueprint: {},
+                    canonical_output: { title: "Ultra fast case" },
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const streamPromise = api.authoring.streamProgress("job-fast", (event) => events.push(event));
+
+        await flushAsyncWork();
+        await vi.advanceTimersByTimeAsync(2000);
+        await streamPromise;
+
+        expect(events).toContainEqual({
+            event: "metadata",
+            data: "{\"status\":\"processing\",\"bootstrap_state\":\"initializing\"}",
+        });
+        expect(events).toContainEqual({ event: "metadata", data: "{\"status\":\"completed\"}" });
+        expect(events[events.length - 1]).toEqual({
+            event: "result",
+            data: "{\"canonical_output\":{\"title\":\"Ultra fast case\"}}",
+        });
+        expect(removeChannelMock).toHaveBeenCalledTimes(1);
+    });
+
     it("ignores stale post-subscribe snapshots after newer realtime progress", async () => {
         vi.useFakeTimers();
         vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
@@ -412,6 +486,94 @@ describe("api auth + stream glue", () => {
         expect(events).toContainEqual({
             event: "error",
             data: "{\"status\":\"failed\",\"detail\":\"checkpoint unavailable\"}",
+        });
+        expect(removeChannelMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("rehydrates state when a subscribed channel stays silent and the backend completes", async () => {
+        vi.useFakeTimers();
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+
+        const channel = {
+            on: vi.fn().mockReturnThis(),
+            subscribe: vi.fn((handler: (status: string) => void) => {
+                handler("SUBSCRIBED");
+                return channel;
+            }),
+        };
+        const removeChannelMock = vi.fn().mockResolvedValue(undefined);
+
+        createClientMock.mockImplementationOnce(() => ({
+            auth: {
+                getSession: getSessionMock,
+            },
+            channel: vi.fn(() => channel),
+            removeChannel: removeChannelMock,
+        }));
+
+        const events: Array<{ event: string; data: string }> = [];
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-silent",
+                    status: "processing",
+                    bootstrap_state: "initializing",
+                    progress_seq: 1,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-silent",
+                    status: "processing",
+                    bootstrap_state: "initializing",
+                    progress_seq: 1,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-silent",
+                    status: "completed",
+                    current_step: "completed",
+                    progress_seq: 2,
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    job_id: "job-silent",
+                    assignment_id: "assignment-1",
+                    blueprint: {},
+                    canonical_output: { title: "Recovered case" },
+                }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const streamPromise = api.authoring.streamProgress("job-silent", (event) => events.push(event));
+
+        await flushAsyncWork();
+        await vi.advanceTimersByTimeAsync(3000);
+        await streamPromise;
+
+        expect(events).toContainEqual({
+            event: "metadata",
+            data: "{\"status\":\"processing\",\"bootstrap_state\":\"initializing\"}",
+        });
+        expect(events).toContainEqual({ event: "metadata", data: "{\"status\":\"completed\"}" });
+        expect(events[events.length - 1]).toEqual({
+            event: "result",
+            data: "{\"canonical_output\":{\"title\":\"Recovered case\"}}",
         });
         expect(removeChannelMock).toHaveBeenCalledTimes(1);
     });

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -596,215 +596,212 @@ async function streamRealtimeProgress(
         await pollProgressUntilTerminal();
         return;
     }
+    const realtimeClient = client;
 
-    try {
-        await new Promise<void>((resolve, reject) => {
-            let settled = false;
-            let subscribed = false;
-            let subscribeWatchdog: ReturnType<typeof setTimeout> | null = null;
-            let silenceWatchdog: ReturnType<typeof setTimeout> | null = null;
+    await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        let subscribed = false;
+        let subscribeWatchdog: ReturnType<typeof setTimeout> | null = null;
+        let silenceWatchdog: ReturnType<typeof setTimeout> | null = null;
 
-            const channel = client
-                .channel(`authoring-job-${jobId}`)
-                .on(
-                    "postgres_changes",
-                    {
-                        event: "UPDATE",
-                        schema: "public",
-                        table: "authoring_jobs",
-                        filter: `id=eq.${jobId}`,
-                    },
-                    (payload: { new: AuthoringJobRealtimeRow | null }) => {
-                        if (settled || !payload.new) {
-                            return;
-                        }
-
-                        const taskPayload = asObject(payload.new.task_payload);
-                        applyProgressUpdate(
-                            payload.new.status,
-                            taskPayload.current_step,
-                            taskPayload.progress_seq,
-                            taskPayload.bootstrap_state,
-                        );
-                        armSilenceWatchdog();
-
-                        const nextStatus = payload.new.status;
-                        if (
-                            nextStatus === "completed"
-                            || nextStatus === "failed"
-                            || nextStatus === "failed_resumable"
-                        ) {
-                            settled = true;
-                            void emitTerminalEvent(jobId, nextStatus, taskPayload, onEvent)
-                                .then(() => client.removeChannel(channel))
-                                .then(() => resolve())
-                                .catch((error) => reject(error));
-                        }
-                    },
-                )
-                .subscribe((subscriptionStatus) => {
-                    if (settled) {
+        const channel = realtimeClient
+            .channel(`authoring-job-${jobId}`)
+            .on(
+                "postgres_changes",
+                {
+                    event: "UPDATE",
+                    schema: "public",
+                    table: "authoring_jobs",
+                    filter: `id=eq.${jobId}`,
+                },
+                (payload: { new: AuthoringJobRealtimeRow | null }) => {
+                    if (settled || !payload.new) {
                         return;
                     }
 
-                    if (subscriptionStatus === "SUBSCRIBED") {
-                        subscribed = true;
-                        clearSubscribeWatchdog();
-                        console.info("[authoring-progress] realtime subscribed", { jobId });
-                        void reconcileLatestSnapshot()
-                            .then((reconciledTerminalState) => {
-                                if (settled) {
-                                    return;
-                                }
+                    const taskPayload = asObject(payload.new.task_payload);
+                    applyProgressUpdate(
+                        payload.new.status,
+                        taskPayload.current_step,
+                        taskPayload.progress_seq,
+                        taskPayload.bootstrap_state,
+                    );
+                    armSilenceWatchdog();
 
-                                if (!reconciledTerminalState) {
-                                    armSilenceWatchdog();
-                                    return;
-                                }
-
-                                settled = true;
-                                void client.removeChannel(channel).then(() => resolve()).catch((error) => reject(error));
-                            })
-                            .catch((error) => {
-                                if (settled) {
-                                    return;
-                                }
-                                settled = true;
-                                void client.removeChannel(channel).finally(() => reject(error));
-                            });
-                        return;
-                    }
-
-                    if (subscriptionStatus === "CHANNEL_ERROR" || subscriptionStatus === "TIMED_OUT" || subscriptionStatus === "CLOSED") {
-                        console.error("[authoring-progress] realtime subscription failed", {
-                            jobId,
-                            subscriptionStatus,
-                        });
-                        clearSubscribeWatchdog();
-                        clearSilenceWatchdog();
-
-                        if (!subscribed) {
-                            settled = true;
-                            void client.removeChannel(channel)
-                                .catch(() => undefined)
-                                .then(async () => {
-                                    const reconciledTerminalState = await reconcileLatestSnapshot();
-                                    if (reconciledTerminalState) {
-                                        resolve();
-                                        return;
-                                    }
-
-                                    reject(new ProgressTransportDegradedError(subscriptionStatus));
-                                })
-                                .catch((error) => reject(error));
-                            return;
-                        }
-
+                    const nextStatus = payload.new.status;
+                    if (
+                        nextStatus === "completed"
+                        || nextStatus === "failed"
+                        || nextStatus === "failed_resumable"
+                    ) {
                         settled = true;
-                        void client.removeChannel(channel)
-                            .catch(() => undefined)
-                            .then(() => pollProgressUntilTerminal())
+                        void emitTerminalEvent(jobId, nextStatus, taskPayload, onEvent)
+                            .then(() => realtimeClient.removeChannel(channel))
                             .then(() => resolve())
                             .catch((error) => reject(error));
                     }
-                });
-
-            function clearSubscribeWatchdog() {
-                if (subscribeWatchdog !== null) {
-                    clearTimeout(subscribeWatchdog);
-                    subscribeWatchdog = null;
-                }
-            }
-
-            function clearSilenceWatchdog() {
-                if (silenceWatchdog !== null) {
-                    clearTimeout(silenceWatchdog);
-                    silenceWatchdog = null;
-                }
-            }
-
-            function armSilenceWatchdog() {
-                if (!subscribed || settled) {
+                },
+            )
+            .subscribe((subscriptionStatus) => {
+                if (settled) {
                     return;
                 }
 
-                clearSilenceWatchdog();
-                silenceWatchdog = setTimeout(() => {
-                    if (settled) {
-                        return;
-                    }
-
-                    console.warn("[authoring-progress] realtime silence detected", { jobId });
+                if (subscriptionStatus === "SUBSCRIBED") {
+                    subscribed = true;
+                    clearSubscribeWatchdog();
+                    console.info("[authoring-progress] realtime subscribed", { jobId });
                     void reconcileLatestSnapshot()
                         .then((reconciledTerminalState) => {
                             if (settled) {
                                 return;
                             }
 
-                            if (reconciledTerminalState) {
-                                settled = true;
-                                clearSilenceWatchdog();
-                                void client.removeChannel(channel).then(() => resolve()).catch((error) => reject(error));
+                            if (!reconciledTerminalState) {
+                                armSilenceWatchdog();
                                 return;
                             }
 
-                            armSilenceWatchdog();
+                            settled = true;
+                            void realtimeClient.removeChannel(channel).then(() => resolve()).catch((error) => reject(error));
                         })
                         .catch((error) => {
                             if (settled) {
                                 return;
                             }
-
                             settled = true;
-                            clearSilenceWatchdog();
-                            void client.removeChannel(channel).finally(() => reject(error));
+                            void realtimeClient.removeChannel(channel).finally(() => reject(error));
                         });
-                }, AUTHORING_REALTIME_SILENCE_TIMEOUT_MS);
-            }
-
-            subscribeWatchdog = setTimeout(() => {
-                if (settled || subscribed) {
                     return;
                 }
 
-                console.warn("[authoring-progress] realtime subscribe watchdog triggered", { jobId });
-                settled = true;
-                clearSubscribeWatchdog();
-                void client.removeChannel(channel)
-                    .catch(() => undefined)
-                    .then(async () => {
-                        const reconciledTerminalState = await reconcileLatestSnapshot();
-                        if (reconciledTerminalState) {
-                            resolve();
-                            return;
-                        }
+                if (subscriptionStatus === "CHANNEL_ERROR" || subscriptionStatus === "TIMED_OUT" || subscriptionStatus === "CLOSED") {
+                    console.error("[authoring-progress] realtime subscription failed", {
+                        jobId,
+                        subscriptionStatus,
+                    });
+                    clearSubscribeWatchdog();
+                    clearSilenceWatchdog();
 
-                        reject(new ProgressTransportDegradedError("SUBSCRIBE_TIMEOUT"));
-                    })
-                    .catch((error) => reject(error));
-            }, AUTHORING_REALTIME_SUBSCRIBE_TIMEOUT_MS);
+                    if (!subscribed) {
+                        settled = true;
+                        void realtimeClient.removeChannel(channel)
+                            .catch(() => undefined)
+                            .then(async () => {
+                                const reconciledTerminalState = await reconcileLatestSnapshot();
+                                if (reconciledTerminalState) {
+                                    resolve();
+                                    return;
+                                }
 
-            const onAbort = () => {
+                                reject(new ProgressTransportDegradedError(subscriptionStatus));
+                            })
+                            .catch((error) => reject(error));
+                        return;
+                    }
+
+                    settled = true;
+                    void realtimeClient.removeChannel(channel)
+                        .catch(() => undefined)
+                        .then(() => pollProgressUntilTerminal())
+                        .then(() => resolve())
+                        .catch((error) => reject(error));
+                }
+            });
+
+        function clearSubscribeWatchdog() {
+            if (subscribeWatchdog !== null) {
+                clearTimeout(subscribeWatchdog);
+                subscribeWatchdog = null;
+            }
+        }
+
+        function clearSilenceWatchdog() {
+            if (silenceWatchdog !== null) {
+                clearTimeout(silenceWatchdog);
+                silenceWatchdog = null;
+            }
+        }
+
+        function armSilenceWatchdog() {
+            if (!subscribed || settled) {
+                return;
+            }
+
+            clearSilenceWatchdog();
+            silenceWatchdog = setTimeout(() => {
                 if (settled) {
                     return;
                 }
-                settled = true;
-                clearSubscribeWatchdog();
-                clearSilenceWatchdog();
-                void client.removeChannel(channel).finally(() => resolve());
-            };
 
-            if (signal) {
-                if (signal.aborted) {
-                    onAbort();
-                    return;
-                }
-                signal.addEventListener("abort", onAbort, { once: true });
+                console.warn("[authoring-progress] realtime silence detected", { jobId });
+                void reconcileLatestSnapshot()
+                    .then((reconciledTerminalState) => {
+                        if (settled) {
+                            return;
+                        }
+
+                        if (reconciledTerminalState) {
+                            settled = true;
+                            clearSilenceWatchdog();
+                            void realtimeClient.removeChannel(channel).then(() => resolve()).catch((error) => reject(error));
+                            return;
+                        }
+
+                        armSilenceWatchdog();
+                    })
+                    .catch((error) => {
+                        if (settled) {
+                            return;
+                        }
+
+                        settled = true;
+                        clearSilenceWatchdog();
+                        void realtimeClient.removeChannel(channel).finally(() => reject(error));
+                    });
+            }, AUTHORING_REALTIME_SILENCE_TIMEOUT_MS);
+        }
+
+        subscribeWatchdog = setTimeout(() => {
+            if (settled || subscribed) {
+                return;
             }
-        });
-    } catch (error) {
-        throw error;
-    }
+
+            console.warn("[authoring-progress] realtime subscribe watchdog triggered", { jobId });
+            settled = true;
+            clearSubscribeWatchdog();
+            void realtimeClient.removeChannel(channel)
+                .catch(() => undefined)
+                .then(async () => {
+                    const reconciledTerminalState = await reconcileLatestSnapshot();
+                    if (reconciledTerminalState) {
+                        resolve();
+                        return;
+                    }
+
+                    reject(new ProgressTransportDegradedError("SUBSCRIBE_TIMEOUT"));
+                })
+                .catch((error) => reject(error));
+        }, AUTHORING_REALTIME_SUBSCRIBE_TIMEOUT_MS);
+
+        const onAbort = () => {
+                    if (settled) {
+                        return;
+                    }
+            settled = true;
+            clearSubscribeWatchdog();
+            clearSilenceWatchdog();
+            void realtimeClient.removeChannel(channel).finally(() => resolve());
+        };
+
+        if (signal) {
+            if (signal.aborted) {
+                onAbort();
+                return;
+            }
+            signal.addEventListener("abort", onAbort, { once: true });
+        }
+    });
 }
 
 export const api = {

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -73,11 +73,13 @@ interface AuthoringJobRealtimeRow {
 
 const AUTHORING_PROGRESS_STEP_SET = new Set<string>(AUTHORING_PROGRESS_STEP_IDS);
 const AUTHORING_PROGRESS_POLL_INTERVAL_MS = 3000;
+const AUTHORING_REALTIME_SUBSCRIBE_TIMEOUT_MS = 1800;
+const AUTHORING_REALTIME_SILENCE_TIMEOUT_MS = AUTHORING_PROGRESS_POLL_INTERVAL_MS;
 
-class ProgressPollingFallbackError extends Error {
+export class ProgressTransportDegradedError extends Error {
     constructor(message: string) {
         super(message);
-        this.name = "ProgressPollingFallbackError";
+        this.name = "ProgressTransportDegradedError";
     }
 }
 
@@ -402,6 +404,7 @@ async function streamRealtimeProgress(
             lastProgressSeq !== null &&
             normalizedSeq === lastProgressSeq &&
             status === lastEmittedStatus &&
+            normalizedBootstrapState === lastBootstrapState &&
             (normalizedStep === null || normalizedStep === lastEmittedStep)
         ) {
             return;
@@ -410,6 +413,7 @@ async function streamRealtimeProgress(
         if (
             normalizedSeq === null &&
             status === lastEmittedStatus &&
+            normalizedBootstrapState === lastBootstrapState &&
             (normalizedStep === null || normalizedStep === lastEmittedStep)
         ) {
             return;
@@ -431,46 +435,69 @@ async function streamRealtimeProgress(
         }
     };
 
-    emitMonotonicProgress(
+    const applyProgressUpdate = (
+        status: unknown,
+        step: unknown,
+        progressSeq: unknown,
+        bootstrapState?: unknown,
+    ) => {
+        emitMonotonicProgress(status, step, progressSeq, bootstrapState);
+    };
+
+    applyProgressUpdate(
         snapshot.status,
         snapshot.current_step,
         snapshot.progress_seq,
         snapshot.bootstrap_state,
     );
 
+    let reconcileInFlight: Promise<boolean> | null = null;
+
     const reconcileLatestSnapshot = async (): Promise<boolean> => {
-        const latestSnapshot = await parseJsonResponse<AuthoringJobProgressSnapshotResponse>(
-            `/authoring/jobs/${jobId}/progress`,
-            { signal },
-        );
-
-        emitMonotonicProgress(
-            latestSnapshot.status,
-            latestSnapshot.current_step,
-            latestSnapshot.progress_seq,
-            latestSnapshot.bootstrap_state,
-        );
-
-        if (latestSnapshot.status === "completed") {
-            await emitTerminalEvent(jobId, "completed", {}, onEvent);
-            return true;
+        if (reconcileInFlight) {
+            return reconcileInFlight;
         }
 
-        if (latestSnapshot.status === "failed" || latestSnapshot.status === "failed_resumable") {
-            await emitTerminalEvent(
-                jobId,
-                latestSnapshot.status,
-                { error_trace: latestSnapshot.error_trace ?? "Error del servidor durante la generacion." },
-                onEvent,
+        reconcileInFlight = (async () => {
+            const latestSnapshot = await parseJsonResponse<AuthoringJobProgressSnapshotResponse>(
+                `/authoring/jobs/${jobId}/progress`,
+                { signal },
             );
-            return true;
-        }
 
-        return false;
+            applyProgressUpdate(
+                latestSnapshot.status,
+                latestSnapshot.current_step,
+                latestSnapshot.progress_seq,
+                latestSnapshot.bootstrap_state,
+            );
+
+            if (latestSnapshot.status === "completed") {
+                await emitTerminalEvent(jobId, "completed", {}, onEvent);
+                return true;
+            }
+
+            if (latestSnapshot.status === "failed" || latestSnapshot.status === "failed_resumable") {
+                await emitTerminalEvent(
+                    jobId,
+                    latestSnapshot.status,
+                    { error_trace: latestSnapshot.error_trace ?? "Error del servidor durante la generacion." },
+                    onEvent,
+                );
+                return true;
+            }
+
+            return false;
+        })();
+
+        try {
+            return await reconcileInFlight;
+        } finally {
+            reconcileInFlight = null;
+        }
     };
 
     // Realtime is the preferred path. Polling is the durable fallback when the
-    // channel cannot be established or later degrades with CHANNEL_ERROR/TIMED_OUT.
+    // client is unavailable or an established channel later degrades.
     const pollProgressUntilTerminal = async (): Promise<void> => {
         await new Promise<void>((resolve, reject) => {
             let settled = false;
@@ -573,6 +600,9 @@ async function streamRealtimeProgress(
     try {
         await new Promise<void>((resolve, reject) => {
             let settled = false;
+            let subscribed = false;
+            let subscribeWatchdog: ReturnType<typeof setTimeout> | null = null;
+            let silenceWatchdog: ReturnType<typeof setTimeout> | null = null;
 
             const channel = client
                 .channel(`authoring-job-${jobId}`)
@@ -590,7 +620,13 @@ async function streamRealtimeProgress(
                         }
 
                         const taskPayload = asObject(payload.new.task_payload);
-                        emitMonotonicProgress(payload.new.status, taskPayload.current_step, taskPayload.progress_seq);
+                        applyProgressUpdate(
+                            payload.new.status,
+                            taskPayload.current_step,
+                            taskPayload.progress_seq,
+                            taskPayload.bootstrap_state,
+                        );
+                        armSilenceWatchdog();
 
                         const nextStatus = payload.new.status;
                         if (
@@ -612,6 +648,8 @@ async function streamRealtimeProgress(
                     }
 
                     if (subscriptionStatus === "SUBSCRIBED") {
+                        subscribed = true;
+                        clearSubscribeWatchdog();
                         console.info("[authoring-progress] realtime subscribed", { jobId });
                         void reconcileLatestSnapshot()
                             .then((reconciledTerminalState) => {
@@ -620,6 +658,7 @@ async function streamRealtimeProgress(
                                 }
 
                                 if (!reconciledTerminalState) {
+                                    armSilenceWatchdog();
                                     return;
                                 }
 
@@ -636,23 +675,122 @@ async function streamRealtimeProgress(
                         return;
                     }
 
-                    if (subscriptionStatus === "CHANNEL_ERROR" || subscriptionStatus === "TIMED_OUT") {
+                    if (subscriptionStatus === "CHANNEL_ERROR" || subscriptionStatus === "TIMED_OUT" || subscriptionStatus === "CLOSED") {
                         console.error("[authoring-progress] realtime subscription failed", {
                             jobId,
                             subscriptionStatus,
                         });
+                        clearSubscribeWatchdog();
+                        clearSilenceWatchdog();
+
+                        if (!subscribed) {
+                            settled = true;
+                            void client.removeChannel(channel)
+                                .catch(() => undefined)
+                                .then(async () => {
+                                    const reconciledTerminalState = await reconcileLatestSnapshot();
+                                    if (reconciledTerminalState) {
+                                        resolve();
+                                        return;
+                                    }
+
+                                    reject(new ProgressTransportDegradedError(subscriptionStatus));
+                                })
+                                .catch((error) => reject(error));
+                            return;
+                        }
+
                         settled = true;
                         void client.removeChannel(channel)
                             .catch(() => undefined)
-                            .then(() => reject(new ProgressPollingFallbackError(subscriptionStatus)));
+                            .then(() => pollProgressUntilTerminal())
+                            .then(() => resolve())
+                            .catch((error) => reject(error));
                     }
                 });
+
+            function clearSubscribeWatchdog() {
+                if (subscribeWatchdog !== null) {
+                    clearTimeout(subscribeWatchdog);
+                    subscribeWatchdog = null;
+                }
+            }
+
+            function clearSilenceWatchdog() {
+                if (silenceWatchdog !== null) {
+                    clearTimeout(silenceWatchdog);
+                    silenceWatchdog = null;
+                }
+            }
+
+            function armSilenceWatchdog() {
+                if (!subscribed || settled) {
+                    return;
+                }
+
+                clearSilenceWatchdog();
+                silenceWatchdog = setTimeout(() => {
+                    if (settled) {
+                        return;
+                    }
+
+                    console.warn("[authoring-progress] realtime silence detected", { jobId });
+                    void reconcileLatestSnapshot()
+                        .then((reconciledTerminalState) => {
+                            if (settled) {
+                                return;
+                            }
+
+                            if (reconciledTerminalState) {
+                                settled = true;
+                                clearSilenceWatchdog();
+                                void client.removeChannel(channel).then(() => resolve()).catch((error) => reject(error));
+                                return;
+                            }
+
+                            armSilenceWatchdog();
+                        })
+                        .catch((error) => {
+                            if (settled) {
+                                return;
+                            }
+
+                            settled = true;
+                            clearSilenceWatchdog();
+                            void client.removeChannel(channel).finally(() => reject(error));
+                        });
+                }, AUTHORING_REALTIME_SILENCE_TIMEOUT_MS);
+            }
+
+            subscribeWatchdog = setTimeout(() => {
+                if (settled || subscribed) {
+                    return;
+                }
+
+                console.warn("[authoring-progress] realtime subscribe watchdog triggered", { jobId });
+                settled = true;
+                clearSubscribeWatchdog();
+                void client.removeChannel(channel)
+                    .catch(() => undefined)
+                    .then(async () => {
+                        const reconciledTerminalState = await reconcileLatestSnapshot();
+                        if (reconciledTerminalState) {
+                            resolve();
+                            return;
+                        }
+
+                        reject(new ProgressTransportDegradedError("SUBSCRIBE_TIMEOUT"));
+                    })
+                    .catch((error) => reject(error));
+            }, AUTHORING_REALTIME_SUBSCRIBE_TIMEOUT_MS);
 
             const onAbort = () => {
                 if (settled) {
                     return;
                 }
                 settled = true;
+                clearSubscribeWatchdog();
+                clearSilenceWatchdog();
                 void client.removeChannel(channel).finally(() => resolve());
             };
 
@@ -665,10 +803,6 @@ async function streamRealtimeProgress(
             }
         });
     } catch (error) {
-        if (error instanceof ProgressPollingFallbackError) {
-            await pollProgressUntilTerminal();
-            return;
-        }
         throw error;
     }
 }

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,29 @@
+﻿## Summary
+- fixes the frontend race where ultra-fast authoring jobs could finish before the realtime subscription settled, leaving the progress UI stuck until refresh
+- adds realtime watchdogs for subscribe timeout, silent channels, and `CLOSED` transport degradation in the authoring progress client
+- propagates `bootstrap_state` consistently from durable snapshots and realtime events so the bootstrap timeline remains visible during startup
+- makes `useAuthoringJobProgress` self-heal once via `bootstrapResumedJob` when the transport degrades instead of failing closed immediately
+- adds a Plotly compatibility shim in the app entrypoint to prevent `ReferenceError: global is not defined` in browser bundles
+- records follow-up backend debt separately via issues #126, #127, and #128
+
+## Pre-Landing Review
+Pre-Landing Review: 2 issues (0 critical, 2 informational)
+
+**AUTO-FIXED:**
+- [TODOS.md:156] Duplicate TODO identifiers after adding new LangGraph follow-ups → renumbered downstream TODOs to keep IDs unique and monotonic
+- [pr_body.txt:1] Stale PR body content from an unrelated bootstrap observability change → replaced with the actual PR #125 summary, review notes, and test plan
+
+## Eval Results
+No prompt-related files changed — evals skipped.
+
+## Test Plan
+- [x] `uv run --directory backend pytest -q` (240 passed, 12 skipped)
+- [x] `npm --prefix frontend run test` (231 passed, 34 files)
+- [x] Targeted authoring hot path remained green during backend baseline audit
+
+## Backend Baseline Debt
+- #126 Normalize backend auth error contracts that leak `profile_incomplete` into unrelated flows
+- #127 Fix full-suite instability in authoring resilience and status backend tests
+- #128 Stabilize backend pytest isolation across full-suite runs
+
+🤖 Generated with GitHub Copilot


### PR DESCRIPTION
﻿## Summary
- fixes the frontend race where ultra-fast authoring jobs could finish before the realtime subscription settled, leaving the progress UI stuck until refresh
- adds realtime watchdogs for subscribe timeout, silent channels, and `CLOSED` transport degradation in the authoring progress client
- propagates `bootstrap_state` consistently from durable snapshots and realtime events so the bootstrap timeline remains visible during startup
- makes `useAuthoringJobProgress` self-heal once via `bootstrapResumedJob` when the transport degrades instead of failing closed immediately
- adds a Plotly compatibility shim in the app entrypoint to prevent `ReferenceError: global is not defined` in browser bundles
- records follow-up backend debt separately via issues #126, #127, and #128

## Pre-Landing Review
Pre-Landing Review: 2 issues (0 critical, 2 informational)

**AUTO-FIXED:**
- [TODOS.md:156] Duplicate TODO identifiers after adding new LangGraph follow-ups → renumbered downstream TODOs to keep IDs unique and monotonic
- [pr_body.txt:1] Stale PR body content from an unrelated bootstrap observability change → replaced with the actual PR #125 summary, review notes, and test plan

## Eval Results
No prompt-related files changed — evals skipped.

## Test Plan
- [x] `uv run --directory backend pytest -q` (240 passed, 12 skipped)
- [x] `npm --prefix frontend run test` (231 passed, 34 files)
- [x] Targeted authoring hot path remained green during backend baseline audit

## Backend Baseline Debt
- #126 Normalize backend auth error contracts that leak `profile_incomplete` into unrelated flows
- #127 Fix full-suite instability in authoring resilience and status backend tests
- #128 Stabilize backend pytest isolation across full-suite runs

🤖 Generated with GitHub Copilot
