### PR TITLE
fix: stabilize test harness flakiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,13 @@ Issue 23 adds a migration test that creates and drops temporary databases. In th
 local Docker Postgres this works with the `postgres` user. On other Postgres environments,
 the backend test suite now assumes `CREATE DATABASE` and `DROP DATABASE` privileges.
 
+Ordinary backend DB-backed tests now run under a per-test dedicated connection + outer
+transaction + `SAVEPOINT` session contract. Keep shared seed fixtures flush-only by default.
+Use explicit pytest markers for carve-outs:
+
+- `ddl_isolation` for temp-database or DDL-heavy tests
+- `shared_db_commit_visibility` for tests that require real cross-connection committed visibility and fall back to `TRUNCATE` cleanup
+
 Issue 23 also introduces `backend/sql/rls_policies.sql` as a separate artifact. Alembic
 does not apply that file. Treat it as an explicit secondary-RLS deployment step only for
 Supabase or another environment that exposes compatible Auth helpers like `auth.uid()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,13 @@ Issue 23 adds a migration test that creates and drops temporary databases. In th
 local Docker Postgres this works with the `postgres` user. On other Postgres environments,
 the backend test suite now assumes `CREATE DATABASE` and `DROP DATABASE` privileges.
 
+Ordinary backend DB-backed tests now run under a per-test dedicated connection + outer
+transaction + `SAVEPOINT` session contract. Shared seed fixtures should stay flush-only by
+default. Use explicit pytest markers for carve-outs:
+
+- `ddl_isolation` for temp-database or DDL-heavy tests
+- `shared_db_commit_visibility` for tests that require real cross-connection committed visibility and fall back to `TRUNCATE` cleanup
+
 Issue 23 also introduces `backend/sql/rls_policies.sql` as a separate artifact. Alembic
 does not apply that file. Treat it as an explicit secondary-RLS deployment step only for
 Supabase or another environment that exposes compatible Auth helpers like `auth.uid()`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,16 @@ npm --prefix frontend run test
 La suite backend actual debe correr en serie. No uses `pytest-xdist` ni `pytest -n ...`
 mientras el harness siga compartiendo una sola base de datos local.
 
+Para tests backend DB-backed ordinarios, el harness usa una conexion dedicada por test,
+una transaccion externa y `SAVEPOINT` por sesion. Los fixtures compartidos deben sembrar
+con `add()` + `flush()`; `commit()` solo se permite cuando el comportamiento del test lo
+requiere de forma explicita.
+
+Carve-outs explicitos del harness:
+
+- `@pytest.mark.ddl_isolation`: tests que crean su propia base temporal o ejercen DDL fuera del contrato normal
+- `@pytest.mark.shared_db_commit_visibility`: tests que necesitan visibilidad real entre conexiones independientes y vuelven temporalmente a cleanup por `TRUNCATE`
+
 Nota: la prueba de migracion del Issue 23 crea y elimina bases temporales. En el entorno
 local default eso funciona con el usuario `postgres`, pero en otros entornos necesitaras
 permisos `CREATE DATABASE` y `DROP DATABASE` para que `pytest` pase completo.
@@ -98,6 +108,8 @@ worker:
 - no uses `pytest -n auto` ni otra variante con `pytest-xdist`
 - si alguien fuerza `xdist`, la suite debe fallar rapido con un mensaje explicito
 - no dejes backend local, shells `psql` u otras sesiones conectadas a la misma DB mientras corre la suite
+- asume `SAVEPOINT` como aislamiento default para tests DB-backed ordinarios
+- usa markers explicitos cuando un test no cabe en ese contrato, en lugar de introducir `commit()` oculto en fixtures compartidos
 
 ## Reglas para agentes
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -230,3 +230,19 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** Esta fue la alternativa 1B considerada en la revisión de corrección de Issue #112. Se rechazó para el fix inicial por preferencia de diff mínimo, pero queda capturada como hardening posterior si el patrón lazy muestra límites reales.
 
 **Depends on / blocked by:** Observar primero el comportamiento del wiring async lazy en validación local, tests y worker real después de que el blocker quede resuelto.
+
+---
+
+## TODO-015: Aislamiento por worker para habilitar pytest-xdist
+
+**What:** Diseñar aislamiento de base por worker para la suite backend, de modo que `pytest-xdist` pueda habilitarse sin compartir la misma DB entre workers.
+
+**Why:** Issue #128 deja la suite serial determinística con `SAVEPOINT` por test, pero no resuelve paralelización. Mientras todos los workers apunten a la misma base, `xdist` sigue siendo inseguro.
+
+**Pros:** Desbloquea paralelización real del backend, reduce tiempo de CI y elimina la restricción operativa de correr siempre en serie.
+
+**Cons:** Requiere crear o aprovisionar una DB por worker, coordinar bootstrap de Alembic por worker y revisar tests con carve-outs (`ddl_isolation`, `shared_db_commit_visibility`). Es cambio de infraestructura de harness, no un patch chico.
+
+**Context:** Diferido explícitamente durante Issue #128 para mantener el diff enfocado en la causa raíz de la contaminación cruzada: commits opacos, ausencia de transacción externa por test y teardown global insuficiente.
+
+**Depends on / blocked by:** Mantener estable el harness serial con `SAVEPOINT` durante varias corridas de CI y definir estrategia de naming/bootstrap para DBs temporales por worker.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -32,6 +32,15 @@ uv run pytest -q
 uv run mypy src
 ```
 
+Ordinary DB-backed tests run under a per-test dedicated connection + outer transaction +
+`SAVEPOINT` session contract. Keep shared seed fixtures flush-only unless a test needs an
+explicit commit.
+
+Use explicit pytest markers when a test cannot fit the default harness:
+
+- `ddl_isolation` for temp-database or DDL-heavy tests
+- `shared_db_commit_visibility` for tests that need real committed visibility across independent connections and fall back to `TRUNCATE` cleanup
+
 If the change touches live LLM behavior, only run marked live tests explicitly:
 
 ```powershell

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -77,6 +77,8 @@ convention = "google"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 markers = [
+    "ddl_isolation: tests that manage their own temporary database and bypass the default SAVEPOINT harness",
+    "shared_db_commit_visibility: tests that need real committed visibility across independent DB connections and fall back to truncate cleanup",
     "live_llm: tests that require Gemini/network and only run when RUN_LIVE_LLM_TESTS=1",
 ]
 

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -30,7 +30,13 @@ from shared.blueprint_schema import (
     StudentArtifacts,
     ValidationContract,
 )
-from shared.database import SessionLocal, register_active_authoring_job, settings, unregister_active_authoring_job
+from shared.database import (
+    SessionLocal,
+    register_active_authoring_job,
+    register_authoring_task,
+    settings,
+    unregister_active_authoring_job,
+)
 from shared.models import (
     AUTHORING_JOB_RETRYABLE_STATUSES,
     AUTHORING_JOB_STATUS_COMPLETED,
@@ -866,7 +872,9 @@ class AuthoringService:
 
                     return final_state
 
-                graph_task = asyncio.create_task(_run_graph_stream(), name=f"authoring-job-{job_id}")
+                graph_task = register_authoring_task(
+                    asyncio.create_task(_run_graph_stream(), name=f"authoring-job-{job_id}")
+                )
                 graph_output = await asyncio.wait_for(graph_task, timeout=900)
                 logger.info("AuthoringService: LangGraph execution finished for Job %s.", job_id)
             finally:

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -6,6 +6,7 @@ import sys
 import threading
 import time
 from typing import Any
+from weakref import WeakSet
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool, ConnectionPool
 from sqlalchemy import create_engine, Engine
@@ -121,6 +122,8 @@ _langgraph_checkpointer_async_pool_lock_loop: asyncio.AbstractEventLoop | None =
 _langgraph_checkpointer_async_pool_lock_guard = threading.Lock()
 _active_authoring_jobs: set[str] = set()
 _active_authoring_jobs_guard = threading.Lock()
+_tracked_authoring_tasks: WeakSet[asyncio.Task[Any]] = WeakSet()
+_tracked_authoring_tasks_guard = threading.Lock()
 
 
 class _SessionFactoryProxy:
@@ -170,6 +173,20 @@ def reset_active_authoring_job_registry() -> None:
         _active_authoring_jobs.clear()
 
 
+def register_authoring_task(task: asyncio.Task[Any]) -> asyncio.Task[Any]:
+    """Track authoring tasks independently from the currently running event loop."""
+    with _tracked_authoring_tasks_guard:
+        _tracked_authoring_tasks.add(task)
+    task.add_done_callback(unregister_authoring_task)
+    return task
+
+
+def unregister_authoring_task(task: asyncio.Task[Any]) -> None:
+    """Remove a finished authoring task from the runtime tracker."""
+    with _tracked_authoring_tasks_guard:
+        _tracked_authoring_tasks.discard(task)
+
+
 def install_session_factory_override(factory: sessionmaker[Session]) -> None:
     """Route SessionLocal() calls through a test-scoped session factory."""
     global _session_factory_override
@@ -194,24 +211,48 @@ def snapshot_authoring_runtime_state() -> dict[str, list[str]]:
     }
 
 
+def _describe_authoring_task(task: asyncio.Task[Any]) -> str | None:
+    if task.done():
+        return None
+
+    task_name = task.get_name()
+    coro = task.get_coro()
+    coro_name = getattr(coro, "__qualname__", type(coro).__name__)
+    if task_name.startswith("authoring-job-") or "run_job" in coro_name or "_run_graph_stream" in coro_name:
+        return f"{task_name}:{coro_name}"
+
+    return None
+
+
+def _snapshot_tracked_authoring_task_names() -> list[str]:
+    with _tracked_authoring_tasks_guard:
+        tracked_tasks = list(_tracked_authoring_tasks)
+
+    task_names = {
+        task_name
+        for task in tracked_tasks
+        if (task_name := _describe_authoring_task(task)) is not None
+    }
+    return sorted(task_names)
+
+
 def _snapshot_authoring_task_names() -> list[str]:
     """Return pending asyncio task names relevant to authoring shutdown."""
+    task_names = set(_snapshot_tracked_authoring_task_names())
+
     try:
         current_loop = asyncio.get_running_loop()
     except RuntimeError:
-        return []
+        return sorted(task_names)
 
     current_task = asyncio.current_task(current_loop)
-    task_names: list[str] = []
     for task in asyncio.all_tasks(current_loop):
         if task is current_task or task.done():
             continue
 
-        task_name = task.get_name()
-        coro = task.get_coro()
-        coro_name = getattr(coro, "__qualname__", type(coro).__name__)
-        if task_name.startswith("authoring-job-") or "run_job" in coro_name or "_run_graph_stream" in coro_name:
-            task_names.append(f"{task_name}:{coro_name}")
+        described_task = _describe_authoring_task(task)
+        if described_task is not None:
+            task_names.add(described_task)
 
     return sorted(task_names)
 

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -110,7 +110,9 @@ def _make_engine(s: Settings) -> Engine:
 
 settings = Settings()
 engine = _make_engine(settings)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+_default_session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+_session_factory_override: sessionmaker[Session] | None = None
+_session_factory_override_guard = threading.Lock()
 _langgraph_checkpointer_pool: ConnectionPool | None = None
 _langgraph_checkpointer_async_pool: AsyncConnectionPool | None = None
 _langgraph_checkpointer_async_pool_loop: asyncio.AbstractEventLoop | None = None
@@ -119,6 +121,24 @@ _langgraph_checkpointer_async_pool_lock_loop: asyncio.AbstractEventLoop | None =
 _langgraph_checkpointer_async_pool_lock_guard = threading.Lock()
 _active_authoring_jobs: set[str] = set()
 _active_authoring_jobs_guard = threading.Lock()
+
+
+class _SessionFactoryProxy:
+    """Dispatch SessionLocal() calls to the default or a test-scoped override."""
+
+    def __init__(self, default_factory: sessionmaker[Session]) -> None:
+        self._default_factory = default_factory
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Session:
+        with _session_factory_override_guard:
+            active_factory = _session_factory_override or self._default_factory
+        return active_factory(*args, **kwargs)
+
+    def configure(self, **kwargs: Any) -> None:
+        self._default_factory.configure(**kwargs)
+
+
+SessionLocal = _SessionFactoryProxy(_default_session_factory)
 
 class Base(DeclarativeBase):
     """Base declarative class for SQLAlchemy models."""
@@ -142,6 +162,36 @@ def snapshot_active_authoring_jobs() -> list[str]:
     """Return the currently tracked durable authoring jobs."""
     with _active_authoring_jobs_guard:
         return sorted(_active_authoring_jobs)
+
+
+def reset_active_authoring_job_registry() -> None:
+    """Clear tracked durable authoring jobs for test or shutdown cleanup."""
+    with _active_authoring_jobs_guard:
+        _active_authoring_jobs.clear()
+
+
+def install_session_factory_override(factory: sessionmaker[Session]) -> None:
+    """Route SessionLocal() calls through a test-scoped session factory."""
+    global _session_factory_override
+
+    with _session_factory_override_guard:
+        _session_factory_override = factory
+
+
+def reset_session_factory_override() -> None:
+    """Restore SessionLocal() calls to the default runtime session factory."""
+    global _session_factory_override
+
+    with _session_factory_override_guard:
+        _session_factory_override = None
+
+
+def snapshot_authoring_runtime_state() -> dict[str, list[str]]:
+    """Return authoring runtime residue relevant to harness teardown."""
+    return {
+        "active_jobs": snapshot_active_authoring_jobs(),
+        "pending_tasks": _snapshot_authoring_task_names(),
+    }
 
 
 def _snapshot_authoring_task_names() -> list[str]:
@@ -528,7 +578,7 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
         return pool
 
 
-async def close_langgraph_checkpointer_async_pool(timeout_seconds: float = 5.0) -> None:
+async def close_langgraph_checkpointer_async_pool(timeout_seconds: float = 5.0) -> bool:
     """Close and clear the cached async LangGraph checkpointer pool."""
     global _langgraph_checkpointer_async_pool
     global _langgraph_checkpointer_async_pool_loop
@@ -536,13 +586,18 @@ async def close_langgraph_checkpointer_async_pool(timeout_seconds: float = 5.0) 
     global _langgraph_checkpointer_async_pool_lock_loop
 
     pool = _langgraph_checkpointer_async_pool
+    pool_loop = _langgraph_checkpointer_async_pool_loop
     _langgraph_checkpointer_async_pool = None
     _langgraph_checkpointer_async_pool_loop = None
     _langgraph_checkpointer_async_pool_lock = None
     _langgraph_checkpointer_async_pool_lock_loop = None
 
     if pool is None:
-        return
+        return True
+
+    if pool_loop is not None and pool_loop.is_closed():
+        logger.warning("Skipping LangGraph async checkpointer pool close because the owning event loop is already closed")
+        return True
 
     active_jobs = snapshot_active_authoring_jobs()
     pending_task_names = _snapshot_authoring_task_names()
@@ -565,6 +620,7 @@ async def close_langgraph_checkpointer_async_pool(timeout_seconds: float = 5.0) 
             closed_stats.get("pool_available", 0),
             closed_stats.get("requests_waiting", 0),
         )
+        return True
     except asyncio.TimeoutError:
         timed_out_stats = _pool_stats_snapshot(pool)
         logger.error(
@@ -576,6 +632,12 @@ async def close_langgraph_checkpointer_async_pool(timeout_seconds: float = 5.0) 
             active_jobs,
             pending_task_names,
         )
+        return False
+    except asyncio.CancelledError:
+        logger.warning(
+            "LangGraph async checkpointer pool close was cancelled after the owning loop changed or shut down"
+        )
+        return pool_loop is not None and pool_loop.is_closed()
     except Exception as exc:
         failed_stats = _pool_stats_snapshot(pool)
         logger.error(
@@ -587,22 +649,28 @@ async def close_langgraph_checkpointer_async_pool(timeout_seconds: float = 5.0) 
             active_jobs,
             pending_task_names,
         )
+        return False
 
 
-def close_langgraph_checkpointer_pool() -> None:
+def close_langgraph_checkpointer_pool() -> bool:
     """Close and clear the cached sync LangGraph checkpointer pool."""
     global _langgraph_checkpointer_pool
 
     pool = _langgraph_checkpointer_pool
     _langgraph_checkpointer_pool = None
     if pool is None:
-        return
+        return True
+
+    if not hasattr(pool, "close"):
+        return True
 
     try:
         logger.info("Closing LangGraph sync checkpointer pool")
         pool.close()
+        return True
     except Exception as exc:
         logger.error("Could not close LangGraph sync checkpointer pool cleanly: %s", exc)
+        return False
 
 
 def dispose_database_engine() -> None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Generator
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 import os
+import threading
 import uuid
 
 from alembic import command
@@ -11,14 +13,26 @@ from alembic.config import Config
 import jwt
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import select, text
+from sqlalchemy import Connection, select, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import close_all_sessions
+from sqlalchemy.orm import Session, close_all_sessions, sessionmaker
 
+from case_generator.graph import reset_graph_singleton
 from shared.app import app
 from shared.auth import get_auth_settings, get_jwt_verifier, get_supabase_admin_auth_client
-from shared.database import SessionLocal, engine, settings
+from shared.database import (
+    SessionLocal,
+    close_langgraph_checkpointer_async_pool,
+    close_langgraph_checkpointer_pool,
+    engine,
+    get_db,
+    install_session_factory_override,
+    reset_active_authoring_job_registry,
+    reset_session_factory_override,
+    settings,
+    snapshot_authoring_runtime_state,
+)
 from shared.models import Base, Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, Tenant, User
 
 
@@ -104,6 +118,14 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
 
 def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "ddl_isolation: tests that manage their own temporary database and bypass the default SAVEPOINT harness",
+    )
+    config.addinivalue_line(
+        "markers",
+        "shared_db_commit_visibility: tests that need real committed visibility across independent DB connections and fall back to truncate cleanup",
+    )
     numprocesses = getattr(config.option, "numprocesses", None)
     if getattr(config, "workerinput", None) is not None:
         raise pytest.UsageError(
@@ -117,6 +139,18 @@ def pytest_configure(config: pytest.Config) -> None:
         )
 
 
+def _uses_ddl_isolation(request: pytest.FixtureRequest) -> bool:
+    return request.node.get_closest_marker("ddl_isolation") is not None
+
+
+def _uses_shared_db_commit_visibility(request: pytest.FixtureRequest) -> bool:
+    return request.node.get_closest_marker("shared_db_commit_visibility") is not None
+
+
+def _uses_default_transactional_harness(request: pytest.FixtureRequest) -> bool:
+    return not _uses_ddl_isolation(request) and not _uses_shared_db_commit_visibility(request)
+
+
 def _truncate_all_tables() -> None:
     table_names = [table.name for table in Base.metadata.sorted_tables]
     table_names.extend(_CHECKPOINT_TABLES)
@@ -124,22 +158,120 @@ def _truncate_all_tables() -> None:
     table_names_csv = ", ".join(ordered_table_names)
     if not table_names_csv:
         return
+
     truncate_sql = text(f"TRUNCATE TABLE {table_names_csv} RESTART IDENTITY CASCADE")
     close_all_sessions()
-    # The backend suite assumes exclusive ownership of the local test DB while it runs.
     with engine.begin() as connection:
         connection.execute(truncate_sql)
 
 
-@pytest.fixture(autouse=True)
-def clean_db(ensure_db_schema: None, request: pytest.FixtureRequest) -> Generator[None, None, None]:
-    if request.node.module.__name__.endswith("test_issue23_identity_schema"):
-        yield
-        return
+def _build_test_session_factory(connection: Connection) -> sessionmaker[Session]:
+    return sessionmaker(
+        bind=connection,
+        autocommit=False,
+        autoflush=False,
+        expire_on_commit=False,
+        join_transaction_mode="create_savepoint",
+    )
 
-    _truncate_all_tables()
-    yield
-    _truncate_all_tables()
+
+def _close_async_checkpointer_pool_for_test(timeout_seconds: float = 5.0) -> bool:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(close_langgraph_checkpointer_async_pool(timeout_seconds=timeout_seconds))
+
+    result: dict[str, bool] = {}
+    errors: list[BaseException] = []
+
+    def _runner() -> None:
+        try:
+            result["closed_cleanly"] = asyncio.run(
+                close_langgraph_checkpointer_async_pool(timeout_seconds=timeout_seconds)
+            )
+        except BaseException as exc:  # pragma: no cover - defensive bridge
+            errors.append(exc)
+
+    cleanup_thread = threading.Thread(target=_runner, name="test-runtime-cleanup", daemon=True)
+    cleanup_thread.start()
+    cleanup_thread.join()
+    if errors:
+        raise errors[0]
+    return result.get("closed_cleanly", False)
+
+
+def _cleanup_runtime_state() -> None:
+    close_all_sessions()
+    async_pool_closed_cleanly = _close_async_checkpointer_pool_for_test()
+    sync_pool_closed_cleanly = close_langgraph_checkpointer_pool()
+    pre_reset_state = snapshot_authoring_runtime_state()
+    reset_graph_singleton()
+    reset_active_authoring_job_registry()
+    post_reset_state = snapshot_authoring_runtime_state()
+
+    failures: list[str] = []
+    if pre_reset_state["active_jobs"]:
+        failures.append(f"active authoring jobs leaked across test boundary: {pre_reset_state['active_jobs']}")
+    if not async_pool_closed_cleanly:
+        failures.append("LangGraph async checkpointer pool did not close cleanly")
+    if not sync_pool_closed_cleanly:
+        failures.append("LangGraph sync checkpointer pool did not close cleanly")
+    if post_reset_state["pending_tasks"]:
+        failures.append(f"authoring tasks still pending after cleanup: {post_reset_state['pending_tasks']}")
+    if post_reset_state["active_jobs"]:
+        failures.append(f"active authoring job registry still populated after cleanup: {post_reset_state['active_jobs']}")
+
+    if failures:
+        raise AssertionError("; ".join(failures))
+
+
+@pytest.fixture(autouse=True)
+def transactional_test_harness(
+    ensure_db_schema: None,
+    request: pytest.FixtureRequest,
+) -> Generator[None, None, None]:
+    """Default DB-backed tests run inside one outer transaction plus SAVEPOINT sessions.
+
+    test
+      -> dedicated connection
+      -> outer transaction
+      -> SessionLocal() uses SAVEPOINT join mode
+      -> test cleanup rolls back outer transaction
+    """
+    connection: Connection | None = None
+    transaction = None
+    use_transactional_harness = _uses_default_transactional_harness(request)
+    use_truncate_cleanup = _uses_shared_db_commit_visibility(request)
+
+    if use_transactional_harness:
+        close_all_sessions()
+        connection = engine.connect()
+        transaction = connection.begin()
+        install_session_factory_override(_build_test_session_factory(connection))
+
+    try:
+        yield
+    finally:
+        close_all_sessions()
+        runtime_cleanup_error: AssertionError | None = None
+        try:
+            _cleanup_runtime_state()
+        except AssertionError as exc:
+            runtime_cleanup_error = exc
+
+        reset_session_factory_override()
+        try:
+            if transaction is not None and transaction.is_active:
+                transaction.rollback()
+        finally:
+            if connection is not None:
+                connection.close()
+
+        if use_truncate_cleanup:
+            _truncate_all_tables()
+
+        if runtime_cleanup_error is not None:
+            pytest.fail(str(runtime_cleanup_error))
 
 
 @pytest.fixture
@@ -148,14 +280,42 @@ def db(ensure_db_schema: None):
     try:
         yield session
     finally:
-        session.rollback()
+        if session.in_transaction():
+            session.rollback()
         session.close()
 
 
 @pytest.fixture
-def client() -> Generator[TestClient, None, None]:
-    with TestClient(app) as test_client:
-        yield test_client
+def client(request: pytest.FixtureRequest) -> Generator[TestClient, None, None]:
+    if _uses_default_transactional_harness(request):
+        def _get_test_db() -> Generator[Session, None, None]:
+            session = SessionLocal()
+            try:
+                yield session
+            finally:
+                if session.in_transaction():
+                    session.rollback()
+                session.close()
+
+        app.dependency_overrides[get_db] = _get_test_db
+
+    try:
+        with TestClient(app) as test_client:
+            yield test_client
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture
+def independent_session() -> Generator[Session, None, None]:
+    """Yield a real engine-bound session for lock and visibility tests."""
+    session = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)()
+    try:
+        yield session
+    finally:
+        if session.in_transaction():
+            session.rollback()
+        session.close()
 
 
 @pytest.fixture
@@ -257,7 +417,7 @@ def seed_identity(db) -> Callable[..., dict[str, object]]:
                 db.add(legacy_user)
                 db.flush()
 
-        db.commit()
+        db.flush()
         return {
             "tenant": tenant,
             "profile": profile,
@@ -297,7 +457,7 @@ def seed_course(db):
             status=status,
         )
         db.add(course)
-        db.commit()
+        db.flush()
         db.refresh(course)
         return course
 
@@ -337,7 +497,7 @@ def seed_invite(db):
             expires_at=expires_at or (datetime.now(timezone.utc) + timedelta(days=1)),
         )
         db.add(invite)
-        db.commit()
+        db.flush()
         db.refresh(invite)
         return invite, token
 
@@ -363,7 +523,7 @@ def seed_course_access_link(db):
             rotated_at=rotated_at,
         )
         db.add(access_link)
-        db.commit()
+        db.flush()
         db.refresh(access_link)
         return access_link, token
 
@@ -378,7 +538,7 @@ def seed_course_membership(db):
             membership_id=membership_id,
         )
         db.add(course_membership)
-        db.commit()
+        db.flush()
         db.refresh(course_membership)
         return course_membership
 

--- a/backend/tests/test_admin_auth.py
+++ b/backend/tests/test_admin_auth.py
@@ -257,6 +257,7 @@ def test_change_password_clears_all_university_admin_memberships(
     assert resp.status_code == 200
 
     # Both memberships must have flag cleared
+    db.expire_all()
     memberships = db.scalars(
         select(Membership).where(
             Membership.user_id == user_id,

--- a/backend/tests/test_harness_isolation.py
+++ b/backend/tests/test_harness_isolation.py
@@ -5,7 +5,12 @@ from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 import uuid
 
-from shared.database import register_active_authoring_job, reset_active_authoring_job_registry, snapshot_authoring_runtime_state
+from shared.database import (
+    register_active_authoring_job,
+    register_authoring_task,
+    reset_active_authoring_job_registry,
+    snapshot_authoring_runtime_state,
+)
 from shared.models import Profile
 
 _previous_test_user_id: str | None = None
@@ -81,12 +86,16 @@ async def test_runtime_state_snapshot_reports_active_jobs_and_pending_authoring_
         await gate.wait()
 
     register_active_authoring_job(job_id)
-    task = asyncio.create_task(_pending_authoring_task(), name=f"authoring-job-{job_id}")
+    task = register_authoring_task(asyncio.create_task(_pending_authoring_task(), name=f"authoring-job-{job_id}"))
     await asyncio.sleep(0)
 
     state = snapshot_authoring_runtime_state()
     assert state["active_jobs"] == [job_id]
     assert any(entry.startswith(f"authoring-job-{job_id}:") for entry in state["pending_tasks"])
+
+    state_without_active_loop = await asyncio.to_thread(snapshot_authoring_runtime_state)
+    assert state_without_active_loop["active_jobs"] == [job_id]
+    assert any(entry.startswith(f"authoring-job-{job_id}:") for entry in state_without_active_loop["pending_tasks"])
 
     gate.set()
     await task

--- a/backend/tests/test_harness_isolation.py
+++ b/backend/tests/test_harness_isolation.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import uuid
+
+from shared.database import register_active_authoring_job, reset_active_authoring_job_registry, snapshot_authoring_runtime_state
+from shared.models import Profile
+
+_previous_test_user_id: str | None = None
+
+
+def _load_test_module(path: Path, module_name: str):
+    spec = spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _has_ddl_isolation_marker(obj: object) -> bool:
+    marks = getattr(obj, "pytestmark", [])
+    if not isinstance(marks, list):
+        marks = [marks]
+    return any(getattr(mark, "name", None) == "ddl_isolation" for mark in marks)
+
+
+# These two tests intentionally rely on file order to prove that a committed write
+# inside one test is still rolled back before the next test starts.
+def test_01_harness_keeps_committed_rows_inside_the_current_test(db, seed_identity) -> None:
+    global _previous_test_user_id
+
+    user_id = str(uuid.uuid4())
+    seed_identity(user_id=user_id, email="rollback-proof@example.edu", role="teacher")
+    db.commit()
+
+    assert db.get(Profile, user_id) is not None
+    _previous_test_user_id = user_id
+
+
+def test_02_harness_rolls_back_committed_rows_before_the_next_test(independent_session) -> None:
+    assert _previous_test_user_id is not None
+    assert independent_session.get(Profile, _previous_test_user_id) is None
+
+
+def test_flush_only_seed_fixture_does_not_escape_to_an_independent_connection(
+    independent_session,
+    seed_identity,
+) -> None:
+    user_id = str(uuid.uuid4())
+    seed_identity(user_id=user_id, email="flush-only@example.edu", role="teacher")
+
+    assert independent_session.get(Profile, user_id) is None
+
+
+def test_client_reads_flush_only_seed_data_inside_the_same_outer_transaction(
+    client,
+    auth_headers_factory,
+    seed_identity,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "client-shared-transaction@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    response = client.get(
+        "/api/auth/me",
+        headers=auth_headers_factory(sub=teacher_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["auth_user_id"] == teacher_id
+
+
+async def test_runtime_state_snapshot_reports_active_jobs_and_pending_authoring_tasks() -> None:
+    job_id = f"job-{uuid.uuid4()}"
+    gate = asyncio.Event()
+
+    async def _pending_authoring_task() -> None:
+        await gate.wait()
+
+    register_active_authoring_job(job_id)
+    task = asyncio.create_task(_pending_authoring_task(), name=f"authoring-job-{job_id}")
+    await asyncio.sleep(0)
+
+    state = snapshot_authoring_runtime_state()
+    assert state["active_jobs"] == [job_id]
+    assert any(entry.startswith(f"authoring-job-{job_id}:") for entry in state["pending_tasks"])
+
+    gate.set()
+    await task
+    reset_active_authoring_job_registry()
+
+
+def test_ddl_temp_database_tests_are_explicitly_marked() -> None:
+    tests_dir = Path(__file__).resolve().parent
+    issue23_module = _load_test_module(tests_dir / "test_issue23_identity_schema.py", "issue23_identity_schema")
+    issue52_module = _load_test_module(tests_dir / "test_issue52_admin_catalog_infra.py", "issue52_admin_catalog_infra")
+    issue90_module = _load_test_module(
+        tests_dir / "test_issue90_assignment_deadline_migration.py", "issue90_assignment_deadline_migration"
+    )
+
+    assert _has_ddl_isolation_marker(issue23_module.test_issue23_alembic_upgrade_and_downgrade)
+    assert _has_ddl_isolation_marker(issue23_module.test_issue23_migration_rejects_unknown_legacy_roles)
+    assert _has_ddl_isolation_marker(issue23_module.test_issue23_migration_rejects_non_uuid_legacy_user_ids)
+    assert not _has_ddl_isolation_marker(issue23_module.test_issue23_rls_sql_exists)
+
+    assert _has_ddl_isolation_marker(issue52_module.test_issue52_alembic_upgrade_backfill_and_downgrade)
+    assert _has_ddl_isolation_marker(issue52_module.test_issue52_downgrade_rejects_pending_teacher_only_courses)
+    assert not _has_ddl_isolation_marker(issue52_module.test_issue52_course_constraints_allow_teacher_membership_assignment)
+
+    assert _has_ddl_isolation_marker(issue90_module.test_issue90_alembic_upgrade_and_downgrade)

--- a/backend/tests/test_issue23_identity_schema.py
+++ b/backend/tests/test_issue23_identity_schema.py
@@ -96,6 +96,7 @@ def _seed_legacy_tenant_and_user(
         )
 
 
+@pytest.mark.ddl_isolation
 def test_issue23_alembic_upgrade_and_downgrade() -> None:
     with temporary_database() as db_url:
         config = _alembic_config(db_url)
@@ -286,6 +287,7 @@ def test_issue23_rls_sql_exists() -> None:
     assert "hmac.compare_digest()" in content
 
 
+@pytest.mark.ddl_isolation
 def test_issue23_migration_rejects_unknown_legacy_roles() -> None:
     with temporary_database() as db_url:
         config = _alembic_config(db_url)
@@ -305,6 +307,7 @@ def test_issue23_migration_rejects_unknown_legacy_roles() -> None:
         engine.dispose()
 
 
+@pytest.mark.ddl_isolation
 def test_issue23_migration_rejects_non_uuid_legacy_user_ids() -> None:
     with temporary_database() as db_url:
         config = _alembic_config(db_url)

--- a/backend/tests/test_issue30_auth_perimeter.py
+++ b/backend/tests/test_issue30_auth_perimeter.py
@@ -724,6 +724,7 @@ def test_redeem_success_and_repeat_is_idempotent(
     assert refreshed_invite.status == "consumed"
 
 
+@pytest.mark.shared_db_commit_visibility
 def test_redeem_concurrent_double_redemption_is_idempotent(
     client, seed_course, seed_identity, seed_invite, auth_headers_factory, db
 ) -> None:
@@ -761,6 +762,7 @@ def test_redeem_concurrent_double_redemption_is_idempotent(
         role="student",
         course_id=course.id,
     )
+    db.commit()
     headers = auth_headers_factory(sub=student_id, email="concurrent-student@example.edu")
 
     barrier = threading.Barrier(2)

--- a/backend/tests/test_issue52_admin_catalog_infra.py
+++ b/backend/tests/test_issue52_admin_catalog_infra.py
@@ -139,6 +139,7 @@ def _seed_issue52_legacy_course(engine) -> None:
         )
 
 
+@pytest.mark.ddl_isolation
 def test_issue52_alembic_upgrade_backfill_and_downgrade() -> None:
     with temporary_database() as db_url:
         config = _alembic_config(db_url)
@@ -241,6 +242,7 @@ def test_issue52_alembic_upgrade_backfill_and_downgrade() -> None:
         engine.dispose()
 
 
+@pytest.mark.ddl_isolation
 def test_issue52_downgrade_rejects_pending_teacher_only_courses() -> None:
     with temporary_database() as db_url:
         config = _alembic_config(db_url)

--- a/backend/tests/test_issue56_admin_writes.py
+++ b/backend/tests/test_issue56_admin_writes.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from datetime import timedelta
 import uuid
 
+import pytest
 from sqlalchemy import func, select
 
 from shared.course_access_links import course_regeneration_lock_key
-from shared.database import SessionLocal
 from shared.invite_status import utc_now
 from shared.models import Course, CourseAccessLink, CourseMembership, Invite, Membership, UniversitySsoConfig
 
@@ -191,8 +191,11 @@ def test_issue56_create_course_rejects_stale_pending_teacher_invite(
     assert response.json()["detail"] == "stale_pending_teacher_invite"
 
 
+@pytest.mark.shared_db_commit_visibility
 def test_issue56_create_course_rejects_pending_teacher_invite_locked_by_activation(
     client,
+    db,
+    independent_session,
     seed_identity,
     seed_invite,
     auth_headers_factory,
@@ -205,8 +208,9 @@ def test_issue56_create_course_rejects_pending_teacher_invite_locked_by_activati
         role="teacher",
         full_name="Locked Create",
     )
+    db.commit()
 
-    blocking_session = SessionLocal()
+    blocking_session = independent_session
     try:
         locked_invite = blocking_session.scalar(
             select(Invite).where(Invite.id == invite.id).with_for_update()
@@ -574,8 +578,11 @@ def test_issue56_patch_course_rejects_stale_pending_teacher_invite(
     assert response.json()["detail"] == "stale_pending_teacher_invite"
 
 
+@pytest.mark.shared_db_commit_visibility
 def test_issue56_patch_course_rejects_pending_teacher_invite_locked_by_activation(
     client,
+    db,
+    independent_session,
     seed_identity,
     seed_course,
     seed_invite,
@@ -601,8 +608,9 @@ def test_issue56_patch_course_rejects_pending_teacher_invite_locked_by_activatio
         title="Locked Patch Course",
         code="LOCKED-PATCH-001",
     )
+    db.commit()
 
-    blocking_session = SessionLocal()
+    blocking_session = independent_session
     try:
         locked_invite = blocking_session.scalar(
             select(Invite).where(Invite.id == invite.id).with_for_update()
@@ -881,8 +889,11 @@ def test_issue56_regenerate_course_access_link_rejects_inactive_course(
     assert response.json()["detail"] == "course_inactive"
 
 
+@pytest.mark.shared_db_commit_visibility
 def test_issue56_regenerate_course_access_link_returns_conflict_when_lock_is_held(
     client,
+    db,
+    independent_session,
     seed_identity,
     seed_course,
     seed_course_access_link,
@@ -903,8 +914,9 @@ def test_issue56_regenerate_course_access_link_returns_conflict_when_lock_is_hel
         code="ROTATE-CONCURRENT-001",
     )
     seed_course_access_link(course_id=course.id, status="active")
+    db.commit()
 
-    blocking_session = SessionLocal()
+    blocking_session = independent_session
     try:
         blocking_session.execute(select(func.pg_advisory_xact_lock(course_regeneration_lock_key(course.id))))
 

--- a/backend/tests/test_issue57_course_access.py
+++ b/backend/tests/test_issue57_course_access.py
@@ -194,6 +194,7 @@ def test_issue57_course_access_enroll_validates_actor_email_domain(
     assert response.json()["detail"] == "email_domain_not_allowed"
 
 
+@pytest.mark.shared_db_commit_visibility
 def test_issue57_course_access_enroll_is_idempotent_under_concurrency(
     client,
     db,
@@ -222,6 +223,7 @@ def test_issue57_course_access_enroll_is_idempotent_under_concurrency(
         code="COURSE-ACCESS-004",
     )
     _, token = seed_course_access_link(course_id=course.id, status="active")
+    db.commit()
     headers = auth_headers_factory(sub=student["profile"].id, email="student.concurrent@example.edu")
     barrier = threading.Barrier(2)
 

--- a/backend/tests/test_issue90_assignment_deadline_migration.py
+++ b/backend/tests/test_issue90_assignment_deadline_migration.py
@@ -66,6 +66,7 @@ def clean_db():
     yield
 
 
+@pytest.mark.ddl_isolation
 def test_issue90_alembic_upgrade_and_downgrade() -> None:
     with temporary_database() as db_url:
         config = _alembic_config(db_url)

--- a/backend/tests/test_phase1a_smoke.py
+++ b/backend/tests/test_phase1a_smoke.py
@@ -1,8 +1,13 @@
 from unittest.mock import patch
 import uuid
 
+import pytest
+
 from shared.database import SessionLocal
 from shared.models import Assignment, AuthoringJob
+
+
+pytestmark = pytest.mark.shared_db_commit_visibility
 
 
 def test_database_connection() -> None:
@@ -13,10 +18,11 @@ def test_database_connection() -> None:
         db.close()
 
 
-def test_intake_and_idempotency_workflow(client, auth_headers_factory, seed_identity) -> None:
+def test_intake_and_idempotency_workflow(client, db, auth_headers_factory, seed_identity) -> None:
     teacher_id = "00000000-0000-0000-0000-000000000101"
     teacher_email = "teacher101@example.edu"
     seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    db.commit()
     headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
 
     payload = {
@@ -107,7 +113,7 @@ def test_intake_and_idempotency_workflow(client, auth_headers_factory, seed_iden
         finally:
             db2.close()
 
-    with patch("shared.app.AuthoringService.run_job", side_effect=_stub_run_job):
+    with patch("shared.internal_tasks.AuthoringService.run_job", side_effect=_stub_run_job):
         internal_response = client.post(
             "/api/internal/tasks/authoring_step",
             json=task_payload,

--- a/backend/tests/test_phase1b_integration.py
+++ b/backend/tests/test_phase1b_integration.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from shared.database import SessionLocal
 from shared.models import Assignment, AuthoringJob
+
+
+pytestmark = pytest.mark.shared_db_commit_visibility
 
 TEACHER_ID = "00000000-0000-0000-0000-000000000102"
 ERROR_TEACHER_ID = "00000000-0000-0000-0000-000000000103"
@@ -30,9 +35,10 @@ class _StubGraph:
         return self._stream_impl(*args, **kwargs)
 
 
-def test_phase1b_intake_and_authoring_stubbed(client, auth_headers_factory, seed_identity) -> None:
+def test_phase1b_intake_and_authoring_stubbed(client, db, auth_headers_factory, seed_identity) -> None:
     teacher_email = "teacher102@example.edu"
     seed_identity(user_id=TEACHER_ID, email=teacher_email, role="teacher")
+    db.commit()
     headers = auth_headers_factory(sub=TEACHER_ID, email=teacher_email)
     payload = {
         "assignment_title": "Phase 1B Integration Test Title",
@@ -68,9 +74,10 @@ def test_phase1b_intake_and_authoring_stubbed(client, auth_headers_factory, seed
         db.close()
 
 
-def test_phase1b_authoring_service_failure(client, auth_headers_factory, seed_identity) -> None:
+def test_phase1b_authoring_service_failure(client, db, auth_headers_factory, seed_identity) -> None:
     teacher_email = "teacher103@example.edu"
     seed_identity(user_id=ERROR_TEACHER_ID, email=teacher_email, role="teacher")
+    db.commit()
     headers = auth_headers_factory(sub=ERROR_TEACHER_ID, email=teacher_email)
     payload = {
         "assignment_title": "Phase 1B Error Test Title",

--- a/frontend/src/app/auth/AuthProvider.test.tsx
+++ b/frontend/src/app/auth/AuthProvider.test.tsx
@@ -170,7 +170,9 @@ describe("AuthProvider", () => {
         );
 
         queryClient.setQueryData(["admin", "summary"], { value: 1 });
-        capturedCallback!("SIGNED_OUT", null);
+        await act(async () => {
+            capturedCallback!("SIGNED_OUT", null);
+        });
 
         await waitFor(() =>
             expect(screen.getByTestId("actor").textContent).toBe("none"),
@@ -235,7 +237,9 @@ describe("AuthProvider", () => {
         );
         expect(mockApiFetch).toHaveBeenCalledTimes(1);
 
-        capturedCallback!("TOKEN_REFRESHED", { access_token: "jwt-refreshed" });
+        await act(async () => {
+            capturedCallback!("TOKEN_REFRESHED", { access_token: "jwt-refreshed" });
+        });
 
         await waitFor(() =>
             expect(screen.getByTestId("session-token").textContent).toBe("jwt-refreshed"),

--- a/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
@@ -204,7 +204,7 @@ describe("AuthoringForm", () => {
             expect(screen.queryByDisplayValue("Respuesta vieja")).not.toBeInTheDocument();
         });
         expect(screen.getByLabelText(/industria/i)).toHaveTextContent(/retail/i);
-    });
+    }, 20_000);
 
     it("ignores a stale response after clearing the form and resets visible mutation errors", async () => {
         const user = userEvent.setup();
@@ -247,5 +247,5 @@ describe("AuthoringForm", () => {
         await waitFor(() => {
             expect(screen.queryByDisplayValue("No debe aplicar")).not.toBeInTheDocument();
         });
-    });
+    }, 20_000);
 });


### PR DESCRIPTION
Closes #128

## Summary
- harden the backend test harness around per-test dedicated connections, outer transactions, and SAVEPOINT-backed session overrides
- add regression coverage and explicit pytest carve-out markers for temp-database, lock, and committed-visibility scenarios
- stabilize frontend auth and authoring tests and sync contributor docs with the new harness contract

## Pre-Landing Review
Pre-Landing Review: 1 issue (0 critical, 1 informational)
- [backend/src/shared/database.py] pending authoring-task leak detection only inspects the currently running loop, so sync teardown may miss leaked tasks owned by another loop/thread.

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] `uv run --directory backend mypy src`
- [x] `uv run --directory backend pytest -q` (3 consecutive green runs)
- [x] `npm --prefix frontend run lint`
- [x] `npm --prefix frontend run test`
- [x] `npm --prefix frontend run build`

🤖 Generated with GitHub Copilot