### PR TITLE
fix: harden authoring runtime clean-room

### DIFF
--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -32,6 +32,7 @@ from shared.blueprint_schema import (
 )
 from shared.database import (
     SessionLocal,
+    clean_authoring_runtime,
     register_active_authoring_job,
     register_authoring_task,
     settings,
@@ -747,6 +748,7 @@ class AuthoringService:
         #     -> completed | failed_resumable | failed
         graph_output: dict[str, Any] | None = None
         error_msg: str | None = None
+        clean_room_reason: str | None = None
         try:
             level_map = {
                 "pregrado": "undergrad",
@@ -887,6 +889,7 @@ class AuthoringService:
             )
             error_code = "checkpoint_unavailable"
             error_msg = _DURABLE_CHECKPOINT_ERROR_MESSAGE
+            clean_room_reason = "authoring_checkpoint_bootstrap_unavailable"
         except GraphBootstrapTimeoutError:
             logger.error(
                 "AuthoringService: Graph bootstrap timeout for Job %s",
@@ -898,6 +901,7 @@ class AuthoringService:
                 "La infraestructura de generacion tardo demasiado en inicializarse. "
                 "Puedes reintentar sin perder el progreso ya completado."
             )
+            clean_room_reason = "authoring_checkpoint_bootstrap_timeout"
         except asyncio.TimeoutError:
             logger.error("AuthoringService: TIMEOUT — Job %s exceeded 900s", job_id)
             error_code = "llm_timeout"
@@ -914,6 +918,7 @@ class AuthoringService:
                 )
                 error_code = "checkpoint_unavailable"
                 error_msg = _DURABLE_CHECKPOINT_ERROR_MESSAGE
+                clean_room_reason = "authoring_checkpoint_runtime_failed"
             else:
                 # Secondary guard: catch DB/pool errors wrapped by LangGraph retry
                 # machinery that escape the outer _is_durable_checkpoint_runtime_failure
@@ -929,6 +934,7 @@ class AuthoringService:
                     )
                     error_code = "checkpoint_unavailable"
                     error_msg = _DURABLE_CHECKPOINT_ERROR_MESSAGE
+                    clean_room_reason = "authoring_checkpoint_runtime_failed"
                 else:
                     logger.error("AuthoringService: LangGraph raised exception for Job %s", job_id, exc_info=True)
                     error_trace = traceback.format_exc()
@@ -954,6 +960,13 @@ class AuthoringService:
                     else:
                         error_code = "llm_unhandled_error"
                         error_msg = error_trace
+
+        if clean_room_reason is not None:
+            await clean_authoring_runtime(
+                reason=clean_room_reason,
+                timeout_seconds=5.0,
+                clear_active_jobs=False,
+            )
 
         # --- MICRO-SESSION 2: Persist Results ---
         db = SessionLocal()

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -100,7 +100,7 @@ from case_generator.tools_and_schemas import (
 from case_generator.orchestration.frontend_adapter import adapter_canonical_to_legacy
 from case_generator.orchestration.frontend_output_adapter import adapter_legacy_to_canonical_output
 from shared.database import (
-    close_langgraph_checkpointer_async_pool,
+    clean_authoring_runtime,
     collect_langgraph_bootstrap_diagnostics,
     get_checkpoint_migrations_version,
     get_langgraph_checkpointer_async_pool,
@@ -3357,8 +3357,11 @@ async def _build_async_postgres_checkpointer(*, is_first_init: bool) -> AsyncPos
                     "bootstrap_is_first_init": is_first_init,
                 },
             )
-        await close_langgraph_checkpointer_async_pool()
-        reset_graph_singleton()
+        await clean_authoring_runtime(
+            reason="graph_bootstrap_cancelled",
+            timeout_seconds=5.0,
+            clear_active_jobs=False,
+        )
         raise
     except Exception as exc:
         setup_ms = 0.0 if setup_started_at is None else round((time.perf_counter() - setup_started_at) * 1000, 3)
@@ -3382,8 +3385,11 @@ async def _build_async_postgres_checkpointer(*, is_first_init: bool) -> AsyncPos
                     "bootstrap_is_first_init": is_first_init,
                 },
             )
-        await close_langgraph_checkpointer_async_pool()
-        reset_graph_singleton()
+        await clean_authoring_runtime(
+            reason="graph_bootstrap_failed",
+            timeout_seconds=5.0,
+            clear_active_jobs=False,
+        )
         raise
 
     setup_ms = 0.0 if setup_started_at is None else round((time.perf_counter() - setup_started_at) * 1000, 3)

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -28,7 +28,6 @@ from sqlalchemy.exc import TimeoutError as SATimeoutError
 from sqlalchemy.orm import Session
 
 from case_generator.core.authoring import AuthoringService, derive_progress_percentage
-from case_generator.graph import reset_graph_singleton
 from case_generator.suggest_service import SuggestRequest, SuggestResponse, generate_suggestion
 from shared.admin_router import router as admin_router
 from shared.course_access_router import router as course_access_router
@@ -57,11 +56,9 @@ from shared.identity_activation import (
     upsert_profile as upsert_profile_impl,
 )
 from shared.database import (
-    close_langgraph_checkpointer_async_pool,
-    close_langgraph_checkpointer_pool,
+    clean_authoring_runtime,
     dispose_database_engine,
     get_db,
-    snapshot_active_authoring_jobs,
     validate_runtime_database_configuration,
 )
 from shared.db_resilience import (
@@ -452,10 +449,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     try:
         yield
     finally:
-        logger.info("Cleaning up resources... active_authoring_jobs=%s", snapshot_active_authoring_jobs())
-        reset_graph_singleton()
-        await close_langgraph_checkpointer_async_pool()
-        close_langgraph_checkpointer_pool()
+        await clean_authoring_runtime(
+            reason="fastapi_lifespan_shutdown",
+            timeout_seconds=5.0,
+            clear_active_jobs=True,
+        )
         dispose_database_engine()
 
 

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -257,6 +257,55 @@ def _snapshot_authoring_task_names() -> list[str]:
     return sorted(task_names)
 
 
+def _clear_langgraph_checkpointer_async_pool_registration(*, expected_pool: AsyncConnectionPool | None = None) -> None:
+    """Clear cached async-pool registration, optionally only for one pool instance."""
+    global _langgraph_checkpointer_async_pool
+    global _langgraph_checkpointer_async_pool_loop
+    global _langgraph_checkpointer_async_pool_lock
+    global _langgraph_checkpointer_async_pool_lock_loop
+
+    with _langgraph_checkpointer_async_pool_lock_guard:
+        if expected_pool is not None and _langgraph_checkpointer_async_pool is not expected_pool:
+            return
+
+        _langgraph_checkpointer_async_pool = None
+        _langgraph_checkpointer_async_pool_loop = None
+        _langgraph_checkpointer_async_pool_lock = None
+        _langgraph_checkpointer_async_pool_lock_loop = None
+
+
+async def _await_langgraph_async_pool_close(
+    pool: AsyncConnectionPool,
+    *,
+    pool_loop: asyncio.AbstractEventLoop | None,
+    timeout_seconds: float,
+    close_reason: str,
+) -> None:
+    """Close a psycopg async pool on the loop that owns its worker tasks."""
+    current_loop = asyncio.get_running_loop()
+    if pool_loop is None or pool_loop is current_loop:
+        await asyncio.wait_for(pool.close(), timeout=timeout_seconds)
+        return
+
+    if pool_loop.is_closed():
+        raise RuntimeError("LangGraph async checkpointer pool owner loop is already closed")
+
+    logger.info(
+        "Closing LangGraph async checkpointer pool on owning event loop",
+        extra={
+            "close_reason": close_reason,
+            "current_loop_id": id(current_loop),
+            "owner_loop_id": id(pool_loop),
+        },
+    )
+    close_future = asyncio.run_coroutine_threadsafe(pool.close(), pool_loop)
+    try:
+        await asyncio.wait_for(asyncio.wrap_future(close_future), timeout=timeout_seconds)
+    except asyncio.TimeoutError:
+        close_future.cancel()
+        raise
+
+
 def _pool_stats_snapshot(pool: Any) -> dict[str, int]:
     """Return stable pool telemetry fields even if the underlying API shifts."""
     try:
@@ -528,6 +577,16 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
             return current_pool
 
         previous_pool = _langgraph_checkpointer_async_pool
+        previous_pool_loop = _langgraph_checkpointer_async_pool_loop
+        if previous_pool is not None:
+            previous_pool_closed_cleanly = await close_langgraph_checkpointer_async_pool(timeout_seconds=5.0)
+            if not previous_pool_closed_cleanly and _langgraph_checkpointer_async_pool is previous_pool:
+                previous_loop_id = None if previous_pool_loop is None else id(previous_pool_loop)
+                raise RuntimeError(
+                    "LangGraph async checkpointer pool rotation aborted because the previous pool could not be closed "
+                    f"cleanly on loop {previous_loop_id}."
+                )
+
         parsed_url = make_url(settings.database_url)
         min_size, max_size = _langgraph_checkpointer_pool_bounds()
         logger.debug(
@@ -604,40 +663,16 @@ async def get_langgraph_checkpointer_async_pool() -> AsyncConnectionPool:
         _langgraph_checkpointer_async_pool = pool
         _langgraph_checkpointer_async_pool_loop = current_loop
 
-        if previous_pool is not None and previous_pool is not pool:
-            try:
-                logger.info("Closing previous LangGraph async checkpointer pool", extra={"loop_id": id(current_loop)})
-                await asyncio.wait_for(previous_pool.close(), timeout=5.0)
-            except (asyncio.TimeoutError, Exception) as exc:
-                logger.error(
-                    "Could not close previous LangGraph async checkpointer pool cleanly: %s",
-                    exc,
-                )
-            finally:
-                previous_pool = None  # allow GC regardless
-
         return pool
 
 
 async def close_langgraph_checkpointer_async_pool(timeout_seconds: float = 5.0) -> bool:
     """Close and clear the cached async LangGraph checkpointer pool."""
-    global _langgraph_checkpointer_async_pool
-    global _langgraph_checkpointer_async_pool_loop
-    global _langgraph_checkpointer_async_pool_lock
-    global _langgraph_checkpointer_async_pool_lock_loop
-
     pool = _langgraph_checkpointer_async_pool
     pool_loop = _langgraph_checkpointer_async_pool_loop
-    _langgraph_checkpointer_async_pool = None
-    _langgraph_checkpointer_async_pool_loop = None
-    _langgraph_checkpointer_async_pool_lock = None
-    _langgraph_checkpointer_async_pool_lock_loop = None
 
     if pool is None:
-        return True
-
-    if pool_loop is not None and pool_loop.is_closed():
-        logger.warning("Skipping LangGraph async checkpointer pool close because the owning event loop is already closed")
+        _clear_langgraph_checkpointer_async_pool_registration()
         return True
 
     active_jobs = snapshot_active_authoring_jobs()
@@ -653,8 +688,20 @@ async def close_langgraph_checkpointer_async_pool(timeout_seconds: float = 5.0) 
             active_jobs,
             pending_task_names,
         )
-        await asyncio.wait_for(pool.close(), timeout=timeout_seconds)
+        if pool_loop is not None and pool_loop.is_closed():
+            logger.warning(
+                "LangGraph async checkpointer pool owner loop is already closed; attempting best-effort close on the current loop"
+            )
+            await asyncio.wait_for(pool.close(), timeout=timeout_seconds)
+        else:
+            await _await_langgraph_async_pool_close(
+                pool,
+                pool_loop=pool_loop,
+                timeout_seconds=timeout_seconds,
+                close_reason="clean_room_shutdown",
+            )
         closed_stats = _pool_stats_snapshot(pool)
+        _clear_langgraph_checkpointer_async_pool_registration(expected_pool=pool)
         logger.info(
             "LangGraph async checkpointer pool closed successfully. busy=%s available=%s waiting=%s",
             closed_stats.get("pool_busy", 0),

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -714,6 +714,103 @@ def close_langgraph_checkpointer_pool() -> bool:
         return False
 
 
+async def clean_authoring_runtime(
+    *,
+    reason: str,
+    timeout_seconds: float = 5.0,
+    clear_active_jobs: bool = False,
+) -> dict[str, Any]:
+    """Reset Authoring runtime residue without purging durable checkpoints.
+
+    This is the canonical clean-room surface for test teardown, process shutdown,
+    and checkpoint-infrastructure failure recovery. It closes the LangGraph pools,
+    resets the loop-bound compiled graph state, and optionally clears the in-memory
+    active-job registry. Durable checkpoints are intentionally preserved so normal
+    retries with the same thread_id/job_id can resume lineage; test-local purge of
+    checkpoint rows remains owned by the pytest harness when it opts into TRUNCATE
+    cleanup via shared_db_commit_visibility.
+    """
+
+    async_pool = _langgraph_checkpointer_async_pool
+    sync_pool = _langgraph_checkpointer_pool
+    pre_reset_state = snapshot_authoring_runtime_state()
+    async_pool_stats_before = _pool_stats_snapshot(async_pool) if async_pool is not None else {}
+    sync_pool_stats_before = _pool_stats_snapshot(sync_pool) if sync_pool is not None else {}
+
+    logger.info(
+        "Starting Authoring clean-room cleanup",
+        extra={
+            "clean_room_reason": reason,
+            "clean_room_clear_active_jobs": clear_active_jobs,
+            "clean_room_preserves_checkpoints": True,
+            "active_jobs_before": pre_reset_state["active_jobs"],
+            "pending_tasks_before": pre_reset_state["pending_tasks"],
+            "async_pool_stats_before": async_pool_stats_before,
+            "sync_pool_stats_before": sync_pool_stats_before,
+        },
+    )
+
+    async_pool_closed_cleanly = await close_langgraph_checkpointer_async_pool(timeout_seconds=timeout_seconds)
+    sync_pool_closed_cleanly = close_langgraph_checkpointer_pool()
+
+    from case_generator.graph import reset_graph_singleton
+
+    reset_graph_singleton()
+    if clear_active_jobs:
+        reset_active_authoring_job_registry()
+
+    post_reset_state = snapshot_authoring_runtime_state()
+    result = {
+        "reason": reason,
+        "preserved_checkpoints": True,
+        "clear_active_jobs": clear_active_jobs,
+        "async_pool_closed_cleanly": async_pool_closed_cleanly,
+        "sync_pool_closed_cleanly": sync_pool_closed_cleanly,
+        "pre_reset_state": pre_reset_state,
+        "post_reset_state": post_reset_state,
+        "async_pool_stats_before": async_pool_stats_before,
+        "sync_pool_stats_before": sync_pool_stats_before,
+    }
+
+    if (
+        not async_pool_closed_cleanly
+        or not sync_pool_closed_cleanly
+        or post_reset_state["pending_tasks"]
+        or (clear_active_jobs and post_reset_state["active_jobs"])
+    ):
+        logger.warning(
+            "Authoring clean-room cleanup finished with residue",
+            extra={
+                "clean_room_reason": reason,
+                "clean_room_clear_active_jobs": clear_active_jobs,
+                "clean_room_preserves_checkpoints": True,
+                "async_pool_closed_cleanly": async_pool_closed_cleanly,
+                "sync_pool_closed_cleanly": sync_pool_closed_cleanly,
+                "active_jobs_before": pre_reset_state["active_jobs"],
+                "pending_tasks_before": pre_reset_state["pending_tasks"],
+                "active_jobs_after": post_reset_state["active_jobs"],
+                "pending_tasks_after": post_reset_state["pending_tasks"],
+                "async_pool_stats_before": async_pool_stats_before,
+                "sync_pool_stats_before": sync_pool_stats_before,
+            },
+        )
+    else:
+        logger.info(
+            "Authoring clean-room cleanup completed",
+            extra={
+                "clean_room_reason": reason,
+                "clean_room_clear_active_jobs": clear_active_jobs,
+                "clean_room_preserves_checkpoints": True,
+                "async_pool_closed_cleanly": async_pool_closed_cleanly,
+                "sync_pool_closed_cleanly": sync_pool_closed_cleanly,
+                "active_jobs_after": post_reset_state["active_jobs"],
+                "pending_tasks_after": post_reset_state["pending_tasks"],
+            },
+        )
+
+    return result
+
+
 def dispose_database_engine() -> None:
     """Dispose the shared SQLAlchemy engine at process shutdown."""
     logger.info("Disposing shared SQLAlchemy engine")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,20 +18,16 @@ from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, close_all_sessions, sessionmaker
 
-from case_generator.graph import reset_graph_singleton
 from shared.app import app
 from shared.auth import get_auth_settings, get_jwt_verifier, get_supabase_admin_auth_client
 from shared.database import (
     SessionLocal,
-    close_langgraph_checkpointer_async_pool,
-    close_langgraph_checkpointer_pool,
+    clean_authoring_runtime,
     engine,
     get_db,
     install_session_factory_override,
-    reset_active_authoring_job_registry,
     reset_session_factory_override,
     settings,
-    snapshot_authoring_runtime_state,
 )
 from shared.models import Base, Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, Tenant, User
 
@@ -175,19 +171,29 @@ def _build_test_session_factory(connection: Connection) -> sessionmaker[Session]
     )
 
 
-def _close_async_checkpointer_pool_for_test(timeout_seconds: float = 5.0) -> bool:
+def _run_authoring_clean_room_for_test(timeout_seconds: float = 5.0) -> dict[str, object]:
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        return asyncio.run(close_langgraph_checkpointer_async_pool(timeout_seconds=timeout_seconds))
+        return asyncio.run(
+            clean_authoring_runtime(
+                reason="pytest_test_teardown",
+                timeout_seconds=timeout_seconds,
+                clear_active_jobs=True,
+            )
+        )
 
-    result: dict[str, bool] = {}
+    result: dict[str, dict[str, object]] = {}
     errors: list[BaseException] = []
 
     def _runner() -> None:
         try:
-            result["closed_cleanly"] = asyncio.run(
-                close_langgraph_checkpointer_async_pool(timeout_seconds=timeout_seconds)
+            result["clean_room"] = asyncio.run(
+                clean_authoring_runtime(
+                    reason="pytest_test_teardown",
+                    timeout_seconds=timeout_seconds,
+                    clear_active_jobs=True,
+                )
             )
         except BaseException as exc:  # pragma: no cover - defensive bridge
             errors.append(exc)
@@ -197,28 +203,27 @@ def _close_async_checkpointer_pool_for_test(timeout_seconds: float = 5.0) -> boo
     cleanup_thread.join()
     if errors:
         raise errors[0]
-    return result.get("closed_cleanly", False)
+    return result.get("clean_room", {})
 
 
 def _cleanup_runtime_state() -> None:
     close_all_sessions()
-    async_pool_closed_cleanly = _close_async_checkpointer_pool_for_test()
-    sync_pool_closed_cleanly = close_langgraph_checkpointer_pool()
-    pre_reset_state = snapshot_authoring_runtime_state()
-    reset_graph_singleton()
-    reset_active_authoring_job_registry()
-    post_reset_state = snapshot_authoring_runtime_state()
+    cleanup_result = _run_authoring_clean_room_for_test()
+    async_pool_closed_cleanly = bool(cleanup_result.get("async_pool_closed_cleanly", False))
+    sync_pool_closed_cleanly = bool(cleanup_result.get("sync_pool_closed_cleanly", False))
+    pre_reset_state = dict(cleanup_result.get("pre_reset_state", {}))
+    post_reset_state = dict(cleanup_result.get("post_reset_state", {}))
 
     failures: list[str] = []
-    if pre_reset_state["active_jobs"]:
+    if pre_reset_state.get("active_jobs"):
         failures.append(f"active authoring jobs leaked across test boundary: {pre_reset_state['active_jobs']}")
     if not async_pool_closed_cleanly:
         failures.append("LangGraph async checkpointer pool did not close cleanly")
     if not sync_pool_closed_cleanly:
         failures.append("LangGraph sync checkpointer pool did not close cleanly")
-    if post_reset_state["pending_tasks"]:
+    if post_reset_state.get("pending_tasks"):
         failures.append(f"authoring tasks still pending after cleanup: {post_reset_state['pending_tasks']}")
-    if post_reset_state["active_jobs"]:
+    if post_reset_state.get("active_jobs"):
         failures.append(f"active authoring job registry still populated after cleanup: {post_reset_state['active_jobs']}")
 
     if failures:

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -1,6 +1,7 @@
 import contextlib
 import asyncio
 import logging
+import threading
 import uuid
 from unittest.mock import AsyncMock, patch
 
@@ -406,6 +407,81 @@ def test_async_checkpointer_pool_rebuilds_when_event_loop_changes(monkeypatch) -
     assert state["open_calls"] == 2
 
 
+def test_close_async_checkpointer_pool_uses_owner_loop_when_running_in_other_thread(monkeypatch) -> None:
+    state = {
+        "close_calls": 0,
+        "close_loop_id": None,
+        "owner_loop_id": None,
+    }
+    ready = threading.Event()
+    stop_requested = threading.Event()
+    owner_loop_holder: dict[str, asyncio.AbstractEventLoop] = {}
+
+    class FakeAsyncConnectionPool:
+        async def close(self) -> None:
+            state["close_calls"] += 1
+            state["close_loop_id"] = id(asyncio.get_running_loop())
+
+    def _run_owner_loop() -> None:
+        owner_loop = asyncio.new_event_loop()
+        owner_loop_holder["loop"] = owner_loop
+        state["owner_loop_id"] = id(owner_loop)
+        asyncio.set_event_loop(owner_loop)
+        ready.set()
+        try:
+            owner_loop.run_until_complete(_wait_for_stop())
+        finally:
+            owner_loop.close()
+
+    async def _wait_for_stop() -> None:
+        while not stop_requested.is_set():
+            await asyncio.sleep(0.01)
+
+    cleanup_thread = threading.Thread(target=_run_owner_loop, name="langgraph-owner-loop", daemon=True)
+    cleanup_thread.start()
+    assert ready.wait(timeout=5.0)
+
+    fake_pool = FakeAsyncConnectionPool()
+    owner_loop = owner_loop_holder["loop"]
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", fake_pool)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", owner_loop)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", asyncio.Lock())
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock_loop", owner_loop)
+
+    try:
+        assert asyncio.run(database_module.close_langgraph_checkpointer_async_pool()) is True
+    finally:
+        stop_requested.set()
+        owner_loop.call_soon_threadsafe(lambda: None)
+        cleanup_thread.join(timeout=5.0)
+
+    assert state["close_calls"] == 1
+    assert state["close_loop_id"] == state["owner_loop_id"]
+    assert database_module._langgraph_checkpointer_async_pool is None
+    assert database_module._langgraph_checkpointer_async_pool_loop is None
+
+
+async def test_close_async_checkpointer_pool_keeps_registration_on_close_failure(monkeypatch) -> None:
+    class BrokenAsyncConnectionPool:
+        async def close(self) -> None:
+            raise RuntimeError("close failed")
+
+    fake_pool = BrokenAsyncConnectionPool()
+    current_loop = asyncio.get_running_loop()
+    current_lock = asyncio.Lock()
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", fake_pool)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", current_loop)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", current_lock)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock_loop", current_loop)
+
+    assert await database_module.close_langgraph_checkpointer_async_pool() is False
+    assert database_module._langgraph_checkpointer_async_pool is fake_pool
+    assert database_module._langgraph_checkpointer_async_pool_loop is current_loop
+    assert database_module._langgraph_checkpointer_async_pool_lock is current_lock
+    assert database_module._langgraph_checkpointer_async_pool_lock_loop is current_loop
+    database_module._clear_langgraph_checkpointer_async_pool_registration(expected_pool=fake_pool)
+
+
 async def test_close_async_checkpointer_pool_clears_singleton(monkeypatch) -> None:
     state = {"close_calls": 0}
 
@@ -462,6 +538,7 @@ async def test_close_async_checkpointer_pool_logs_timeout_telemetry(monkeypatch,
     assert "LEAK DETECTED" in caplog.text
     assert "job-timeout" in caplog.text
     assert "authoring-job-job-timeout" in caplog.text
+    database_module._clear_langgraph_checkpointer_async_pool_registration()
 
 
 async def test_async_checkpointer_pool_logs_stable_pool_open_key_and_warning(monkeypatch, caplog) -> None:

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 from unittest.mock import AsyncMock, patch
 
+from psycopg.errors import LockNotAvailable
 from psycopg_pool import PoolClosed, PoolTimeout
 import pytest
 from sqlalchemy import text
@@ -66,6 +67,40 @@ def _seed_authoring_job(
     db.commit()
     db.refresh(job)
     return job
+
+
+def _insert_checkpoint_lineage(db, thread_id: str) -> str:
+    checkpoint_id = f"checkpoint-{uuid.uuid4()}"
+    db.execute(
+        text(
+            "INSERT INTO checkpoints ("
+            "thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, type, checkpoint, metadata"
+            ") VALUES ("
+            ":thread_id, :checkpoint_ns, :checkpoint_id, :parent_checkpoint_id, :type, "
+            "CAST(:checkpoint AS jsonb), CAST(:metadata AS jsonb)"
+            ")"
+        ),
+        {
+            "thread_id": thread_id,
+            "checkpoint_ns": "",
+            "checkpoint_id": checkpoint_id,
+            "parent_checkpoint_id": None,
+            "type": "json",
+            "checkpoint": "{}",
+            "metadata": "{}",
+        },
+    )
+    db.commit()
+    return checkpoint_id
+
+
+def _count_checkpoint_lineage(db, thread_id: str) -> int:
+    return int(
+        db.execute(
+            text("SELECT count(*) FROM checkpoints WHERE thread_id = :thread_id"),
+            {"thread_id": thread_id},
+        ).scalar_one()
+    )
 
 
 def test_canonical_progress_step_mapping_is_stable() -> None:
@@ -785,8 +820,8 @@ async def test_build_async_postgres_checkpointer_cleans_up_and_retries_with_fres
     async def fake_get_checkpoint_migrations_version(_pool):
         return 9
 
-    async def wrapped_close(*args, **kwargs):
-        await database_module.close_langgraph_checkpointer_async_pool(*args, **kwargs)
+    async def wrapped_clean_room(*args, **kwargs):
+        return await database_module.clean_authoring_runtime(*args, **kwargs)
 
     reset_mock = patch.object(graph_module, "reset_graph_singleton", wraps=graph_module.reset_graph_singleton)
 
@@ -800,15 +835,16 @@ async def test_build_async_postgres_checkpointer_cleans_up_and_retries_with_fres
     monkeypatch.setattr(graph_module, "AsyncPostgresSaver", FlakyAsyncPostgresSaver)
 
     with reset_mock as reset_graph_singleton_mock:
-        close_mock = AsyncMock(side_effect=wrapped_close)
-        monkeypatch.setattr(graph_module, "close_langgraph_checkpointer_async_pool", close_mock)
+        clean_room_mock = AsyncMock(side_effect=wrapped_clean_room)
+        monkeypatch.setattr(graph_module, "clean_authoring_runtime", clean_room_mock)
 
         with pytest.raises(PoolTimeout):
             await graph_module._build_async_postgres_checkpointer(is_first_init=True)
 
         retry_checkpointer = await graph_module._build_async_postgres_checkpointer(is_first_init=True)
 
-    assert close_mock.await_count == 1
+    assert clean_room_mock.await_count == 1
+    assert clean_room_mock.await_args.kwargs["reason"] == "graph_bootstrap_failed"
     assert reset_graph_singleton_mock.call_count == 1
     assert len(created_pools) == 2
     assert created_pools[0] is not created_pools[1]
@@ -1051,3 +1087,183 @@ def test_run_job_duplicate_retry_race_allows_only_one_checkpoint_attempt(
     assert payload.get("error_code") == "checkpoint_unavailable"
     assert payload.get("last_known_step") == "case_writer"
     orphan_mock.assert_not_called()
+
+
+async def test_run_job_same_thread_retry_preserves_checkpoint_lineage_and_rebuilds_runtime(
+    db,
+    seed_identity,
+    monkeypatch,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-same-thread-retry@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    job = _seed_authoring_job(
+        db,
+        teacher_id,
+        status="failed_resumable",
+        task_payload={
+            "current_step": "case_writer",
+            "progress_seq": 4,
+            "error_code": "checkpoint_unavailable",
+        },
+    )
+    _insert_checkpoint_lineage(db, job.id)
+
+    class CorruptGraph:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def astream(self, *args, **kwargs):
+            self.calls += 1
+
+            async def _stream():
+                raise PoolClosed("checkpoint pool closed")
+                yield {}
+
+            return _stream()
+
+    class FreshGraph:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def astream(self, *args, **kwargs):
+            self.calls += 1
+
+            async def _stream():
+                yield {
+                    "doc1_narrativa": "Narrative text with enough detail to finalize the retry path.",
+                    "doc2_eda": "",
+                    "current_agent": "case_writer",
+                }
+
+            return _stream()
+
+    state = {"checkpointer_calls": 0, "compile_calls": 0}
+    corrupt_graph = CorruptGraph()
+    fresh_graph = FreshGraph()
+
+    async def fake_build_async_postgres_checkpointer(*, is_first_init: bool):
+        state["checkpointer_calls"] += 1
+        await asyncio.sleep(0)
+        return {
+            "checkpointer_calls": state["checkpointer_calls"],
+            "is_first_init": is_first_init,
+        }
+
+    def fake_compile(*, name: str, checkpointer: object):
+        state["compile_calls"] += 1
+        assert name == "adam-agent"
+        return fresh_graph
+
+    monkeypatch.setattr(graph_module, "_graph_singleton", corrupt_graph)
+    monkeypatch.setattr(graph_module, "_graph_singleton_loop", asyncio.get_running_loop())
+    monkeypatch.setattr(graph_module, "_graph_singleton_lock", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton_lock_loop", None)
+    monkeypatch.setattr(graph_module, "_build_async_postgres_checkpointer", fake_build_async_postgres_checkpointer)
+    monkeypatch.setattr(graph_module.master_builder, "compile", fake_compile)
+
+    prefetch_mock = AsyncMock(return_value={})
+    save_artifact_mock = AsyncMock(return_value="artifact-1")
+
+    with (
+        patch("case_generator.core.authoring.get_storage_provider", return_value=object()),
+        patch("case_generator.core.authoring.ArtifactManager.prefetch_resume_artifacts", new=prefetch_mock),
+        patch("case_generator.core.authoring.ArtifactManager.save_artifact", new=save_artifact_mock),
+        patch("case_generator.core.authoring.ArtifactManager.publish_job_artifacts") as publish_mock,
+        patch(
+            "case_generator.core.authoring.adapter_legacy_to_canonical_output",
+            return_value={"canonical_output": {}},
+        ),
+        patch("case_generator.core.authoring.ArtifactManager.orphan_job_artifacts") as orphan_mock,
+    ):
+        await AuthoringService.run_job(job.id)
+
+        assert graph_module._graph_singleton is None
+        assert database_module._langgraph_checkpointer_async_pool is None
+        assert _count_checkpoint_lineage(db, job.id) == 1
+
+        db.expire_all()
+        failed_retry = db.get(AuthoringJob, job.id)
+        assert failed_retry is not None
+        failed_payload = dict(failed_retry.task_payload or {})
+        assert failed_retry.status == "failed_resumable"
+        assert failed_retry.retry_count == 1
+        assert failed_payload.get("error_code") == "checkpoint_unavailable"
+        assert failed_payload.get("last_known_step") == "case_writer"
+
+        await AuthoringService.run_job(job.id)
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+
+    payload = dict(refreshed.task_payload or {})
+    assert refreshed.status == "completed"
+    assert refreshed.retry_count == 2
+    assert payload.get("current_step") == "completed"
+    assert corrupt_graph.calls == 1
+    assert fresh_graph.calls == 1
+    assert state["checkpointer_calls"] == 1
+    assert state["compile_calls"] == 1
+    assert prefetch_mock.await_count == 2
+    assert save_artifact_mock.await_count == 1
+    assert _count_checkpoint_lineage(db, job.id) == 1
+    publish_mock.assert_called_once()
+    assert publish_mock.call_args.args[1] == job.id
+    orphan_mock.assert_not_called()
+
+
+@pytest.mark.shared_db_commit_visibility
+async def test_build_async_postgres_checkpointer_reproduces_lock_not_available_and_recovers(
+    independent_session,
+    monkeypatch,
+    caplog,
+) -> None:
+    await database_module.clean_authoring_runtime(
+        reason="test_lock_contention_preflight",
+        timeout_seconds=0.1,
+        clear_active_jobs=True,
+    )
+
+    monkeypatch.setattr(database_module.settings, "db_lock_timeout_ms", 50, raising=False)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_loop", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock", None)
+    monkeypatch.setattr(database_module, "_langgraph_checkpointer_async_pool_lock_loop", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton_loop", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton_lock", None)
+    monkeypatch.setattr(graph_module, "_graph_singleton_lock_loop", None)
+
+    caplog.set_level(logging.INFO, logger="adam.graph")
+
+    independent_session.execute(text("LOCK TABLE checkpoint_migrations IN ACCESS EXCLUSIVE MODE"))
+
+    try:
+        with pytest.raises(LockNotAvailable):
+            await graph_module._build_async_postgres_checkpointer(is_first_init=True)
+    finally:
+        independent_session.rollback()
+
+    error_record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "[graph] AsyncPostgresSaver setup failed"
+    )
+
+    assert isinstance(error_record.pg_locks, list)
+    assert isinstance(error_record.pg_stat_activity, list)
+    assert error_record.pg_locks or error_record.pg_stat_activity
+    assert database_module._langgraph_checkpointer_async_pool is None
+    assert graph_module._graph_singleton is None
+
+    retry_checkpointer = await graph_module._build_async_postgres_checkpointer(is_first_init=True)
+
+    assert retry_checkpointer is not None
+
+    await database_module.clean_authoring_runtime(
+        reason="test_lock_contention_recovery",
+        timeout_seconds=0.1,
+        clear_active_jobs=True,
+    )

--- a/backend/tests/test_phase3_status_api.py
+++ b/backend/tests/test_phase3_status_api.py
@@ -4,9 +4,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from case_generator.graph import reset_graph_singleton
 import shared.database as database_module
-from shared.database import close_langgraph_checkpointer_async_pool, snapshot_active_authoring_jobs
+from shared.database import clean_authoring_runtime, snapshot_active_authoring_jobs
 from shared.models import Assignment, AuthoringJob
 
 
@@ -17,8 +16,13 @@ _teardown_verification_state = {"close_calls": 0}
 def ensure_no_authoring_runtime_leaks() -> None:
     yield
     assert snapshot_active_authoring_jobs() == []
-    reset_graph_singleton()
-    asyncio.run(close_langgraph_checkpointer_async_pool(timeout_seconds=0.1))
+    asyncio.run(
+        clean_authoring_runtime(
+            reason="test_phase3_status_api_teardown",
+            timeout_seconds=0.1,
+            clear_active_jobs=True,
+        )
+    )
 
 
 def test_phase3_status_api_teardown_primes_pool_cleanup() -> None:


### PR DESCRIPTION
## Summary
- centralize Authoring clean-room cleanup across FastAPI shutdown, graph bootstrap failure handling, and pytest teardown without purging durable checkpoints
- reset runtime residue selectively on checkpoint infrastructure failures so same-job retries rebuild graph and pool state while preserving \	hread_id = job_id\ checkpoint lineage
- add deterministic regressions for same-thread retry recovery and real \LockNotAvailable\ contention on \checkpoint_migrations\
- **loop-handoff hardening**: Ensure owner-loop-safe async-pool shutdown and atomic registry cleanup during runtime handoff or shutdown.

## Root Cause
The residual flake was in the Authoring runtime boundary, not in the generic pytest harness. Bootstrap failures already cleaned up pool and graph state, but runtime checkpoint failures and test teardown still used different cleanup paths. That let stale compiled-graph or checkpointer-pool state survive an infrastructure failure and leak into the next retry with the same \job_id\ and \	hread_id\.

The lock path was reproduced directly on the real checkpoint setup path by holding \LOCK TABLE checkpoint_migrations IN ACCESS EXCLUSIVE MODE\ from one session while \AsyncPostgresSaver.setup()\ ran from another. In this repo and environment, that deterministically raised \psycopg.errors.LockNotAvailable\.

## Validation
- **Targeted regression pair**: \uv run --directory backend pytest tests/test_authoring_progress_resilience.py tests/test_phase3_status_api.py -q\ (Green)
- **Typing**: \uv run --directory backend mypy src\ (Green)
- **Full-suite stability**: Three consecutive runs at \250 passed, 12 skipped\
  - Run 1: \250 passed, 12 skipped\
  - Run 2: \250 passed, 12 skipped\
  - Run 3: \250 passed, 12 skipped\

Across the three full-suite runs there were no pool-leak, pending-task, clean-room residue, or \LockNotAvailable\ fallout diagnostics.

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] Targeted regression pair green (\	ests/test_authoring_progress_resilience.py\, \	ests/test_phase3_status_api.py\)
- [x] \uv run --directory backend mypy src\ green
- [x] Three consecutive full-suite runs at \250 passed, 12 skipped\

🤖 Generated with [Claude Code](https://claude.com/claude-code)