### PR TITLE
feat(backend): add syllabuses, revisions, and teacher course detail for issue #137

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -246,3 +246,35 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** Diferido explícitamente durante Issue #128 para mantener el diff enfocado en la causa raíz de la contaminación cruzada: commits opacos, ausencia de transacción externa por test y teardown global insuficiente.
 
 **Depends on / blocked by:** Mantener estable el harness serial con `SAVEPOINT` durante varias corridas de CI y definir estrategia de naming/bootstrap para DBs temporales por worker.
+
+---
+
+## TODO-016: Documentar el contrato operativo de clean-room para Authoring
+
+**What:** Documentar el contrato operativo canonico del clean-room de Authoring: ownership de teardown, simbolos reutilizables, politica de purge de checkpoints y evidencia minima de logs para diagnostico de fugas o contencion.
+
+**Why:** La estabilizacion de Authoring depende de una frontera precisa entre el harness de pytest, el runtime de `AuthoringService` y el lifecycle de LangGraph. Si esa frontera queda solo implícita en el codigo o en una PR, es facil reintroducir residuos de pools, tareas o checkpoints en cambios futuros.
+
+**Pros:** Preserva el razonamiento operativo, reduce regresiones por drift entre tests y runtime, y acelera debugging cuando reaparezcan sintomas como `LockNotAvailable` o leaks de pools.
+
+**Cons:** Añade trabajo de documentacion fuera del fix principal y exige mantener sincronizado el texto cuando cambie el contrato de cleanup.
+
+**Context:** Aceptado durante la revision de rediseño de Issue #127. El objetivo es que la solucion de clean-room sea invisible para quien escriba nuevos tests, pero explicita para quien mantenga el runtime. La documentacion debe referenciar el contrato centralizado una vez exista como superficie canonica.
+
+**Depends on / blocked by:** Depende de cerrar primero la implementacion de Issue #127 y de fijar cuales helpers quedan como API operativa estable para clean-room y diagnostico.
+
+---
+
+## TODO-017: Stress harness post-fix para contencion de checkpoints y churn de event loops
+
+**What:** Evaluar un stress harness diferido que repita secuencias de bootstrap, retry, teardown y cambio de event loop para el path de checkpoints de LangGraph mas alla de `test_authoring_progress_resilience.py` y `test_phase3_status_api.py`.
+
+**Why:** Issue #127 debe resolver la inestabilidad determinista actual con el menor diff posible. Un soak test o stress harness mas amplio puede ser valioso despues, pero mezclarlo ahora convertiria un fix de integracion Authoring en una epica de validacion de carga.
+
+**Pros:** Captura una siguiente capa de hardening para detectar contencion intermitente, churn multi-loop y regresiones de lifecycle antes de que aparezcan en CI o staging.
+
+**Cons:** Puede inflar scope y tiempo de mantenimiento; si se adelanta demasiado, corre el riesgo de probar comportamientos todavia no estabilizados por el fix principal.
+
+**Context:** Aceptado como follow-up durante la revision de la nueva especificacion de Issue #127. La evidencia actual apunta a dos modulos pesados concretos; el stress harness seria una fase posterior una vez el clean-room de Authoring quede estable y reusable.
+
+**Depends on / blocked by:** Bloqueado por la implementacion y validacion completa de Issue #127, incluyendo el contrato de clean-room, la reproduccion determinista del path de locks y tres corridas full-suite consecutivas en verde.

--- a/TODOS.md
+++ b/TODOS.md
@@ -265,6 +265,38 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
+## TODO-019: Vincular `Assignment.course_id` y authoring al dominio de syllabus
+
+**What:** Agregar `course_id` real a `assignments`, propagarlo por el intake de authoring y reemplazar el placeholder `active_cases_count=0` de teacher courses por conteos reales por curso.
+
+**Why:** La base backend de syllabuses y revisiones puede vivir sola en Issue #137, pero el authoring y los indicadores de casos siguen desacoplados del curso hasta que exista ese puente explícito.
+
+**Pros:** Elimina una costura conocida entre gestión docente y generación de casos, permite grounding y guardrails por curso en el flujo de authoring, y cierra el TODO ya existente en `backend/src/shared/teacher_reads.py`.
+
+**Cons:** Amplía el scope hacia el dominio de authoring, requiere migración adicional sobre `assignments`, ajustes de contratos y tests cruzados con el pipeline de generación.
+
+**Context:** Durante la revisión de Issue #137 se decidió mantener el backend de syllabus aislado y deferir la integración completa con authoring a la issue hermana #139 para no mezclar persistencia pedagógica con orquestación/generation guardrails en la misma PR.
+
+**Depends on / blocked by:** Issue #139 y la definición final del contrato `course_id` en authoring intake, pipeline y queries de progreso/resultado.
+
+---
+
+## TODO-020: Endpoint docente para gestionar access link del curso
+
+**What:** Crear un endpoint docente dedicado para visualizar o regenerar el access link vigente del curso, con auditoría y reglas explícitas de exposición del raw token.
+
+**Why:** En Issue #137 el detalle docente devuelve solo metadata y `access_link_status`, porque el modelo actual persiste hashes y no puede reconstruir un link bruto existente de forma segura.
+
+**Pros:** Hace accionable la pestaña Configuración sin degradar el modelo de secretos del endpoint de detalle; separa claramente lectura de estado y emisión/regeneración de links.
+
+**Cons:** Añade una nueva superficie de escritura sensible, implica definir ownership docente, UX de one-time display y política de rotación para no filtrar tokens sin control.
+
+**Context:** La revisión de arquitectura de Issue #137 eligió fail-closed en el detalle compuesto: no exponer raw links en `GET /api/teacher/courses/{course_id}` y dejar la gestión activa del link como follow-up deliberado.
+
+**Depends on / blocked by:** Alineación de producto para self-service docente en la pestaña Configuración y decisión explícita sobre si la acción debe regenerar el token o solo mostrar un token recién emitido.
+
+---
+
 ## TODO-017: Stress harness post-fix para contencion de checkpoints y churn de event loops
 
 **What:** Evaluar un stress harness diferido que repita secuencias de bootstrap, retry, teardown y cambio de event loop para el path de checkpoints de LangGraph mas alla de `test_authoring_progress_resilience.py` y `test_phase3_status_api.py`.

--- a/backend/alembic/versions/e1b3c4d5f6a7_issue137_teacher_syllabuses.py
+++ b/backend/alembic/versions/e1b3c4d5f6a7_issue137_teacher_syllabuses.py
@@ -1,0 +1,78 @@
+"""Issue 137 teacher syllabuses and revisions
+
+Revision ID: e1b3c4d5f6a7
+Revises: 97a740b07c66
+Create Date: 2026-04-19 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e1b3c4d5f6a7"
+down_revision: Union[str, Sequence[str], None] = "97a740b07c66"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "syllabuses",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("course_id", sa.Text(), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("department", sa.Text(), nullable=False),
+        sa.Column("knowledge_area", sa.Text(), nullable=False),
+        sa.Column("nbc", sa.Text(), nullable=False),
+        sa.Column("version_label", sa.Text(), nullable=False),
+        sa.Column("academic_load", sa.Text(), nullable=False),
+        sa.Column("course_description", sa.Text(), nullable=False),
+        sa.Column("general_objective", sa.Text(), nullable=False),
+        sa.Column("specific_objectives", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("modules", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("evaluation_strategy", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("didactic_strategy", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("integrative_project", sa.Text(), nullable=False),
+        sa.Column("bibliography", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("teacher_notes", sa.Text(), nullable=False),
+        sa.Column("ai_grounding_context", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("saved_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("saved_by_membership_id", sa.Text(), nullable=False),
+        sa.CheckConstraint("revision > 0", name="ck_syllabuses_revision_positive"),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"]),
+        sa.ForeignKeyConstraint(["saved_by_membership_id"], ["memberships.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("course_id", name="uix_syllabuses_course_id"),
+    )
+
+    op.create_table(
+        "syllabus_revisions",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("syllabus_id", sa.Text(), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("snapshot", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("saved_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("saved_by_membership_id", sa.Text(), nullable=False),
+        sa.CheckConstraint("revision > 0", name="ck_syllabus_revisions_revision_positive"),
+        sa.ForeignKeyConstraint(["saved_by_membership_id"], ["memberships.id"]),
+        sa.ForeignKeyConstraint(["syllabus_id"], ["syllabuses.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        "ix_syllabus_revisions_syllabus_revision",
+        "syllabus_revisions",
+        ["syllabus_id", "revision"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_syllabus_revisions_syllabus_revision", table_name="syllabus_revisions")
+    op.drop_table("syllabus_revisions")
+    op.drop_table("syllabuses")

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -202,6 +202,7 @@ class Course(Base):
     invites: Mapped[list["Invite"]] = relationship(back_populates="course", foreign_keys="Invite.course_id")
     access_links: Mapped[list["CourseAccessLink"]] = relationship(back_populates="course")
     course_memberships: Mapped[list["CourseMembership"]] = relationship(back_populates="course")
+    syllabus: Mapped["Syllabus | None"] = relationship(back_populates="course", uselist=False)
 
 
 class Invite(Base):
@@ -345,6 +346,70 @@ class Assignment(Base):
     teacher: Mapped["User"] = relationship(back_populates="assignments")
     authoring_jobs: Mapped[list["AuthoringJob"]] = relationship(back_populates="assignment")
     artifacts: Mapped[list["ArtifactManifest"]] = relationship(back_populates="assignment")
+
+
+class Syllabus(Base):
+    """
+    Current pedagogical syllabus state for a course.
+
+    Course 1:1 Syllabus
+          |
+          +--> SyllabusRevision (append-only snapshots)
+    """
+
+    __tablename__ = "syllabuses"
+    __table_args__ = (
+        UniqueConstraint("course_id", name="uix_syllabuses_course_id"),
+        CheckConstraint("revision > 0", name="ck_syllabuses_revision_positive"),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
+    course_id: Mapped[str] = mapped_column(Text, ForeignKey("courses.id"), nullable=False)
+    revision: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    department: Mapped[str] = mapped_column(Text, nullable=False)
+    knowledge_area: Mapped[str] = mapped_column(Text, nullable=False)
+    nbc: Mapped[str] = mapped_column(Text, nullable=False)
+    version_label: Mapped[str] = mapped_column(Text, nullable=False)
+    academic_load: Mapped[str] = mapped_column(Text, nullable=False)
+    course_description: Mapped[str] = mapped_column(Text, nullable=False)
+    general_objective: Mapped[str] = mapped_column(Text, nullable=False)
+    specific_objectives: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
+    modules: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False, default=list)
+    evaluation_strategy: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False, default=list)
+    didactic_strategy: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict)
+    integrative_project: Mapped[str] = mapped_column(Text, nullable=False)
+    bibliography: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
+    teacher_notes: Mapped[str] = mapped_column(Text, nullable=False)
+    ai_grounding_context: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict)
+    saved_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    saved_by_membership_id: Mapped[str] = mapped_column(Text, ForeignKey("memberships.id"), nullable=False)
+
+    course: Mapped["Course"] = relationship(back_populates="syllabus")
+    revisions: Mapped[list["SyllabusRevision"]] = relationship(back_populates="syllabus")
+
+
+class SyllabusRevision(Base):
+    """Append-only snapshot ledger for syllabus saves."""
+
+    __tablename__ = "syllabus_revisions"
+    __table_args__ = (
+        CheckConstraint("revision > 0", name="ck_syllabus_revisions_revision_positive"),
+        Index(
+            "ix_syllabus_revisions_syllabus_revision",
+            "syllabus_id",
+            "revision",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
+    syllabus_id: Mapped[str] = mapped_column(Text, ForeignKey("syllabuses.id"), nullable=False)
+    revision: Mapped[int] = mapped_column(Integer, nullable=False)
+    snapshot: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    saved_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    saved_by_membership_id: Mapped[str] = mapped_column(Text, ForeignKey("memberships.id"), nullable=False)
+
+    syllabus: Mapped["Syllabus"] = relationship(back_populates="revisions")
 
 
 AUTHORING_JOB_STATUS_PENDING = "pending"

--- a/backend/src/shared/syllabus_schema.py
+++ b/backend/src/shared/syllabus_schema.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SyllabusUnitPayload(StrictModel):
+    unit_id: str
+    title: str
+    topics: str
+
+
+class SyllabusModulePayload(StrictModel):
+    module_id: str
+    module_title: str
+    weeks: str
+    module_summary: str
+    learning_outcomes: list[str]
+    units: list[SyllabusUnitPayload]
+    cross_course_connections: str
+
+
+class EvaluationStrategyItemPayload(StrictModel):
+    activity: str
+    weight: float = Field(ge=0)
+    linked_objectives: list[str]
+    expected_outcome: str
+
+
+class DidacticStrategyPayload(StrictModel):
+    methodological_perspective: str
+    pedagogical_modality: str
+
+
+class TeacherSyllabusPayload(StrictModel):
+    department: str
+    knowledge_area: str
+    nbc: str
+    version_label: str
+    academic_load: str
+    course_description: str
+    general_objective: str
+    specific_objectives: list[str]
+    modules: list[SyllabusModulePayload]
+    evaluation_strategy: list[EvaluationStrategyItemPayload]
+    didactic_strategy: DidacticStrategyPayload
+    integrative_project: str
+    bibliography: list[str]
+    teacher_notes: str
+
+
+class GroundingCourseIdentity(StrictModel):
+    course_id: str
+    course_title: str
+    academic_level: str
+    department: str
+    knowledge_area: str
+    nbc: str
+
+
+class GroundingPedagogicalIntent(StrictModel):
+    course_description: str
+    general_objective: str
+    specific_objectives: list[str]
+
+
+class GroundingInstructionalScope(StrictModel):
+    modules: list[SyllabusModulePayload]
+    evaluation_strategy: list[EvaluationStrategyItemPayload]
+    didactic_strategy: DidacticStrategyPayload
+
+
+class GroundingGenerationHints(StrictModel):
+    target_student_profile: str
+    scenario_constraints: list[str]
+    preferred_techniques: list[str]
+    difficulty_signal: str
+    forbidden_mismatches: list[str]
+
+
+class GroundingMetadata(StrictModel):
+    syllabus_revision: int = Field(ge=1)
+    saved_at: datetime
+    saved_by_membership_id: str
+
+
+class SyllabusGroundingContext(StrictModel):
+    course_identity: GroundingCourseIdentity
+    pedagogical_intent: GroundingPedagogicalIntent
+    instructional_scope: GroundingInstructionalScope
+    generation_hints: GroundingGenerationHints
+    metadata: GroundingMetadata
+
+
+class TeacherSyllabusResponse(TeacherSyllabusPayload):
+    ai_grounding_context: SyllabusGroundingContext
+
+
+class TeacherSyllabusRevisionMetadataResponse(StrictModel):
+    current_revision: int = Field(ge=0)
+    saved_at: datetime | None
+    saved_by_membership_id: str | None
+
+
+class TeacherCourseInstitutionalResponse(StrictModel):
+    id: str
+    title: str
+    code: str
+    semester: str
+    academic_level: str
+    status: Literal["active", "inactive"]
+    max_students: int
+    students_count: int
+    active_cases_count: int
+
+
+class TeacherCourseConfigurationResponse(StrictModel):
+    access_link_status: Literal["active", "missing"]
+    access_link_id: str | None = None
+    access_link_created_at: datetime | None = None
+    join_path: str = "/app/join"
+
+
+class TeacherCourseDetailResponse(StrictModel):
+    course: TeacherCourseInstitutionalResponse
+    syllabus: TeacherSyllabusResponse | None
+    revision_metadata: TeacherSyllabusRevisionMetadataResponse
+    configuration: TeacherCourseConfigurationResponse
+
+
+class TeacherSyllabusSaveRequest(StrictModel):
+    expected_revision: int = Field(ge=0)
+    syllabus: TeacherSyllabusPayload
+
+
+def derive_syllabus_grounding_context(
+    *,
+    course_id: str,
+    course_title: str,
+    academic_level: str,
+    syllabus: TeacherSyllabusPayload,
+    revision: int,
+    saved_at: datetime,
+    saved_by_membership_id: str,
+) -> SyllabusGroundingContext:
+    difficulty_signal = "foundational" if academic_level == "Pregrado" else "advanced"
+    return SyllabusGroundingContext(
+        course_identity=GroundingCourseIdentity(
+            course_id=course_id,
+            course_title=course_title,
+            academic_level=academic_level,
+            department=syllabus.department,
+            knowledge_area=syllabus.knowledge_area,
+            nbc=syllabus.nbc,
+        ),
+        pedagogical_intent=GroundingPedagogicalIntent(
+            course_description=syllabus.course_description,
+            general_objective=syllabus.general_objective,
+            specific_objectives=list(syllabus.specific_objectives),
+        ),
+        instructional_scope=GroundingInstructionalScope(
+            modules=list(syllabus.modules),
+            evaluation_strategy=list(syllabus.evaluation_strategy),
+            didactic_strategy=syllabus.didactic_strategy,
+        ),
+        generation_hints=GroundingGenerationHints(
+            target_student_profile="",
+            scenario_constraints=[],
+            preferred_techniques=[],
+            difficulty_signal=difficulty_signal,
+            forbidden_mismatches=["No generar un caso que ignore el syllabus vigente del curso."],
+        ),
+        metadata=GroundingMetadata(
+            syllabus_revision=revision,
+            saved_at=saved_at,
+            saved_by_membership_id=saved_by_membership_id,
+        ),
+    )

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -4,12 +4,20 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
+from fastapi import HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session, load_only
 
 from shared.auth import CurrentActor, ensure_legacy_teacher_bridge
-from shared.models import Assignment, Course, CourseMembership, Membership
+from shared.models import Assignment, Course, CourseAccessLink, CourseMembership, Membership, Syllabus
+from shared.syllabus_schema import (
+    TeacherCourseConfigurationResponse,
+    TeacherCourseDetailResponse,
+    TeacherCourseInstitutionalResponse,
+    TeacherSyllabusResponse,
+    TeacherSyllabusRevisionMetadataResponse,
+)
 from shared.teacher_context import TeacherContext
 
 
@@ -38,9 +46,8 @@ class TeacherCaseItem:
     course_codes: list[str]
 
 
-def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCoursesResponse:
-    """Return the teacher-scoped course directory for the authenticated membership."""
-    student_counts = (
+def _build_student_counts_subquery(context: TeacherContext):
+    return (
         select(
             CourseMembership.course_id.label("course_id"),
             func.count().label("students_count"),
@@ -58,6 +65,36 @@ def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCourses
         .group_by(CourseMembership.course_id)
         .subquery()
     )
+
+
+def _serialize_syllabus_response(syllabus: Syllabus | None) -> TeacherSyllabusResponse | None:
+    if syllabus is None:
+        return None
+
+    return TeacherSyllabusResponse.model_validate(
+        {
+            "department": syllabus.department,
+            "knowledge_area": syllabus.knowledge_area,
+            "nbc": syllabus.nbc,
+            "version_label": syllabus.version_label,
+            "academic_load": syllabus.academic_load,
+            "course_description": syllabus.course_description,
+            "general_objective": syllabus.general_objective,
+            "specific_objectives": syllabus.specific_objectives,
+            "modules": syllabus.modules,
+            "evaluation_strategy": syllabus.evaluation_strategy,
+            "didactic_strategy": syllabus.didactic_strategy,
+            "integrative_project": syllabus.integrative_project,
+            "bibliography": syllabus.bibliography,
+            "teacher_notes": syllabus.teacher_notes,
+            "ai_grounding_context": syllabus.ai_grounding_context,
+        }
+    )
+
+
+def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCoursesResponse:
+    """Return the teacher-scoped course directory for the authenticated membership."""
+    student_counts = _build_student_counts_subquery(context)
 
     rows = (
         db.execute(
@@ -97,6 +134,83 @@ def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCourses
     ]
 
     return TeacherCoursesResponse(courses=courses, total=len(courses))
+
+
+def get_teacher_course_detail(
+    db: Session,
+    context: TeacherContext,
+    course_id: str,
+) -> TeacherCourseDetailResponse:
+    """Return the teacher-owned composed course detail payload."""
+    student_counts = _build_student_counts_subquery(context)
+
+    row = (
+        db.execute(
+            select(
+                Course.id.label("id"),
+                Course.title.label("title"),
+                Course.code.label("code"),
+                Course.semester.label("semester"),
+                Course.academic_level.label("academic_level"),
+                Course.status.label("status"),
+                Course.max_students.label("max_students"),
+                func.coalesce(student_counts.c.students_count, 0).label("students_count"),
+                CourseAccessLink.id.label("access_link_id"),
+                CourseAccessLink.status.label("access_link_status"),
+                CourseAccessLink.created_at.label("access_link_created_at"),
+            )
+            .select_from(Course)
+            .outerjoin(student_counts, student_counts.c.course_id == Course.id)
+            .outerjoin(
+                CourseAccessLink,
+                and_(
+                    CourseAccessLink.course_id == Course.id,
+                    CourseAccessLink.status == "active",
+                ),
+            )
+            .where(
+                Course.id == course_id,
+                Course.university_id == context.university_id,
+                Course.teacher_membership_id == context.teacher_membership_id,
+            )
+            .limit(1)
+        )
+        .mappings()
+        .first()
+    )
+
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="course_not_found")
+
+    syllabus = db.scalar(select(Syllabus).where(Syllabus.course_id == course_id))
+    current_revision = syllabus.revision if syllabus is not None else 0
+    saved_at = syllabus.saved_at if syllabus is not None else None
+    saved_by_membership_id = syllabus.saved_by_membership_id if syllabus is not None else None
+
+    return TeacherCourseDetailResponse(
+        course=TeacherCourseInstitutionalResponse(
+            id=row["id"],
+            title=row["title"],
+            code=row["code"],
+            semester=row["semester"],
+            academic_level=row["academic_level"],
+            status=row["status"],
+            max_students=int(row["max_students"]),
+            students_count=int(row["students_count"]),
+            active_cases_count=0,
+        ),
+        syllabus=_serialize_syllabus_response(syllabus),
+        revision_metadata=TeacherSyllabusRevisionMetadataResponse(
+            current_revision=current_revision,
+            saved_at=saved_at,
+            saved_by_membership_id=saved_by_membership_id,
+        ),
+        configuration=TeacherCourseConfigurationResponse(
+            access_link_status="active" if row["access_link_status"] == "active" else "missing",
+            access_link_id=row["access_link_id"],
+            access_link_created_at=row["access_link_created_at"],
+        ),
+    )
 
 
 def list_teacher_active_cases(

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -10,8 +10,10 @@ from sqlalchemy.orm import Session
 
 from shared.auth import CurrentActor, require_current_actor_password_ready
 from shared.database import get_db
+from shared.syllabus_schema import TeacherCourseDetailResponse, TeacherSyllabusSaveRequest
 from shared.teacher_context import TeacherContext, require_teacher_context
-from shared.teacher_reads import TeacherCoursesResponse, list_teacher_active_cases, list_teacher_courses
+from shared.teacher_reads import TeacherCoursesResponse, get_teacher_course_detail, list_teacher_active_cases, list_teacher_courses
+from shared.teacher_writes import save_teacher_course_syllabus
 
 router = APIRouter(prefix="/api/teacher", tags=["teacher"])
 
@@ -48,6 +50,25 @@ def get_teacher_courses(
     db: Session = Depends(get_db),
 ) -> TeacherCoursesResponse:
     return list_teacher_courses(db, context)
+
+
+@router.get("/courses/{course_id}", response_model=TeacherCourseDetailResponse)
+def get_teacher_course(
+    course_id: str,
+    context: Annotated[TeacherContext, Depends(require_teacher_context)],
+    db: Session = Depends(get_db),
+) -> TeacherCourseDetailResponse:
+    return get_teacher_course_detail(db, context, course_id)
+
+
+@router.put("/courses/{course_id}/syllabus", response_model=TeacherCourseDetailResponse)
+def put_teacher_course_syllabus(
+    course_id: str,
+    request: TeacherSyllabusSaveRequest,
+    context: Annotated[TeacherContext, Depends(require_teacher_context)],
+    db: Session = Depends(get_db),
+) -> TeacherCourseDetailResponse:
+    return save_teacher_course_syllabus(db, context, course_id, request)
 
 
 @router.get("/cases", response_model=TeacherCasesResponse)

--- a/backend/src/shared/teacher_writes.py
+++ b/backend/src/shared/teacher_writes.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from shared.auth import audit_log
+from shared.models import Course, Syllabus, SyllabusRevision
+from shared.syllabus_schema import (
+    TeacherCourseDetailResponse,
+    TeacherSyllabusPayload,
+    TeacherSyllabusSaveRequest,
+    derive_syllabus_grounding_context,
+)
+from shared.teacher_context import TeacherContext
+from shared.teacher_reads import get_teacher_course_detail
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _build_syllabus_snapshot(
+    *,
+    syllabus: TeacherSyllabusPayload,
+    ai_grounding_context: dict[str, Any],
+    revision: int,
+    saved_at: datetime,
+    saved_by_membership_id: str,
+) -> dict[str, Any]:
+    return {
+        "department": syllabus.department,
+        "knowledge_area": syllabus.knowledge_area,
+        "nbc": syllabus.nbc,
+        "version_label": syllabus.version_label,
+        "academic_load": syllabus.academic_load,
+        "course_description": syllabus.course_description,
+        "general_objective": syllabus.general_objective,
+        "specific_objectives": list(syllabus.specific_objectives),
+        "modules": [module.model_dump(mode="json") for module in syllabus.modules],
+        "evaluation_strategy": [item.model_dump(mode="json") for item in syllabus.evaluation_strategy],
+        "didactic_strategy": syllabus.didactic_strategy.model_dump(mode="json"),
+        "integrative_project": syllabus.integrative_project,
+        "bibliography": list(syllabus.bibliography),
+        "teacher_notes": syllabus.teacher_notes,
+        "ai_grounding_context": ai_grounding_context,
+        "revision": revision,
+        "saved_at": saved_at.isoformat(),
+        "saved_by_membership_id": saved_by_membership_id,
+    }
+
+
+def save_teacher_course_syllabus(
+    db: Session,
+    context: TeacherContext,
+    course_id: str,
+    request: TeacherSyllabusSaveRequest,
+) -> TeacherCourseDetailResponse:
+    """
+    Save pipeline
+      validate request
+        -> lock owned course
+        -> compare expected revision
+        -> derive grounding
+        -> persist live syllabus
+        -> append immutable snapshot
+    """
+    try:
+        course = db.scalar(
+            select(Course)
+            .where(
+                Course.id == course_id,
+                Course.university_id == context.university_id,
+                Course.teacher_membership_id == context.teacher_membership_id,
+            )
+            .with_for_update()
+        )
+        if course is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="course_not_found")
+
+        syllabus = db.scalar(
+            select(Syllabus)
+            .where(Syllabus.course_id == course.id)
+            .with_for_update()
+        )
+        current_revision = syllabus.revision if syllabus is not None else 0
+        if request.expected_revision != current_revision:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="stale_syllabus_revision")
+
+        next_revision = current_revision + 1
+        saved_at = utc_now()
+        grounding = derive_syllabus_grounding_context(
+            course_id=course.id,
+            course_title=course.title,
+            academic_level=course.academic_level,
+            syllabus=request.syllabus,
+            revision=next_revision,
+            saved_at=saved_at,
+            saved_by_membership_id=context.teacher_membership_id,
+        ).model_dump(mode="json")
+
+        if syllabus is None:
+            syllabus = Syllabus(
+                course_id=course.id,
+                revision=next_revision,
+                department=request.syllabus.department,
+                knowledge_area=request.syllabus.knowledge_area,
+                nbc=request.syllabus.nbc,
+                version_label=request.syllabus.version_label,
+                academic_load=request.syllabus.academic_load,
+                course_description=request.syllabus.course_description,
+                general_objective=request.syllabus.general_objective,
+                specific_objectives=list(request.syllabus.specific_objectives),
+                modules=[module.model_dump(mode="json") for module in request.syllabus.modules],
+                evaluation_strategy=[item.model_dump(mode="json") for item in request.syllabus.evaluation_strategy],
+                didactic_strategy=request.syllabus.didactic_strategy.model_dump(mode="json"),
+                integrative_project=request.syllabus.integrative_project,
+                bibliography=list(request.syllabus.bibliography),
+                teacher_notes=request.syllabus.teacher_notes,
+                ai_grounding_context=grounding,
+                saved_at=saved_at,
+                saved_by_membership_id=context.teacher_membership_id,
+            )
+            db.add(syllabus)
+            db.flush()
+        else:
+            syllabus.revision = next_revision
+            syllabus.department = request.syllabus.department
+            syllabus.knowledge_area = request.syllabus.knowledge_area
+            syllabus.nbc = request.syllabus.nbc
+            syllabus.version_label = request.syllabus.version_label
+            syllabus.academic_load = request.syllabus.academic_load
+            syllabus.course_description = request.syllabus.course_description
+            syllabus.general_objective = request.syllabus.general_objective
+            syllabus.specific_objectives = list(request.syllabus.specific_objectives)
+            syllabus.modules = [module.model_dump(mode="json") for module in request.syllabus.modules]
+            syllabus.evaluation_strategy = [item.model_dump(mode="json") for item in request.syllabus.evaluation_strategy]
+            syllabus.didactic_strategy = request.syllabus.didactic_strategy.model_dump(mode="json")
+            syllabus.integrative_project = request.syllabus.integrative_project
+            syllabus.bibliography = list(request.syllabus.bibliography)
+            syllabus.teacher_notes = request.syllabus.teacher_notes
+            syllabus.ai_grounding_context = grounding
+            syllabus.saved_at = saved_at
+            syllabus.saved_by_membership_id = context.teacher_membership_id
+            db.flush()
+
+        db.add(
+            SyllabusRevision(
+                syllabus_id=syllabus.id,
+                revision=next_revision,
+                snapshot=_build_syllabus_snapshot(
+                    syllabus=request.syllabus,
+                    ai_grounding_context=grounding,
+                    revision=next_revision,
+                    saved_at=saved_at,
+                    saved_by_membership_id=context.teacher_membership_id,
+                ),
+                saved_at=saved_at,
+                saved_by_membership_id=context.teacher_membership_id,
+            )
+        )
+        db.commit()
+    except HTTPException:
+        db.rollback()
+        raise
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="syllabus_save_failed",
+        ) from exc
+
+    audit_log(
+        "teacher.syllabus.save",
+        "success",
+        university_id=context.university_id,
+        membership_id=context.teacher_membership_id,
+        course_id=course.id,
+        revision=next_revision,
+    )
+    return get_teacher_course_detail(db, context, course.id)

--- a/backend/tests/test_issue30_auth_perimeter.py
+++ b/backend/tests/test_issue30_auth_perimeter.py
@@ -403,6 +403,104 @@ def test_teacher_context_password_rotation_required_precedes_context_checks(
     assert response.json()["detail"] == "password_rotation_required"
 
 
+def test_teacher_course_detail_password_rotation_required_precedes_lookup(
+    client,
+    auth_headers_factory,
+    seed_identity,
+    seed_course,
+) -> None:
+    user_id = str(uuid.uuid4())
+    email = "rotate-course-detail@example.edu"
+    teacher = seed_identity(
+        user_id=user_id,
+        email=email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000073",
+        full_name="Teacher Rotate Detail",
+        must_rotate_password=True,
+    )
+    course = seed_course(
+        university_id="10000000-0000-0000-0000-000000000073",
+        teacher_membership_id=teacher["membership"].id,
+    )
+    headers = auth_headers_factory(sub=user_id, email=email)
+
+    response = client.get(f"/api/teacher/courses/{course.id}", headers=headers)
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "password_rotation_required"
+
+
+def test_teacher_course_syllabus_save_password_rotation_required_precedes_write(
+    client,
+    auth_headers_factory,
+    seed_identity,
+    seed_course,
+) -> None:
+    user_id = str(uuid.uuid4())
+    email = "rotate-course-save@example.edu"
+    teacher = seed_identity(
+        user_id=user_id,
+        email=email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000074",
+        full_name="Teacher Rotate Save",
+        must_rotate_password=True,
+    )
+    course = seed_course(
+        university_id="10000000-0000-0000-0000-000000000074",
+        teacher_membership_id=teacher["membership"].id,
+    )
+    headers = auth_headers_factory(sub=user_id, email=email)
+
+    response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json={
+            "expected_revision": 0,
+            "syllabus": {
+                "department": "Gestion",
+                "knowledge_area": "Administracion",
+                "nbc": "Administracion",
+                "version_label": "2026.1",
+                "academic_load": "32 horas",
+                "course_description": "Curso de prueba.",
+                "general_objective": "Objetivo general.",
+                "specific_objectives": ["Objetivo especifico"],
+                "modules": [
+                    {
+                        "module_id": "m1",
+                        "module_title": "Modulo 1",
+                        "weeks": "1-2",
+                        "module_summary": "Resumen.",
+                        "learning_outcomes": ["Outcome 1"],
+                        "units": [{"unit_id": "u1", "title": "Unidad 1", "topics": "Tema 1"}],
+                        "cross_course_connections": "Conexion 1",
+                    }
+                ],
+                "evaluation_strategy": [
+                    {
+                        "activity": "Actividad 1",
+                        "weight": 50,
+                        "linked_objectives": ["O1"],
+                        "expected_outcome": "Resultado esperado",
+                    }
+                ],
+                "didactic_strategy": {
+                    "methodological_perspective": "Metodo 1",
+                    "pedagogical_modality": "Modalidad 1",
+                },
+                "integrative_project": "Proyecto integrador.",
+                "bibliography": ["Referencia 1"],
+                "teacher_notes": "Notas.",
+            },
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "password_rotation_required"
+
+
 def test_auth_me_returns_memberships_and_primary_role(client, auth_headers_factory, seed_identity) -> None:
     user_id = str(uuid.uuid4())
     email = "multirole@example.edu"

--- a/backend/tests/test_issue88_teacher_courses.py
+++ b/backend/tests/test_issue88_teacher_courses.py
@@ -1,12 +1,120 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from datetime import datetime, timezone
 import uuid
 
+from sqlalchemy import select
+
 from shared.models import Membership
+from shared.models import Syllabus, SyllabusRevision
+from shared.syllabus_schema import TeacherSyllabusPayload, derive_syllabus_grounding_context
 
 
 def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
     return auth_headers_factory(sub=user_id, email=email)
+
+
+def _syllabus_payload() -> dict[str, object]:
+    return {
+        "department": "Gestion de las Organizaciones",
+        "knowledge_area": "Economia, Administracion, Contaduria y afines",
+        "nbc": "Administracion",
+        "version_label": "2026.1",
+        "academic_load": "48 horas",
+        "course_description": "Curso enfocado en estrategia y toma de decisiones en ecosistemas digitales.",
+        "general_objective": "Aplicar marcos estrategicos a contextos empresariales complejos.",
+        "specific_objectives": [
+            "Analizar escenarios competitivos.",
+            "Evaluar decisiones de crecimiento.",
+        ],
+        "modules": [
+            {
+                "module_id": "m1",
+                "module_title": "Fundamentos de estrategia digital",
+                "weeks": "1-3",
+                "module_summary": "Panorama general de la estrategia en contextos digitales.",
+                "learning_outcomes": ["Identificar drivers competitivos."],
+                "units": [
+                    {
+                        "unit_id": "1.1",
+                        "title": "Evolucion estrategica",
+                        "topics": "Transformacion digital, ventaja competitiva, plataformas.",
+                    }
+                ],
+                "cross_course_connections": "Conecta con innovacion y analitica.",
+            }
+        ],
+        "evaluation_strategy": [
+            {
+                "activity": "Caso escrito",
+                "weight": 40,
+                "linked_objectives": ["O1"],
+                "expected_outcome": "Analisis estructurado con recomendaciones.",
+            }
+        ],
+        "didactic_strategy": {
+            "methodological_perspective": "Aprendizaje basado en casos.",
+            "pedagogical_modality": "Seminario presencial con talleres.",
+        },
+        "integrative_project": "Disenar una recomendacion estrategica para una empresa digital.",
+        "bibliography": ["Porter - Competitive Strategy", "Ries - Lean Startup"],
+        "teacher_notes": "Enfatizar diagnostico y consistencia argumentativa.",
+    }
+
+
+def _insert_syllabus(db, *, course, membership_id: str, payload: dict[str, object], revision: int = 1) -> Syllabus:
+    validated_payload = TeacherSyllabusPayload.model_validate(payload)
+    saved_at = datetime.now(timezone.utc)
+    grounding = derive_syllabus_grounding_context(
+        course_id=course.id,
+        course_title=course.title,
+        academic_level=course.academic_level,
+        syllabus=validated_payload,
+        revision=revision,
+        saved_at=saved_at,
+        saved_by_membership_id=membership_id,
+    ).model_dump(mode="json")
+    syllabus = Syllabus(
+        course_id=course.id,
+        revision=revision,
+        department=validated_payload.department,
+        knowledge_area=validated_payload.knowledge_area,
+        nbc=validated_payload.nbc,
+        version_label=validated_payload.version_label,
+        academic_load=validated_payload.academic_load,
+        course_description=validated_payload.course_description,
+        general_objective=validated_payload.general_objective,
+        specific_objectives=list(validated_payload.specific_objectives),
+        modules=[module.model_dump(mode="json") for module in validated_payload.modules],
+        evaluation_strategy=[item.model_dump(mode="json") for item in validated_payload.evaluation_strategy],
+        didactic_strategy=validated_payload.didactic_strategy.model_dump(mode="json"),
+        integrative_project=validated_payload.integrative_project,
+        bibliography=list(validated_payload.bibliography),
+        teacher_notes=validated_payload.teacher_notes,
+        ai_grounding_context=grounding,
+        saved_at=saved_at,
+        saved_by_membership_id=membership_id,
+    )
+    db.add(syllabus)
+    db.flush()
+    db.add(
+        SyllabusRevision(
+            syllabus_id=syllabus.id,
+            revision=revision,
+            snapshot={
+                **payload,
+                "ai_grounding_context": grounding,
+                "revision": revision,
+                "saved_at": saved_at.isoformat(),
+                "saved_by_membership_id": membership_id,
+            },
+            saved_at=saved_at,
+            saved_by_membership_id=membership_id,
+        )
+    )
+    db.flush()
+    return syllabus
 
 
 def test_issue88_teacher_courses_returns_assigned_courses_with_student_counts(
@@ -325,3 +433,613 @@ def test_issue88_teacher_courses_multiple_teacher_memberships_returns_409(
         .statement
     ).all()
     assert len(memberships) == 2
+
+
+def test_issue88_teacher_course_detail_returns_composed_payload(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000890"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-detail@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Detail",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Gerencia Estrategica",
+        code="ADM-330",
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-detail@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Student Detail",
+    )
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    access_link, raw_token = seed_course_access_link(course_id=course.id)
+    _insert_syllabus(
+        db,
+        course=course,
+        membership_id=teacher["membership"].id,
+        payload=_syllabus_payload(),
+    )
+
+    response = client.get(
+        f"/api/teacher/courses/{course.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["course"] == {
+        "id": course.id,
+        "title": "Gerencia Estrategica",
+        "code": "ADM-330",
+        "semester": "2026-I",
+        "academic_level": "Pregrado",
+        "status": "active",
+        "max_students": 30,
+        "students_count": 1,
+        "active_cases_count": 0,
+    }
+    assert payload["revision_metadata"]["current_revision"] == 1
+    assert payload["revision_metadata"]["saved_by_membership_id"] == teacher["membership"].id
+    assert payload["configuration"]["access_link_status"] == "active"
+    assert payload["configuration"]["access_link_id"] == access_link.id
+    assert payload["syllabus"]["department"] == "Gestion de las Organizaciones"
+    assert payload["syllabus"]["ai_grounding_context"]["course_identity"] == {
+        "course_id": course.id,
+        "course_title": "Gerencia Estrategica",
+        "academic_level": "Pregrado",
+        "department": "Gestion de las Organizaciones",
+        "knowledge_area": "Economia, Administracion, Contaduria y afines",
+        "nbc": "Administracion",
+    }
+    assert payload["syllabus"]["ai_grounding_context"]["metadata"]["syllabus_revision"] == 1
+    assert raw_token not in response.text
+
+
+def test_issue88_teacher_course_detail_student_token_returns_403(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000891"
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-detail-role@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student_user_id = str(uuid.uuid4())
+    student_email = "student-detail-role@example.edu"
+    seed_identity(
+        user_id=student_user_id,
+        email=student_email,
+        role="student",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+
+    response = client.get(
+        f"/api/teacher/courses/{course.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=student_user_id, email=student_email),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "teacher_role_required"
+
+
+def test_issue88_teacher_course_detail_admin_token_returns_403(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000892"
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-detail-admin@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    admin_user_id = str(uuid.uuid4())
+    admin_email = "admin-detail@example.edu"
+    seed_identity(
+        user_id=admin_user_id,
+        email=admin_email,
+        role="university_admin",
+        university_id=university_id,
+        create_legacy_user=False,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+
+    response = client.get(
+        f"/api/teacher/courses/{course.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_user_id, email=admin_email),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "teacher_role_required"
+
+
+def test_issue88_teacher_course_detail_non_owner_returns_404(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000893"
+    owner = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-owner-detail@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    other_teacher_user_id = str(uuid.uuid4())
+    other_teacher_email = "teacher-other-detail@example.edu"
+    seed_identity(
+        user_id=other_teacher_user_id,
+        email=other_teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=owner["membership"].id)
+
+    response = client.get(
+        f"/api/teacher/courses/{course.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=other_teacher_user_id, email=other_teacher_email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "course_not_found"
+
+
+def test_issue88_teacher_course_detail_enforces_tenant_isolation(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    owner = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-owner-tenant@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000894",
+    )
+    foreign_teacher_user_id = str(uuid.uuid4())
+    foreign_teacher_email = "teacher-foreign-tenant@example.edu"
+    seed_identity(
+        user_id=foreign_teacher_user_id,
+        email=foreign_teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000895",
+    )
+    course = seed_course(
+        university_id="10000000-0000-0000-0000-000000000894",
+        teacher_membership_id=owner["membership"].id,
+    )
+
+    response = client.get(
+        f"/api/teacher/courses/{course.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=foreign_teacher_user_id, email=foreign_teacher_email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "course_not_found"
+
+
+def test_issue88_teacher_course_detail_multiple_teacher_memberships_returns_409(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-multi-detail@example.edu"
+    first_teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000904",
+        full_name="Teacher Multi Detail",
+    )
+    seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000905",
+        full_name="Teacher Multi Detail",
+        create_legacy_user=False,
+    )
+    course = seed_course(
+        university_id="10000000-0000-0000-0000-000000000904",
+        teacher_membership_id=first_teacher["membership"].id,
+    )
+
+    response = client.get(
+        f"/api/teacher/courses/{course.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "teacher_membership_context_required"
+
+
+def test_issue88_teacher_course_syllabus_save_happy_path_creates_initial_syllabus(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000896"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-save@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+    request_payload = {"expected_revision": 0, "syllabus": _syllabus_payload()}
+
+    response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json=request_payload,
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["revision_metadata"]["current_revision"] == 1
+    assert payload["configuration"]["access_link_status"] == "missing"
+    assert payload["syllabus"]["version_label"] == "2026.1"
+    assert payload["syllabus"]["ai_grounding_context"]["metadata"]["saved_by_membership_id"] == teacher["membership"].id
+
+    syllabus = db.scalar(select(Syllabus).where(Syllabus.course_id == course.id))
+    revisions = db.scalars(
+        select(SyllabusRevision)
+        .where(SyllabusRevision.syllabus_id == syllabus.id)
+        .order_by(SyllabusRevision.revision.asc())
+    ).all()
+    assert syllabus is not None
+    assert syllabus.revision == 1
+    assert syllabus.saved_by_membership_id == teacher["membership"].id
+    assert len(revisions) == 1
+    assert revisions[0].revision == 1
+    assert revisions[0].snapshot["ai_grounding_context"]["metadata"]["syllabus_revision"] == 1
+
+
+def test_issue88_teacher_course_syllabus_save_appends_revision_snapshots(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000897"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-save-revisions@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+
+    first_payload = {"expected_revision": 0, "syllabus": _syllabus_payload()}
+    first_response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json=first_payload,
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+    assert first_response.status_code == 200, first_response.text
+
+    second_syllabus = deepcopy(_syllabus_payload())
+    second_syllabus["version_label"] = "2026.2"
+    second_syllabus["teacher_notes"] = "Actualizar conexiones interdisciplinarias."
+    second_response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json={"expected_revision": 1, "syllabus": second_syllabus},
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert second_response.status_code == 200, second_response.text
+    payload = second_response.json()
+    assert payload["revision_metadata"]["current_revision"] == 2
+    assert payload["syllabus"]["version_label"] == "2026.2"
+    assert payload["syllabus"]["teacher_notes"] == "Actualizar conexiones interdisciplinarias."
+    assert payload["syllabus"]["ai_grounding_context"]["metadata"]["syllabus_revision"] == 2
+
+    syllabus = db.scalar(select(Syllabus).where(Syllabus.course_id == course.id))
+    revisions = db.scalars(
+        select(SyllabusRevision)
+        .where(SyllabusRevision.syllabus_id == syllabus.id)
+        .order_by(SyllabusRevision.revision.asc())
+    ).all()
+    assert syllabus.revision == 2
+    assert [revision.revision for revision in revisions] == [1, 2]
+    assert revisions[0].snapshot["version_label"] == "2026.1"
+    assert revisions[1].snapshot["version_label"] == "2026.2"
+
+
+def test_issue88_teacher_course_syllabus_save_rejects_stale_revision(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000898"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-stale@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+    _insert_syllabus(db, course=course, membership_id=teacher["membership"].id, payload=_syllabus_payload(), revision=1)
+
+    response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json={"expected_revision": 0, "syllabus": _syllabus_payload()},
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "stale_syllabus_revision"
+    syllabus = db.scalar(select(Syllabus).where(Syllabus.course_id == course.id))
+    revisions = db.scalars(select(SyllabusRevision).where(SyllabusRevision.syllabus_id == syllabus.id)).all()
+    assert syllabus.revision == 1
+    assert len(revisions) == 1
+
+
+def test_issue88_teacher_course_syllabus_save_rejects_institutional_fields(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000899"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-reject-fields@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+    invalid_payload = _syllabus_payload()
+    invalid_payload["title"] = "Intento de editar campo institucional"
+
+    response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json={"expected_revision": 0, "syllabus": invalid_payload},
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 422
+    assert db.scalar(select(Syllabus).where(Syllabus.course_id == course.id)) is None
+
+
+def test_issue88_teacher_course_syllabus_save_rejects_client_grounding_payload(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000900"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-reject-grounding@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+    invalid_payload = _syllabus_payload()
+    invalid_payload["ai_grounding_context"] = {"forged": True}
+
+    response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json={"expected_revision": 0, "syllabus": invalid_payload},
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 422
+    assert db.scalar(select(Syllabus).where(Syllabus.course_id == course.id)) is None
+
+
+def test_issue88_teacher_course_syllabus_save_student_token_returns_403(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000901"
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-save-student@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student_user_id = str(uuid.uuid4())
+    student_email = "student-save@example.edu"
+    seed_identity(
+        user_id=student_user_id,
+        email=student_email,
+        role="student",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+
+    response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json={"expected_revision": 0, "syllabus": _syllabus_payload()},
+        headers=_auth_headers(auth_headers_factory, user_id=student_user_id, email=student_email),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "teacher_role_required"
+
+
+def test_issue88_teacher_course_syllabus_save_admin_token_returns_403(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000902"
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-save-admin@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    admin_user_id = str(uuid.uuid4())
+    admin_email = "admin-save@example.edu"
+    seed_identity(
+        user_id=admin_user_id,
+        email=admin_email,
+        role="university_admin",
+        university_id=university_id,
+        create_legacy_user=False,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+
+    response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json={"expected_revision": 0, "syllabus": _syllabus_payload()},
+        headers=_auth_headers(auth_headers_factory, user_id=admin_user_id, email=admin_email),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "teacher_role_required"
+
+
+def test_issue88_teacher_course_syllabus_save_non_owner_returns_404(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000903"
+    owner = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-owner-save@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    other_teacher_user_id = str(uuid.uuid4())
+    other_teacher_email = "teacher-other-save@example.edu"
+    seed_identity(
+        user_id=other_teacher_user_id,
+        email=other_teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=owner["membership"].id)
+
+    response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json={"expected_revision": 0, "syllabus": _syllabus_payload()},
+        headers=_auth_headers(auth_headers_factory, user_id=other_teacher_user_id, email=other_teacher_email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "course_not_found"
+
+
+def test_issue88_teacher_course_syllabus_save_enforces_tenant_isolation(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    owner = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-owner-save-tenant@example.edu",
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000906",
+    )
+    foreign_teacher_user_id = str(uuid.uuid4())
+    foreign_teacher_email = "teacher-foreign-save-tenant@example.edu"
+    seed_identity(
+        user_id=foreign_teacher_user_id,
+        email=foreign_teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000907",
+    )
+    course = seed_course(
+        university_id="10000000-0000-0000-0000-000000000906",
+        teacher_membership_id=owner["membership"].id,
+    )
+
+    response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json={"expected_revision": 0, "syllabus": _syllabus_payload()},
+        headers=_auth_headers(auth_headers_factory, user_id=foreign_teacher_user_id, email=foreign_teacher_email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "course_not_found"
+
+
+def test_issue88_teacher_course_syllabus_save_multiple_teacher_memberships_returns_409(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-multi-save@example.edu"
+    first_teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000908",
+        full_name="Teacher Multi Save",
+    )
+    seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000000909",
+        full_name="Teacher Multi Save",
+        create_legacy_user=False,
+    )
+    course = seed_course(
+        university_id="10000000-0000-0000-0000-000000000908",
+        teacher_membership_id=first_teacher["membership"].id,
+    )
+
+    response = client.put(
+        f"/api/teacher/courses/{course.id}/syllabus",
+        json={"expected_revision": 0, "syllabus": _syllabus_payload()},
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "teacher_membership_context_required"

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,29 +1,45 @@
 ﻿## Summary
-- fixes the frontend race where ultra-fast authoring jobs could finish before the realtime subscription settled, leaving the progress UI stuck until refresh
-- adds realtime watchdogs for subscribe timeout, silent channels, and `CLOSED` transport degradation in the authoring progress client
-- propagates `bootstrap_state` consistently from durable snapshots and realtime events so the bootstrap timeline remains visible during startup
-- makes `useAuthoringJobProgress` self-heal once via `bootstrapResumedJob` when the transport degrades instead of failing closed immediately
-- adds a Plotly compatibility shim in the app entrypoint to prevent `ReferenceError: global is not defined` in browser bundles
-- records follow-up backend debt separately via issues #126, #127, and #128
+- adds the backend syllabus domain as a course-separated 1:1 persistence model with append-only revision snapshots
+- exposes `GET /api/teacher/courses/{course_id}` as a composed teacher detail endpoint with institutional data, syllabus state, revision metadata, and access-link configuration status
+- exposes `PUT /api/teacher/courses/{course_id}/syllabus` with strict teacher ownership, tenant isolation, optimistic concurrency, and immutable revision creation on save
+- persists `ai_grounding_context` as a validated server-derived JSON contract instead of trusting client-provided grounding
+- extends backend coverage for teacher detail/save happy paths, auth perimeter, tenant isolation, stale writes, and grounding shape validation
+- records deferred follow-ups in `TODOS.md` for `Assignment.course_id` integration and teacher self-service access-link management
 
-## Pre-Landing Review
-Pre-Landing Review: 2 issues (0 critical, 2 informational)
+## Executive Summary
+This PR delivers the backend production base for issue #137 without expanding into frontend or authoring integration work that belongs to #139. `Course` remains the institutional source of truth, `Syllabus` owns editable pedagogical content, and every successful teacher save appends an immutable revision snapshot while updating the live syllabus row.
 
-**AUTO-FIXED:**
-- [TODOS.md:156] Duplicate TODO identifiers after adding new LangGraph follow-ups → renumbered downstream TODOs to keep IDs unique and monotonic
-- [pr_body.txt:1] Stale PR body content from an unrelated bootstrap observability change → replaced with the actual PR #125 summary, review notes, and test plan
+## Architecture Decisions
+- Keep `courses` authoritative for `title`, `code`, `semester`, and `academic_level`
+- Store editable pedagogical content in a separate `syllabuses` table with a unique `course_id`
+- Store revision history in append-only `syllabus_revisions` snapshots with a unique `(syllabus_id, revision)` index
+- Keep teacher detail fail-closed for access links by returning status/config metadata only, not raw tokens
+- Reject client-authored `ai_grounding_context` and derive it server-side on every successful syllabus save
+- Require `expected_revision` on save and return `409 stale_syllabus_revision` for stale writes
 
-## Eval Results
-No prompt-related files changed — evals skipped.
+## Main Files Changed
+- `backend/src/shared/models.py`
+- `backend/src/shared/syllabus_schema.py`
+- `backend/src/shared/teacher_reads.py`
+- `backend/src/shared/teacher_writes.py`
+- `backend/src/shared/teacher_router.py`
+- `backend/alembic/versions/e1b3c4d5f6a7_issue137_teacher_syllabuses.py`
+- `backend/tests/test_issue88_teacher_courses.py`
+- `backend/tests/test_issue30_auth_perimeter.py`
+- `TODOS.md`
 
-## Test Plan
-- [x] `uv run --directory backend pytest -q` (240 passed, 12 skipped)
-- [x] `npm --prefix frontend run test` (231 passed, 34 files)
-- [x] Targeted authoring hot path remained green during backend baseline audit
+## Validation Evidence
+- [x] `uv run --directory backend pytest -q tests/test_issue88_teacher_courses.py tests/test_issue30_auth_perimeter.py` (77 passed)
+- [x] `uv run --directory backend pytest -q` (277 passed, 12 skipped)
+- [x] `uv run --directory backend mypy src` (no issues found)
 
-## Backend Baseline Debt
-- #126 Normalize backend auth error contracts that leak `profile_incomplete` into unrelated flows
-- #127 Fix full-suite instability in authoring resilience and status backend tests
-- #128 Stabilize backend pytest isolation across full-suite runs
+## Residual Risks
+- `Assignment.course_id` and syllabus-aware authoring enforcement are still deferred to #139 by design
+- teacher detail currently exposes access-link status/config only; raw link management needs a follow-up product/security path
+- grounding generation hints are persisted with a stable contract now, but downstream authoring exploitation remains a separate step
+
+## References
+- Closes #137
+- Parent issue: #140
 
 🤖 Generated with GitHub Copilot


### PR DESCRIPTION
﻿## Summary
- adds the backend syllabus domain as a course-separated 1:1 persistence model with append-only revision snapshots
- exposes `GET /api/teacher/courses/{course_id}` as a composed teacher detail endpoint with institutional data, syllabus state, revision metadata, and access-link configuration status
- exposes `PUT /api/teacher/courses/{course_id}/syllabus` with strict teacher ownership, tenant isolation, optimistic concurrency, and immutable revision creation on save
- persists `ai_grounding_context` as a validated server-derived JSON contract instead of trusting client-provided grounding
- extends backend coverage for teacher detail/save happy paths, auth perimeter, tenant isolation, stale writes, and grounding shape validation
- records deferred follow-ups in `TODOS.md` for `Assignment.course_id` integration and teacher self-service access-link management

## Executive Summary
This PR delivers the backend production base for issue #137 without expanding into frontend or authoring integration work that belongs to #139. `Course` remains the institutional source of truth, `Syllabus` owns editable pedagogical content, and every successful teacher save appends an immutable revision snapshot while updating the live syllabus row.

## Architecture Decisions
- Keep `courses` authoritative for `title`, `code`, `semester`, and `academic_level`
- Store editable pedagogical content in a separate `syllabuses` table with a unique `course_id`
- Store revision history in append-only `syllabus_revisions` snapshots with a unique `(syllabus_id, revision)` index
- Keep teacher detail fail-closed for access links by returning status/config metadata only, not raw tokens
- Reject client-authored `ai_grounding_context` and derive it server-side on every successful syllabus save
- Require `expected_revision` on save and return `409 stale_syllabus_revision` for stale writes

## Main Files Changed
- `backend/src/shared/models.py`
- `backend/src/shared/syllabus_schema.py`
- `backend/src/shared/teacher_reads.py`
- `backend/src/shared/teacher_writes.py`
- `backend/src/shared/teacher_router.py`
- `backend/alembic/versions/e1b3c4d5f6a7_issue137_teacher_syllabuses.py`
- `backend/tests/test_issue88_teacher_courses.py`
- `backend/tests/test_issue30_auth_perimeter.py`
- `TODOS.md`

## Validation Evidence
- [x] `uv run --directory backend pytest -q tests/test_issue88_teacher_courses.py tests/test_issue30_auth_perimeter.py` (77 passed)
- [x] `uv run --directory backend pytest -q` (277 passed, 12 skipped)
- [x] `uv run --directory backend mypy src` (no issues found)

## Residual Risks
- `Assignment.course_id` and syllabus-aware authoring enforcement are still deferred to #139 by design
- teacher detail currently exposes access-link status/config only; raw link management needs a follow-up product/security path
- grounding generation hints are persisted with a stable contract now, but downstream authoring exploitation remains a separate step

## References
- Closes #137
- Parent issue: #140

🤖 Generated with GitHub Copilot
