### PR TITLE
feat: enforce authoring syllabus grounding

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -246,3 +246,35 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** Diferido explícitamente durante Issue #128 para mantener el diff enfocado en la causa raíz de la contaminación cruzada: commits opacos, ausencia de transacción externa por test y teardown global insuficiente.
 
 **Depends on / blocked by:** Mantener estable el harness serial con `SAVEPOINT` durante varias corridas de CI y definir estrategia de naming/bootstrap para DBs temporales por worker.
+
+---
+
+## TODO-016: Documentar el contrato operativo de clean-room para Authoring
+
+**What:** Documentar el contrato operativo canonico del clean-room de Authoring: ownership de teardown, simbolos reutilizables, politica de purge de checkpoints y evidencia minima de logs para diagnostico de fugas o contencion.
+
+**Why:** La estabilizacion de Authoring depende de una frontera precisa entre el harness de pytest, el runtime de `AuthoringService` y el lifecycle de LangGraph. Si esa frontera queda solo implícita en el codigo o en una PR, es facil reintroducir residuos de pools, tareas o checkpoints en cambios futuros.
+
+**Pros:** Preserva el razonamiento operativo, reduce regresiones por drift entre tests y runtime, y acelera debugging cuando reaparezcan sintomas como `LockNotAvailable` o leaks de pools.
+
+**Cons:** Añade trabajo de documentacion fuera del fix principal y exige mantener sincronizado el texto cuando cambie el contrato de cleanup.
+
+**Context:** Aceptado durante la revision de rediseño de Issue #127. El objetivo es que la solucion de clean-room sea invisible para quien escriba nuevos tests, pero explicita para quien mantenga el runtime. La documentacion debe referenciar el contrato centralizado una vez exista como superficie canonica.
+
+**Depends on / blocked by:** Depende de cerrar primero la implementacion de Issue #127 y de fijar cuales helpers quedan como API operativa estable para clean-room y diagnostico.
+
+---
+
+## TODO-017: Stress harness post-fix para contencion de checkpoints y churn de event loops
+
+**What:** Evaluar un stress harness diferido que repita secuencias de bootstrap, retry, teardown y cambio de event loop para el path de checkpoints de LangGraph mas alla de `test_authoring_progress_resilience.py` y `test_phase3_status_api.py`.
+
+**Why:** Issue #127 debe resolver la inestabilidad determinista actual con el menor diff posible. Un soak test o stress harness mas amplio puede ser valioso despues, pero mezclarlo ahora convertiria un fix de integracion Authoring en una epica de validacion de carga.
+
+**Pros:** Captura una siguiente capa de hardening para detectar contencion intermitente, churn multi-loop y regresiones de lifecycle antes de que aparezcan en CI o staging.
+
+**Cons:** Puede inflar scope y tiempo de mantenimiento; si se adelanta demasiado, corre el riesgo de probar comportamientos todavia no estabilizados por el fix principal.
+
+**Context:** Aceptado como follow-up durante la revision de la nueva especificacion de Issue #127. La evidencia actual apunta a dos modulos pesados concretos; el stress harness seria una fase posterior una vez el clean-room de Authoring quede estable y reusable.
+
+**Depends on / blocked by:** Bloqueado por la implementacion y validacion completa de Issue #127, incluyendo el contrato de clean-room, la reproduccion determinista del path de locks y tres corridas full-suite consecutivas en verde.

--- a/TODOS.md
+++ b/TODOS.md
@@ -295,24 +295,6 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 **Depends on / blocked by:** Depende de cerrar primero la implementacion de Issue #127 y de fijar cuales helpers quedan como API operativa estable para clean-room y diagnostico.
 
----
-
-## TODO-019: Vincular `Assignment.course_id` y authoring al dominio de syllabus
-
-**What:** Agregar `course_id` real a `assignments`, propagarlo por el intake de authoring y reemplazar el placeholder `active_cases_count=0` de teacher courses por conteos reales por curso.
-
-**Why:** La base backend de syllabuses y revisiones puede vivir sola en Issue #137, pero el authoring y los indicadores de casos siguen desacoplados del curso hasta que exista ese puente explícito.
-
-**Pros:** Elimina una costura conocida entre gestión docente y generación de casos, permite grounding y guardrails por curso en el flujo de authoring, y cierra el TODO ya existente en `backend/src/shared/teacher_reads.py`.
-
-**Cons:** Amplía el scope hacia el dominio de authoring, requiere migración adicional sobre `assignments`, ajustes de contratos y tests cruzados con el pipeline de generación.
-
-**Context:** Durante la revisión de Issue #137 se decidió mantener el backend de syllabus aislado y deferir la integración completa con authoring a la issue hermana #139 para no mezclar persistencia pedagógica con orquestación/generation guardrails en la misma PR.
-
-**Depends on / blocked by:** Issue #139 y la definición final del contrato `course_id` en authoring intake, pipeline y queries de progreso/resultado.
-
----
-
 ## TODO-020: Endpoint docente para gestionar access link del curso
 
 **What:** Crear un endpoint docente dedicado para visualizar o regenerar el access link vigente del curso, con auditoría y reglas explícitas de exposición del raw token.

--- a/backend/alembic/versions/9f3e2a1b7c4d_issue139_authoring_course_grounding.py
+++ b/backend/alembic/versions/9f3e2a1b7c4d_issue139_authoring_course_grounding.py
@@ -1,0 +1,37 @@
+"""Issue 139 authoring course grounding
+
+Revision ID: 9f3e2a1b7c4d
+Revises: e1b3c4d5f6a7
+Create Date: 2026-04-20 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9f3e2a1b7c4d"
+down_revision: Union[str, Sequence[str], None] = "e1b3c4d5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("assignments", sa.Column("course_id", sa.Text(), nullable=True))
+    op.create_index("ix_assignments_course_id", "assignments", ["course_id"], unique=False)
+    op.create_foreign_key(
+        "fk_assignments_course_id_courses",
+        "assignments",
+        "courses",
+        ["course_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_assignments_course_id_courses", "assignments", type_="foreignkey")
+    op.drop_index("ix_assignments_course_id", table_name="assignments")
+    op.drop_column("assignments", "course_id")

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -15,7 +15,7 @@ from case_generator.core.storage import get_storage_provider
 from case_generator.graph import DurableCheckpointUnavailableError, RESUME_CACHE_STATE_KEY, get_graph
 from case_generator.orchestration.frontend_output_adapter import adapter_legacy_to_canonical_output
 from langchain_core.runnables import RunnableConfig
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.exc import TimeoutError as SATimeoutError
 from shared.blueprint_schema import (
@@ -46,8 +46,12 @@ from shared.models import (
     AUTHORING_JOB_STATUS_PROCESSING,
     Assignment,
     AuthoringJob,
+    Syllabus,
+    SyllabusRevision,
 )
 from shared.sanitization import sanitize_untrusted_text
+from shared.syllabus_schema import SyllabusGroundingContext
+from shared.teacher_reads import resolve_syllabus_selection_titles
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +141,10 @@ _BOOTSTRAP_STATE_KEYS = (
 class GraphBootstrapTimeoutError(RuntimeError):
     """Raised when the graph bootstrap exceeds the configured timeout."""
 
+
+class GroundingContextResolutionError(RuntimeError):
+    """Raised when a persisted syllabus-grounding snapshot cannot be resolved for a job."""
+
 _TRANSIENT_TIMEOUT_MARKERS = (
     "timed out",
     "read timeout",
@@ -175,6 +183,66 @@ def _classify_failure_status(error_code: str | None) -> str:
     if error_code in _RESUMABLE_FAILURE_CODES:
         return AUTHORING_JOB_STATUS_FAILED_RESUMABLE
     return AUTHORING_JOB_STATUS_FAILED
+
+
+def _resolve_job_grounding_snapshot(
+    db: Any,
+    *,
+    payload: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, str, str, list[str]]:
+    raw_selected_techniques = payload.get(
+        "algoritmos",
+        payload.get("suggested_techniques", payload.get("suggestedTechniques", [])),
+    )
+    selected_techniques = list(raw_selected_techniques) if isinstance(raw_selected_techniques, list | tuple) else []
+    course_id = payload.get("course_id")
+    syllabus_revision = payload.get("syllabus_revision")
+    module_id = str(payload.get("syllabus_module_id", ""))
+    unit_id = str(payload.get("topic_unit_id", ""))
+
+    if not isinstance(course_id, str) or not course_id.strip():
+        return (
+            None,
+            str(payload.get("modulo", payload.get("syllabusModule", ""))),
+            str(payload.get("topicUnit", "")),
+            selected_techniques,
+        )
+
+    if not isinstance(syllabus_revision, int) or syllabus_revision <= 0:
+        raise GroundingContextResolutionError(
+            "No se pudo resolver la revision del syllabus asociada a este trabajo de authoring."
+        )
+
+    row = db.execute(
+        select(SyllabusRevision.snapshot)
+        .select_from(SyllabusRevision)
+        .join(Syllabus, SyllabusRevision.syllabus_id == Syllabus.id)
+        .where(
+            Syllabus.course_id == course_id,
+            SyllabusRevision.revision == syllabus_revision,
+        )
+        .limit(1)
+    ).first()
+    if row is None:
+        raise GroundingContextResolutionError(
+            "No se encontro el snapshot persistido del syllabus asociado a este trabajo de authoring."
+        )
+
+    snapshot = dict(row[0] or {})
+    raw_grounding = snapshot.get("ai_grounding_context")
+    if not isinstance(raw_grounding, dict):
+        raise GroundingContextResolutionError(
+            "El snapshot persistido del syllabus no contiene un grounding valido para authoring."
+        )
+
+    grounding = SyllabusGroundingContext.model_validate(raw_grounding)
+    module_title, unit_title = resolve_syllabus_selection_titles(
+        list(snapshot.get("modules", [])),
+        module_id=module_id,
+        unit_id=unit_id,
+    )
+    preferred_techniques = list(grounding.generation_hints.preferred_techniques)
+    return grounding.model_dump(mode="json"), module_title, unit_title, preferred_techniques
 
 
 def _iter_exception_chain(exc: BaseException) -> list[BaseException]:
@@ -611,6 +679,10 @@ class AuthoringService:
         storage_provider = get_storage_provider()
         resume_cached_nodes: dict[str, dict[str, str]] = {}
         is_resume_retry = False
+        grounding_context: dict[str, Any] | None = None
+        grounded_module_title = ""
+        grounded_unit_title = ""
+        preferred_techniques: list[str] = []
 
         # --- DB MICRO-SESSION 1: transition the job into processing ---
         # Winner-takes-lock CAS: only one concurrent retry may move status to processing.
@@ -694,7 +766,28 @@ class AuthoringService:
                 return
 
             owner_id = assignment.teacher_id
+            grounding_context, grounded_module_title, grounded_unit_title, preferred_techniques = _resolve_job_grounding_snapshot(
+                db,
+                payload=payload,
+            )
             db.commit()
+        except GroundingContextResolutionError as exc:
+            logger.error("AuthoringService: Failure locking job %s: %s", job_id, exc)
+            payload_with_error = _next_progress_payload(
+                payload,
+                status=AUTHORING_JOB_STATUS_FAILED,
+                current_step="failed",
+                error_code="syllabus_grounding_unavailable",
+                error_trace=str(exc),
+            )
+            db.rollback()
+            db.execute(
+                update(AuthoringJob)
+                .where(AuthoringJob.id == job_id)
+                .values(status=AUTHORING_JOB_STATUS_FAILED, task_payload=payload_with_error)
+            )
+            db.commit()
+            return
         except Exception as exc:
             logger.error("AuthoringService: Failure locking job %s: %s", job_id, exc)
             db.rollback()
@@ -763,24 +856,32 @@ class AuthoringService:
             output_depth = _derive_output_depth(payload)
             scenario_description = payload.get("escenario", payload.get("scenarioDescription", ""))
             target_groups = payload.get("targetGroups", [])
+            raw_selected_techniques = payload.get(
+                "algoritmos",
+                payload.get("suggested_techniques", payload.get("suggestedTechniques", [])),
+            )
+            selected_techniques = list(raw_selected_techniques) if isinstance(raw_selected_techniques, list | tuple) else []
+            for technique in preferred_techniques:
+                if technique not in selected_techniques:
+                    selected_techniques.append(technique)
 
             state_input: dict[str, Any] = {
                 "asignatura": payload.get("asignatura", "Default Subject"),
                 "nivel": payload.get("nivel", "pregrado"),
                 "industria": payload.get("industria", "General"),
                 "studentProfile": payload.get("studentProfile", "business"),
-                "algoritmos": payload.get("algoritmos", []),
+                "algoritmos": selected_techniques,
                 "edaDepth": payload.get("edaDepth"),
                 "includePythonCode": payload.get("includePythonCode", False),
-                "topicUnit": payload.get("topicUnit", ""),
+                "topicUnit": grounded_unit_title or payload.get("topicUnit", ""),
                 "targetGroups": target_groups,
                 "caseType": payload.get("caseType", "harvard_only"),
                 "guidingQuestion": payload.get("pregunta_guia", payload.get("guidingQuestion", "")),
                 "scenarioDescription": scenario_description,
-                "syllabusModule": payload.get("modulo", payload.get("syllabusModule", "")),
+                "syllabusModule": grounded_module_title or payload.get("modulo", payload.get("syllabusModule", "")),
                 "output_depth": output_depth,
                 # Legacy-compatible aliases still consumed by graph.py prompt builders.
-                "modulos": target_groups,
+                "modulos": [grounded_module_title] if grounded_module_title else [],
                 "horas": payload.get("horas", 4),
                 "descripcion": scenario_description,
                 "scope": "technical" if output_depth else "narrative",
@@ -795,6 +896,8 @@ class AuthoringService:
                 "industry_cagr_range": "5-8%",
                 RESUME_CACHE_STATE_KEY: resume_cached_nodes,
             }
+            if grounding_context is not None:
+                state_input["ai_grounding_context"] = grounding_context
 
             # Inject hydrated artifacts into initial graph state so downstream nodes
             # keep context even when upstream generation is skipped.
@@ -909,6 +1012,14 @@ class AuthoringService:
                 "Nuestros servidores de IA estan a maxima capacidad y el tiempo de espera se agoto. "
                 "Por favor, reintenta en unos minutos."
             )
+        except GroundingContextResolutionError as exc:
+            logger.error(
+                "AuthoringService: Persisted syllabus grounding unavailable for Job %s",
+                job_id,
+                exc_info=True,
+            )
+            error_code = "syllabus_grounding_unavailable"
+            error_msg = str(exc)
         except Exception as exc:
             if _is_durable_checkpoint_runtime_failure(exc):
                 logger.error(

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -236,11 +236,17 @@ def _resolve_job_grounding_snapshot(
         )
 
     grounding = SyllabusGroundingContext.model_validate(raw_grounding)
-    module_title, unit_title = resolve_syllabus_selection_titles(
-        list(snapshot.get("modules", [])),
-        module_id=module_id,
-        unit_id=unit_id,
-    )
+    try:
+        module_title, unit_title = resolve_syllabus_selection_titles(
+            list(snapshot.get("modules", [])),
+            module_id=module_id,
+            unit_id=unit_id,
+            strict=True,
+        )
+    except ValueError as exc:
+        raise GroundingContextResolutionError(
+            "El snapshot persistido del syllabus no contiene el modulo o la unidad seleccionados para este trabajo de authoring."
+        ) from exc
     preferred_techniques = list(grounding.generation_hints.preferred_techniques)
     return grounding.model_dump(mode="json"), module_title, unit_title, preferred_techniques
 

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -669,6 +669,22 @@ def _build_base_context(state: ADAMState) -> dict:
     else:
         impl_time = "el próximo semestre"
 
+    grounding = state.get("ai_grounding_context", {})
+    grounding_generation_hints: dict[str, Any] = {}
+    grounding_instructional_scope: dict[str, Any] = {}
+    grounding_pedagogical_intent: dict[str, Any] = {}
+    grounding_course_identity: dict[str, Any] = {}
+    if isinstance(grounding, dict):
+        grounding_generation_hints = cast(dict[str, Any], grounding.get("generation_hints", {}))
+        grounding_instructional_scope = cast(dict[str, Any], grounding.get("instructional_scope", {}))
+        grounding_pedagogical_intent = cast(dict[str, Any], grounding.get("pedagogical_intent", {}))
+        grounding_course_identity = cast(dict[str, Any], grounding.get("course_identity", {}))
+
+    algoritmos = list(state.get("algoritmos", []))
+    for preferred in grounding_generation_hints.get("preferred_techniques", []):
+        if isinstance(preferred, str) and preferred and preferred not in algoritmos:
+            algoritmos.append(preferred)
+
     return {
         "student_profile": profile,
         "output_language": state.get("output_language", "es"),
@@ -687,8 +703,15 @@ def _build_base_context(state: ADAMState) -> dict:
         "nombre_empresa": nombre_empresa,
         "dilema_hypotheses": dilema_hypotheses,
         "output_depth": state.get("output_depth", ""),
-        "algoritmos": json.dumps(state.get("algoritmos", [])),
+        "algoritmos": json.dumps(algoritmos, ensure_ascii=False),
         "titulo": state.get("titulo", ""),
+        "grounding_modules": json.dumps(grounding_instructional_scope.get("modules", []), ensure_ascii=False),
+        "grounding_objectives": json.dumps(
+            grounding_pedagogical_intent.get("specific_objectives", []),
+            ensure_ascii=False,
+        ),
+        "grounding_generation_hints": json.dumps(grounding_generation_hints, ensure_ascii=False),
+        "grounding_course_identity": json.dumps(grounding_course_identity, ensure_ascii=False),
     }
 
 
@@ -711,6 +734,10 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
             "industria": state.get("industria", ""),
             "descripcion_escenario": state.get("descripcion", ""),
             "pregunta_guia_directiva": state.get("guidingQuestion", ""),
+            "grounding_course_identity": context.get("grounding_course_identity", ""),
+            "grounding_modules": context.get("grounding_modules", ""),
+            "grounding_objectives": context.get("grounding_objectives", ""),
+            "grounding_generation_hints": context.get("grounding_generation_hints", ""),
         }, per_field_limit=800, total_limit=2500),
     })
 

--- a/backend/src/case_generator/state.py
+++ b/backend/src/case_generator/state.py
@@ -166,4 +166,5 @@ class ADAMState(CanonicalInputState):
     dataset_retry_count: NotRequired[int]      # Contador de retries del data_serializer
     dataset_errors: NotRequired[list[str]]     # Errores de validación
     dataset_metadata: NotRequired[dict]        # Metadata del dataset (rows, columns, target_variable…)
+    ai_grounding_context: NotRequired[dict[str, Any]]
 

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -605,7 +605,7 @@ def create_authoring_job(
             )
         except ValueError as exc:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail="Seleccion invalida de modulo o unidad del syllabus",
             ) from exc
 

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -596,11 +596,18 @@ def create_authoring_job(
         owned_course = get_teacher_owned_course_with_syllabus(db, context, req.course_id, lock=True)
         SyllabusGroundingContext.model_validate(owned_course.syllabus.ai_grounding_context)
         deadline, normalized_due_at = _normalize_deadline_input(req.due_at)
-        module_title, unit_title = resolve_syllabus_selection_titles(
-            owned_course.syllabus.modules,
-            module_id=req.syllabus_module,
-            unit_id=req.topic_unit,
-        )
+        try:
+            module_title, unit_title = resolve_syllabus_selection_titles(
+                owned_course.syllabus.modules,
+                module_id=req.syllabus_module,
+                unit_id=req.topic_unit,
+                strict=True,
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Seleccion invalida de modulo o unidad del syllabus",
+            ) from exc
 
         assignment = Assignment(
             teacher_id=teacher.id,

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -21,8 +21,8 @@ from fastapi import BackgroundTasks, Depends, FastAPI, Header, HTTPException, Re
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
-from sqlalchemy import select, update
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import and_, or_, select, update
 from sqlalchemy.exc import DBAPIError, IntegrityError, OperationalError
 from sqlalchemy.exc import TimeoutError as SATimeoutError
 from sqlalchemy.orm import Session
@@ -93,6 +93,9 @@ from shared.models import (
     User,
 )
 from shared.internal_tasks import process_authoring_job_task
+from shared.syllabus_schema import SyllabusGroundingContext
+from shared.teacher_context import resolve_teacher_context
+from shared.teacher_reads import get_teacher_owned_course_with_syllabus, resolve_syllabus_selection_titles
 
 load_dotenv()
 
@@ -254,12 +257,24 @@ def get_legacy_teacher_or_500(db: Session, actor: CurrentActor) -> User:
 
 
 def get_owned_job_or_404(db: Session, job_id: str, actor: CurrentActor) -> AuthoringJob:
+    context = resolve_teacher_context(actor)
     stmt = (
         select(AuthoringJob)
         .join(Assignment, AuthoringJob.assignment_id == Assignment.id)
+        .outerjoin(Course, Assignment.course_id == Course.id)
         .where(
             AuthoringJob.id == job_id,
-            Assignment.teacher_id == actor.auth_user_id,
+            or_(
+                and_(
+                    Assignment.course_id.is_(None),
+                    Assignment.teacher_id == actor.auth_user_id,
+                ),
+                and_(
+                    Assignment.course_id.is_not(None),
+                    Course.university_id == context.university_id,
+                    Course.teacher_membership_id == context.teacher_membership_id,
+                ),
+            ),
         )
     )
     job = db.scalar(stmt)
@@ -529,7 +544,10 @@ async def health_check() -> dict[str, str]:
 
 
 class IntakeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     assignment_title: str
+    course_id: str
     subject: str = ""
     academic_level: str = "Pregrado"
     industry: str = "General"
@@ -573,11 +591,20 @@ def create_authoring_job(
 ) -> JobCreatedResponse:
     started = time.monotonic()
     try:
+        context = resolve_teacher_context(actor)
         teacher = get_legacy_teacher_or_500(db, actor)
+        owned_course = get_teacher_owned_course_with_syllabus(db, context, req.course_id, lock=True)
+        SyllabusGroundingContext.model_validate(owned_course.syllabus.ai_grounding_context)
         deadline, normalized_due_at = _normalize_deadline_input(req.due_at)
+        module_title, unit_title = resolve_syllabus_selection_titles(
+            owned_course.syllabus.modules,
+            module_id=req.syllabus_module,
+            unit_id=req.topic_unit,
+        )
 
         assignment = Assignment(
             teacher_id=teacher.id,
+            course_id=owned_course.course.id,
             title=req.assignment_title,
             status="draft",
             deadline=deadline,
@@ -593,15 +620,19 @@ def create_authoring_job(
             status=AUTHORING_JOB_STATUS_PENDING,
             task_payload={
                 "step": "authoring",
-                "asignatura": req.subject or req.assignment_title,
-                "nivel": req.academic_level,
+                "course_id": owned_course.course.id,
+                "syllabus_revision": owned_course.syllabus.revision,
+                "syllabus_module_id": req.syllabus_module,
+                "topic_unit_id": req.topic_unit,
+                "asignatura": owned_course.course.title,
+                "nivel": owned_course.course.academic_level,
                 "industria": req.industry,
                 "studentProfile": req.student_profile,
                 "caseType": req.case_type,
-                "modulo": req.syllabus_module,
+                "modulo": module_title,
                 "escenario": req.scenario_description,
                 "pregunta_guia": req.guiding_question,
-                "topicUnit": req.topic_unit,
+                "topicUnit": unit_title,
                 "targetGroups": req.target_groups,
                 "edaDepth": req.eda_depth,
                 "includePythonCode": req.include_python_code,

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -203,6 +203,7 @@ class Course(Base):
     access_links: Mapped[list["CourseAccessLink"]] = relationship(back_populates="course")
     course_memberships: Mapped[list["CourseMembership"]] = relationship(back_populates="course")
     syllabus: Mapped["Syllabus | None"] = relationship(back_populates="course", uselist=False)
+    assignments: Mapped[list["Assignment"]] = relationship(back_populates="course")
 
 
 class Invite(Base):
@@ -323,6 +324,7 @@ class Assignment(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
     teacher_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    course_id: Mapped[str | None] = mapped_column(Text, ForeignKey("courses.id"), nullable=True, index=True)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
 
     # Internal blueprint contract retained for compatibility and future continuity.
@@ -344,6 +346,7 @@ class Assignment(Base):
     )
 
     teacher: Mapped["User"] = relationship(back_populates="assignments")
+    course: Mapped["Course | None"] = relationship(back_populates="assignments")
     authoring_jobs: Mapped[list["AuthoringJob"]] = relationship(back_populates="assignment")
     artifacts: Mapped[list["ArtifactManifest"]] = relationship(back_populates="assignment")
 

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel
@@ -44,6 +44,12 @@ class TeacherCaseItem:
     deadline: datetime | None
     status: str
     course_codes: list[str]
+
+
+@dataclass(slots=True)
+class TeacherOwnedCourseSyllabus:
+    course: Course
+    syllabus: Syllabus
 
 
 def _build_student_counts_subquery(context: TeacherContext):
@@ -211,6 +217,75 @@ def get_teacher_course_detail(
             access_link_created_at=row["access_link_created_at"],
         ),
     )
+
+
+def get_teacher_owned_course_with_syllabus(
+    db: Session,
+    context: TeacherContext,
+    course_id: str,
+    *,
+    lock: bool = False,
+) -> TeacherOwnedCourseSyllabus:
+    course_stmt = select(Course).where(
+        Course.id == course_id,
+        Course.university_id == context.university_id,
+        Course.teacher_membership_id == context.teacher_membership_id,
+    )
+    syllabus_stmt = select(Syllabus).where(Syllabus.course_id == course_id)
+
+    if lock:
+        course_stmt = course_stmt.with_for_update()
+        syllabus_stmt = syllabus_stmt.with_for_update()
+
+    course = db.scalar(course_stmt)
+    if course is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="course_not_found")
+
+    syllabus = db.scalar(syllabus_stmt)
+    if syllabus is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail="Syllabus no configurado para este curso",
+        )
+
+    return TeacherOwnedCourseSyllabus(course=course, syllabus=syllabus)
+
+
+def resolve_syllabus_selection_titles(
+    modules: list[dict[str, Any]],
+    *,
+    module_id: str,
+    unit_id: str,
+) -> tuple[str, str]:
+    module_title = ""
+    unit_title = ""
+
+    if not module_id:
+        return module_title, unit_title
+
+    selected_module = next(
+        (candidate for candidate in modules if str(candidate.get("module_id", "")) == module_id),
+        None,
+    )
+    if selected_module is None:
+        return module_title, unit_title
+
+    module_title = str(selected_module.get("module_title", ""))
+    if not unit_id:
+        return module_title, unit_title
+
+    selected_unit = next(
+        (
+            candidate
+            for candidate in selected_module.get("units", [])
+            if str(candidate.get("unit_id", "")) == unit_id
+        ),
+        None,
+    )
+    if selected_unit is None:
+        return module_title, unit_title
+
+    return module_title, str(selected_unit.get("title", ""))
 
 
 def list_teacher_active_cases(

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -256,11 +256,14 @@ def resolve_syllabus_selection_titles(
     *,
     module_id: str,
     unit_id: str,
+    strict: bool = False,
 ) -> tuple[str, str]:
     module_title = ""
     unit_title = ""
 
     if not module_id:
+        if strict:
+            raise ValueError("invalid_syllabus_selection")
         return module_title, unit_title
 
     selected_module = next(
@@ -268,6 +271,8 @@ def resolve_syllabus_selection_titles(
         None,
     )
     if selected_module is None:
+        if strict:
+            raise ValueError("invalid_syllabus_selection")
         return module_title, unit_title
 
     module_title = str(selected_module.get("module_title", ""))
@@ -283,6 +288,8 @@ def resolve_syllabus_selection_titles(
         None,
     )
     if selected_unit is None:
+        if strict:
+            raise ValueError("invalid_syllabus_selection")
         return module_title, unit_title
 
     return module_title, str(selected_unit.get("title", ""))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -29,7 +29,8 @@ from shared.database import (
     reset_session_factory_override,
     settings,
 )
-from shared.models import Base, Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, Tenant, User
+from shared.models import Base, Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, Syllabus, SyllabusRevision, Tenant, User
+from shared.syllabus_schema import TeacherSyllabusPayload, derive_syllabus_grounding_context
 
 
 _CHECKPOINT_TABLES = (
@@ -546,6 +547,124 @@ def seed_course_membership(db):
         db.flush()
         db.refresh(course_membership)
         return course_membership
+
+    return _factory
+
+
+@pytest.fixture
+def seed_course_with_syllabus(db, seed_course):
+    def _factory(
+        *,
+        university_id: str,
+        teacher_membership_id: str,
+        title: str = "Test Course",
+        academic_level: str = "Pregrado",
+        revision: int = 1,
+    ) -> Course:
+        course = seed_course(
+            university_id=university_id,
+            teacher_membership_id=teacher_membership_id,
+            title=title,
+            academic_level=academic_level,
+        )
+        payload = TeacherSyllabusPayload.model_validate(
+            {
+                "department": "Gestion",
+                "knowledge_area": "Administracion",
+                "nbc": "Administracion",
+                "version_label": "2026.1",
+                "academic_load": "48 horas",
+                "course_description": "Curso de prueba para authoring.",
+                "general_objective": "Aplicar analisis estructurado en contextos empresariales.",
+                "specific_objectives": [
+                    "Diagnosticar situaciones con evidencia.",
+                    "Sustentar decisiones con tecnicas analiticas.",
+                ],
+                "modules": [
+                    {
+                        "module_id": "m1",
+                        "module_title": "Fundamentos",
+                        "weeks": "1-4",
+                        "module_summary": "Base conceptual del curso.",
+                        "learning_outcomes": ["Comprender el contexto del problema."],
+                        "units": [
+                            {
+                                "unit_id": "u1",
+                                "title": "Unidad Inicial",
+                                "topics": "Conceptos y diagnostico.",
+                            }
+                        ],
+                        "cross_course_connections": "Integra finanzas y estrategia.",
+                    }
+                ],
+                "evaluation_strategy": [
+                    {
+                        "activity": "Caso escrito",
+                        "weight": 40,
+                        "linked_objectives": ["obj-1"],
+                        "expected_outcome": "Analisis defendible.",
+                    }
+                ],
+                "didactic_strategy": {
+                    "methodological_perspective": "Aprendizaje basado en casos.",
+                    "pedagogical_modality": "Presencial",
+                },
+                "integrative_project": "Proyecto integrador final.",
+                "bibliography": ["Referencia 1"],
+                "teacher_notes": "Usar contexto empresarial realista.",
+            }
+        )
+        saved_at = datetime.now(timezone.utc)
+        grounding = derive_syllabus_grounding_context(
+            course_id=course.id,
+            course_title=course.title,
+            academic_level=course.academic_level,
+            syllabus=payload,
+            revision=revision,
+            saved_at=saved_at,
+            saved_by_membership_id=teacher_membership_id,
+        ).model_dump(mode="json")
+        syllabus = Syllabus(
+            course_id=course.id,
+            revision=revision,
+            department=payload.department,
+            knowledge_area=payload.knowledge_area,
+            nbc=payload.nbc,
+            version_label=payload.version_label,
+            academic_load=payload.academic_load,
+            course_description=payload.course_description,
+            general_objective=payload.general_objective,
+            specific_objectives=list(payload.specific_objectives),
+            modules=[module.model_dump(mode="json") for module in payload.modules],
+            evaluation_strategy=[item.model_dump(mode="json") for item in payload.evaluation_strategy],
+            didactic_strategy=payload.didactic_strategy.model_dump(mode="json"),
+            integrative_project=payload.integrative_project,
+            bibliography=list(payload.bibliography),
+            teacher_notes=payload.teacher_notes,
+            ai_grounding_context=grounding,
+            saved_at=saved_at,
+            saved_by_membership_id=teacher_membership_id,
+        )
+        db.add(syllabus)
+        db.flush()
+        db.add(
+            SyllabusRevision(
+                syllabus_id=syllabus.id,
+                revision=revision,
+                snapshot={
+                    **payload.model_dump(mode="json"),
+                    "ai_grounding_context": grounding,
+                    "revision": revision,
+                    "saved_at": saved_at.isoformat(),
+                    "saved_by_membership_id": teacher_membership_id,
+                },
+                saved_at=saved_at,
+                saved_by_membership_id=teacher_membership_id,
+            )
+        )
+        db.flush()
+        db.refresh(course)
+        return course
 
     return _factory
 

--- a/backend/tests/test_issue109_db_resilience.py
+++ b/backend/tests/test_issue109_db_resilience.py
@@ -59,7 +59,7 @@ def test_intake_maps_connection_saturation_to_503(client, auth_headers_factory, 
         response = client.post(
             "/api/authoring/jobs",
             headers=headers,
-            json={"assignment_title": "Load test case"},
+            json={"assignment_title": "Load test case", "course_id": str(uuid.uuid4())},
         )
 
     assert response.status_code == 503

--- a/backend/tests/test_issue139_authoring_grounding.py
+++ b/backend/tests/test_issue139_authoring_grounding.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import patch
+
+from case_generator.core.authoring import AuthoringService
+from shared.models import Assignment, AuthoringJob
+
+
+def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
+    return auth_headers_factory(sub=user_id, email=email)
+
+
+def _build_authoring_payload(*, course_id: str, syllabus_module: str = "m1", topic_unit: str = "u1") -> dict[str, object]:
+    return {
+        "assignment_title": "Issue 139 Case",
+        "course_id": course_id,
+        "syllabus_module": syllabus_module,
+        "topic_unit": topic_unit,
+        "target_groups": ["Grupo 01"],
+        "scenario_description": "Escenario de prueba",
+        "guiding_question": "Pregunta de prueba",
+    }
+
+
+def test_issue139_authoring_intake_rejects_course_without_syllabus(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-no-syllabus@example.edu"
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Course Without Syllabus",
+    )
+    db.commit()
+
+    with patch("fastapi.BackgroundTasks.add_task"):
+        response = client.post(
+            "/api/authoring/jobs",
+            json=_build_authoring_payload(course_id=course.id),
+            headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+        )
+
+    assert response.status_code == 412
+    assert response.json()["detail"] == "Syllabus no configurado para este curso"
+
+
+def test_issue139_authoring_intake_rejects_foreign_course(
+    client,
+    db,
+    seed_identity,
+    seed_course_with_syllabus,
+    auth_headers_factory,
+) -> None:
+    requester_id = str(uuid.uuid4())
+    requester_email = "teacher-requester@example.edu"
+    requester = seed_identity(user_id=requester_id, email=requester_email, role="teacher")
+
+    owner_id = str(uuid.uuid4())
+    owner_email = "teacher-owner@example.edu"
+    owner = seed_identity(user_id=owner_id, email=owner_email, role="teacher")
+    foreign_course = seed_course_with_syllabus(
+        university_id=owner["membership"].university_id,
+        teacher_membership_id=owner["membership"].id,
+        title="Foreign Course",
+    )
+    db.commit()
+
+    with patch("fastapi.BackgroundTasks.add_task"):
+        response = client.post(
+            "/api/authoring/jobs",
+            json=_build_authoring_payload(course_id=foreign_course.id),
+            headers=_auth_headers(auth_headers_factory, user_id=requester_id, email=requester_email),
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "course_not_found"
+
+
+def test_issue139_authoring_intake_rejects_invalid_syllabus_selection(
+    client,
+    db,
+    seed_identity,
+    seed_course_with_syllabus,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-invalid-selection@example.edu"
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Invalid Selection Course",
+    )
+    db.commit()
+
+    with patch("fastapi.BackgroundTasks.add_task"):
+        response = client.post(
+            "/api/authoring/jobs",
+            json=_build_authoring_payload(course_id=course.id, syllabus_module="bogus-module"),
+            headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Seleccion invalida de modulo o unidad del syllabus"
+
+
+def test_issue139_authoring_intake_rejects_client_grounding_injection(
+    client,
+    db,
+    seed_identity,
+    seed_course_with_syllabus,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-grounding-injection@example.edu"
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Grounding Injection Course",
+    )
+    db.commit()
+
+    payload = _build_authoring_payload(course_id=course.id)
+    payload["ai_grounding_context"] = {"forged": True}
+
+    with patch("fastapi.BackgroundTasks.add_task"):
+        response = client.post(
+            "/api/authoring/jobs",
+            json=payload,
+            headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+        )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert isinstance(detail, list)
+    assert any(item.get("loc") == ["body", "ai_grounding_context"] for item in detail)
+
+
+def test_issue139_authoring_runtime_fails_closed_on_invalid_persisted_selection(
+    db,
+    seed_identity,
+    seed_course_with_syllabus,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-runtime-invalid-selection@example.edu"
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Runtime Invalid Selection Course",
+    )
+
+    assignment = Assignment(
+        teacher_id=teacher_id,
+        course_id=course.id,
+        title="Runtime Invalid Selection",
+        status="draft",
+    )
+    db.add(assignment)
+    db.flush()
+
+    job = AuthoringJob(
+        assignment_id=assignment.id,
+        idempotency_key=f"job-{uuid.uuid4()}",
+        status="pending",
+        task_payload={
+            "step": "authoring",
+            "course_id": course.id,
+            "syllabus_revision": 1,
+            "syllabus_module_id": "bogus-module",
+            "topic_unit_id": "u1",
+            "asignatura": course.title,
+            "nivel": course.academic_level,
+        },
+    )
+    db.add(job)
+    db.commit()
+
+    with patch("case_generator.core.authoring.get_storage_provider", return_value=object()):
+        asyncio.run(AuthoringService.run_job(job.id))
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+    payload = dict(refreshed.task_payload or {})
+    assert refreshed.status == "failed"
+    assert payload.get("error_code") == "syllabus_grounding_unavailable"
+    assert "modulo o la unidad seleccionados" in str(payload.get("error_trace", ""))

--- a/backend/tests/test_issue30_auth_perimeter.py
+++ b/backend/tests/test_issue30_auth_perimeter.py
@@ -543,7 +543,11 @@ def test_authoring_denies_student(client, auth_headers_factory, seed_identity) -
     seed_identity(user_id=user_id, email=email, role="student")
     headers = auth_headers_factory(sub=user_id, email=email)
 
-    response = client.post("/api/authoring/jobs", json={"assignment_title": "Nope"}, headers=headers)
+    response = client.post(
+        "/api/authoring/jobs",
+        json={"assignment_title": "Nope", "course_id": str(uuid.uuid4())},
+        headers=headers,
+    )
     assert response.status_code == 403
     assert response.json()["detail"] == "authoring_forbidden"
 
@@ -554,7 +558,11 @@ def test_authoring_requires_legacy_bridge(client, auth_headers_factory, seed_ide
     seed_identity(user_id=user_id, email=email, role="teacher", create_legacy_user=False)
     headers = auth_headers_factory(sub=user_id, email=email)
 
-    response = client.post("/api/authoring/jobs", json={"assignment_title": "No bridge"}, headers=headers)
+    response = client.post(
+        "/api/authoring/jobs",
+        json={"assignment_title": "No bridge", "course_id": str(uuid.uuid4())},
+        headers=headers,
+    )
     assert response.status_code == 500
     assert response.json()["detail"] == "legacy_bridge_missing"
 

--- a/backend/tests/test_issue90_teacher_cases.py
+++ b/backend/tests/test_issue90_teacher_cases.py
@@ -16,17 +16,27 @@ def test_issue90_authoring_job_persists_deadline_and_normalizes_due_at(
     db,
     seed_identity,
     auth_headers_factory,
+    seed_course_with_syllabus,
 ) -> None:
     teacher_id = str(uuid.uuid4())
     teacher_email = "teacher-deadline@example.edu"
-    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Deadline Case",
+    )
 
     with patch("fastapi.BackgroundTasks.add_task"):
         response = client.post(
             "/api/authoring/jobs",
             json={
                 "assignment_title": "Deadline Case",
+                "course_id": course.id,
                 "subject": "Deadline Case",
+                "syllabus_module": "m1",
+                "topic_unit": "u1",
+                "target_groups": ["Grupo 01"],
                 "due_at": "2026-04-15T09:30",
             },
             headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
@@ -43,16 +53,26 @@ def test_issue90_authoring_job_preserves_string_payload_shape_and_allows_null_de
     db,
     seed_identity,
     auth_headers_factory,
+    seed_course_with_syllabus,
 ) -> None:
     teacher_id = str(uuid.uuid4())
     teacher_email = "teacher-null-deadline@example.edu"
-    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Null Deadline Case",
+    )
 
     with patch("fastapi.BackgroundTasks.add_task"):
         response = client.post(
             "/api/authoring/jobs",
             json={
                 "assignment_title": "Null Deadline Case",
+                "course_id": course.id,
+                "syllabus_module": "m1",
+                "topic_unit": "u1",
+                "target_groups": ["Grupo 01"],
                 "due_at": None,
             },
             headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
@@ -69,16 +89,26 @@ def test_issue90_authoring_job_rejects_invalid_due_at(
     client,
     seed_identity,
     auth_headers_factory,
+    seed_course_with_syllabus,
 ) -> None:
     teacher_id = str(uuid.uuid4())
     teacher_email = "teacher-invalid-deadline@example.edu"
-    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Invalid Deadline Case",
+    )
 
     with patch("fastapi.BackgroundTasks.add_task"):
         response = client.post(
             "/api/authoring/jobs",
             json={
                 "assignment_title": "Invalid Deadline Case",
+                "course_id": course.id,
+                "syllabus_module": "m1",
+                "topic_unit": "u1",
+                "target_groups": ["Grupo 01"],
                 "due_at": "not-a-date",
             },
             headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),

--- a/backend/tests/test_phase1a_smoke.py
+++ b/backend/tests/test_phase1a_smoke.py
@@ -18,15 +18,24 @@ def test_database_connection() -> None:
         db.close()
 
 
-def test_intake_and_idempotency_workflow(client, db, auth_headers_factory, seed_identity) -> None:
+def test_intake_and_idempotency_workflow(client, db, auth_headers_factory, seed_identity, seed_course_with_syllabus) -> None:
     teacher_id = "00000000-0000-0000-0000-000000000101"
     teacher_email = "teacher101@example.edu"
-    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Post-Hardening Smoke Test Verification",
+    )
     db.commit()
     headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
 
     payload = {
         "assignment_title": "Post-Hardening Smoke Test Verification",
+        "course_id": course.id,
+        "syllabus_module": "m1",
+        "topic_unit": "u1",
+        "target_groups": ["Grupo 01"],
     }
     with patch("fastapi.BackgroundTasks.add_task"):
         response = client.post("/api/authoring/jobs", json=payload, headers=headers)
@@ -132,7 +141,7 @@ def test_intake_and_idempotency_workflow(client, db, auth_headers_factory, seed_
 
 
 def test_intake_requires_bearer_auth(client) -> None:
-    payload = {"assignment_title": f"Case {uuid.uuid4()}"}
+    payload = {"assignment_title": f"Case {uuid.uuid4()}", "course_id": str(uuid.uuid4())}
     response = client.post("/api/authoring/jobs", json=payload)
     assert response.status_code == 401
     assert response.json()["detail"] == "invalid_token"

--- a/backend/tests/test_phase1b_integration.py
+++ b/backend/tests/test_phase1b_integration.py
@@ -35,13 +35,22 @@ class _StubGraph:
         return self._stream_impl(*args, **kwargs)
 
 
-def test_phase1b_intake_and_authoring_stubbed(client, db, auth_headers_factory, seed_identity) -> None:
+def test_phase1b_intake_and_authoring_stubbed(client, db, auth_headers_factory, seed_identity, seed_course_with_syllabus) -> None:
     teacher_email = "teacher102@example.edu"
-    seed_identity(user_id=TEACHER_ID, email=teacher_email, role="teacher")
+    teacher = seed_identity(user_id=TEACHER_ID, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Phase 1B Integration Test Title",
+    )
     db.commit()
     headers = auth_headers_factory(sub=TEACHER_ID, email=teacher_email)
     payload = {
         "assignment_title": "Phase 1B Integration Test Title",
+        "course_id": course.id,
+        "syllabus_module": "m1",
+        "topic_unit": "u1",
+        "target_groups": ["Grupo 01"],
     }
 
     graph_getter = AsyncMock(return_value=_StubGraph(_successful_astream))
@@ -74,13 +83,22 @@ def test_phase1b_intake_and_authoring_stubbed(client, db, auth_headers_factory, 
         db.close()
 
 
-def test_phase1b_authoring_service_failure(client, db, auth_headers_factory, seed_identity) -> None:
+def test_phase1b_authoring_service_failure(client, db, auth_headers_factory, seed_identity, seed_course_with_syllabus) -> None:
     teacher_email = "teacher103@example.edu"
-    seed_identity(user_id=ERROR_TEACHER_ID, email=teacher_email, role="teacher")
+    teacher = seed_identity(user_id=ERROR_TEACHER_ID, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Phase 1B Error Test Title",
+    )
     db.commit()
     headers = auth_headers_factory(sub=ERROR_TEACHER_ID, email=teacher_email)
     payload = {
         "assignment_title": "Phase 1B Error Test Title",
+        "course_id": course.id,
+        "syllabus_module": "m1",
+        "topic_unit": "u1",
+        "target_groups": ["Grupo 01"],
     }
 
     graph_getter = AsyncMock(return_value=_StubGraph(_failing_astream))

--- a/backend/tests/test_phase1b_real.py
+++ b/backend/tests/test_phase1b_real.py
@@ -7,14 +7,23 @@ from shared.models import AuthoringJob, Assignment
 
 pytestmark = pytest.mark.live_llm
 
-def test_real_success_and_idempotency(client, auth_headers_factory, seed_identity):
+def test_real_success_and_idempotency(client, auth_headers_factory, seed_identity, seed_course_with_syllabus):
     print("\n--- Testing Real Success ---")
     teacher_id = str(uuid.uuid4())
     teacher_email = f"{teacher_id}@example.edu"
-    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Real LLM Test Case",
+    )
     headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
     payload = {
-        "assignment_title": "Real LLM Test Case"
+        "assignment_title": "Real LLM Test Case",
+        "course_id": course.id,
+        "syllabus_module": "m1",
+        "topic_unit": "u1",
+        "target_groups": ["Grupo 01"],
     }
 
     # Execute Intake
@@ -60,14 +69,23 @@ def test_real_success_and_idempotency(client, auth_headers_factory, seed_identit
         db.close()
 
 
-def test_real_failure_handling(client, auth_headers_factory, seed_identity):
+def test_real_failure_handling(client, auth_headers_factory, seed_identity, seed_course_with_syllabus):
     print("\n--- Testing Real Failure (Invalid API Key) ---")
     teacher_id = str(uuid.uuid4())
     teacher_email = f"{teacher_id}@example.edu"
-    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Real Error LLM Test Case",
+    )
     headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
     payload = {
-        "assignment_title": "Real Error LLM Test Case"
+        "assignment_title": "Real Error LLM Test Case",
+        "course_id": course.id,
+        "syllabus_module": "m1",
+        "topic_unit": "u1",
+        "target_groups": ["Grupo 01"],
     }
 
     # Patch the environment variable to an invalid key during the run

--- a/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
@@ -32,7 +32,8 @@ async function selectOption(
 
 async function enableSuggestions(user: ReturnType<typeof userEvent.setup>) {
     await selectOption(user, /asignatura/i, /gerencia/i);
-    await user.click(screen.getByLabelText(/grupo 01/i));
+    await user.type(screen.getByLabelText(/grupo destino/i), "Grupo 01");
+    await user.keyboard("{Enter}");
     await selectOption(user, /m[oó]dulo del syllabus/i, /fundamentos/i);
 }
 
@@ -50,6 +51,139 @@ describe("AuthoringForm", () => {
 
     beforeEach(() => {
         vi.restoreAllMocks();
+        server.use(
+            http.get("/api/teacher/courses", () => HttpResponse.json({
+                courses: [
+                    {
+                        id: "course-1",
+                        title: "Gerencia de Operaciones",
+                        code: "GO-101",
+                        semester: "2025-1",
+                        academic_level: "MBA",
+                        status: "active",
+                        students_count: 32,
+                        active_cases_count: 1,
+                    },
+                ],
+                total: 1,
+            })),
+            http.get("/api/teacher/courses/:courseId", ({ params }) => {
+                if (params.courseId !== "course-1") {
+                    return HttpResponse.text("Not found", { status: 404 });
+                }
+
+                return HttpResponse.json({
+                    course: {
+                        id: "course-1",
+                        title: "Gerencia de Operaciones",
+                        code: "GO-101",
+                        semester: "2025-1",
+                        academic_level: "MBA",
+                        status: "active",
+                        max_students: 35,
+                        students_count: 32,
+                        active_cases_count: 1,
+                    },
+                    syllabus: {
+                        department: "Administracion",
+                        knowledge_area: "Operaciones",
+                        nbc: "Administracion",
+                        version_label: "v1",
+                        academic_load: "48 horas",
+                        course_description: "Curso de operaciones",
+                        general_objective: "Tomar decisiones operativas",
+                        specific_objectives: ["Analizar capacidad"],
+                        modules: [
+                            {
+                                module_id: "module-1",
+                                module_title: "Fundamentos de Operaciones",
+                                weeks: "1-4",
+                                module_summary: "Base conceptual",
+                                learning_outcomes: ["Diagnosticar procesos"],
+                                units: [
+                                    {
+                                        unit_id: "unit-1",
+                                        title: "Pronosticos",
+                                        topics: "Series de tiempo",
+                                    },
+                                ],
+                                cross_course_connections: "Finanzas",
+                            },
+                        ],
+                        evaluation_strategy: [],
+                        didactic_strategy: {
+                            methodological_perspective: "Aplicada",
+                            pedagogical_modality: "Presencial",
+                        },
+                        integrative_project: "Proyecto final",
+                        bibliography: ["Libro 1"],
+                        teacher_notes: "",
+                        ai_grounding_context: {
+                            course_identity: {
+                                course_id: "course-1",
+                                course_title: "Gerencia de Operaciones",
+                                academic_level: "MBA",
+                                department: "Administracion",
+                                knowledge_area: "Operaciones",
+                                nbc: "Administracion",
+                            },
+                            pedagogical_intent: {
+                                course_description: "Curso de operaciones",
+                                general_objective: "Tomar decisiones operativas",
+                                specific_objectives: ["Analizar capacidad"],
+                            },
+                            instructional_scope: {
+                                modules: [
+                                    {
+                                        module_id: "module-1",
+                                        module_title: "Fundamentos de Operaciones",
+                                        weeks: "1-4",
+                                        module_summary: "Base conceptual",
+                                        learning_outcomes: ["Diagnosticar procesos"],
+                                        units: [
+                                            {
+                                                unit_id: "unit-1",
+                                                title: "Pronosticos",
+                                                topics: "Series de tiempo",
+                                            },
+                                        ],
+                                        cross_course_connections: "Finanzas",
+                                    },
+                                ],
+                                evaluation_strategy: [],
+                                didactic_strategy: {
+                                    methodological_perspective: "Aplicada",
+                                    pedagogical_modality: "Presencial",
+                                },
+                            },
+                            generation_hints: {
+                                target_student_profile: "business",
+                                scenario_constraints: ["Use datos reales"],
+                                preferred_techniques: ["Arbol de decision"],
+                                difficulty_signal: "intermediate",
+                                forbidden_mismatches: [],
+                            },
+                            metadata: {
+                                syllabus_revision: 3,
+                                saved_at: "2025-02-01T00:00:00Z",
+                                saved_by_membership_id: "membership-1",
+                            },
+                        },
+                    },
+                    revision_metadata: {
+                        current_revision: 3,
+                        saved_at: "2025-02-01T00:00:00Z",
+                        saved_by_membership_id: "membership-1",
+                    },
+                    configuration: {
+                        access_link_status: "active",
+                        access_link_id: "link-1",
+                        access_link_created_at: "2025-02-01T00:00:00Z",
+                        join_path: "/c/course-1/join",
+                    },
+                });
+            }),
+        );
     });
 
     it("fills scenario fields from the scenario mutation and shows loading state", async () => {

--- a/frontend/src/features/teacher-authoring/AuthoringForm.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.tsx
@@ -2,15 +2,15 @@
 
 
 import { useState, useCallback, useEffect, useRef, type KeyboardEvent, type FormEvent } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type { CaseFormData, CaseType, EDADepth, StudentProfile, SuggestRequest } from "@/shared/adam-types";
 import {
     Select, SelectContent, SelectGroup,
     SelectItem, SelectTrigger, SelectValue,
 } from "@/shared/ui/select";
 import { api } from "@/shared/api";
+import { queryKeys } from "@/shared/queryKeys";
 import {
-    professorDB,
     INDUSTRIAS_OPTIONS,
     STUDENT_PROFILES,
     FORM_STYLES
@@ -45,6 +45,7 @@ export function AuthoringForm({
     const [guidingQuestion, setGuidingQuestion] = useState("");
     const [suggestedTechniques, setSuggestedTechniques] = useState<string[]>([]);
     const [algoInput, setAlgoInput] = useState("");
+    const [targetGroupInput, setTargetGroupInput] = useState("");
 
     const [availableFrom, setAvailableFrom] = useState("");
     const [dueAt, setDueAt] = useState("");
@@ -56,15 +57,29 @@ export function AuthoringForm({
     // ── Validation ──
     const [errors, setErrors] = useState<Record<string, boolean>>({});
 
+    const teacherCoursesQuery = useQuery({
+        queryKey: queryKeys.teacher.courses(),
+        queryFn: () => api.teacher.getCourses(),
+    });
+
+    const selectedCourseId = subject;
+    const selectedCourseDetailQuery = useQuery({
+        queryKey: queryKeys.teacher.course(selectedCourseId),
+        queryFn: () => api.teacher.getCourseDetail(selectedCourseId),
+        enabled: !!selectedCourseId,
+    });
+
     // ── Derived data ──
-    const selectedCourse = professorDB.courses.find((c) => c.id === subject);
-    const academicLevel = selectedCourse?.level ?? "";
-    const modules = selectedCourse?.syllabus ?? [];
-    const selectedModule = modules.find((m) => m.id === syllabusModule);
+    const teacherCourses = teacherCoursesQuery.data?.courses ?? [];
+    const selectedCourse = teacherCourses.find((course) => course.id === selectedCourseId);
+    const academicLevel = selectedCourse?.academic_level ?? "";
+    const modules = selectedCourseDetailQuery.data?.syllabus?.modules ?? [];
+    const selectedModule = modules.find((module) => module.module_id === syllabusModule);
     const units = selectedModule?.units ?? [];
-    const selectedUnit = units.find((u) => u.id === topicUnit);
+    const selectedUnit = units.find((unit) => unit.unit_id === topicUnit);
     const selectedIndustry = INDUSTRIAS_OPTIONS.find((option) => option.value === industry);
     const suggestionGenerationRef = useRef({ scenario: 0, techniques: 0 });
+    const hasPersistedSyllabus = !!selectedCourseDetailQuery.data?.syllabus;
 
     // ── EDA depth + notebook toggle logic ──
     // business + harvard_with_eda → edaDepth="charts_plus_explanation", no UI
@@ -106,15 +121,13 @@ export function AuthoringForm({
         !!industry;
 
     const buildSuggestPayload = useCallback((): SuggestRequest => {
-        const selectedCourseForAI = professorDB.courses.find((course) => course.id === subject);
-        const modulesForAI = selectedCourseForAI?.syllabus ?? [];
-        const moduleName = modulesForAI.find((module) => module.id === syllabusModule)?.name ?? "";
-        const unitName = selectedUnit?.name ?? "";
+        const moduleName = selectedModule?.module_title ?? "";
+        const unitName = selectedUnit?.title ?? "";
         const industryLabel = selectedIndustry?.label ?? industry;
 
         return {
-            subject: selectedCourseForAI?.name ?? "",
-            academicLevel: selectedCourseForAI?.level ?? "",
+            subject: selectedCourse?.title ?? "",
+            academicLevel: selectedCourse?.academic_level ?? "",
             targetGroups,
             syllabusModule: moduleName,
             topicUnit: unitName,
@@ -134,10 +147,10 @@ export function AuthoringForm({
         industry,
         scenarioDescription,
         selectedIndustry,
+        selectedCourse,
+        selectedModule,
         selectedUnit,
         studentProfile,
-        subject,
-        syllabusModule,
         targetGroups,
     ]);
 
@@ -231,15 +244,27 @@ export function AuthoringForm({
         setTopicUnit(id);
     };
 
-    // ── Group toggle ──
-    const toggleGroup = (group: string) => {
+    const addTargetGroup = useCallback((value: string) => {
+        const trimmed = value.trim();
+        if (!trimmed) return;
+        if (targetGroups.some((group) => group.toLowerCase() === trimmed.toLowerCase())) return;
         invalidateSuggestionResponses();
-        setTargetGroups((prev) => {
-            return prev.includes(group)
-                ? prev.filter((g) => g !== group)
-                : [...prev, group];
-        });
-    };
+        setTargetGroups((prev) => [...prev, trimmed]);
+        setTargetGroupInput("");
+        setErrors((prev) => ({ ...prev, targetGroups: false }));
+    }, [invalidateSuggestionResponses, targetGroups]);
+
+    const removeTargetGroup = useCallback((group: string) => {
+        invalidateSuggestionResponses();
+        setTargetGroups((prev) => prev.filter((value) => value !== group));
+    }, [invalidateSuggestionResponses]);
+
+    const handleTargetGroupKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter" || e.key === ",") {
+            e.preventDefault();
+            addTargetGroup(targetGroupInput);
+        }
+    }, [addTargetGroup, targetGroupInput]);
 
     // ── Chips Orchestration ──
     const addChip = useCallback(
@@ -334,11 +359,12 @@ export function AuthoringForm({
             setErrors({});
 
             const formData: CaseFormData = {
-                subject: selectedCourse?.name ?? "",
+                courseId: selectedCourseId,
+                subject: selectedCourse?.title ?? "",
                 academicLevel,
                 targetGroups,
-                syllabusModule: selectedModule?.name ?? "",
-                topicUnit: selectedUnit?.name ?? "",
+                syllabusModule,
+                topicUnit,
                 industry: selectedIndustry?.label ?? industry,
                 studentProfile,
                 caseType,
@@ -367,6 +393,7 @@ export function AuthoringForm({
         setGuidingQuestion("");
         setSuggestedTechniques([]);
         setAlgoInput("");
+        setTargetGroupInput("");
         setErrors({});
         scenarioMutation.reset();
         techniquesMutation.reset();
@@ -438,13 +465,16 @@ export function AuthoringForm({
                                                 </SelectTrigger>
                                                 <SelectContent>
                                                     <SelectGroup>
-                                                        {professorDB.courses.map((c) => (
-                                                            <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+                                                        {teacherCourses.map((course) => (
+                                                            <SelectItem key={course.id} value={course.id}>{course.title}</SelectItem>
                                                         ))}
                                                     </SelectGroup>
                                                 </SelectContent>
                                             </Select>
                                             <ErrorMsg show={!!errors.asignatura} />
+                                            {teacherCoursesQuery.error instanceof Error ? (
+                                                <p className="field-hint text-red-500">{teacherCoursesQuery.error.message}</p>
+                                            ) : null}
                                         </div>
 
                                         <div>
@@ -467,26 +497,41 @@ export function AuthoringForm({
                                         <label className="block text-sm font-semibold text-slate-700 mb-2">
                                             Grupos Destino <span className="text-red-500" aria-hidden="true">*</span>
                                         </label>
-                                        <div className="grid grid-cols-2 md:grid-cols-3 gap-3 p-3 bg-slate-50 border border-slate-200 rounded-lg">
-                                            {selectedCourse ? (
-                                                selectedCourse.activeGroups.map((grp) => (
-                                                    <label key={grp} className="flex items-center gap-2 cursor-pointer bg-white border border-slate-200 rounded px-3 py-2 hover:border-blue-300 transition-colors">
-                                                        <input
-                                                            type="checkbox"
-                                                            checked={targetGroups.includes(grp)}
-                                                            onChange={() => toggleGroup(grp)}
-                                                            className="w-4 h-4 text-[#0144a0] border-slate-300 rounded focus:ring-[#0144a0]"
-                                                        />
-                                                        <span className="text-sm text-slate-700 font-medium">{grp}</span>
-                                                    </label>
-                                                ))
-                                            ) : (
-                                                <span className="text-sm text-slate-400 col-span-full py-1">
-                                                </span>
-                                            )}
+                                        <div className="space-y-3 p-3 bg-slate-50 border border-slate-200 rounded-lg">
+                                            <div className="flex flex-col gap-3 md:flex-row">
+                                                <input
+                                                    type="text"
+                                                    value={targetGroupInput}
+                                                    onChange={(e) => setTargetGroupInput(e.target.value)}
+                                                    onKeyDown={handleTargetGroupKeyDown}
+                                                    placeholder="Escriba un grupo o seccion y presione Enter"
+                                                    className="input-base w-full rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-800"
+                                                    aria-label="Grupo destino"
+                                                />
+                                                <button
+                                                    type="button"
+                                                    onClick={() => addTargetGroup(targetGroupInput)}
+                                                    className="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-[#0144a0] hover:text-[#0144a0]"
+                                                >
+                                                    Agregar grupo
+                                                </button>
+                                            </div>
+                                            <div className="flex flex-wrap gap-2">
+                                                {targetGroups.map((group) => (
+                                                    <button
+                                                        key={group}
+                                                        type="button"
+                                                        onClick={() => removeTargetGroup(group)}
+                                                        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:border-[#0144a0] hover:text-[#0144a0]"
+                                                    >
+                                                        <span>{group}</span>
+                                                        <span aria-hidden="true">x</span>
+                                                    </button>
+                                                ))}
+                                            </div>
                                         </div>
                                         {errors.targetGroups && <ErrorMsg show={true} />}
-                                        <p className="field-hint">Seleccione uno o más grupos para asignar este caso simultáneamente.</p>
+                                        <p className="field-hint">Registre manualmente los grupos o secciones que recibiran este caso.</p>
                                     </div>
 
                                     {/* Módulo + Unidad */}
@@ -509,12 +554,15 @@ export function AuthoringForm({
                                                 <SelectContent>
                                                     <SelectGroup>
                                                         {modules.map((m) => (
-                                                            <SelectItem key={m.id} value={m.id}>{m.name}</SelectItem>
+                                                            <SelectItem key={m.module_id} value={m.module_id}>{m.module_title}</SelectItem>
                                                         ))}
                                                     </SelectGroup>
                                                 </SelectContent>
                                             </Select>
                                             <ErrorMsg show={!!errors.modulo} />
+                                            {subject && !hasPersistedSyllabus ? (
+                                                <p className="field-hint text-amber-700">Este curso aun no tiene un syllabus guardado.</p>
+                                            ) : null}
                                         </div>
 
                                         <div>
@@ -535,7 +583,7 @@ export function AuthoringForm({
                                                 <SelectContent>
                                                     <SelectGroup>
                                                         {units.map((u) => (
-                                                            <SelectItem key={u.id} value={u.id}>{u.name}</SelectItem>
+                                                            <SelectItem key={u.unit_id} value={u.unit_id}>{u.title}</SelectItem>
                                                         ))}
                                                     </SelectGroup>
                                                 </SelectContent>

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.test.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.test.ts
@@ -8,6 +8,7 @@ describe("buildAuthoringJobCreateRequest", () => {
     it("does not serialize teacher_id and preserves the body-only contract", () => {
         const request = buildAuthoringJobCreateRequest({
             ...EMPTY_FORM,
+            courseId: "course-1",
             subject: "Decision Analysis",
             academicLevel: "MBA",
             industry: "Retail",
@@ -24,6 +25,7 @@ describe("buildAuthoringJobCreateRequest", () => {
         expect("teacher_id" in request).toBe(false);
         expect(request).toEqual({
             assignment_title: "Decision Analysis",
+            course_id: "course-1",
             subject: "Decision Analysis",
             academic_level: "MBA",
             industry: "Retail",

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
@@ -126,6 +126,7 @@ function toCanonicalCaseOutput(response: AuthoringJobResultResponse): CanonicalC
 export function buildAuthoringJobCreateRequest(formData: CaseFormData): AuthoringJobCreateRequest {
     return {
         assignment_title: formData.subject || "Untitled Case",
+        course_id: formData.courseId,
         subject: formData.subject,
         academic_level: formData.academicLevel,
         industry: formData.industry,

--- a/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
@@ -222,8 +222,8 @@ describe("TeacherCoursePage", () => {
         expect(api.teacher.getCourseDetail).toHaveBeenCalledWith("course-1");
         expect(screen.getByDisplayValue("GTD-GEME-01-2026")).toBeTruthy();
         expect(
-            screen.getByDisplayValue("Gestión de las Organizaciones"),
-        ).toBeTruthy();
+            screen.getByLabelText(/Departamento que la ofrece/i),
+        ).toHaveValue("Gestión de las Organizaciones");
     });
 
     it("persists the active tab in the URL", async () => {

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -63,6 +63,7 @@ export type IntentType = "scenario" | "techniques" | "both";
 export type StudentProfile = "business" | "ml_ds";
 export type ModuleId = "m1" | "m2" | "m3" | "m4" | "m5" | "m6";
 export interface CaseFormData {
+    courseId: string;
     subject: string;
     academicLevel: string;
     targetGroups: string[];
@@ -137,6 +138,7 @@ export interface CanonicalCaseOutput {
 
 export interface AuthoringJobCreateRequest {
     assignment_title: string;
+    course_id: string;
     subject: string;
     academic_level: string;
     industry: string;
@@ -675,6 +677,7 @@ export interface TeacherCasesResponse {
 }
 
 export const EMPTY_FORM: CaseFormData = {
+    courseId: "",
     subject: "",
     academicLevel: "Pregrado",
     targetGroups: [],

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -72,6 +72,7 @@ describe("api auth + stream glue", () => {
 
         await api.authoring.submitJob({
             assignment_title: "Case",
+            course_id: "course-1",
             subject: "Case",
             academic_level: "MBA",
             industry: "FinTech",

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,45 +1,52 @@
 ﻿## Summary
-- adds the backend syllabus domain as a course-separated 1:1 persistence model with append-only revision snapshots
-- exposes `GET /api/teacher/courses/{course_id}` as a composed teacher detail endpoint with institutional data, syllabus state, revision metadata, and access-link configuration status
-- exposes `PUT /api/teacher/courses/{course_id}/syllabus` with strict teacher ownership, tenant isolation, optimistic concurrency, and immutable revision creation on save
-- persists `ai_grounding_context` as a validated server-derived JSON contract instead of trusting client-provided grounding
-- extends backend coverage for teacher detail/save happy paths, auth perimeter, tenant isolation, stale writes, and grounding shape validation
-- records deferred follow-ups in `TODOS.md` for `Assignment.course_id` integration and teacher self-service access-link management
+- requires `course_id` on authoring intake, persists `assignments.course_id`, and keeps legacy job ownership paths readable
+- resolves syllabus grounding only from persisted server snapshots during authoring execution and fails explicitly when that snapshot is unavailable
+- injects canonical syllabus context and preferred techniques into the LangGraph runtime instead of trusting frontend-authored grounding
+- rewires teacher authoring UI to real teacher course/detail APIs and removes mock course-module authority from the form
+- adds migration, reusable test fixtures, and regression coverage across backend auth/intake/runtime plus frontend authoring flows
+- removes the resolved Issue #139 follow-up from `TODOS.md`
 
 ## Executive Summary
-This PR delivers the backend production base for issue #137 without expanding into frontend or authoring integration work that belongs to #139. `Course` remains the institutional source of truth, `Syllabus` owns editable pedagogical content, and every successful teacher save appends an immutable revision snapshot while updating the live syllabus row.
+This PR closes the production gap between teacher authoring and the syllabus domain. The backend is now the sole source of truth for course-linked grounding: the intake only accepts a real teacher-owned `course_id`, the runtime resolves the immutable syllabus snapshot captured at job creation, and the frontend only selects canonical course/module/unit identifiers without inventing grounding state client-side.
 
 ## Architecture Decisions
-- Keep `courses` authoritative for `title`, `code`, `semester`, and `academic_level`
-- Store editable pedagogical content in a separate `syllabuses` table with a unique `course_id`
-- Store revision history in append-only `syllabus_revisions` snapshots with a unique `(syllabus_id, revision)` index
-- Keep teacher detail fail-closed for access links by returning status/config metadata only, not raw tokens
-- Reject client-authored `ai_grounding_context` and derive it server-side on every successful syllabus save
-- Require `expected_revision` on save and return `409 stale_syllabus_revision` for stale writes
+- Keep `Course` authoritative for teacher-owned course identity and persist that link on `Assignment`
+- Validate ownership and syllabus presence at intake time with an explicit `412` guard for courses without syllabus
+- Persist only canonical syllabus identifiers in the job payload and resolve human-readable titles plus grounding from `SyllabusRevision.snapshot`
+- Keep old jobs without `course_id` readable through the legacy ownership branch while new jobs authorize by teacher membership + university scope
+- Feed LangGraph with server-resolved `ai_grounding_context` and merged preferred techniques instead of client strings
+- Replace authoring mock course data with `GET /teacher/courses` and `GET /teacher/courses/{course_id}`; keep target groups as teacher-entered data rather than fake backend-derived options
 
 ## Main Files Changed
+- `backend/src/shared/app.py`
 - `backend/src/shared/models.py`
-- `backend/src/shared/syllabus_schema.py`
 - `backend/src/shared/teacher_reads.py`
-- `backend/src/shared/teacher_writes.py`
-- `backend/src/shared/teacher_router.py`
-- `backend/alembic/versions/e1b3c4d5f6a7_issue137_teacher_syllabuses.py`
-- `backend/tests/test_issue88_teacher_courses.py`
-- `backend/tests/test_issue30_auth_perimeter.py`
-- `TODOS.md`
+- `backend/src/case_generator/core/authoring.py`
+- `backend/src/case_generator/graph.py`
+- `backend/src/case_generator/state.py`
+- `backend/alembic/versions/9f3e2a1b7c4d_issue139_authoring_course_grounding.py`
+- `frontend/src/features/teacher-authoring/AuthoringForm.tsx`
+- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts`
+- `frontend/src/shared/adam-types.ts`
+- `backend/tests/conftest.py`
+- `backend/tests/test_issue90_teacher_cases.py`
+- `backend/tests/test_phase1a_smoke.py`
+- `backend/tests/test_phase1b_integration.py`
+- `frontend/src/features/teacher-authoring/AuthoringForm.test.tsx`
 
 ## Validation Evidence
-- [x] `uv run --directory backend pytest -q tests/test_issue88_teacher_courses.py tests/test_issue30_auth_perimeter.py` (77 passed)
-- [x] `uv run --directory backend pytest -q` (277 passed, 12 skipped)
-- [x] `uv run --directory backend mypy src` (no issues found)
+- [x] `uv run --directory backend pytest -q` (`277 passed, 12 skipped`)
+- [x] `uv run --directory backend mypy src`
+- [x] `npm --prefix frontend run lint`
+- [x] `npm --prefix frontend run test`
+- [x] `npm --prefix frontend run build`
 
 ## Residual Risks
-- `Assignment.course_id` and syllabus-aware authoring enforcement are still deferred to #139 by design
-- teacher detail currently exposes access-link status/config only; raw link management needs a follow-up product/security path
-- grounding generation hints are persisted with a stable contract now, but downstream authoring exploitation remains a separate step
+- Existing legacy jobs remain supported, but only new course-linked jobs get strict syllabus grounding enforcement
+- Target groups remain freeform teacher input because there is still no canonical backend source for section/group options
+- The frontend build still emits the pre-existing Vite chunk-size warning; this PR does not change bundling strategy
 
 ## References
-- Closes #137
-- Parent issue: #140
+- Closes #139
 
 🤖 Generated with GitHub Copilot


### PR DESCRIPTION
﻿## Summary
- requires `course_id` on authoring intake, persists `assignments.course_id`, and keeps legacy job ownership paths readable
- resolves syllabus grounding only from persisted server snapshots during authoring execution and fails explicitly when that snapshot is unavailable
- injects canonical syllabus context and preferred techniques into the LangGraph runtime instead of trusting frontend-authored grounding
- rewires teacher authoring UI to real teacher course/detail APIs and removes mock course-module authority from the form
- adds migration, reusable test fixtures, and regression coverage across backend auth/intake/runtime plus frontend authoring flows
- removes the resolved Issue #139 follow-up from `TODOS.md`

## Executive Summary
This PR closes the production gap between teacher authoring and the syllabus domain. The backend is now the sole source of truth for course-linked grounding: the intake only accepts a real teacher-owned `course_id`, the runtime resolves the immutable syllabus snapshot captured at job creation, and the frontend only selects canonical course/module/unit identifiers without inventing grounding state client-side.

## Architecture Decisions
- Keep `Course` authoritative for teacher-owned course identity and persist that link on `Assignment`
- Validate ownership and syllabus presence at intake time with an explicit `412` guard for courses without syllabus
- Persist only canonical syllabus identifiers in the job payload and resolve human-readable titles plus grounding from `SyllabusRevision.snapshot`
- Keep old jobs without `course_id` readable through the legacy ownership branch while new jobs authorize by teacher membership + university scope
- Feed LangGraph with server-resolved `ai_grounding_context` and merged preferred techniques instead of client strings
- Replace authoring mock course data with `GET /teacher/courses` and `GET /teacher/courses/{course_id}`; keep target groups as teacher-entered data rather than fake backend-derived options

## Main Files Changed
- `backend/src/shared/app.py`
- `backend/src/shared/models.py`
- `backend/src/shared/teacher_reads.py`
- `backend/src/case_generator/core/authoring.py`
- `backend/src/case_generator/graph.py`
- `backend/src/case_generator/state.py`
- `backend/alembic/versions/9f3e2a1b7c4d_issue139_authoring_course_grounding.py`
- `frontend/src/features/teacher-authoring/AuthoringForm.tsx`
- `frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts`
- `frontend/src/shared/adam-types.ts`
- `backend/tests/conftest.py`
- `backend/tests/test_issue90_teacher_cases.py`
- `backend/tests/test_phase1a_smoke.py`
- `backend/tests/test_phase1b_integration.py`
- `frontend/src/features/teacher-authoring/AuthoringForm.test.tsx`

## Validation Evidence
- [x] `uv run --directory backend pytest -q` (`277 passed, 12 skipped`)
- [x] `uv run --directory backend mypy src`
- [x] `npm --prefix frontend run lint`
- [x] `npm --prefix frontend run test`
- [x] `npm --prefix frontend run build`

## Residual Risks
- Existing legacy jobs remain supported, but only new course-linked jobs get strict syllabus grounding enforcement
- Target groups remain freeform teacher input because there is still no canonical backend source for section/group options
- The frontend build still emits the pre-existing Vite chunk-size warning; this PR does not change bundling strategy

## References
- Closes #139

🤖 Generated with GitHub Copilot
