### PR TITLE
feat(authoring): production-ready form audit

### DIFF
--- a/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -7,6 +7,7 @@ import { renderWithProviders } from "@/shared/test-utils";
 import { server } from "@/shared/testing/msw/server";
 
 import { AuthoringForm } from "./AuthoringForm";
+import { FORM_STATE_SESSION_KEY } from "./authoringFormConfig";
 
 type DeferredHttpResponse =
     | ReturnType<typeof HttpResponse.json>
@@ -477,5 +478,360 @@ describe("GroupsCombobox (within AuthoringForm)", () => {
         await user.click(chip);
 
         expect(screen.queryByText("Gerencia de Operaciones (GO-101)")).not.toBeInTheDocument();
+    });
+});
+
+// ─── Shared MSW setup helpers for the new describe blocks ───────────────────
+
+const baseCoursesHandler = http.get("/api/teacher/courses", () =>
+    HttpResponse.json({
+        courses: [{
+            id: "course-1", title: "Gerencia de Operaciones", code: "GO-101",
+            semester: "2025-1", academic_level: "MBA", status: "active",
+            students_count: 32, active_cases_count: 1,
+        }],
+        total: 1,
+    }),
+);
+
+const baseCourseDetailHandler = http.get("/api/teacher/courses/:courseId", () =>
+    HttpResponse.json({
+        course: {
+            id: "course-1", title: "Gerencia de Operaciones", code: "GO-101",
+            semester: "2025-1", academic_level: "MBA", status: "active",
+            max_students: 35, students_count: 32, active_cases_count: 1,
+        },
+        syllabus: {
+            department: "Administracion", knowledge_area: "Operaciones",
+            nbc: "Administracion", version_label: "v1", academic_load: "48 horas",
+            course_description: "Curso", general_objective: "Obj",
+            specific_objectives: [], evaluation_strategy: [],
+            didactic_strategy: { methodological_perspective: "Aplicada", pedagogical_modality: "Presencial" },
+            integrative_project: "", bibliography: [], teacher_notes: "",
+            ai_grounding_context: {
+                course_identity: {
+                    course_id: "course-1", course_title: "Gerencia de Operaciones",
+                    academic_level: "MBA", department: "Administracion",
+                    knowledge_area: "Operaciones", nbc: "Administracion",
+                },
+                pedagogical_intent: { general_objective: "Obj", specific_objectives: [] },
+                curriculum_scope: { coverage_signal: "focused" },
+            },
+            modules: [{
+                module_id: "module-1",
+                module_title: "Fundamentos de Operaciones",
+                weeks: "1-4",
+                module_summary: "Base conceptual",
+                learning_outcomes: [],
+                units: [{ unit_id: "unit-1", title: "Pronosticos", topics: "Series de tiempo" }],
+                cross_course_connections: "",
+            }],
+        },
+    }),
+);
+
+// ─── Task 1 — Required fields & disabled submit button ───────────────────────
+
+describe("Task 1 — Required fields and disabled submit button", () => {
+    beforeAll(() => {
+        Element.prototype.hasPointerCapture ??= () => false;
+        Element.prototype.releasePointerCapture ??= () => {};
+        Element.prototype.setPointerCapture ??= () => {};
+        Element.prototype.scrollIntoView ??= () => {};
+    });
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        server.use(baseCoursesHandler, baseCourseDetailHandler);
+    });
+
+    it("submit button is disabled on initial render", () => {
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+        expect(screen.getByRole("button", { name: /generar caso harvard/i })).toBeDisabled();
+    });
+
+    it("submit button is enabled after all required fields are filled", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        await enableSuggestions(user);
+        await selectOption(user, /unidad tem/i, /pronosticos/i);
+        fireEvent.change(screen.getByRole("textbox", { name: /descripci[oó]n/i }), { target: { value: "Escenario completo de prueba" } });
+        fireEvent.change(screen.getByLabelText(/pregunta gu[ií]a/i), { target: { value: "¿Qué decisión tomar?" } });
+        fireEvent.change(screen.getByLabelText(/disponibilidad/i), { target: { value: "2025-06-01T00:00" } });
+        fireEvent.change(screen.getByLabelText(/fecha de cierre/i), { target: { value: "2025-07-01T00:00" } });
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /generar caso harvard/i })).not.toBeDisabled();
+        });
+    }, 15_000);
+
+    it("handleSubmit shows topicUnit error when module has units and no unit is selected", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        await enableSuggestions(user);
+        // Do NOT select a topicUnit — bypass disabled button via fireEvent.submit
+        fireEvent.submit(document.querySelector("form")!);
+
+        await waitFor(() => {
+            expect(screen.getAllByRole("alert").length).toBeGreaterThan(0);
+        });
+    });
+
+    it("handleSubmit shows availableFrom error when date is not set", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        await enableSuggestions(user);
+        await selectOption(user, /unidad tem/i, /pronosticos/i);
+        await user.type(screen.getByRole("textbox", { name: /descripci[oó]n/i }), "Escenario");
+        await user.type(screen.getByLabelText(/pregunta gu[ií]a/i), "Pregunta");
+        fireEvent.change(screen.getByLabelText(/fecha de cierre/i), { target: { value: "2025-07-01T00:00" } });
+        // availableFrom intentionally left empty
+        fireEvent.submit(document.querySelector("form")!);
+
+        await waitFor(() => {
+            expect(screen.getAllByRole("alert").length).toBeGreaterThan(0);
+        });
+    });
+
+    it("handleSubmit shows dueAt error when date is not set", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        await enableSuggestions(user);
+        await selectOption(user, /unidad tem/i, /pronosticos/i);
+        await user.type(screen.getByRole("textbox", { name: /descripci[oó]n/i }), "Escenario");
+        await user.type(screen.getByLabelText(/pregunta gu[ií]a/i), "Pregunta");
+        fireEvent.change(screen.getByLabelText(/disponibilidad/i), { target: { value: "2025-06-01T00:00" } });
+        // dueAt intentionally left empty
+        fireEvent.submit(document.querySelector("form")!);
+
+        await waitFor(() => {
+            expect(screen.getAllByRole("alert").length).toBeGreaterThan(0);
+        });
+    });
+
+    it("handleSubmit shows suggestedTechniques error in EDA mode when no techniques added", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        await enableSuggestions(user);
+        await selectOption(user, /unidad tem/i, /pronosticos/i);
+        await showTechniquesSection(user); // switch to harvard_with_eda
+        await user.type(screen.getByRole("textbox", { name: /descripci[oó]n/i }), "Escenario completo");
+        await user.type(screen.getByLabelText(/pregunta gu[ií]a/i), "Pregunta guía");
+        fireEvent.change(screen.getByLabelText(/disponibilidad/i), { target: { value: "2025-06-01T00:00" } });
+        fireEvent.change(screen.getByLabelText(/fecha de cierre/i), { target: { value: "2025-07-01T00:00" } });
+        // No techniques added — bypass disabled button
+        fireEvent.submit(document.querySelector("form")!);
+
+        await waitFor(() => {
+            expect(screen.getAllByRole("alert").length).toBeGreaterThan(0);
+        });
+    });
+
+    it("topicUnit is not required when the selected module has no units", async () => {
+        // Override course detail to return a module with no units
+        server.use(
+            http.get("/api/teacher/courses/:courseId", () =>
+                HttpResponse.json({
+                    course: {
+                        id: "course-1", title: "Gerencia de Operaciones", code: "GO-101",
+                        semester: "2025-1", academic_level: "MBA", status: "active",
+                        max_students: 35, students_count: 32, active_cases_count: 1,
+                    },
+                    syllabus: {
+                        department: "Administracion", knowledge_area: "Operaciones",
+                        nbc: "Administracion", version_label: "v1", academic_load: "48 horas",
+                        course_description: "Curso", general_objective: "Obj",
+                        specific_objectives: [], evaluation_strategy: [],
+                        didactic_strategy: { methodological_perspective: "Aplicada", pedagogical_modality: "Presencial" },
+                        integrative_project: "", bibliography: [], teacher_notes: "",
+                        ai_grounding_context: {
+                            course_identity: {
+                                course_id: "course-1", course_title: "Gerencia de Operaciones",
+                                academic_level: "MBA", department: "Administracion",
+                                knowledge_area: "Operaciones", nbc: "Administracion",
+                            },
+                            pedagogical_intent: { general_objective: "Obj", specific_objectives: [] },
+                            curriculum_scope: { coverage_signal: "focused" },
+                        },
+                        modules: [{
+                            module_id: "module-1",
+                            module_title: "Fundamentos de Operaciones",
+                            weeks: "1-4",
+                            module_summary: "Base",
+                            learning_outcomes: [],
+                            units: [], // No units
+                            cross_course_connections: "",
+                        }],
+                    },
+                }),
+            ),
+        );
+
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        await enableSuggestions(user);
+        // No topicUnit selected — unit Select is disabled (no units)
+        await user.type(screen.getByRole("textbox", { name: /descripci[oó]n/i }), "Escenario completo");
+        await user.type(screen.getByLabelText(/pregunta gu[ií]a/i), "Pregunta guía");
+        fireEvent.change(screen.getByLabelText(/disponibilidad/i), { target: { value: "2025-06-01T00:00" } });
+        fireEvent.change(screen.getByLabelText(/fecha de cierre/i), { target: { value: "2025-07-01T00:00" } });
+
+        // Button should be enabled even without topicUnit (units.length === 0 → not required)
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /generar caso harvard/i })).not.toBeDisabled();
+        });
+    });
+});
+
+// ─── Task 2 — Profile restriction for harvard_only ───────────────────────────
+
+describe("Task 2 — Profile restriction for harvard_only", () => {
+    beforeAll(() => {
+        Element.prototype.hasPointerCapture ??= () => false;
+        Element.prototype.releasePointerCapture ??= () => {};
+        Element.prototype.setPointerCapture ??= () => {};
+        Element.prototype.scrollIntoView ??= () => {};
+    });
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        server.use(
+            http.get("/api/teacher/courses", () =>
+                HttpResponse.json({ courses: [], total: 0 }),
+            ),
+        );
+    });
+
+    it("ml_ds option is not shown in the profile dropdown when caseType is harvard_only (default)", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        await user.click(screen.getByLabelText(/perfil del curso/i));
+        const options = await screen.findAllByRole("option");
+        const labels = options.map((o) => o.textContent ?? "");
+
+        expect(labels.some((l) => /machine learning/i.test(l))).toBe(false);
+        expect(labels.some((l) => /negocios/i.test(l))).toBe(true);
+    });
+
+    it("switching to harvard_only auto-resets studentProfile from ml_ds to business", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        // Switch to harvard_with_eda to unlock ml_ds option
+        await user.click(screen.getByRole("radio", { name: /caso .*an[aá]lisis de datos/i }));
+
+        // Select ml_ds profile
+        await user.click(screen.getByLabelText(/perfil del curso/i));
+        await user.click(await screen.findByRole("option", { name: /machine learning/i }));
+
+        expect(screen.getByLabelText(/perfil del curso/i)).toHaveTextContent(/machine learning/i);
+
+        // Switch back to harvard_only — should auto-reset profile
+        await user.click(screen.getByRole("radio", { name: /solo caso harvard/i }));
+
+        await waitFor(() => {
+            expect(screen.getByLabelText(/perfil del curso/i)).toHaveTextContent(/negocios/i);
+        });
+    });
+
+    it("ml_ds option reappears when switching to harvard_with_eda", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        // Confirm ml_ds is absent by default
+        await user.click(screen.getByLabelText(/perfil del curso/i));
+        const optsBefore = await screen.findAllByRole("option");
+        expect(optsBefore.some((o) => /machine learning/i.test(o.textContent ?? ""))).toBe(false);
+
+        // Close dropdown
+        await user.keyboard("{Escape}");
+
+        // Switch to harvard_with_eda
+        await user.click(screen.getByRole("radio", { name: /caso .*an[aá]lisis de datos/i }));
+
+        // ml_ds should now be present
+        await user.click(screen.getByLabelText(/perfil del curso/i));
+        const optsAfter = await screen.findAllByRole("option");
+        expect(optsAfter.some((o) => /machine learning/i.test(o.textContent ?? ""))).toBe(true);
+    });
+});
+
+// ─── Task 3 — sessionStorage persistence ─────────────────────────────────────
+
+describe("Task 3 — sessionStorage persistence", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        sessionStorage.clear();
+        server.use(
+            http.get("/api/teacher/courses", () =>
+                HttpResponse.json({ courses: [], total: 0 }),
+            ),
+        );
+    });
+
+    afterEach(() => {
+        sessionStorage.clear();
+    });
+
+    it("restores form fields from valid sessionStorage data on mount", async () => {
+        sessionStorage.setItem(
+            FORM_STATE_SESSION_KEY,
+            JSON.stringify({
+                scenarioDescription: "Escenario restaurado desde storage",
+                guidingQuestion: "Pregunta restaurada desde storage",
+                subject: "",
+                syllabusModule: "",
+                topicUnit: "",
+                targetGroups: [],
+                studentProfile: "business",
+                industry: "fintech",
+                caseType: "harvard_only",
+                notebookToggle: false,
+                suggestedTechniques: [],
+                algoInput: "",
+                availableFrom: "",
+                dueAt: "",
+            }),
+        );
+
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        expect(await screen.findByDisplayValue("Escenario restaurado desde storage")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Pregunta restaurada desde storage")).toBeInTheDocument();
+    });
+
+    it("writes form state to sessionStorage within 1 second of a field change", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+
+        const textarea = screen.getByRole("textbox", { name: /descripci[oó]n/i });
+        await user.type(textarea, "Texto guardado en storage");
+
+        await waitFor(
+            () => {
+                const raw = sessionStorage.getItem(FORM_STATE_SESSION_KEY);
+                expect(raw).not.toBeNull();
+                const parsed = JSON.parse(raw!);
+                expect(parsed.scenarioDescription).toContain("Texto guardado en storage");
+            },
+            { timeout: 1500 },
+        );
+    });
+
+    it("removes a corrupted sessionStorage key silently on mount without throwing", () => {
+        sessionStorage.setItem(FORM_STATE_SESSION_KEY, "{invalid-json-payload}");
+
+        expect(() => {
+            renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+        }).not.toThrow();
+
+        expect(sessionStorage.getItem(FORM_STATE_SESSION_KEY)).toBeNull();
     });
 });

--- a/frontend/src/features/teacher-authoring/AuthoringForm.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.tsx
@@ -13,7 +13,8 @@ import { queryKeys } from "@/shared/queryKeys";
 import {
     INDUSTRIAS_OPTIONS,
     STUDENT_PROFILES,
-    FORM_STYLES
+    FORM_STYLES,
+    FORM_STATE_SESSION_KEY,
 } from "./authoringFormConfig";
 import { GroupsCombobox } from "./GroupsCombobox";
 
@@ -25,30 +26,32 @@ interface Props {
 }
 
 export function AuthoringForm({
+    initialData,
     onSubmit,
     showCancelEdit,
     onCancelEdit,
 }: Props) {
     // ── Form state ──
-    const [subject, setSubject] = useState("");
-    const [syllabusModule, setSyllabusModule] = useState("");
-    const [topicUnit, setTopicUnit] = useState("");
-    const [targetGroups, setTargetGroups] = useState<string[]>([]);
-    const [studentProfile, setStudentProfile] = useState<StudentProfile>("business");
+    const [subject, setSubject] = useState(initialData?.courseId ?? "");
+    const [syllabusModule, setSyllabusModule] = useState(initialData?.syllabusModule ?? "");
+    const [topicUnit, setTopicUnit] = useState(initialData?.topicUnit ?? "");
+    const [targetGroups, setTargetGroups] = useState<string[]>(initialData?.targetGroups ?? []);
+    const [studentProfile, setStudentProfile] = useState<StudentProfile>(initialData?.studentProfile ?? "business");
 
-    const [industry, setIndustry] = useState("fintech");
-    const [caseType, setCaseType] = useState<CaseType>("harvard_only");
-    const [edaDepth, setEdaDepth] = useState<EDADepth | undefined>(undefined);
-    const [includePythonCode, setIncludePythonCode] = useState(false);
-    const [notebookToggle, setNotebookToggle] = useState(false);
+    const initialIndustry = INDUSTRIAS_OPTIONS.find((o) => o.label === initialData?.industry)?.value ?? "fintech";
+    const [industry, setIndustry] = useState(initialIndustry);
+    const [caseType, setCaseType] = useState<CaseType>(initialData?.caseType ?? "harvard_only");
+    const [edaDepth, setEdaDepth] = useState<EDADepth | undefined>(initialData?.edaDepth);
+    const [includePythonCode, setIncludePythonCode] = useState(initialData?.includePythonCode ?? false);
+    const [notebookToggle, setNotebookToggle] = useState(initialData?.edaDepth === "charts_plus_code");
 
-    const [scenarioDescription, setScenarioDescription] = useState("");
-    const [guidingQuestion, setGuidingQuestion] = useState("");
-    const [suggestedTechniques, setSuggestedTechniques] = useState<string[]>([]);
+    const [scenarioDescription, setScenarioDescription] = useState(initialData?.scenarioDescription ?? "");
+    const [guidingQuestion, setGuidingQuestion] = useState(initialData?.guidingQuestion ?? "");
+    const [suggestedTechniques, setSuggestedTechniques] = useState<string[]>(initialData?.suggestedTechniques ?? []);
     const [algoInput, setAlgoInput] = useState("");
 
-    const [availableFrom, setAvailableFrom] = useState("");
-    const [dueAt, setDueAt] = useState("");
+    const [availableFrom, setAvailableFrom] = useState(initialData?.availableFrom ?? "");
+    const [dueAt, setDueAt] = useState(initialData?.dueAt ?? "");
 
     // ── Estados IA ──
     const [formAlertError, setFormAlertError] = useState<string | null>(null);
@@ -56,6 +59,34 @@ export function AuthoringForm({
 
     // ── Validation ──
     const [errors, setErrors] = useState<Record<string, boolean>>({});
+
+    // ── SessionStorage persistence ref ──
+    const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // ── Restore form state from sessionStorage on mount ──
+    useEffect(() => {
+        const raw = sessionStorage.getItem(FORM_STATE_SESSION_KEY);
+        if (!raw) return;
+        try {
+            const saved = JSON.parse(raw) as Record<string, unknown>;
+            if (typeof saved.subject === "string") setSubject(saved.subject);
+            if (typeof saved.syllabusModule === "string") setSyllabusModule(saved.syllabusModule);
+            if (typeof saved.topicUnit === "string") setTopicUnit(saved.topicUnit);
+            if (Array.isArray(saved.targetGroups)) setTargetGroups(saved.targetGroups as string[]);
+            if (saved.studentProfile === "business" || saved.studentProfile === "ml_ds") setStudentProfile(saved.studentProfile);
+            if (typeof saved.industry === "string") setIndustry(saved.industry);
+            if (saved.caseType === "harvard_only" || saved.caseType === "harvard_with_eda") setCaseType(saved.caseType as CaseType);
+            if (typeof saved.notebookToggle === "boolean") setNotebookToggle(saved.notebookToggle);
+            if (typeof saved.scenarioDescription === "string") setScenarioDescription(saved.scenarioDescription);
+            if (typeof saved.guidingQuestion === "string") setGuidingQuestion(saved.guidingQuestion);
+            if (Array.isArray(saved.suggestedTechniques)) setSuggestedTechniques(saved.suggestedTechniques as string[]);
+            if (typeof saved.algoInput === "string") setAlgoInput(saved.algoInput);
+            if (typeof saved.availableFrom === "string") setAvailableFrom(saved.availableFrom);
+            if (typeof saved.dueAt === "string") setDueAt(saved.dueAt);
+        } catch {
+            sessionStorage.removeItem(FORM_STATE_SESSION_KEY);
+        }
+    }, []);
 
     const teacherCoursesQuery = useQuery({
         queryKey: queryKeys.teacher.courses(),
@@ -78,6 +109,9 @@ export function AuthoringForm({
     const units = selectedModule?.units ?? [];
     const selectedUnit = units.find((unit) => unit.unit_id === topicUnit);
     const selectedIndustry = INDUSTRIAS_OPTIONS.find((option) => option.value === industry);
+    const availableProfiles = caseType === "harvard_only"
+        ? STUDENT_PROFILES.filter((p) => p.value !== "ml_ds")
+        : STUDENT_PROFILES;
     const suggestionGenerationRef = useRef({ scenario: 0, techniques: 0 });
     const hasPersistedSyllabus = !!selectedCourseDetailQuery.data?.syllabus;
 
@@ -102,6 +136,28 @@ export function AuthoringForm({
         }
     }, [caseType, studentProfile, notebookToggle]);
 
+    // ── Debounced sessionStorage persist ──
+    useEffect(() => {
+        if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+        persistTimerRef.current = setTimeout(() => {
+            try {
+                sessionStorage.setItem(FORM_STATE_SESSION_KEY, JSON.stringify({
+                    subject, syllabusModule, topicUnit, targetGroups, studentProfile,
+                    industry, caseType, notebookToggle,
+                    scenarioDescription, guidingQuestion, suggestedTechniques, algoInput,
+                    availableFrom, dueAt,
+                }));
+            } catch {
+                // sessionStorage quota exceeded or unavailable — fail silently
+            }
+        }, 300);
+        return () => {
+            if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+        };
+    }, [subject, syllabusModule, topicUnit, targetGroups, studentProfile, industry, caseType,
+        notebookToggle, scenarioDescription, guidingQuestion, suggestedTechniques, algoInput,
+        availableFrom, dueAt]);
+
     const markStale = useCallback(() => {
         if (suggestedTechniques.length > 0) {
             setAreTechniquesStale(true);
@@ -119,6 +175,21 @@ export function AuthoringForm({
         targetGroups.length > 0 &&
         !!syllabusModule &&
         !!industry;
+
+    // ── Validation CanSubmit ──
+    const isAlgorithmsRequired = caseType === "harvard_with_eda" || studentProfile === "ml_ds";
+    const hasValidTopicUnit = units.length === 0 || !!topicUnit;
+    const canSubmit =
+        !!subject &&
+        !!syllabusModule &&
+        hasValidTopicUnit &&
+        targetGroups.length > 0 &&
+        !!industry &&
+        !!scenarioDescription.trim() &&
+        !!guidingQuestion.trim() &&
+        !!availableFrom &&
+        !!dueAt &&
+        (!isAlgorithmsRequired || suggestedTechniques.length > 0);
 
     const buildSuggestPayload = useCallback((): SuggestRequest => {
         const moduleName = selectedModule?.module_title ?? "";
@@ -230,18 +301,20 @@ export function AuthoringForm({
         setSyllabusModule("");
         setTopicUnit("");
         setTargetGroups([]);
-        setErrors((prev) => ({ ...prev, asignatura: false }));
+        setErrors((prev) => ({ ...prev, asignatura: false, modulo: false, topicUnit: false }));
     };
 
     const handleSyllabusModuleChange = (id: string) => {
         invalidateSuggestionResponses();
         setSyllabusModule(id);
         setTopicUnit("");
+        setErrors((prev) => ({ ...prev, modulo: false, topicUnit: false }));
     };
 
     const handleTopicUnitChange = (id: string) => {
         invalidateSuggestionResponses();
         setTopicUnit(id);
+        setErrors((prev) => ({ ...prev, topicUnit: false }));
     };
 
     const addTargetGroup = useCallback((value: string) => {
@@ -308,16 +381,21 @@ export function AuthoringForm({
     };
     const onCaseTypeChange = (val: CaseType) => {
         invalidateSuggestionResponses();
+        if (val === "harvard_only" && studentProfile === "ml_ds") {
+            setStudentProfile("business");
+        }
         setCaseType(val);
         markStale();
     };
     const onChangeAvailableFrom = (val: string) => {
         setAvailableFrom(val);
         setFormAlertError(null);
+        if (val) setErrors((prev) => ({ ...prev, availableFrom: false, dateOrder: false }));
     };
     const onChangeDueAt = (val: string) => {
         setDueAt(val);
         setFormAlertError(null);
+        if (val) setErrors((prev) => ({ ...prev, dueAt: false, dateOrder: false }));
     };
     // ── Submit ──
     const handleSubmit = (e: FormEvent) => {
@@ -326,13 +404,17 @@ export function AuthoringForm({
             const newErrors: Record<string, boolean> = {};
             if (!subject) newErrors.asignatura = true;
             if (!syllabusModule) newErrors.modulo = true;
+            if (units.length > 0 && !topicUnit) newErrors.topicUnit = true;
             if (targetGroups.length === 0) newErrors.targetGroups = true;
             if (!industry) newErrors.industria = true;
             if (!scenarioDescription.trim()) newErrors.scenario = true;
             if (!guidingQuestion.trim()) newErrors.guidingQuestion = true;
+            if (!availableFrom) newErrors.availableFrom = true;
+            if (!dueAt) newErrors.dueAt = true;
+            if (isAlgorithmsRequired && suggestedTechniques.length === 0) newErrors.suggestedTechniques = true;
             // edaDepth is calculated automatically — no user validation needed
 
-            // Validate dates implicitly relying on logical flow, highlight if reversed
+            // Validate date order after presence checks
             if (availableFrom && dueAt && new Date(dueAt) < new Date(availableFrom)) {
                 newErrors.dateOrder = true;
                 setFormAlertError("La Fecha de Cierre no puede ser anterior a la Disponibilidad.");
@@ -340,10 +422,12 @@ export function AuthoringForm({
 
             if (Object.keys(newErrors).length > 0) {
                 setErrors(newErrors);
-                // Scroll simple check if date error
+                // Scroll to top unless the only error is date ordering
                 const firstId = Object.keys(newErrors)[0];
                 if (firstId === "dateOrder") {
                     window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+                } else {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
                 }
                 return;
             }
@@ -374,6 +458,7 @@ export function AuthoringForm({
 
     // ── Clear ──
     const clearForm = () => {
+        sessionStorage.removeItem(FORM_STATE_SESSION_KEY);
         invalidateSuggestionResponses();
         setSubject("");
         setSyllabusModule("");
@@ -532,18 +617,18 @@ export function AuthoringForm({
 
                                         <div>
                                             <label htmlFor="field-unidad" className="block text-sm font-semibold text-slate-700 mb-1.5">
-                                                Unidad Temática <span className="text-xs font-normal text-slate-400 ml-1">(Opcional, mayor precisión)</span>
+                                                Unidad Temática <span className="text-red-500" aria-hidden="true">*</span>
                                             </label>
                                             <Select
-                                                disabled={!syllabusModule}
+                                                disabled={!syllabusModule || units.length === 0}
                                                 value={topicUnit}
                                                 onValueChange={handleTopicUnitChange}
                                             >
                                                 <SelectTrigger
                                                     id="field-unidad"
-                                                    className="input-base w-full rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-800 disabled:bg-slate-50 disabled:text-slate-400"
+                                                    className={`input-base w-full rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-800 disabled:bg-slate-50 disabled:text-slate-400 ${errors.topicUnit ? "input-error" : ""}`}
                                                 >
-                                                    <SelectValue placeholder={syllabusModule ? "Todas las unidades (General)" : "Seleccione módulo primero..."} />
+                                                    <SelectValue placeholder={!syllabusModule ? "Seleccione módulo primero..." : units.length === 0 ? "Este módulo no define unidades" : "Seleccione una unidad..."} />
                                                 </SelectTrigger>
                                                 <SelectContent>
                                                     <SelectGroup>
@@ -553,6 +638,7 @@ export function AuthoringForm({
                                                     </SelectGroup>
                                                 </SelectContent>
                                             </Select>
+                                            <ErrorMsg show={!!errors.topicUnit} />
                                         </div>
                                     </div>
 
@@ -632,7 +718,7 @@ export function AuthoringForm({
                                                 </SelectTrigger>
                                                 <SelectContent>
                                                     <SelectGroup>
-                                                        {STUDENT_PROFILES.map((opt) => (
+                                                        {availableProfiles.map((opt) => (
                                                             <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
                                                         ))}
                                                     </SelectGroup>
@@ -753,7 +839,7 @@ export function AuthoringForm({
                                             <div className="flex items-center justify-between mb-2.5">
                                                 <div>
                                                     <label className="text-sm font-semibold text-slate-700 block" htmlFor="algo-input">
-                                                        Algoritmos / Técnicas Sugeridas
+                                                        Algoritmos / Técnicas Sugeridas <span className="text-red-500" aria-hidden="true">*</span>
                                                         <button
                                                             type="button"
                                                             onClick={handleSuggestTechniques}
@@ -769,8 +855,8 @@ export function AuthoringForm({
                                                     </label>
                                                     <span className="text-xs text-slate-400 font-normal">
                                                         {caseType === "harvard_only"
-                                                            ? "Opcional — sin datos adjuntos en este modo. Sirven como contexto pedagógico del perfil ML/DS."
-                                                            : "Si las dejas vacías, ADAM sugerirá las técnicas más adecuadas según el contexto del caso. Máx. 5"}
+                                                            ? "Sirven como contexto pedagógico del perfil ML/DS. Máx. 5."
+                                                            : "Al menos una técnica requerida. ADAM las usará para el dataset sintético del caso. Máx. 5."}
                                                     </span>
                                                 </div>
 
@@ -813,6 +899,7 @@ export function AuthoringForm({
                                                     ⚠️ Las técnicas sugeridas podrían estar desactualizadas de acuerdo al último contexto académico configurado.
                                                 </div>
                                             )}
+                                            <ErrorMsg show={!!errors.suggestedTechniques} />
                                             <p className="field-hint mt-1.5">ADAM optimizará estas variables sobre el Dataset ficticio si logras predefinirlas.</p>
                                         </div>
                                     )}
@@ -835,8 +922,9 @@ export function AuthoringForm({
                                             id="field-fecha-inicio"
                                             value={availableFrom}
                                             onChange={(e) => onChangeAvailableFrom(e.target.value)}
-                                            className="input-base w-full rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-800 cursor-pointer"
+                                            className={`input-base w-full rounded-lg border bg-white px-3.5 py-2.5 text-sm text-slate-800 cursor-pointer ${errors.availableFrom ? "border-red-400 input-error" : "border-slate-200"}`}
                                         />
+                                        <ErrorMsg show={!!errors.availableFrom} />
                                     </div>
                                     <div className="date-arrow" aria-hidden="true">
                                         <svg className="w-5 h-5 text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -852,8 +940,9 @@ export function AuthoringForm({
                                             id="field-fecha-cierre"
                                             value={dueAt}
                                             onChange={(e) => onChangeDueAt(e.target.value)}
-                                            className="input-base w-full rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-800 cursor-pointer"
+                                            className={`input-base w-full rounded-lg border bg-white px-3.5 py-2.5 text-sm text-slate-800 cursor-pointer ${errors.dueAt ? "border-red-400 input-error" : "border-slate-200"}`}
                                         />
+                                        <ErrorMsg show={!!errors.dueAt} />
                                     </div>
                                 </div>
                                 {errors.dateOrder && (
@@ -890,7 +979,8 @@ export function AuthoringForm({
 
                                     <button
                                         type="submit"
-                                        className="flex items-center gap-2 rounded-xl bg-[#0144a0] px-7 py-2.5 text-sm font-bold text-white shadow-md transition-all hover:bg-[#00337a] hover:shadow-lg active:scale-[0.98]"
+                                        disabled={!canSubmit}
+                                        className={`flex items-center gap-2 rounded-xl bg-[#0144a0] px-7 py-2.5 text-sm font-bold text-white shadow-md transition-all ${canSubmit ? "hover:bg-[#00337a] hover:shadow-lg active:scale-[0.98]" : "opacity-50 cursor-not-allowed"}`}
                                     >
                                         {caseType === "harvard_with_eda" ? "Generar Caso + EDA" : "Generar Caso Harvard"}
                                     </button>

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
@@ -192,4 +192,28 @@ describe("TeacherAuthoringPage", () => {
             expect(retryJob).toHaveBeenCalledTimes(1);
         });
     });
+
+    it("clears the form sessionStorage key when the job completes successfully", async () => {
+        sessionStorage.setItem("adam_authoring_form_state", JSON.stringify({ subject: "course-1" }));
+
+        vi.mocked(useAuthoringJobProgress).mockReturnValue({
+            jobId: "job-success",
+            status: "completed",
+            errorTrace: null,
+            result: {} as never,
+            activeAgent: undefined,
+            submitJob: vi.fn(),
+            retryJob: vi.fn(),
+            reset: vi.fn(),
+            isStreaming: false,
+            progressScope: null,
+            bootstrapState: undefined,
+        });
+
+        render(<TeacherAuthoringPage />);
+
+        await waitFor(() => {
+            expect(sessionStorage.getItem("adam_authoring_form_state")).toBeNull();
+        });
+    });
 });

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
@@ -9,6 +9,7 @@ import { AuthoringErrorState } from "./AuthoringErrorState";
 import { AuthoringForm } from "./AuthoringForm";
 import { AuthoringProgressTimeline } from "./AuthoringProgressTimeline";
 import { useAuthoringJobProgress } from "./useAuthoringJobProgress";
+import { FORM_STATE_SESSION_KEY } from "./authoringFormConfig";
 
 type AppState = "idle" | "generating" | "editing" | "error" | "success" | "paused";
 
@@ -75,6 +76,13 @@ export function TeacherAuthoringPage() {
     },
     [submitJob],
   );
+
+  // ── Clear form sessionStorage when the job completes successfully ──
+  useEffect(() => {
+    if (appState === "success") {
+      sessionStorage.removeItem(FORM_STATE_SESSION_KEY);
+    }
+  }, [appState]);
 
   const handleResumeEDA = useCallback(() => {
     // Placeholder para un futuro flujo HITL.

--- a/frontend/src/features/teacher-authoring/authoringFormConfig.ts
+++ b/frontend/src/features/teacher-authoring/authoringFormConfig.ts
@@ -56,6 +56,8 @@ export const STUDENT_PROFILES = [
     { value: "ml_ds", label: "Machine Learning / Data Science" },
 ];
 
+export const FORM_STATE_SESSION_KEY = "adam_authoring_form_state";
+
 export const FORM_STYLES = `
 .teacher-form .input-base {
   transition: border-color 0.18s, box-shadow 0.18s;


### PR DESCRIPTION
## Cambios

### AuthoringForm -- Auditoría para producción

**Campos obligatorios + botón bloqueado (Task 1)**
- Todos los campos son ahora obligatorios
- Botón \Generar caso\ deshabilitado hasta que todos los campos estén completos (\disabled={!canSubmit}\ + \opacity-50 cursor-not-allowed\)
- Validación extendida en \handleSubmit\ para \	opicUnit\, \vailableFrom\, \dueAt\ y \suggestedTechniques\

**Restricción de perfil para Caso Harvard (Task 2)**
- \Machine Learning / Data Science\ se oculta cuando el tipo es solo \Caso Harvard\
- Al cambiar a \Caso Harvard\ con ML/DS seleccionado, el perfil se resetea automáticamente a \Negocios / Gestión\

**Persistencia del formulario en sessionStorage (Task 3)**
- El formulario sobrevive refresh del navegador y navegación de regreso desde error/reintento
- Se limpia únicamente cuando el caso se guarda con éxito (manejado por \TeacherAuthoringPage\)
- \clearForm()\ ahora borra sessionStorage de forma síncrona (fix race condition)
- Fix del bug donde \initialData\ era declarado en Props pero silenciosamente ignorado

**Auditoría del suggest IA (Task 4 -- sin cambios de código)**
- El suggest solo usa \module_title\ y \unit.title\ del syllabus
- \learning_outcomes\ y \	opics\ están disponibles pero no se usan -- oportunidad de mejora futura

**Limpieza (Auditoría final)**
- Eliminado \eslint-disable-next-line\ innecesario en el \useEffect\ de restauración de sessionStorage

## Pre-Landing Review

No issues found. Auditoría manual completa:
- Sin labels \Opcional\ ni comentarios de debug
- \disabled={!canSubmit}\ correctamente conectado con estilos visuales
- Todos los \<ErrorMsg>\ ligados al objeto \errors\
- Prioridad sessionStorage > initialData correcta para todos los flujos
- Validación condicional de \suggestedTechniques\ alineada con visibilidad del campo
- \clearForm()\ limpia sessionStorage síncronamente antes de resetear estado React

## Tests

- [x] 261/261 tests pasan en 37 archivos -- todos verdes
- [x] 14 tests nuevos: 7 Task 1, 3 Task 2, 3 Task 3, 1 TeacherAuthoringPage
- [x] \
pm run lint\: 0 errores, 0 warnings
- [x] \
pm run build\: TypeScript limpio, Vite build exitoso