### PR TITLE
fix(backend): include null deadline in GET /api/teacher/cases filter (#150)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -185,6 +185,18 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
+## TODO-012: Recuperación de casos en estado borrador (Draft Case Recovery)
+
+**What:** Agregar una sección "Borradores" en el dashboard del docente que liste los `Assignment` con `status='draft'` que tienen `canonical_output` generado pero no han sido publicados. Requiere un endpoint `GET /api/teacher/cases?status=draft` y una UI separada de "Casos Activos".
+
+**Why:** Si un docente cierra el navegador después de que el caso fue generado pero antes de presionar "Enviar Caso", el borrador queda huérfano en la base de datos. La recuperación por `sessionStorage` solo funciona en la misma sesión. El usuario no tiene forma de encontrar el caso generado desde el dashboard.
+
+**Context:** Identificado en la revisión de eng-review de Issue #149. La implementación de "Enviar Caso" (Issue #156) y el dashboard de casos activos (Issue #157) filtran explícitamente `status='published'`, lo que significa que los borradores quedan ocultos por diseño. La solución mínima viable es un endpoint filtrado por `status='draft'` + `canonical_output IS NOT NULL` y una tabla colapsable "Borradores" en el dashboard.
+
+**Depends on / blocked by:** Issue #149 (Case Management foundation). Los endpoints y la lógica de ownership helper (`get_owned_assignment_or_404`) definidos en Issue #151 son el punto de partida natural para el endpoint de borradores.
+
+---
+
 ## TODO-012: Utilidad de reconciliación de artefactos huérfanos legacy
 
 **What:** Crear una utilidad operativa para reconciliar artefactos huérfanos históricos (manifest en DB vs blob en storage) y aplicar remediación controlada (marcar, limpiar o re-vincular según reglas).
@@ -340,3 +352,19 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** Aceptado como follow-up durante la refinacion tecnica de Issue #130. La decision explicita fue no mezclar el guardrail de CI con la issue de aislamiento de Plotly para mantener #130 enfocada en el critical path y no convertirla en una iniciativa general de performance governance.
 
 **Depends on / blocked by:** Bloqueado por la implementacion de Issue #130 y por una corrida de build post-fix que deje una baseline confiable para `index` y el chunk `vendor-plotly`. Tambien depende de decidir si el guardrail vivira en GitHub Actions, otro pipeline de CI, o una verificacion local reutilizable por ambos.
+
+---
+
+## TODO-021: Poblar `active_cases_count` en listado de cursos del docente
+
+**What:** Implementar el conteo de casos activos por curso en `list_teacher_courses` (`backend/src/shared/teacher_reads.py`). Actualmente `active_cases_count` se hardcodea a `0` en `TeacherCourseItemResponse` y en `get_teacher_course_detail`.
+
+**Why:** El dashboard del docente muestra el número de casos activos por curso. Con el valor siempre en `0`, el profesor no puede saber cuántos casos activos tiene en cada materia sin entrar a cada curso individualmente.
+
+**Pros:** Completa la información visible en el listado de cursos; habilita UX de resumen en el dashboard sin round-trips adicionales.
+
+**Cons:** Requiere que `Assignment` tenga una FK a `Course` (`course_id`) para que el join sea posible. Sin esa FK, cualquier implementación sería un proxy no confiable (p.ej. join por `teacher_id` + `course_id` en payload de metadata). Introducir la FK es un cambio de schema que requiere migración Alembic.
+
+**Context:** El `TODO(#90)` en el código fue registrado explícitamente durante Issue #90 con la nota: `# TODO(#90): populate once Assignment gains course_id FK`. El campo existe en el contrato API (`TeacherCourseItemResponse.active_cases_count`) pero siempre retorna `0`. El fix de Issue #150 (null deadline) dejó expuesto que `Assignment` ya soporta `deadline=None`; el siguiente gap visible es este conteo. No bloquea ningún flujo actual.
+
+**Depends on / blocked by:** Bloqueado por la adición de una FK `Assignment.course_id` + migración Alembic correspondiente. Ese cambio de schema debe coordinarse con el authoring job intake (`/api/authoring/jobs`) para que el `course_id` del payload se persista en la fila de `Assignment`.

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import Session, load_only
 
 from shared.auth import CurrentActor, ensure_legacy_teacher_bridge
@@ -328,8 +328,7 @@ def list_teacher_active_cases(
         .where(
             Assignment.teacher_id == legacy_user.id,
             Assignment.status == "published",
-            Assignment.deadline.is_not(None),
-            Assignment.deadline >= now,
+            or_(Assignment.deadline.is_(None), Assignment.deadline >= now),
         )
         .order_by(Assignment.deadline.asc(), Assignment.id.asc())
     ).all()

--- a/backend/tests/test_issue90_teacher_cases.py
+++ b/backend/tests/test_issue90_teacher_cases.py
@@ -184,10 +184,12 @@ def test_issue90_teacher_cases_returns_only_future_published_assignments_sorted(
 
     assert response.status_code == 200, response.text
     body = response.json()
-    assert body["total"] == 2
-    assert [item["title"] for item in body["cases"]] == ["Sooner", "Later"]
+    # After fix: null-deadline published assignment is now visible (sorts LAST with PG ASC NULLS LAST)
+    assert body["total"] == 3
+    assert [item["title"] for item in body["cases"]] == ["Sooner", "Later", "No Deadline"]
     assert body["cases"][0]["days_remaining"] == 0
     assert body["cases"][1]["days_remaining"] == 2
+    assert body["cases"][2]["days_remaining"] is None
     assert body["cases"][0]["course_codes"] == []
 
 
@@ -318,3 +320,80 @@ def test_issue90_teacher_cases_requires_legacy_bridge_for_teacher_reads(
 
     assert response.status_code == 500
     assert response.json()["detail"] == "legacy_bridge_missing"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #150 — null deadline filter bug
+# ---------------------------------------------------------------------------
+
+
+def test_cases_published_null_deadline_visible(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    """A published assignment with deadline=None must appear in GET /api/teacher/cases.
+
+    Before fix: Assignment.deadline.is_not(None) and Assignment.deadline >= now both
+    silently excluded NULLs (SQL NULL comparisons evaluate to NULL, which is falsy).
+    After fix: or_(deadline.is_(None), deadline >= now) explicitly includes them.
+    """
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-null-visible@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    assignment = Assignment(
+        teacher_id=teacher_id,
+        title="Evergreen Case",
+        status="published",
+        deadline=None,
+    )
+    db.add(assignment)
+    db.commit()
+
+    response = client.get(
+        "/api/teacher/cases",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 1
+    assert body["cases"][0]["title"] == "Evergreen Case"
+    assert body["cases"][0]["days_remaining"] is None
+
+
+def test_cases_draft_null_deadline_not_visible(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    """A draft assignment with deadline=None must NOT appear in GET /api/teacher/cases.
+
+    The status filter (status == 'published') still applies; null-deadline fix only
+    affects the deadline predicate, not the status gate.
+    """
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-draft-null@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    assignment = Assignment(
+        teacher_id=teacher_id,
+        title="Draft No Deadline",
+        status="draft",
+        deadline=None,
+    )
+    db.add(assignment)
+    db.commit()
+
+    response = client.get(
+        "/api/teacher/cases",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 0
+    assert body["cases"] == []


### PR DESCRIPTION
## Summary

Closes #150

Published assignments with `deadline = NULL` were silently excluded from `GET /api/teacher/cases` because two conditions in `list_teacher_active_cases` both filter out NULLs in SQL:

```sql
-- BEFORE: SQL NULL comparisons evaluate to NULL (falsy)
Assignment.deadline IS NOT NULL        -- explicit NULL guard
Assignment.deadline >= NOW()           -- NULL >= x → NULL → excluded
```

Fix replaces both with a single `or_` predicate:

```sql
-- AFTER: explicit NULL arm
(Assignment.deadline IS NULL OR Assignment.deadline >= NOW())
```

## Changes

| File | Change |
|---|---|
| `backend/src/shared/teacher_reads.py` | Add `or_` to SQLAlchemy import; replace the two NULL-excluding WHERE conditions with `or_(deadline.is_(None), deadline >= now)` |
| `backend/tests/test_issue90_teacher_cases.py` | Update existing test (total 2→3, titles include "No Deadline", assert `days_remaining=None`); add `test_cases_published_null_deadline_visible` and `test_cases_draft_null_deadline_not_visible` |
| `TODOS.md` | Add TODO-021 for `active_cases_count` gap (Assignment lacks `course_id` FK) |

## Validation

```
pytest tests/test_issue90_teacher_cases.py -v   → 12 passed
pytest -q                                        → 284 passed, 12 skipped
mypy src                                         → Success: no issues found in 38 source files
```

## Note on fix location

The issue description references `teacher_router.py`. The actual query is in `teacher_reads.py → list_teacher_active_cases`. The router only calls that function and shapes its output — no change needed there.