### PR TITLE
feat(db): add available_from column + composite index to assignments

### DIFF
--- a/backend/alembic/versions/f2a3b4c5d6e7_issue151_available_from.py
+++ b/backend/alembic/versions/f2a3b4c5d6e7_issue151_available_from.py
@@ -1,0 +1,37 @@
+"""Issue 151 available_from column and composite index
+
+Revision ID: f2a3b4c5d6e7
+Revises: 9f3e2a1b7c4d
+Create Date: 2026-04-20 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f2a3b4c5d6e7"
+down_revision: Union[str, Sequence[str], None] = "9f3e2a1b7c4d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "assignments",
+        sa.Column("available_from", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_assignments_teacher_status_deadline",
+        "assignments",
+        ["teacher_id", "status", "deadline"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_assignments_teacher_status_deadline", table_name="assignments")
+    op.drop_column("assignments", "available_from")

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -335,6 +335,7 @@ class Assignment(Base):
 
     status: Mapped[str] = mapped_column(String(50), default="draft")
     deadline: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    available_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/backend/tests/test_issue90_assignment_deadline_migration.py
+++ b/backend/tests/test_issue90_assignment_deadline_migration.py
@@ -16,6 +16,7 @@ from shared.database import settings
 ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
 PRE_ISSUE90_REVISION = "c2f8a58d6d1e"
 ISSUE90_REVISION = "d4f4c2f9c1aa"
+ISSUE151_REVISION = "f2a3b4c5d6e7"
 
 
 def _make_temp_database_urls() -> tuple[str, URL, URL]:
@@ -92,5 +93,40 @@ def test_issue90_alembic_upgrade_and_downgrade() -> None:
         assert "deadline" not in downgraded_columns
         downgraded_indexes = {index["name"] for index in downgraded_inspector.get_indexes("assignments")}
         assert "ix_assignments_teacher_id_deadline" not in downgraded_indexes
+
+        engine.dispose()
+
+
+@pytest.mark.ddl_isolation
+def test_issue151_alembic_upgrade_and_downgrade() -> None:
+    with temporary_database() as db_url:
+        config = _alembic_config(db_url)
+
+        # Bring DB to the revision just before issue-151 (HEAD of issue-139).
+        command.upgrade(config, ISSUE90_REVISION)
+        engine = create_engine(db_url)
+        inspector = inspect(engine)
+        pre_columns = {column["name"] for column in inspector.get_columns("assignments")}
+        assert "available_from" not in pre_columns
+        pre_indexes = {index["name"] for index in inspector.get_indexes("assignments")}
+        assert "ix_assignments_teacher_status_deadline" not in pre_indexes
+
+        # Apply the issue-151 migration.
+        command.upgrade(config, ISSUE151_REVISION)
+
+        upgraded_inspector = inspect(engine)
+        upgraded_columns = {column["name"] for column in upgraded_inspector.get_columns("assignments")}
+        assert "available_from" in upgraded_columns
+        upgraded_indexes = {index["name"] for index in upgraded_inspector.get_indexes("assignments")}
+        assert "ix_assignments_teacher_status_deadline" in upgraded_indexes
+
+        # Roll back and verify both additions are gone.
+        command.downgrade(config, ISSUE90_REVISION)
+
+        downgraded_inspector = inspect(engine)
+        downgraded_columns = {column["name"] for column in downgraded_inspector.get_columns("assignments")}
+        assert "available_from" not in downgraded_columns
+        downgraded_indexes = {index["name"] for index in downgraded_inspector.get_indexes("assignments")}
+        assert "ix_assignments_teacher_status_deadline" not in downgraded_indexes
 
         engine.dispose()


### PR DESCRIPTION
Closes #151

## Changes

- **New Alembic migration** `f2a3b4c5d6e7_issue151_available_from.py` — adds `available_from TIMESTAMPTZ` (nullable, no default) and creates composite index `ix_assignments_teacher_status_deadline` on `(teacher_id, status, deadline)`. Reversible downgrade included.
- **ORM model** `backend/src/shared/models.py` — one new field on `Assignment`: `available_from: Mapped[datetime | None]`.
- **Migration test** `backend/tests/test_issue90_assignment_deadline_migration.py` — extended with `test_issue151_alembic_upgrade_and_downgrade` (reuses existing `temporary_database()` + `_alembic_config()` helpers, `@pytest.mark.ddl_isolation`). Verifies full upgrade/downgrade round-trip.

## Validation

All three checks green:

```
uv run --directory backend pytest backend/tests/test_issue90_assignment_deadline_migration.py -v
# test_issue90_alembic_upgrade_and_downgrade PASSED
# test_issue151_alembic_upgrade_and_downgrade PASSED

uv run --directory backend pytest -q
# 285 passed, 12 skipped in 19.54s

uv run --directory backend mypy src
# Success: no issues found in 38 source files
```

## Notes

- Existing index `ix_assignments_teacher_id_deadline` is **not** dropped — both indexes coexist.
- `available_from` has no `server_default` or Python `default` — strictly nullable.