### PR TITLE
feat(backend): add GET detail, PATCH publish, PATCH deadline for teacher cases (#152)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -368,3 +368,20 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** El `TODO(#90)` en el código fue registrado explícitamente durante Issue #90 con la nota: `# TODO(#90): populate once Assignment gains course_id FK`. El campo existe en el contrato API (`TeacherCourseItemResponse.active_cases_count`) pero siempre retorna `0`. El fix de Issue #150 (null deadline) dejó expuesto que `Assignment` ya soporta `deadline=None`; el siguiente gap visible es este conteo. No bloquea ningún flujo actual.
 
 **Depends on / blocked by:** Bloqueado por la adición de una FK `Assignment.course_id` + migración Alembic correspondiente. Ese cambio de schema debe coordinarse con el authoring job intake (`/api/authoring/jobs`) para que el `course_id` del payload se persista en la fila de `Assignment`.
+
+---
+
+## TODO-022: Guard en PATCH publish contra `canonical_output = null`
+
+**What:** Antes de transicionar `status → "published"` en `PATCH /api/teacher/cases/{id}/publish`, verificar que `assignment.canonical_output is not None`. Si es `None`, lanzar 422 con `detail="cannot_publish_without_output"`.
+
+**Why:** Un docente que presione publicar sobre un caso con generación fallida (`status="failed"`, `canonical_output=null`) obtendrá un estado `published` con contenido vacío. El preview mostrará una página en blanco sin ningún mensaje de error — fallo silencioso desde la perspectiva del usuario.
+
+**Pros:** Previene el estado incoherente `published + canonical_output=null`. La guardia es 2 líneas y no agrega dependencias.
+
+**Cons:** Añade una restricción de negocio en el endpoint de publicación que podría querer relajarse si en el futuro se admiten publicaciones parciales (e.g., preview con módulos incompletos).
+
+**Context:** Identificado en la revisión de ingeniería de Issue #152. El spec de ese issue solo exige chequear `status == "published"` para el 409; el caso `canonical_output=null` quedó fuera de scope por minimal diff. El path `PATCH /publish` en `teacher_router.py` (función `patch_teacher_case_publish`) es el lugar exacto donde añadir el guard.
+
+**Depends on / blocked by:** No bloquea nada. Puede incluirse en la PR de tests del Issue #159 o en un PR de hardening independiente.
+

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import math
-from typing import Annotated
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from shared.auth import CurrentActor, require_current_actor_password_ready
 from shared.database import get_db
+from shared.models import Assignment
 from shared.syllabus_schema import TeacherCourseDetailResponse, TeacherSyllabusSaveRequest
 from shared.teacher_context import TeacherContext, require_teacher_context
 from shared.teacher_reads import TeacherCoursesResponse, get_teacher_course_detail, list_teacher_active_cases, list_teacher_courses
@@ -30,6 +32,21 @@ class TeacherCaseItemResponse(BaseModel):
 class TeacherCasesResponse(BaseModel):
     cases: list[TeacherCaseItemResponse]
     total: int
+
+
+class TeacherCaseDetailResponse(BaseModel):
+    id: str
+    title: str
+    status: str
+    available_from: datetime | None
+    deadline: datetime | None
+    course_id: str | None
+    canonical_output: dict[str, Any] | None
+
+
+class DeadlineUpdateRequest(BaseModel):
+    available_from: str | None = None
+    deadline: str | None = None
 
 
 def _days_remaining(deadline: datetime | None, now: datetime) -> int | None:
@@ -91,3 +108,125 @@ def get_teacher_cases(
         for item in cases
     ]
     return TeacherCasesResponse(cases=items, total=len(items))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — not endpoints
+# ---------------------------------------------------------------------------
+
+def _to_case_detail(assignment: Assignment) -> TeacherCaseDetailResponse:
+    """Build a TeacherCaseDetailResponse from an Assignment ORM instance."""
+    return TeacherCaseDetailResponse(
+        id=assignment.id,
+        title=assignment.title,
+        status=assignment.status,
+        available_from=assignment.available_from,
+        deadline=assignment.deadline,
+        course_id=assignment.course_id,
+        canonical_output=assignment.canonical_output,
+    )
+
+
+def _get_owned_assignment_or_404(
+    db: Session,
+    assignment_id: str,
+    actor: CurrentActor,
+) -> Assignment:
+    """Return the assignment owned by this actor or raise 404."""
+    stmt = select(Assignment).where(
+        Assignment.id == assignment_id,
+        Assignment.teacher_id == actor.auth_user_id,
+    )
+    assignment = db.scalar(stmt)
+    if assignment is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Assignment not found",
+        )
+    return assignment
+
+
+def parse_datetime_or_422(value: str | None) -> datetime | None:
+    """Parse an ISO 8601 string to an aware datetime, or raise 422.
+
+    None is returned unchanged (caller interprets as "field not provided").
+    Timezone-naive strings are explicitly rejected — ambiguous offset is worse
+    than a clear error.
+    """
+    if value is None:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="invalid_datetime_format",
+        )
+    if dt.tzinfo is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="invalid_datetime_format",
+        )
+    return dt
+
+
+# ---------------------------------------------------------------------------
+# Case detail, publish, and deadline endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/cases/{assignment_id}", response_model=TeacherCaseDetailResponse)
+def get_teacher_case_detail(
+    assignment_id: str,
+    _: Annotated[TeacherContext, Depends(require_teacher_context)],
+    actor: CurrentActor = Depends(require_current_actor_password_ready),
+    db: Session = Depends(get_db),
+) -> TeacherCaseDetailResponse:
+    assignment = _get_owned_assignment_or_404(db, assignment_id, actor)
+    return _to_case_detail(assignment)
+
+
+@router.patch("/cases/{assignment_id}/publish", response_model=TeacherCaseDetailResponse)
+def patch_teacher_case_publish(
+    assignment_id: str,
+    _: Annotated[TeacherContext, Depends(require_teacher_context)],
+    actor: CurrentActor = Depends(require_current_actor_password_ready),
+    db: Session = Depends(get_db),
+) -> TeacherCaseDetailResponse:
+    assignment = _get_owned_assignment_or_404(db, assignment_id, actor)
+    if assignment.status == "published":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="already_published",
+        )
+    assignment.status = "published"
+    assignment.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(assignment)
+    return _to_case_detail(assignment)
+
+
+@router.patch("/cases/{assignment_id}/deadline", response_model=TeacherCaseDetailResponse)
+def patch_teacher_case_deadline(
+    assignment_id: str,
+    request: DeadlineUpdateRequest,
+    _: Annotated[TeacherContext, Depends(require_teacher_context)],
+    actor: CurrentActor = Depends(require_current_actor_password_ready),
+    db: Session = Depends(get_db),
+) -> TeacherCaseDetailResponse:
+    assignment = _get_owned_assignment_or_404(db, assignment_id, actor)
+    new_available_from = parse_datetime_or_422(request.available_from)
+    new_deadline = parse_datetime_or_422(request.deadline)
+    if new_available_from is not None and new_deadline is not None:
+        if new_deadline <= new_available_from:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="deadline_before_available_from",
+            )
+    if new_available_from is not None:
+        assignment.available_from = new_available_from
+    if new_deadline is not None:
+        assignment.deadline = new_deadline
+    db.commit()
+    db.refresh(assignment)
+    return _to_case_detail(assignment)
+


### PR DESCRIPTION
Closes #152

## What

Adds three new endpoints and supporting helpers to `backend/src/shared/teacher_router.py`:

- `GET /api/teacher/cases/{assignment_id}` — return full case detail for a teacher-owned assignment
- `PATCH /api/teacher/cases/{assignment_id}/publish` — irreversibly publish a case (409 if already published)
- `PATCH /api/teacher/cases/{assignment_id}/deadline` — update `available_from` and/or `deadline` (partial update; `None` means "don't touch")

## Helpers added (same file, no new files)

| Symbol | Purpose |
|---|---|
| `TeacherCaseDetailResponse` | Pydantic response model with `id, title, status, available_from, deadline, course_id, canonical_output` |
| `DeadlineUpdateRequest` | Pydantic request body with optional `available_from: str \| None`, `deadline: str \| None` |
| `_to_case_detail(assignment)` | DRY builder — builds `TeacherCaseDetailResponse` from an ORM instance (used by all 3 endpoints) |
| `_get_owned_assignment_or_404(db, id, actor)` | Ownership check via `Assignment.teacher_id == actor.auth_user_id`; raises 404 if not found or not owned |
| `parse_datetime_or_422(value)` | Parses ISO 8601 string; raises 422 `invalid_datetime_format` for malformed **or timezone-naive** strings |

## Notes

- **No new migration** — `available_from` column and `ix_assignments_teacher_status_deadline` index already exist after #151.
- **No changes to `case_generator/`**.
- `canonical_output` may be `None`; the endpoint returns it as `null` without crashing.
- Publish is irreversible; no revert endpoint.
- `PATCH /deadline` with `None` fields skips those fields (does not clear them).
- Timezone-naive datetime strings are rejected with 422 (explicit > silent UTC coercion).

## Validation

```
285 passed, 12 skipped   ← uv run --directory backend pytest -q
Success: no issues found in 38 source files   ← uv run --directory backend mypy src
```

## Deferred

- Tests for new endpoints → Issue #159
- Guard against publishing when `canonical_output` is `null` → TODO-022 in `TODOS.md`