### PR TITLE
feat(backend): inject and persist caseId in canonical_output

### DIFF
--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -1169,7 +1169,9 @@ class AuthoringService:
             assignment.blueprint = blueprint.model_dump(exclude_none=True)
 
             canonical_result = adapter_legacy_to_canonical_output(graph_output)
-            assignment.canonical_output = canonical_result.get("canonical_output", {})
+            canonical_dict = dict(canonical_result.get("canonical_output", {}))
+            canonical_dict["caseId"] = assignment.id
+            assignment.canonical_output = canonical_dict
             assignment.status = "published"
             job.status = AUTHORING_JOB_STATUS_COMPLETED
             completed_payload = _next_progress_payload(

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -790,11 +790,13 @@ def get_job_result(
             detail="Job completed but blueprint not yet available",
         )
 
+    canonical = dict(assignment.canonical_output or {})
+    canonical["caseId"] = str(assignment.id)
     return JobResultResponse(
         job_id=job.id,
         assignment_id=assignment.id,
         blueprint=assignment.blueprint,
-        canonical_output=assignment.canonical_output,
+        canonical_output=canonical,
     )
 
 

--- a/backend/tests/test_phase3_status_api.py
+++ b/backend/tests/test_phase3_status_api.py
@@ -109,6 +109,7 @@ def test_polling_happy_path(client, db, auth_headers_factory, seed_identity) -> 
         "validation_contract": {"passing_threshold_global": 0.6, "required_modules_passed": 1},
         "artifact_manifest": {"artifact_ids": ["artifact-status-stub"]},
     }
+    assignment.canonical_output = {"title": "Test Phase 3"}
     db.commit()
 
     completed_status_response = client.get(f"/api/authoring/jobs/{job.id}", headers=headers)
@@ -118,6 +119,8 @@ def test_polling_happy_path(client, db, auth_headers_factory, seed_identity) -> 
     completed_result_response = client.get(f"/api/authoring/jobs/{job.id}/result", headers=headers)
     assert completed_result_response.status_code == 200
     assert completed_result_response.json()["blueprint"]["version"] == "adam-v8.0"
+    # PATH B: caseId is injected at response-time even when not yet in DB
+    assert completed_result_response.json()["canonical_output"]["caseId"] == str(assignment.id)
 
 
 def test_job_not_found(client, auth_headers_factory, seed_identity) -> None:
@@ -396,3 +399,27 @@ def test_retry_authoring_job_rejects_non_retryable_status(
     assert response.status_code == 400
     assert response.json()["detail"] == "Job not retryable"
     assert response.headers["X-Job-Status"] == "completed"
+
+
+def test_caseid_persisted_in_canonical_output(client, db, auth_headers_factory, seed_identity) -> None:
+    """PATH A: caseId injected before db.commit() ends up persisted in JSONB."""
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-caseid@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    assignment = Assignment(teacher_id=teacher_id, title="CaseId Persistence Test", status="draft")
+    db.add(assignment)
+    db.flush()
+
+    # Simulate what AuthoringService.run_job does at PATH A: inject caseId before commit.
+    canonical_dict: dict = {"title": "CaseId Persistence Test", "subject": "Finance"}
+    canonical_dict["caseId"] = assignment.id
+    assignment.canonical_output = canonical_dict
+    db.commit()
+
+    # Reload from DB to verify the field was truly persisted (not just in-memory).
+    db.expire(assignment)
+    reloaded = db.query(Assignment).filter(Assignment.id == assignment.id).first()
+    assert reloaded is not None
+    assert reloaded.canonical_output is not None
+    assert reloaded.canonical_output["caseId"] == assignment.id


### PR DESCRIPTION
Closes #153

## Changes

**PATH A — Persistence** (`backend/src/case_generator/core/authoring.py`)  
In `AuthoringService.run_job`, inject `caseId = assignment.id` into the `canonical_output` dict before `db.commit()`. All future completed jobs will have `caseId` persisted in the JSONB column.

**PATH B — Response-time injection** (`backend/src/shared/app.py`)  
In `get_job_result`, build a copy of `canonical_output` and set `caseId` before returning `JobResultResponse`. Guarantees `caseId` is always present in the API response even for records created before this change.

## No schema changes

`canonical_output` is already `JSONB` (`dict[str, Any] | None`). No migration needed.

## Tests

- Extended `test_polling_happy_path` to assert `canonical_output["caseId"] == assignment.id` in the `/result` response (PATH B coverage).
- New `test_caseid_persisted_in_canonical_output`: simulates PATH A dict mutation, commits, reloads from DB, and asserts `caseId` survives the round-trip.

## Validation

```
286 passed, 12 skipped in 52.55s
mypy: Success: no issues found in 38 source files
```