### PR TITLE
feat(frontend): API client + TanStack Query hooks for case actions

### DIFF
--- a/frontend/src/features/teacher-dashboard/useTeacherDashboard.test.tsx
+++ b/frontend/src/features/teacher-dashboard/useTeacherDashboard.test.tsx
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/shared/api";
 import { queryKeys } from "@/shared/queryKeys";
 
-import { useTeacherCases, useTeacherCourses } from "./useTeacherDashboard";
+import { useCaseDetail, usePublishCase, useTeacherCases, useTeacherCourses, useUpdateDeadline } from "./useTeacherDashboard";
 
 vi.mock("@tanstack/react-query", () => ({
     useQuery: vi.fn(),
+    useMutation: vi.fn(),
+    useQueryClient: vi.fn(),
 }));
 
 vi.mock("@/shared/api", async () => {
@@ -20,6 +22,9 @@ vi.mock("@/shared/api", async () => {
             teacher: {
                 getCourses: vi.fn(),
                 getCases: vi.fn(),
+                getCaseDetail: vi.fn(),
+                publishCase: vi.fn(),
+                updateDeadline: vi.fn(),
             },
         },
     };
@@ -74,5 +79,95 @@ describe("useTeacherDashboard", () => {
             signal: new AbortController().signal,
         });
         expect(api.teacher.getCases).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("useCaseDetail", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("is disabled when assignmentId is empty", () => {
+        vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+
+        useCaseDetail("");
+
+        const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+        expect(options.enabled).toBe(false);
+    });
+
+    it("is enabled when assignmentId has a value", () => {
+        vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+
+        useCaseDetail("case-abc");
+
+        const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+        expect(options.enabled).toBe(true);
+    });
+
+    it("configures the case detail query with the correct key and cache policy", async () => {
+        vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+
+        useCaseDetail("case-abc");
+
+        expect(useQuery).toHaveBeenCalledWith({
+            queryKey: queryKeys.teacher.case("case-abc"),
+            queryFn: expect.any(Function),
+            enabled: true,
+            staleTime: 30_000,
+            refetchOnWindowFocus: false,
+        });
+
+        const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as {
+            queryFn: () => Promise<unknown>;
+        };
+        await options.queryFn();
+        expect(api.teacher.getCaseDetail).toHaveBeenCalledWith("case-abc");
+    });
+});
+
+describe("usePublishCase", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("onSuccess sets cache data and invalidates cases list", () => {
+        const setQueryData = vi.fn();
+        const invalidateQueries = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(useQueryClient).mockReturnValue({ setQueryData, invalidateQueries } as never);
+        vi.mocked(useMutation).mockReturnValue({} as never);
+
+        usePublishCase();
+
+        const options = vi.mocked(useMutation).mock.calls[0]?.[0] as unknown as {
+            onSuccess: (detail: { id: string }) => void;
+        };
+        options.onSuccess({ id: "case-abc" } as never);
+
+        expect(setQueryData).toHaveBeenCalledWith(queryKeys.teacher.case("case-abc"), { id: "case-abc" });
+        expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.teacher.cases() });
+    });
+});
+
+describe("useUpdateDeadline", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("onSuccess sets cache data and invalidates cases list", () => {
+        const setQueryData = vi.fn();
+        const invalidateQueries = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(useQueryClient).mockReturnValue({ setQueryData, invalidateQueries } as never);
+        vi.mocked(useMutation).mockReturnValue({} as never);
+
+        useUpdateDeadline();
+
+        const options = vi.mocked(useMutation).mock.calls[0]?.[0] as unknown as {
+            onSuccess: (detail: { id: string }) => void;
+        };
+        options.onSuccess({ id: "case-abc" } as never);
+
+        expect(setQueryData).toHaveBeenCalledWith(queryKeys.teacher.case("case-abc"), { id: "case-abc" });
+        expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.teacher.cases() });
     });
 });

--- a/frontend/src/features/teacher-dashboard/useTeacherDashboard.ts
+++ b/frontend/src/features/teacher-dashboard/useTeacherDashboard.ts
@@ -1,6 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/shared/api";
+import type { DeadlineUpdateRequest } from "@/shared/adam-types";
 import { queryKeys } from "@/shared/queryKeys";
 
 export function useTeacherCourses() {
@@ -20,5 +21,38 @@ export function useTeacherCases() {
         refetchOnWindowFocus: "always",
         refetchInterval: 60_000,
         refetchIntervalInBackground: false,
+    });
+}
+
+export function useCaseDetail(assignmentId: string) {
+    return useQuery({
+        queryKey: queryKeys.teacher.case(assignmentId),
+        queryFn: () => api.teacher.getCaseDetail(assignmentId),
+        enabled: Boolean(assignmentId),
+        staleTime: 30_000,
+        refetchOnWindowFocus: false,
+    });
+}
+
+export function usePublishCase() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (assignmentId: string) => api.teacher.publishCase(assignmentId),
+        onSuccess: (detail) => {
+            queryClient.setQueryData(queryKeys.teacher.case(detail.id), detail);
+            void queryClient.invalidateQueries({ queryKey: queryKeys.teacher.cases() });
+        },
+    });
+}
+
+export function useUpdateDeadline() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ assignmentId, body }: { assignmentId: string; body: DeadlineUpdateRequest }) =>
+            api.teacher.updateDeadline(assignmentId, body),
+        onSuccess: (detail) => {
+            queryClient.setQueryData(queryKeys.teacher.case(detail.id), detail);
+            void queryClient.invalidateQueries({ queryKey: queryKeys.teacher.cases() });
+        },
     });
 }

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -676,6 +676,21 @@ export interface TeacherCasesResponse {
     total: number;
 }
 
+export interface TeacherCaseDetailResponse {
+    id: string;
+    title: string;
+    status: string;
+    available_from: string | null;
+    deadline: string | null;
+    course_id: string | null;
+    canonical_output: Record<string, unknown> | null;
+}
+
+export interface DeadlineUpdateRequest {
+    available_from?: string | null;
+    deadline?: string | null;
+}
+
 export const EMPTY_FORM: CaseFormData = {
     courseId: "",
     subject: "",

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -944,4 +944,136 @@ describe("api auth + stream glue", () => {
         expect(options.method).toBeUndefined();
         expect(new Headers(options.headers).get("Authorization")).toBe("Bearer teacher-token");
     });
+
+    it("fetches teacher case detail with bearer auth", async () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+        getSessionMock.mockResolvedValue({
+            data: { session: { access_token: "teacher-token" } },
+            error: null,
+        });
+
+        const detail = {
+            id: "case-1", title: "Test Case", status: "draft",
+            available_from: null, deadline: null, course_id: null, canonical_output: null,
+        };
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(detail), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await api.teacher.getCaseDetail("case-1");
+
+        expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/teacher/cases/case-1");
+        const options = fetchMock.mock.calls[0]?.[1] as RequestInit;
+        expect(options.method).toBeUndefined();
+        expect(new Headers(options.headers).get("Authorization")).toBe("Bearer teacher-token");
+    });
+
+    it("publishes a teacher case with PATCH and bearer auth", async () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+        getSessionMock.mockResolvedValue({
+            data: { session: { access_token: "teacher-token" } },
+            error: null,
+        });
+
+        const detail = {
+            id: "case-1", title: "Test Case", status: "published",
+            available_from: null, deadline: null, course_id: null, canonical_output: null,
+        };
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(detail), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await api.teacher.publishCase("case-1");
+
+        expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/teacher/cases/case-1/publish");
+        const options = fetchMock.mock.calls[0]?.[1] as RequestInit;
+        expect(options.method).toBe("PATCH");
+        expect(new Headers(options.headers).get("Authorization")).toBe("Bearer teacher-token");
+    });
+
+    it("updates deadline with PATCH, JSON body, and bearer auth", async () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+        getSessionMock.mockResolvedValue({
+            data: { session: { access_token: "teacher-token" } },
+            error: null,
+        });
+
+        const deadline = "2026-06-01T00:00:00Z";
+        const detail = {
+            id: "case-1", title: "Test Case", status: "draft",
+            available_from: null, deadline, course_id: null, canonical_output: null,
+        };
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(detail), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await api.teacher.updateDeadline("case-1", { deadline });
+
+        expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/teacher/cases/case-1/deadline");
+        const options = fetchMock.mock.calls[0]?.[1] as RequestInit;
+        expect(options.method).toBe("PATCH");
+        expect(new Headers(options.headers).get("Content-Type")).toBe("application/json");
+        expect(new Headers(options.headers).get("Authorization")).toBe("Bearer teacher-token");
+        expect(options.body).toBe(JSON.stringify({ deadline }));
+    });
+
+    it("rejects publishCase with ApiError on 409 already_published", async () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+        getSessionMock.mockResolvedValue({
+            data: { session: { access_token: "teacher-token" } },
+            error: null,
+        });
+
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ detail: "already_published" }), {
+                status: 409,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(api.teacher.publishCase("case-1")).rejects.toMatchObject({
+            status: 409,
+        });
+    });
+
+    it("rejects updateDeadline with ApiError on 422 deadline_before_available_from", async () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+        getSessionMock.mockResolvedValue({
+            data: { session: { access_token: "teacher-token" } },
+            error: null,
+        });
+
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ detail: "deadline_before_available_from" }), {
+                status: 422,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(
+            api.teacher.updateDeadline("case-1", {
+                available_from: "2026-06-10T00:00:00Z",
+                deadline: "2026-06-01T00:00:00Z",
+            }),
+        ).rejects.toMatchObject({ status: 422 });
+    });
 });

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -38,9 +38,11 @@ import type {
     InviteResolveResponse,
     SuggestRequest,
     SuggestResponse,
+    TeacherCaseDetailResponse,
     TeacherCourseDetailResponse,
     TeacherCasesResponse,
     TeacherCoursesResponse,
+    DeadlineUpdateRequest,
     TeacherSyllabusSaveRequest,
 } from "@/shared/adam-types";
 
@@ -1033,6 +1035,30 @@ export const api = {
                     method: "PUT",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify(req),
+                },
+            );
+        },
+        async getCaseDetail(assignmentId: string): Promise<TeacherCaseDetailResponse> {
+            return parseJsonResponse<TeacherCaseDetailResponse>(
+                `/teacher/cases/${assignmentId}`,
+            );
+        },
+        async publishCase(assignmentId: string): Promise<TeacherCaseDetailResponse> {
+            return parseJsonResponse<TeacherCaseDetailResponse>(
+                `/teacher/cases/${assignmentId}/publish`,
+                { method: "PATCH" },
+            );
+        },
+        async updateDeadline(
+            assignmentId: string,
+            body: DeadlineUpdateRequest,
+        ): Promise<TeacherCaseDetailResponse> {
+            return parseJsonResponse<TeacherCaseDetailResponse>(
+                `/teacher/cases/${assignmentId}/deadline`,
+                {
+                    method: "PATCH",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(body),
                 },
             );
         },

--- a/frontend/src/shared/queryKeys.test.ts
+++ b/frontend/src/shared/queryKeys.test.ts
@@ -14,4 +14,8 @@ describe("queryKeys.teacher", () => {
     it("returns the teacher cases key", () => {
         expect(queryKeys.teacher.cases()).toEqual(["teacher", "cases"]);
     });
+
+    it("returns the teacher case key", () => {
+        expect(queryKeys.teacher.case("abc")).toEqual(["teacher", "case", "abc"]);
+    });
 });

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -70,5 +70,7 @@ export const queryKeys = {
         course: (courseId: string) => ["teacher", "course", courseId] as const,
         /** ["teacher", "cases"] — casos activos del docente autenticado */
         cases: () => ["teacher", "cases"] as const,
+        /** ["teacher", "case", id] — detalle de un caso del docente */
+        case: (id: string) => ["teacher", "case", id] as const,
     },
 } as const;


### PR DESCRIPTION
## Summary

- Adds TeacherCaseDetailResponse and DeadlineUpdateRequest TypeScript interfaces to shared/adam-types.ts
- Adds queryKeys.teacher.case(id) cache key to centralized key registry
- Adds 3 API methods to pi.teacher: getCaseDetail, publishCase, updateDeadline
- Adds 3 TanStack Query hooks: useCaseDetail (query), usePublishCase (mutation), useUpdateDeadline (mutation)
- Mutations invalidate the cases list and update the detail cache entry on success
- Fixes Bug A: URL paths use \/teacher/cases/...\ (not \/api/teacher/...\) — \piFetch\ already prepends \/api\
- Fixes Bug B: \updateDeadline\ includes \Content-Type: application/json\ header required by FastAPI

## Pre-Landing Review

No issues found.

- No SQL, no database access, no LLM trust boundary exposure
- URL paths correct: \/teacher/cases/...\ (not double-prefixed)
- \Content-Type: application/json\ present on all JSON-body requests
- \enabled: Boolean(assignmentId)\ guards against empty-ID queries
- Cache invalidation on mutations correctly targets \queryKeys.teacher.cases()\

## Test plan

- [x] 39/39 tests pass across the 3 modified test files
- [x] \pi.test.ts\: 28 tests (5 new — 3 happy path + 2 error path: 409/422)
- [x] \queryKeys.test.ts\: 4 tests (1 new)
- [x] \useTeacherDashboard.test.tsx\: 7 tests (5 new)
- [x] Build: exit code 0 (\
pm --prefix frontend run build\)
- [x] Lint: exit code 0 (1 pre-existing Toast.tsx warning, unrelated)

> ⚠️ Pre-existing test failures: \AuthoringForm.test.tsx\ y \TeacherCoursePage.test.tsx\ presentan timeouts y flakiness no relacionados con este PR. Fallan igual en \main\ (pasan en isolated run, fallan solo en el full-suite por resource contention) — ver issue separado.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)