### PR TITLE
fix(test): reduce resource contention with forks pool config

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -385,3 +385,20 @@ Deuda tÃ©cnica y mejoras diferidas identificadas durante el desarrollo.
 
 **Depends on / blocked by:** No bloquea nada. Puede incluirse en la PR de tests del Issue #159 o en un PR de hardening independiente.
 
+
+
+---
+
+## TODO-023: CI guard para aislar fallos de pool regression en frontend tests
+
+**What:** Agregar un step en .github/workflows/ci.yml que ejecute AuthoringForm.test.tsx y TeacherCoursePage.test.tsx en aislado (itest run src/features/teacher-authoring/AuthoringForm.test.tsx src/features/teacher-course/TeacherCoursePage.test.tsx) si el full-suite falla, para distinguir regresiones de pool config de bugs reales.
+
+**Why:** AuthoringForm.test.tsx y TeacherCoursePage.test.tsx son los tests más pesados (MSW + jsdom + timers extensivos). Pasaban 32/32 en isolated run pero fallaban con timeouts en el full-suite por resource contention. Con pool: "forks" + maxForks: 3 + testTimeout: 10000 el full-suite pasa, pero si alguien remueve maxForks o aumenta 	estTimeout en el futuro, la regresión volvería silenciosamente.
+
+**Pros:** Feedback rápido y preciso cuando la causa es contención de workers vs. bug real en el código. Evita falsos positivos que bloqueen el merge de PRs legítimas.
+
+**Cons:** Añade complejidad al workflow de CI. El step condicional requiere if: failure() en GitHub Actions, que tiene algunas limitaciones de contexto.
+
+**Context:** Identificado en PR fix/flaky-tests-vitest-pool-config como riesgo futuro si se revierten los parámetros de pool. El fix actual (pool forks, maxForks 3, testTimeout 10s) es suficiente para el estado actual del suite (38 archivos, 276 tests). Si el suite crece significativamente, puede necesitar ajuste.
+
+**Depends on / blocked by:** No bloquea nada. Mejora de observabilidad de CI independiente.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,6 +22,18 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+    // Use forked processes instead of worker_threads so each worker gets an
+    // isolated V8 heap and event loop. Without this, jsdom timer pressure from
+    // heavy test files (AuthoringForm, TeacherCoursePage) causes timeouts in the
+    // full-suite run. maxForks caps parallelism; on CI (2 vCPUs) Vitest clamps
+    // automatically to min(maxForks, cpuCount).
+    pool: "forks",
+    // @ts-expect-error -- vitest 4.1.2 InlineConfig type omits poolOptions; valid at runtime
+    poolOptions: {
+      forks: { maxForks: 3 },
+    },
+    // Slow async-UI tests (MSW + jsdom) can legitimately take >5s under load.
+    testTimeout: 10_000,
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Problema

AuthoringForm.test.tsx y TeacherCoursePage.test.tsx fallaban con timeouts en el full-suite (38 archivos en paralelo). Pasaban 32/32 en aislado. Detectado durante la revisión de PR #166.

**Causa raíz:** Vitest 4.x usa por defecto el pool 	hreads (worker_threads con heap compartido). Con 16 workers en la máquina de desarrollo, la presión de memoria del GC de jsdom provoca starvation de timers en los tests más pesados.

## Solución

**Opción 1A** — cambios mínimos en ite.config.ts:

- pool: \\orks\\` — cada worker obtiene un heap V8 aislado y event loop propio, eliminando la starvation de jsdom timers bajo carga paralela.
- poolOptions.forks.maxForks: 3 — cap de concurrencia. En CI (2 vCPUs) Vitest aplica \min(maxForks, cpuCount)\ automáticamente.
- \	estTimeout: 10_000\ — los tests MSW+jsdom pueden tomar legítimamente >5s bajo carga; el default de 5s era demasiado ajustado.

**Nota:** \poolOptions\ está ausente del tipo \InlineConfig\ de vitest 4.1.2 (gap en las type defs) aunque funciona correctamente en runtime — marcado con \// @ts-expect-error\ documentado.

## Verificación

- [x] Full-suite: 276/276 passing, 38/38 files — exit 0
- [x] Isolated run: 32/32 passing en AuthoringForm + TeacherCoursePage
- [x] Build: exit 0 (\
pm --prefix frontend run build\)
- [x] TODO-023 agregado a \TODOS.md\ para CI guard de pool regressions

Detected during PR #166 review.