### PR TITLE
feat(frontend): TeacherCaseViewPage + /teacher/cases/:id route

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -434,3 +434,20 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 **Context:** Identificado en PR fix/flaky-tests-vitest-pool-config como riesgo futuro si se revierten los par�metros de pool. El fix actual (pool forks, maxForks 3, testTimeout 10s) es suficiente para el estado actual del suite (38 archivos, 276 tests). Si el suite crece significativamente, puede necesitar ajuste.
 
 **Depends on / blocked by:** No bloquea nada. Mejora de observabilidad de CI independiente.
+
+---
+
+## TODO-024: Deadline-edit y re-publish UI en TeacherCaseViewPage
+
+**What:** Añadir controles de edición de deadline (`useUpdateDeadline`) y un CTA de re-publicación (`usePublishCase`) en `frontend/src/features/teacher-authoring/TeacherCaseViewPage.tsx`.
+
+**Why:** La página TeacherCaseViewPage (#155) es actualmente read-only. Los hooks `useUpdateDeadline` y `usePublishCase` ya existen en `useTeacherDashboard.ts` y los endpoints backend están implementados, pero la vista no expone estas acciones.
+
+**Pros:** Permite al docente gestionar el ciclo de vida del caso (publicar, ajustar deadline) directamente desde la vista de detalle, sin tener que volver al dashboard. El backend ya soporta las operaciones.
+
+**Cons:** Requiere diseñar la UX para deadline-edit (date picker inline vs. modal) y para re-publicación (¿permitir re-publicar un caso ya publicado?). Puede solaparse con flujos futuros del dashboard.
+
+**Context:** Issue #155 especificó explícitamente "read-only" para mantener el diff mínimo. Los hooks existen desde PR #166. La página actual pasa `isAlreadyPublished={data.status === "published"}` para suprimir el botón de envío en `CasePreview`, pero no expone ningún CTA de gestión propio. El punto de partida es `TeacherCaseViewPage.tsx` tras el merge de #155.
+
+**Depends on / blocked by:** Merge de Issue #155. Requiere decisión de producto sobre si el re-publish desde la vista de detalle está en scope.
+

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -23,6 +23,11 @@ const TeacherCoursePage = lazy(() =>
         (module) => ({ default: module.TeacherCoursePage }),
     ),
 );
+const TeacherCaseViewPage = lazy(() =>
+    import("@/features/teacher-authoring/TeacherCaseViewPage").then(
+        (module) => ({ default: module.TeacherCaseViewPage }),
+    ),
+);
 const AuthCallbackPage = lazy(() =>
     import("@/features/auth-callback/AuthCallbackPage").then((module) => ({
         default: module.AuthCallbackPage,
@@ -80,6 +85,7 @@ function App() {
     const isTeacherShellRoute =
         location.pathname.startsWith("/teacher/dashboard") ||
         location.pathname.startsWith("/teacher/courses") ||
+        location.pathname.startsWith("/teacher/cases") ||
         location.pathname.startsWith("/teacher/case-designer") ||
         location.pathname === "/teacher";
 
@@ -115,6 +121,27 @@ function App() {
                             element={
                                 <RequireRole role="teacher">
                                     <TeacherCoursePage />
+                                </RequireRole>
+                            }
+                        />
+                        <Route
+                            path="/teacher/cases/:assignmentId"
+                            element={
+                                <RequireRole role="teacher">
+                                    <TeacherCaseViewPage />
+                                </RequireRole>
+                            }
+                        />
+                        <Route
+                            path="/teacher/cases/:assignmentId/entregas"
+                            element={
+                                <RequireRole role="teacher">
+                                    <div className="flex flex-col items-center justify-center gap-4 px-4 py-24 text-center">
+                                        <h1 className="text-xl font-semibold">Entregas del caso</h1>
+                                        <p className="max-w-xs text-sm text-muted-foreground">
+                                            El listado de entregas estará disponible en la próxima versión.
+                                        </p>
+                                    </div>
                                 </RequireRole>
                             }
                         />

--- a/frontend/src/features/case-preview/CasePreview.test.tsx
+++ b/frontend/src/features/case-preview/CasePreview.test.tsx
@@ -147,4 +147,11 @@ describe("CasePreview Enviar Caso button", () => {
         expect(screen.getByRole("button", { name: /enviar caso/i })).toBeTruthy();
         expect(screen.getByText(/Error al enviar el caso/)).toBeTruthy();
     });
+
+    it("[T7] isAlreadyPublished=true — hides the 'Enviar Caso' button entirely", () => {
+        renderWithProviders(<CasePreview caseData={caseDataWithId} isAlreadyPublished={true} />);
+        expect(screen.queryByRole("button", { name: /enviar caso/i })).toBeNull();
+        expect(screen.queryByText("¿Confirmar envío?")).toBeNull();
+        expect(screen.queryByText(/✓ Caso enviado/)).toBeNull();
+    });
 });

--- a/frontend/src/features/case-preview/CasePreview.tsx
+++ b/frontend/src/features/case-preview/CasePreview.tsx
@@ -469,9 +469,10 @@ interface Props {
     onEditParams?: () => void;
     isPausedWaitingForApproval?: boolean;
     onResumeEDA?: () => void;
+    isAlreadyPublished?: boolean;
 }
 
-export function CasePreview({ caseData, onEditParams, isPausedWaitingForApproval, onResumeEDA }: Props) {
+export function CasePreview({ caseData, onEditParams, isPausedWaitingForApproval, onResumeEDA, isAlreadyPublished }: Props) {
     const result = caseData;
     const content = result.content;
     const isEDA = result.caseType === "harvard_with_eda";
@@ -843,50 +844,53 @@ export function CasePreview({ caseData, onEditParams, isPausedWaitingForApproval
                             </button>
 
                             {/* Enviar Caso — 4-state machine: idle | confirming | loading | sent */}
-                            {sendState === "sent" ? (
-                                <span className="flex items-center gap-1.5 px-3 py-2 text-xs font-semibold text-emerald-700">
-                                    ✓ Caso enviado
-                                </span>
-                            ) : sendState === "confirming" ? (
-                                <span className="flex items-center gap-2">
-                                    <span className="text-xs font-semibold text-slate-700">¿Confirmar envío?</span>
+                            {/* isAlreadyPublished=true: hidden entirely (read-only from TeacherCaseViewPage) */}
+                            {!isAlreadyPublished && (
+                                sendState === "sent" ? (
+                                    <span className="flex items-center gap-1.5 px-3 py-2 text-xs font-semibold text-emerald-700">
+                                        ✓ Caso enviado
+                                    </span>
+                                ) : sendState === "confirming" ? (
+                                    <span className="flex items-center gap-2">
+                                        <span className="text-xs font-semibold text-slate-700">¿Confirmar envío?</span>
+                                        <button
+                                            type="button"
+                                            onClick={() => setSendState("idle")}
+                                            className="px-2.5 py-1.5 bg-slate-100 hover:bg-slate-200 text-slate-700 text-xs font-semibold rounded-lg transition-colors">
+                                            Cancelar
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={handleConfirmSend}
+                                            className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[#0144a0] hover:bg-[#00337a] text-white text-xs font-semibold rounded-lg transition-colors">
+                                            Sí, enviar
+                                        </button>
+                                    </span>
+                                ) : (
                                     <button
                                         type="button"
-                                        onClick={() => setSendState("idle")}
-                                        className="px-2.5 py-1.5 bg-slate-100 hover:bg-slate-200 text-slate-700 text-xs font-semibold rounded-lg transition-colors">
-                                        Cancelar
+                                        aria-label="Enviar caso al estudiante"
+                                        disabled={!caseData.caseId || sendState === "loading"}
+                                        onClick={handleSendClick}
+                                        className="flex items-center gap-1.5 px-3 py-2 bg-[#0144a0] hover:bg-[#00337a] hover:shadow-md active:scale-95 text-white text-xs font-semibold rounded-lg transition-all duration-150 ease-out disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none">
+                                        {sendState === "loading" ? (
+                                            <>
+                                                <svg className="animate-spin h-3.5 w-3.5" fill="none" viewBox="0 0 24 24">
+                                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                                                </svg>
+                                                Enviando...
+                                            </>
+                                        ) : (
+                                            <>
+                                                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+                                                </svg>
+                                                Enviar Caso
+                                            </>
+                                        )}
                                     </button>
-                                    <button
-                                        type="button"
-                                        onClick={handleConfirmSend}
-                                        className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[#0144a0] hover:bg-[#00337a] text-white text-xs font-semibold rounded-lg transition-colors">
-                                        Sí, enviar
-                                    </button>
-                                </span>
-                            ) : (
-                                <button
-                                    type="button"
-                                    aria-label="Enviar caso al estudiante"
-                                    disabled={!caseData.caseId || sendState === "loading"}
-                                    onClick={handleSendClick}
-                                    className="flex items-center gap-1.5 px-3 py-2 bg-[#0144a0] hover:bg-[#00337a] hover:shadow-md active:scale-95 text-white text-xs font-semibold rounded-lg transition-all duration-150 ease-out disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none">
-                                    {sendState === "loading" ? (
-                                        <>
-                                            <svg className="animate-spin h-3.5 w-3.5" fill="none" viewBox="0 0 24 24">
-                                                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                                            </svg>
-                                            Enviando...
-                                        </>
-                                    ) : (
-                                        <>
-                                            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-                                            </svg>
-                                            Enviar Caso
-                                        </>
-                                    )}
-                                </button>
+                                )
                             )}
                         </div>
                     </header>

--- a/frontend/src/features/teacher-authoring/TeacherCaseViewPage.test.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherCaseViewPage.test.tsx
@@ -1,0 +1,193 @@
+import { screen, waitFor } from "@testing-library/react";
+import { Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthContextValue } from "@/app/auth/auth-types";
+import { ApiError, api } from "@/shared/api";
+import type { TeacherCaseDetailResponse } from "@/shared/adam-types";
+import { renderWithProviders } from "@/shared/test-utils";
+
+import { TeacherCaseViewPage } from "./TeacherCaseViewPage";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/shared/api", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/api")>("@/shared/api");
+    return {
+        ...actual,
+        api: {
+            ...actual.api,
+            teacher: {
+                ...actual.api.teacher,
+                getCaseDetail: vi.fn(),
+            },
+        },
+    };
+});
+
+// CasePreview is lazy-loaded; stub it so tests don't need the full module tree
+vi.mock("@/features/case-preview/CasePreview", () => ({
+    CasePreview: ({ isAlreadyPublished }: { isAlreadyPublished?: boolean }) => (
+        <div data-testid="case-preview-stub" data-is-already-published={String(isAlreadyPublished ?? false)}>
+            CasePreview
+        </div>
+    ),
+}));
+
+// ── Auth fixture ─────────────────────────────────────────────────────────────
+
+const teacherAuthValue: AuthContextValue = {
+    session: { access_token: "jwt" } as never,
+    actor: {
+        auth_user_id: "teacher-1",
+        profile: { id: "profile-1", full_name: "Laura Gomez" },
+        memberships: [
+            {
+                id: "membership-1",
+                university_id: "uni-1",
+                role: "teacher",
+                status: "active",
+                must_rotate_password: false,
+            },
+        ],
+        must_rotate_password: false,
+        primary_role: "teacher",
+    },
+    loading: false,
+    error: null,
+    signOut: vi.fn(async () => undefined),
+    refreshActor: vi.fn(async () => undefined),
+};
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+function createCaseDetailResponse(
+    overrides?: Partial<TeacherCaseDetailResponse>,
+): TeacherCaseDetailResponse {
+    return {
+        id: "assignment-1",
+        title: "Caso de prueba Harvard",
+        status: "draft",
+        available_from: null,
+        deadline: null,
+        course_id: "course-1",
+        canonical_output: {
+            title: "Caso de prueba Harvard",
+            subject: "Analítica de Negocios",
+            syllabusModule: "Módulo 1",
+            guidingQuestion: "¿Cómo optimizar el canal digital?",
+            industry: "FinTech",
+            academicLevel: "MBA",
+            caseType: "harvard_only",
+            studentProfile: "business",
+            generatedAt: "2026-04-21T00:00:00Z",
+            outputDepth: "narrative_only",
+            content: {},
+        },
+        ...overrides,
+    };
+}
+
+// ── Render helper ─────────────────────────────────────────────────────────────
+
+function renderTeacherCaseViewPage(initialEntry = "/teacher/cases/assignment-1") {
+    return renderWithProviders(
+        <Routes>
+            <Route
+                path="/teacher/cases/:assignmentId"
+                element={<TeacherCaseViewPage />}
+            />
+            <Route path="/teacher/dashboard" element={<div data-testid="dashboard">Dashboard</div>} />
+        </Routes>,
+        {
+            initialEntries: [initialEntry],
+            authValue: teacherAuthValue,
+        },
+    );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("TeacherCaseViewPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("[T1] isLoading — renders skeleton while fetch is in flight", () => {
+        // Never resolves during this test
+        vi.mocked(api.teacher.getCaseDetail).mockReturnValue(new Promise(() => undefined));
+
+        renderTeacherCaseViewPage();
+
+        expect(screen.getByTestId("teacher-case-view-loading")).toBeTruthy();
+        // Skeleton uses animate-pulse — spot-check a structural element exists
+        const skeleton = screen.getByTestId("teacher-case-view-loading");
+        expect(skeleton.querySelector(".animate-pulse")).toBeTruthy();
+    });
+
+    it("[T2] isError 404 — shows 'Caso no encontrado' and back button", async () => {
+        vi.mocked(api.teacher.getCaseDetail).mockRejectedValueOnce(
+            new ApiError(404, "Not found"),
+        );
+
+        renderTeacherCaseViewPage();
+
+        expect(await screen.findByText("Caso no encontrado")).toBeTruthy();
+        expect(screen.getByRole("button", { name: /volver al dashboard/i })).toBeTruthy();
+        expect(screen.queryByText("Error al cargar el caso")).toBeNull();
+    });
+
+    it("[T3] isError non-404 — shows generic error message", async () => {
+        vi.mocked(api.teacher.getCaseDetail).mockRejectedValueOnce(
+            new ApiError(500, "Internal server error"),
+        );
+
+        renderTeacherCaseViewPage();
+
+        expect(await screen.findByText("Error al cargar el caso")).toBeTruthy();
+        expect(screen.getByRole("button", { name: /volver al dashboard/i })).toBeTruthy();
+        expect(screen.queryByText("Caso no encontrado")).toBeNull();
+    });
+
+    it("[T4] canonical_output null — renders empty state without crashing", async () => {
+        vi.mocked(api.teacher.getCaseDetail).mockResolvedValueOnce(
+            createCaseDetailResponse({ canonical_output: null }),
+        );
+
+        renderTeacherCaseViewPage();
+
+        expect(await screen.findByTestId("case-empty-state")).toBeTruthy();
+        expect(screen.getByText(/El caso aún no tiene contenido generado/)).toBeTruthy();
+        expect(screen.queryByTestId("case-preview-stub")).toBeNull();
+    });
+
+    it("[T5] happy path — CasePreview renders with canonical_output", async () => {
+        vi.mocked(api.teacher.getCaseDetail).mockResolvedValueOnce(
+            createCaseDetailResponse({ status: "draft" }),
+        );
+
+        renderTeacherCaseViewPage();
+
+        expect(await screen.findByTestId("case-preview-stub")).toBeTruthy();
+        // In draft state isAlreadyPublished should be false
+        expect(
+            screen.getByTestId("case-preview-stub").getAttribute("data-is-already-published"),
+        ).toBe("false");
+    });
+
+    it("[T6] happy path published — isAlreadyPublished=true passed to CasePreview", async () => {
+        vi.mocked(api.teacher.getCaseDetail).mockResolvedValueOnce(
+            createCaseDetailResponse({ status: "published" }),
+        );
+
+        renderTeacherCaseViewPage();
+
+        await waitFor(() => {
+            expect(screen.getByTestId("case-preview-stub")).toBeTruthy();
+        });
+
+        expect(
+            screen.getByTestId("case-preview-stub").getAttribute("data-is-already-published"),
+        ).toBe("true");
+    });
+});

--- a/frontend/src/features/teacher-authoring/TeacherCaseViewPage.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherCaseViewPage.tsx
@@ -1,0 +1,178 @@
+import { Suspense, lazy } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { ApiError } from "@/shared/api";
+import { TeacherLayout } from "@/features/teacher-layout/TeacherLayout";
+import { useCaseDetail } from "@/features/teacher-dashboard/useTeacherDashboard";
+
+// ── Lazy boundary: same pattern as TeacherAuthoringPage ──────────────────────
+const CasePreview = lazy(() =>
+    import("@/features/case-preview/CasePreview").then((module) => ({
+        default: module.CasePreview,
+    })),
+);
+
+function CasePreviewFallback() {
+    return (
+        <div className="flex items-center justify-center py-24">
+            <span className="text-sm text-muted-foreground">
+                Cargando vista previa...
+            </span>
+        </div>
+    );
+}
+
+// ── Loading skeleton — mirrors TeacherCourseLoadingState pattern ──────────────
+function CaseViewSkeleton() {
+    return (
+        <div className="mx-auto max-w-[1440px] px-6 py-8">
+            <div className="animate-pulse space-y-6">
+                <div className="rounded-[24px] border border-slate-200 bg-white p-8 shadow-sm">
+                    <div className="h-8 w-72 rounded bg-slate-200" />
+                    <div className="mt-4 h-4 w-96 rounded bg-slate-100" />
+                    <div className="mt-8 grid gap-4 md:grid-cols-2">
+                        <div className="h-12 rounded-xl bg-slate-100" />
+                        <div className="h-12 rounded-xl bg-slate-100" />
+                        <div className="h-12 rounded-xl bg-slate-100" />
+                        <div className="h-12 rounded-xl bg-slate-100" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// TeacherCaseViewPage
+//
+// State machine:
+//   isLoading  → skeleton
+//   isError    → error section (404-aware: "Caso no encontrado" vs generic)
+//   !canonical_output → empty state (no crash)
+//   happy path → CasePreview read-only (no onEditParams)
+//               isAlreadyPublished passed when status === "published"
+// ════════════════════════════════════════════════════════════════════════════
+export function TeacherCaseViewPage() {
+    const { assignmentId = "" } = useParams<{ assignmentId: string }>();
+    const navigate = useNavigate();
+
+    const { data, isLoading, isError, error } = useCaseDetail(assignmentId);
+
+    if (isLoading) {
+        return (
+            <TeacherLayout testId="teacher-case-view-loading">
+                <CaseViewSkeleton />
+            </TeacherLayout>
+        );
+    }
+
+    if (isError || !data) {
+        const is404 = error instanceof ApiError && error.status === 404;
+        return (
+            <TeacherLayout
+                testId="teacher-case-view-page"
+                contentClassName="mx-auto max-w-[1440px] px-6 py-8"
+            >
+                <section
+                    className="rounded-[24px] border border-red-200 bg-white p-8 shadow-sm"
+                    data-testid="global-page-error"
+                >
+                    <div className="flex items-start gap-3 text-red-700">
+                        <svg
+                            className="mt-0.5 h-5 w-5 shrink-0"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            aria-hidden="true"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                            />
+                        </svg>
+                        <div>
+                            <h1 className="text-lg font-bold text-slate-900">
+                                {is404 ? "Caso no encontrado" : "Error al cargar el caso"}
+                            </h1>
+                            <p className="mt-2 max-w-2xl text-sm text-slate-600">
+                                {is404
+                                    ? "Este caso no existe o ya no está disponible."
+                                    : "No se pudo cargar el caso. Inténtalo de nuevo."}
+                            </p>
+                            <div className="mt-5">
+                                <button
+                                    type="button"
+                                    onClick={() => navigate("/teacher/dashboard")}
+                                    className="inline-flex items-center gap-2 rounded-xl bg-[#0144a0] px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-[#00337a]"
+                                >
+                                    Volver al dashboard
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </TeacherLayout>
+        );
+    }
+
+    if (!data.canonical_output) {
+        return (
+            <TeacherLayout
+                testId="teacher-case-view-page"
+                contentClassName="mx-auto max-w-[1440px] px-6 py-8"
+            >
+                <section
+                    className="rounded-[24px] border border-slate-200 bg-white p-8 shadow-sm"
+                    data-testid="case-empty-state"
+                >
+                    <div className="flex items-start gap-3 text-slate-600">
+                        <svg
+                            className="mt-0.5 h-5 w-5 shrink-0"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            aria-hidden="true"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                            />
+                        </svg>
+                        <div>
+                            <h1 className="text-lg font-bold text-slate-900">
+                                El caso aún no tiene contenido generado
+                            </h1>
+                            <p className="mt-2 max-w-2xl text-sm text-slate-600">
+                                El caso fue creado pero la generación no ha producido resultados todavía.
+                            </p>
+                            <div className="mt-5">
+                                <button
+                                    type="button"
+                                    onClick={() => navigate("/teacher/dashboard")}
+                                    className="inline-flex items-center gap-2 rounded-xl bg-[#0144a0] px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-[#00337a]"
+                                >
+                                    Volver al dashboard
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </TeacherLayout>
+        );
+    }
+
+    return (
+        <TeacherLayout testId="teacher-case-view-page" contentClassName="w-full p-0">
+            <Suspense fallback={<CasePreviewFallback />}>
+                <CasePreview
+                    caseData={data.canonical_output}
+                    isAlreadyPublished={data.status === "published"}
+                />
+            </Suspense>
+        </TeacherLayout>
+    );
+}

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -683,7 +683,7 @@ export interface TeacherCaseDetailResponse {
     available_from: string | null;
     deadline: string | null;
     course_id: string | null;
-    canonical_output: Record<string, unknown> | null;
+    canonical_output: CanonicalCaseOutput | null;
 }
 
 export interface DeadlineUpdateRequest {


### PR DESCRIPTION
## Summary

- Add TeacherCaseViewPage at /teacher/cases/:assignmentId — read-only teacher view of a generated case
- Fix isTeacherShellRoute in App.tsx to include /teacher/cases (prevents double-header bug)
- Add /teacher/cases/:assignmentId/entregas placeholder route for future submissions view
- Improve canonical_output type in dam-types.ts from Record<string, unknown> | null to CanonicalCaseOutput | null
- Add isAlreadyPublished?: boolean prop to CasePreview — suppresses 'Enviar Caso' button for already-published cases
- 6 new tests for TeacherCaseViewPage (loading, 404, generic error, empty state, happy path, published propagation)
- 1 new test [T7] in CasePreview.test.tsx verifying button suppression when isAlreadyPublished=true
- Add TODO-024 to TODOS.md for future deadline-edit + re-publish CTA

## Pre-Landing Review

No issues found.
- No backend/SQL changes
- New routes wrapped in \RequireRole role=teacher\
- Architecture boundaries respected
- 289/289 tests passing

## Eval Results

No prompt-related files changed — evals skipped.

## Test plan
- [x] All Vitest tests pass (289 tests, 39 files)
- [x] Frontend build clean (no TypeScript errors)

Closes #155