### PR TITLE
feat(frontend): wire dashboard action buttons + DeadlineEditModal

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -451,3 +451,19 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 **Depends on / blocked by:** Merge de Issue #155. Requiere decisión de producto sobre si el re-publish desde la vista de detalle está en scope.
 
+---
+
+## TODO-025: Exponer `available_from` en el endpoint de lista de casos del docente
+
+**What:** Agregar el campo `available_from` a la respuesta del endpoint `GET /api/teacher/cases`, de forma que `TeacherCaseItem` lo incluya en el payload de lista.
+
+**Why:** `DeadlineEditModal` (Issue #158) pre-rellena el input "Disponible desde" con `caseItem.available_from`. Actualmente el endpoint de lista no devuelve ese campo — solo `TeacherCaseDetailResponse` lo incluye. Sin este campo en la lista, el modal siempre abre el input de disponibilidad vacío y el docente debe introducir la fecha manualmente aunque ya estuviera configurada.
+
+**Pros:** UX coherente: el modal muestra el valor actual en lugar de campo vacío. Alineación entre vista de lista y vista de detalle para el mismo campo. No requiere un fetch adicional del caso específico antes de abrir el modal.
+
+**Cons:** Cambio de backend en el serializador de la respuesta de lista. Requiere alinear el schema Pydantic de `TeacherCaseItem` en el backend con el tipo TypeScript del frontend. Necesita test de endpoint para verificar que `available_from` aparece en la lista.
+
+**Context:** Registrado en la eng review de Issue #158. La decisión explícita fue no tocar el backend en esa issue y aceptar el pre-fill vacío como comportamiento degradado aceptable. El campo ya existe en la tabla `assignments` y en `TeacherCaseDetailResponse`; solo falta exponerlo en la query/serializer de lista.
+
+**Depends on / blocked by:** Issue #158 mergeado. Alineación con el tipo `TeacherCaseItem` en `adam-types.ts` (campo ya agregado como opcional en #158).
+

--- a/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
@@ -701,6 +701,7 @@ describe("Task 2 — Profile restriction for harvard_only", () => {
 
     beforeEach(() => {
         vi.restoreAllMocks();
+        sessionStorage.clear();
         server.use(
             http.get("/api/teacher/courses", () =>
                 HttpResponse.json({ courses: [], total: 0 }),
@@ -747,8 +748,10 @@ describe("Task 2 — Profile restriction for harvard_only", () => {
 
         // Confirm ml_ds is absent by default
         await user.click(screen.getByLabelText(/perfil del curso/i));
-        const optsBefore = await screen.findAllByRole("option");
-        expect(optsBefore.some((o) => /machine learning/i.test(o.textContent ?? ""))).toBe(false);
+        await waitFor(() => {
+            const optsBefore = screen.getAllByRole("option");
+            expect(optsBefore.some((o) => /machine learning/i.test(o.textContent ?? ""))).toBe(false);
+        });
 
         // Close dropdown
         await user.keyboard("{Escape}");

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
@@ -18,6 +18,7 @@ vi.mock("react-router-dom", async () => {
 
 vi.mock("./useTeacherDashboard", () => ({
     useTeacherCases: () => useTeacherCases(),
+    useUpdateDeadline: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 import { CasosActivosSection } from "./CasosActivosSection";
@@ -146,7 +147,7 @@ describe("CasosActivosSection", () => {
         expect(normal.className).toContain("bg-[#e8f0fe]");
     });
 
-    it("triggers placeholder toasts from row actions", async () => {
+    it("click 'Ver Caso' navigates to /teacher/cases/:id", () => {
         useTeacherCases.mockReturnValue({
             data: { cases: [createCase(1)], total: 1 },
             isLoading: false,
@@ -156,14 +157,41 @@ describe("CasosActivosSection", () => {
         renderWithProviders(<CasosActivosSection />);
 
         fireEvent.click(screen.getByRole("button", { name: "Ver Caso" }));
+
+        expect(navigate).toHaveBeenCalledWith("/teacher/cases/case-1");
+    });
+
+    it("click 'Entregas' navigates to /teacher/cases/:id/entregas", () => {
+        useTeacherCases.mockReturnValue({
+            data: { cases: [createCase(1)], total: 1 },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CasosActivosSection />);
+
         fireEvent.click(screen.getByRole("button", { name: "Entregas" }));
+
+        expect(navigate).toHaveBeenCalledWith("/teacher/cases/case-1/entregas");
+    });
+
+    it("click 'Editar' renders DeadlineEditModal with correct props", () => {
+        useTeacherCases.mockReturnValue({
+            data: {
+                cases: [createCase(1, { available_from: "2026-06-01T10:00:00Z" })],
+                total: 1,
+            },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CasosActivosSection />);
+
         fireEvent.click(screen.getByRole("button", { name: "Editar" }));
 
-        const toasts = await screen.findAllByRole("status");
-        const placeholderToasts = toasts.filter(
-            (el) => el.textContent === "Vista disponible próximamente",
-        );
-        expect(placeholderToasts).toHaveLength(3);
+        expect(screen.getByRole("heading", { name: "Editar fechas" })).toBeTruthy();
+        const availableFromInput = screen.getByLabelText("Disponible desde") as HTMLInputElement;
+        expect(availableFromInput.value).toBe("2026-06-01T10:00");
     });
 
     it("handles client-side pagination and button boundaries", () => {

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.tsx
@@ -3,12 +3,11 @@ import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 import type { TeacherCaseItem } from "@/shared/adam-types";
-import { useToast } from "@/shared/Toast";
 
+import { DeadlineEditModal } from "./DeadlineEditModal";
 import { useTeacherCases } from "./useTeacherDashboard";
 
 const PAGE_SIZE = 10;
-const PLACEHOLDER_MSG = "Vista disponible próximamente";
 const CASES_LOAD_ERROR_MSG = "Error al cargar casos. Intenta refrescar la página.";
 const EMPTY_CASES: TeacherCaseItem[] = [];
 
@@ -18,6 +17,7 @@ function buildCasesSignature(cases: TeacherCaseItem[]): string {
             item.id,
             item.title,
             item.deadline,
+            item.available_from,
             item.status,
             item.days_remaining,
             item.course_codes,
@@ -48,25 +48,11 @@ function DeadlineBadge({ days }: { days: number | null }) {
 
 interface CasoRowProps {
     caso: TeacherCaseItem;
+    onEdit: (caso: TeacherCaseItem) => void;
 }
 
-function CasoRow({ caso }: CasoRowProps) {
-    const { showToast } = useToast();
-
-    const handleViewCase = (id: string) => {
-        void id;
-        showToast(PLACEHOLDER_MSG, "info");
-    };
-
-    const handleDeliverables = (id: string) => {
-        void id;
-        showToast(PLACEHOLDER_MSG, "info");
-    };
-
-    const handleEdit = (id: string) => {
-        void id;
-        showToast(PLACEHOLDER_MSG, "info");
-    };
+function CasoRow({ caso, onEdit }: CasoRowProps) {
+    const navigate = useNavigate();
 
     return (
         <tr className="group transition-colors hover:bg-slate-50">
@@ -97,27 +83,21 @@ function CasoRow({ caso }: CasoRowProps) {
                 <div className="flex items-center justify-end gap-2.5 opacity-90 transition-opacity group-hover:opacity-100">
                     <button
                         type="button"
-                        onClick={() => {
-                            handleViewCase(caso.id);
-                        }}
+                        onClick={() => { navigate(`/teacher/cases/${caso.id}`); }}
                         className="inline-flex h-9 items-center justify-center gap-1.5 rounded-[9px] border border-indigo-100 bg-indigo-50 px-3.5 py-2 text-[13px] font-semibold text-indigo-600 transition-all hover:border-indigo-200 hover:bg-indigo-100 hover:shadow-sm"
                     >
                         Ver Caso
                     </button>
                     <button
                         type="button"
-                        onClick={() => {
-                            handleDeliverables(caso.id);
-                        }}
+                        onClick={() => { navigate(`/teacher/cases/${caso.id}/entregas`); }}
                         className="inline-flex h-9 items-center justify-center gap-1.5 rounded-[9px] border-none bg-gradient-to-r from-blue-600 to-indigo-600 px-3.5 py-2 text-[13px] font-bold text-white shadow-md shadow-blue-500/20 transition-all hover:scale-[1.02] hover:shadow-lg hover:shadow-blue-500/30"
                     >
                         Entregas
                     </button>
                     <button
                         type="button"
-                        onClick={() => {
-                            handleEdit(caso.id);
-                        }}
+                        onClick={() => { onEdit(caso); }}
                         className="inline-flex h-9 items-center justify-center gap-1.5 rounded-[9px] border border-amber-100 bg-amber-50 px-3.5 py-2 text-[13px] font-semibold text-amber-600 transition-all hover:border-amber-200 hover:bg-amber-100 hover:shadow-sm"
                     >
                         Editar
@@ -132,6 +112,7 @@ export function CasosActivosSection() {
     const navigate = useNavigate();
     const [page, setPage] = useState(0);
     const { data, isLoading, isError } = useTeacherCases();
+    const [editingCase, setEditingCase] = useState<TeacherCaseItem | null>(null);
 
     const allCases = data?.cases ?? EMPTY_CASES;
     const totalCases = allCases.length;
@@ -268,7 +249,7 @@ export function CasosActivosSection() {
 
                             {!isLoading && !isError
                                 ? pageCases.map((caso) => (
-                                      <CasoRow key={caso.id} caso={caso} />
+                                      <CasoRow key={caso.id} caso={caso} onEdit={setEditingCase} />
                                   ))
                                 : null}
                         </tbody>
@@ -307,6 +288,14 @@ export function CasosActivosSection() {
                     </div>
                 </div>
             </div>
+            {editingCase !== null && (
+                <DeadlineEditModal
+                    caseId={editingCase.id}
+                    currentAvailableFrom={editingCase.available_from ?? null}
+                    currentDeadline={editingCase.deadline ?? null}
+                    onClose={() => { setEditingCase(null); }}
+                />
+            )}
         </section>
     );
 }

--- a/frontend/src/features/teacher-dashboard/DeadlineEditModal.test.tsx
+++ b/frontend/src/features/teacher-dashboard/DeadlineEditModal.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/shared/test-utils";
+
+const mutateFn = vi.fn();
+const showToastFn = vi.fn();
+
+vi.mock("./useTeacherDashboard", () => ({
+    useUpdateDeadline: () => ({ mutate: mutateFn, isPending: false }),
+}));
+
+vi.mock("@/shared/Toast", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/Toast")>("@/shared/Toast");
+    return { ...actual, useToast: () => ({ showToast: showToastFn }) };
+});
+
+import { DeadlineEditModal } from "./DeadlineEditModal";
+
+const onClose = vi.fn();
+
+const BASE_PROPS = {
+    caseId: "case-1",
+    currentAvailableFrom: "2026-06-01T10:00:00Z",
+    currentDeadline: "2026-12-01T23:59:00Z",
+    onClose,
+};
+
+describe("DeadlineEditModal", () => {
+    beforeEach(() => {
+        mutateFn.mockReset();
+        showToastFn.mockReset();
+        onClose.mockReset();
+    });
+
+    it("inputs are pre-filled with currentAvailableFrom and currentDeadline", () => {
+        renderWithProviders(<DeadlineEditModal {...BASE_PROPS} />);
+
+        const availableFromInput = screen.getByLabelText("Disponible desde") as HTMLInputElement;
+        const deadlineInput = screen.getByLabelText("Fecha límite") as HTMLInputElement;
+
+        expect(availableFromInput.value).toBe("2026-06-01T10:00");
+        expect(deadlineInput.value).toBe("2026-12-01T23:59");
+    });
+
+    it("shows inline error and disables submit when deadline is not after available_from", () => {
+        renderWithProviders(<DeadlineEditModal {...BASE_PROPS} />);
+
+        const availableFromInput = screen.getByLabelText("Disponible desde");
+        const deadlineInput = screen.getByLabelText("Fecha límite");
+
+        fireEvent.change(availableFromInput, { target: { value: "2026-12-01T23:59" } });
+        fireEvent.change(deadlineInput, { target: { value: "2026-06-01T10:00" } });
+
+        expect(screen.getByRole("alert")).toBeTruthy();
+        expect(
+            screen.getByText(
+                "La fecha límite debe ser posterior a la fecha de disponibilidad.",
+            ),
+        ).toBeTruthy();
+        expect(screen.getByRole("button", { name: "Guardar" })).toBeDisabled();
+    });
+
+    it("disables submit when values are unchanged from props", () => {
+        renderWithProviders(<DeadlineEditModal {...BASE_PROPS} />);
+
+        expect(screen.getByRole("button", { name: "Guardar" })).toBeDisabled();
+    });
+
+    it("calls mutate with correct arguments on valid submit", () => {
+        renderWithProviders(<DeadlineEditModal {...BASE_PROPS} />);
+
+        const deadlineInput = screen.getByLabelText("Fecha límite");
+        fireEvent.change(deadlineInput, { target: { value: "2027-01-15T12:00" } });
+
+        fireEvent.click(screen.getByRole("button", { name: "Guardar" }));
+
+        expect(mutateFn).toHaveBeenCalledWith(
+            {
+                assignmentId: "case-1",
+                body: { available_from: "2026-06-01T10:00", deadline: "2027-01-15T12:00" },
+            },
+            expect.objectContaining({
+                onSuccess: expect.any(Function),
+                onError: expect.any(Function),
+            }),
+        );
+    });
+
+    it("calls onClose and shows success toast when mutation succeeds", () => {
+        mutateFn.mockImplementation(
+            (_vars: unknown, callbacks: { onSuccess?: () => void }) => {
+                callbacks?.onSuccess?.();
+            },
+        );
+
+        renderWithProviders(<DeadlineEditModal {...BASE_PROPS} />);
+
+        const deadlineInput = screen.getByLabelText("Fecha límite");
+        fireEvent.change(deadlineInput, { target: { value: "2027-01-15T12:00" } });
+        fireEvent.click(screen.getByRole("button", { name: "Guardar" }));
+
+        expect(onClose).toHaveBeenCalledOnce();
+        expect(showToastFn).toHaveBeenCalledWith("Fechas actualizadas", "success");
+    });
+
+    it("keeps modal open and shows error toast when mutation fails", () => {
+        mutateFn.mockImplementation(
+            (_vars: unknown, callbacks: { onError?: () => void }) => {
+                callbacks?.onError?.();
+            },
+        );
+
+        renderWithProviders(<DeadlineEditModal {...BASE_PROPS} />);
+
+        const deadlineInput = screen.getByLabelText("Fecha límite");
+        fireEvent.change(deadlineInput, { target: { value: "2027-01-15T12:00" } });
+        fireEvent.click(screen.getByRole("button", { name: "Guardar" }));
+
+        expect(onClose).not.toHaveBeenCalled();
+        expect(showToastFn).toHaveBeenCalledWith("Error al guardar fechas", "error");
+        expect(screen.getByRole("heading", { name: "Editar fechas" })).toBeTruthy();
+    });
+
+    it("calls onClose when backdrop is clicked", () => {
+        const { container } = renderWithProviders(<DeadlineEditModal {...BASE_PROPS} />);
+
+        fireEvent.click(container.firstChild!);
+
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("calls onClose when cancel button is clicked", () => {
+        renderWithProviders(<DeadlineEditModal {...BASE_PROPS} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Cancelar" }));
+
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+});

--- a/frontend/src/features/teacher-dashboard/DeadlineEditModal.tsx
+++ b/frontend/src/features/teacher-dashboard/DeadlineEditModal.tsx
@@ -1,0 +1,144 @@
+import { useRef, useState } from "react";
+import type { FormEvent } from "react";
+
+import { useToast } from "@/shared/Toast";
+
+import { useUpdateDeadline } from "./useTeacherDashboard";
+
+interface DeadlineEditModalProps {
+    caseId: string;
+    currentAvailableFrom: string | null;
+    currentDeadline: string | null;
+    onClose: () => void;
+}
+
+function toDatetimeLocalValue(iso: string | null): string {
+    if (!iso) return "";
+    return iso.slice(0, 16);
+}
+
+export function DeadlineEditModal({
+    caseId,
+    currentAvailableFrom,
+    currentDeadline,
+    onClose,
+}: DeadlineEditModalProps) {
+    const initialAvailableFrom = useRef(toDatetimeLocalValue(currentAvailableFrom)).current;
+    const initialDeadline = useRef(toDatetimeLocalValue(currentDeadline)).current;
+
+    const [availableFrom, setAvailableFrom] = useState(initialAvailableFrom);
+    const [deadline, setDeadline] = useState(initialDeadline);
+
+    const { mutate, isPending } = useUpdateDeadline();
+    const { showToast } = useToast();
+
+    const isInvalid = Boolean(availableFrom && deadline && deadline <= availableFrom);
+    const hasChanged = availableFrom !== initialAvailableFrom || deadline !== initialDeadline;
+    const canSubmit = hasChanged && !isInvalid && !isPending;
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!canSubmit) return;
+        mutate(
+            {
+                assignmentId: caseId,
+                body: {
+                    available_from: availableFrom || null,
+                    deadline: deadline || null,
+                },
+            },
+            {
+                onSuccess: () => {
+                    onClose();
+                    showToast("Fechas actualizadas", "success");
+                },
+                onError: () => {
+                    showToast("Error al guardar fechas", "error");
+                },
+            },
+        );
+    }
+
+    return (
+        <div
+            className="fixed inset-0 z-[70] flex items-center justify-center bg-slate-950/60 px-4 py-6 backdrop-blur-sm"
+            onClick={onClose}
+        >
+            <div
+                className="w-full max-w-md overflow-hidden rounded-[20px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.22)]"
+                onClick={(e) => { e.stopPropagation(); }}
+            >
+                <div className="px-6 py-5">
+                    <h2 className="text-xl font-bold tracking-tight text-slate-900">
+                        Editar fechas
+                    </h2>
+                    <p className="mt-1 text-sm text-slate-500">
+                        Modifica la disponibilidad y el deadline del caso.
+                    </p>
+                </div>
+                <form onSubmit={handleSubmit}>
+                    <div className="space-y-4 px-6 pb-2">
+                        <div>
+                            <label
+                                htmlFor="available-from"
+                                className="mb-1.5 block text-sm font-semibold text-slate-700"
+                            >
+                                Disponible desde
+                            </label>
+                            <input
+                                id="available-from"
+                                type="datetime-local"
+                                value={availableFrom}
+                                onChange={(e) => { setAvailableFrom(e.target.value); }}
+                                className="w-full rounded-xl border border-slate-200 px-3 py-2.5 text-sm text-slate-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"
+                            />
+                        </div>
+                        <div>
+                            <label
+                                htmlFor="deadline"
+                                className="mb-1.5 block text-sm font-semibold text-slate-700"
+                            >
+                                Fecha límite
+                            </label>
+                            <input
+                                id="deadline"
+                                type="datetime-local"
+                                value={deadline}
+                                onChange={(e) => { setDeadline(e.target.value); }}
+                                className="w-full rounded-xl border border-slate-200 px-3 py-2.5 text-sm text-slate-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"
+                            />
+                        </div>
+                        {isInvalid && (
+                            <p role="alert" className="text-sm text-red-600">
+                                La fecha límite debe ser posterior a la fecha de disponibilidad.
+                            </p>
+                        )}
+                    </div>
+                    <div className="flex items-center justify-end gap-3 border-t border-slate-200 px-6 py-4">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900"
+                        >
+                            Cancelar
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={!canSubmit}
+                            className="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            {isPending ? (
+                                <span
+                                    className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+                                    aria-label="Guardando..."
+                                />
+                            ) : (
+                                "Guardar"
+                            )}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -665,6 +665,7 @@ export interface TeacherSyllabusSaveRequest {
 export interface TeacherCaseItem {
     id: string;
     title: string;
+    available_from?: string | null;
     deadline: string | null;
     status: string;
     course_codes: string[];


### PR DESCRIPTION
## Summary

- Wire three action buttons in \CasoRow\ (\CasosActivosSection\):
  - **Ver Caso** → \
avigate(\/teacher/cases/\\)\
  - **Entregas** → \
avigate(\/teacher/cases/\/entregas\)\
  - **Editar** → opens \DeadlineEditModal\
- Add \DeadlineEditModal\ component with pre-fill, validation (deadline must be after available_from), disabled submit on no-change, success/error toasts via \useUpdateDeadline\
- Add \vailable_from?: string | null\ to \TeacherCaseItem\ type
- Replace placeholder toast tests with 3 focused per-button tests in \CasosActivosSection.test.tsx\
- Add 8-case test suite for \DeadlineEditModal\
- Fix pre-existing flaky test in \AuthoringForm.test.tsx\: sessionStorage leak between Task 2 tests + \waitFor\ guard on dropdown assertion
- Register TODO-025: expose \vailable_from\ in teacher cases list endpoint (backend follow-up)

## Pre-Landing Review

No issues found.

## Test plan
- [x] All Vitest tests pass (300 tests, 41 files)
- [x] Flaky test \ml_ds option reappears when switching to harvard_with_eda\ confirmed stable 5/5 runs after fix

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)