### PR TITLE
test(frontend): mutation hooks + DeadlineEditModal validation tests (#160)

### DIFF
--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
@@ -221,6 +221,25 @@ describe("CasosActivosSection", () => {
         expect(nextButton).toBeDisabled();
     });
 
+    it("DeadlineEditModal is removed from DOM after clicking Cancelar", () => {
+        useTeacherCases.mockReturnValue({
+            data: {
+                cases: [createCase(1, { available_from: "2026-06-01T10:00:00Z" })],
+                total: 1,
+            },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CasosActivosSection />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Editar" }));
+        expect(screen.getByRole("heading", { name: "Editar fechas" })).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: "Cancelar" }));
+        expect(screen.queryByRole("heading", { name: "Editar fechas" })).toBeNull();
+    });
+
     it("resets to page 0 only when dataset changes", () => {
         let currentCases = Array.from({ length: 12 }, (_, index) => createCase(index + 1));
 

--- a/frontend/src/features/teacher-dashboard/DeadlineEditModal.test.tsx
+++ b/frontend/src/features/teacher-dashboard/DeadlineEditModal.test.tsx
@@ -137,4 +137,14 @@ describe("DeadlineEditModal", () => {
 
         expect(onClose).toHaveBeenCalledOnce();
     });
+
+    it("enables submit when deadline is after available_from and values have changed", () => {
+        renderWithProviders(<DeadlineEditModal {...BASE_PROPS} />);
+
+        const deadlineInput = screen.getByLabelText("Fecha l\u00edmite");
+        fireEvent.change(deadlineInput, { target: { value: "2027-01-15T12:00" } });
+
+        expect(screen.queryByRole("alert")).toBeNull();
+        expect(screen.getByRole("button", { name: "Guardar" })).not.toBeDisabled();
+    });
 });

--- a/frontend/src/features/teacher-dashboard/useTeacherDashboard.test.tsx
+++ b/frontend/src/features/teacher-dashboard/useTeacherDashboard.test.tsx
@@ -147,6 +147,37 @@ describe("usePublishCase", () => {
         expect(setQueryData).toHaveBeenCalledWith(queryKeys.teacher.case("case-abc"), { id: "case-abc" });
         expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.teacher.cases() });
     });
+
+    it("mutationFn calls api.teacher.publishCase with the given assignmentId", async () => {
+        vi.mocked(useQueryClient).mockReturnValue({ setQueryData: vi.fn(), invalidateQueries: vi.fn().mockResolvedValue(undefined) } as never);
+        vi.mocked(useMutation).mockReturnValue({} as never);
+        vi.mocked(api.teacher.publishCase).mockResolvedValue({ id: "case-abc" } as never);
+
+        usePublishCase();
+
+        // NOTE: onSuccess invalidates teacher.cases() only, NOT teacher.courses() —
+        // issue #160 spec included courses() invalidation but actual code does not.
+        // Testing real code behavior here.
+        const options = vi.mocked(useMutation).mock.calls[0]?.[0] as unknown as {
+            mutationFn: (assignmentId: string) => Promise<unknown>;
+        };
+        await options.mutationFn("case-abc");
+
+        expect(api.teacher.publishCase).toHaveBeenCalledWith("case-abc");
+    });
+
+    it("mutationFn propagates rejection to caller", async () => {
+        vi.mocked(useQueryClient).mockReturnValue({ setQueryData: vi.fn(), invalidateQueries: vi.fn().mockResolvedValue(undefined) } as never);
+        vi.mocked(useMutation).mockReturnValue({} as never);
+        vi.mocked(api.teacher.publishCase).mockRejectedValue(new Error("409 Conflict"));
+
+        usePublishCase();
+
+        const options = vi.mocked(useMutation).mock.calls[0]?.[0] as unknown as {
+            mutationFn: (assignmentId: string) => Promise<unknown>;
+        };
+        await expect(options.mutationFn("case-abc")).rejects.toThrow("409 Conflict");
+    });
 });
 
 describe("useUpdateDeadline", () => {
@@ -169,5 +200,36 @@ describe("useUpdateDeadline", () => {
 
         expect(setQueryData).toHaveBeenCalledWith(queryKeys.teacher.case("case-abc"), { id: "case-abc" });
         expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.teacher.cases() });
+    });
+
+    it("mutationFn calls api.teacher.updateDeadline with assignmentId and body", async () => {
+        vi.mocked(useQueryClient).mockReturnValue({ setQueryData: vi.fn(), invalidateQueries: vi.fn().mockResolvedValue(undefined) } as never);
+        vi.mocked(useMutation).mockReturnValue({} as never);
+        vi.mocked(api.teacher.updateDeadline).mockResolvedValue({ id: "case-abc" } as never);
+
+        useUpdateDeadline();
+
+        const options = vi.mocked(useMutation).mock.calls[0]?.[0] as unknown as {
+            mutationFn: (vars: { assignmentId: string; body: { available_from: string | null; deadline: string | null } }) => Promise<unknown>;
+        };
+        const body = { available_from: null, deadline: "2026-12-01T23:59" };
+        await options.mutationFn({ assignmentId: "case-abc", body });
+
+        expect(api.teacher.updateDeadline).toHaveBeenCalledWith("case-abc", body);
+    });
+
+    it("mutationFn propagates rejection to caller", async () => {
+        vi.mocked(useQueryClient).mockReturnValue({ setQueryData: vi.fn(), invalidateQueries: vi.fn().mockResolvedValue(undefined) } as never);
+        vi.mocked(useMutation).mockReturnValue({} as never);
+        vi.mocked(api.teacher.updateDeadline).mockRejectedValue(new Error("422 Unprocessable"));
+
+        useUpdateDeadline();
+
+        const options = vi.mocked(useMutation).mock.calls[0]?.[0] as unknown as {
+            mutationFn: (vars: { assignmentId: string; body: { available_from: string | null; deadline: string | null } }) => Promise<unknown>;
+        };
+        await expect(
+            options.mutationFn({ assignmentId: "case-abc", body: { available_from: null, deadline: "2026-12-01T23:59" } }),
+        ).rejects.toThrow("422 Unprocessable");
     });
 });


### PR DESCRIPTION
Closes #160

## What

Extends 3 existing test files with 5 new test cases that fill coverage gaps left by PRs #155 and #158.

## Changes

### `useTeacherDashboard.test.tsx` (+4 tests)

**`usePublishCase`**
- `mutationFn` calls `api.teacher.publishCase` with the given `assignmentId`
- `mutationFn` propagates rejection to the caller

**`useUpdateDeadline`**
- `mutationFn` calls `api.teacher.updateDeadline` with `assignmentId` and `body`
- `mutationFn` propagates rejection to the caller

> Note: `usePublishCase.onSuccess` invalidates `teacher.cases()` only — not `teacher.courses()` as the issue spec stated. Tests reflect actual code behavior; divergence documented with a comment.

### `DeadlineEditModal.test.tsx` (+1 test)

- Enables submit when `deadline > available_from` and values have changed (the valid path was previously untested)

### `CasosActivosSection.test.tsx` (+1 test)

- `DeadlineEditModal` is removed from the DOM after clicking Cancelar

## Verification

305 tests pass, 0 failures (`npm --prefix frontend run test -- --run`). No production files modified.