### PR TITLE
Fix teacher case publication and list contract regressions

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -453,7 +453,9 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
-## TODO-025: Exponer `available_from` en el endpoint de lista de casos del docente
+## TODO-025: Exponer `available_from` en el endpoint de lista de casos del docente [RESUELTO por #175]
+
+**Status:** Cerrado por el fix de la Issue #175. `GET /api/teacher/cases` ya expone `available_from` en el contrato de lista, alineado con `TeacherCaseItem` en frontend y con el pre-fill de `DeadlineEditModal`.
 
 **What:** Agregar el campo `available_from` a la respuesta del endpoint `GET /api/teacher/cases`, de forma que `TeacherCaseItem` lo incluya en el payload de lista.
 

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -1172,7 +1172,6 @@ class AuthoringService:
             canonical_dict = dict(canonical_result.get("canonical_output", {}))
             canonical_dict["caseId"] = assignment.id
             assignment.canonical_output = canonical_dict
-            assignment.status = "published"
             job.status = AUTHORING_JOB_STATUS_COMPLETED
             completed_payload = _next_progress_payload(
                 job.task_payload,

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -227,29 +227,44 @@ def utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _normalize_deadline_input(raw_due_at: str | None) -> tuple[datetime | None, str | None]:
-    if raw_due_at is None:
+def _normalize_optional_assignment_datetime(
+    raw_value: str | None,
+    *,
+    invalid_detail: str,
+) -> tuple[datetime | None, str | None]:
+    if raw_value is None:
         return None, None
 
-    stripped_due_at = raw_due_at.strip()
-    if not stripped_due_at:
+    stripped_value = raw_value.strip()
+    if not stripped_value:
         return None, None
 
     try:
-        parsed_due_at = datetime.fromisoformat(stripped_due_at)
+        parsed_value = datetime.fromisoformat(stripped_value)
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="invalid_due_at",
+            detail=invalid_detail,
         ) from exc
 
-    localized_due_at = (
-        parsed_due_at.replace(tzinfo=_BOGOTA_TZ)
-        if parsed_due_at.tzinfo is None
-        else parsed_due_at
+    localized_value = (
+        parsed_value.replace(tzinfo=_BOGOTA_TZ)
+        if parsed_value.tzinfo is None
+        else parsed_value
     )
-    deadline_utc = localized_due_at.astimezone(timezone.utc)
-    return deadline_utc, deadline_utc.isoformat()
+    value_utc = localized_value.astimezone(timezone.utc)
+    return value_utc, value_utc.isoformat()
+
+
+def _normalize_deadline_input(raw_due_at: str | None) -> tuple[datetime | None, str | None]:
+    return _normalize_optional_assignment_datetime(raw_due_at, invalid_detail="invalid_due_at")
+
+
+def _normalize_available_from_input(raw_available_from: str | None) -> tuple[datetime | None, str | None]:
+    return _normalize_optional_assignment_datetime(
+        raw_available_from,
+        invalid_detail="invalid_available_from",
+    )
 
 
 def get_legacy_teacher_or_500(db: Session, actor: CurrentActor) -> User:
@@ -595,6 +610,7 @@ def create_authoring_job(
         teacher = get_legacy_teacher_or_500(db, actor)
         owned_course = get_teacher_owned_course_with_syllabus(db, context, req.course_id, lock=True)
         SyllabusGroundingContext.model_validate(owned_course.syllabus.ai_grounding_context)
+        available_from, normalized_available_from = _normalize_available_from_input(req.available_from)
         deadline, normalized_due_at = _normalize_deadline_input(req.due_at)
         try:
             module_title, unit_title = resolve_syllabus_selection_titles(
@@ -614,6 +630,7 @@ def create_authoring_job(
             course_id=owned_course.course.id,
             title=req.assignment_title,
             status="draft",
+            available_from=available_from,
             deadline=deadline,
         )
         db.add(assignment)
@@ -644,7 +661,7 @@ def create_authoring_job(
                 "edaDepth": req.eda_depth,
                 "includePythonCode": req.include_python_code,
                 "algoritmos": req.suggested_techniques,
-                "availableFrom": req.available_from,
+                "availableFrom": normalized_available_from,
                 "dueAt": normalized_due_at,
             },
         )

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Literal
+from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel
@@ -10,7 +11,7 @@ from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import Session, joinedload, load_only
 
 from shared.auth import CurrentActor, ensure_legacy_teacher_bridge
-from shared.models import Assignment, Course, CourseAccessLink, CourseMembership, Membership, Syllabus
+from shared.models import Assignment, AuthoringJob, Course, CourseAccessLink, CourseMembership, Membership, Syllabus
 from shared.syllabus_schema import (
     TeacherCourseConfigurationResponse,
     TeacherCourseDetailResponse,
@@ -19,6 +20,8 @@ from shared.syllabus_schema import (
     TeacherSyllabusRevisionMetadataResponse,
 )
 from shared.teacher_context import TeacherContext
+
+_BOGOTA_TZ = ZoneInfo("America/Bogota")
 
 
 class TeacherCourseItemResponse(BaseModel):
@@ -296,6 +299,49 @@ def resolve_syllabus_selection_titles(
     return module_title, str(selected_unit.get("title", ""))
 
 
+def _normalize_schedule_value(raw_value: Any) -> datetime | None:
+    if not isinstance(raw_value, str):
+        return None
+
+    stripped_value = raw_value.strip()
+    if not stripped_value:
+        return None
+
+    normalized_value = stripped_value.replace("Z", "+00:00") if stripped_value.endswith("Z") else stripped_value
+    try:
+        parsed_value = datetime.fromisoformat(normalized_value)
+    except ValueError:
+        return None
+
+    localized_value = (
+        parsed_value.replace(tzinfo=_BOGOTA_TZ)
+        if parsed_value.tzinfo is None
+        else parsed_value
+    )
+    return localized_value.astimezone(timezone.utc)
+
+
+def resolve_assignment_schedule_values(assignment: Assignment) -> tuple[datetime | None, datetime | None]:
+    available_from = assignment.available_from
+    deadline = assignment.deadline
+
+    if available_from is not None and deadline is not None:
+        return available_from, deadline
+
+    if not assignment.authoring_jobs:
+        return available_from, deadline
+
+    latest_job = max(assignment.authoring_jobs, key=lambda job: job.created_at)
+    task_payload = latest_job.task_payload if isinstance(latest_job.task_payload, dict) else {}
+
+    if available_from is None:
+        available_from = _normalize_schedule_value(task_payload.get("availableFrom"))
+    if deadline is None:
+        deadline = _normalize_schedule_value(task_payload.get("dueAt"))
+
+    return available_from, deadline
+
+
 def list_teacher_active_cases(
     db: Session,
     actor: CurrentActor,
@@ -316,27 +362,33 @@ def list_teacher_active_cases(
     """
     legacy_user = ensure_legacy_teacher_bridge(db, actor)
 
-    assignments = db.scalars(
-        select(Assignment)
-        .options(
-            load_only(
-                Assignment.id,
-                Assignment.course_id,
-                Assignment.title,
-                Assignment.canonical_output,
-                Assignment.available_from,
-                Assignment.deadline,
-                Assignment.status,
-            ),
-            joinedload(Assignment.course).load_only(Course.code),
+    assignments = (
+        db.execute(
+            select(Assignment)
+            .options(
+                load_only(
+                    Assignment.id,
+                    Assignment.course_id,
+                    Assignment.title,
+                    Assignment.canonical_output,
+                    Assignment.available_from,
+                    Assignment.deadline,
+                    Assignment.status,
+                ),
+                joinedload(Assignment.course).load_only(Course.code),
+                joinedload(Assignment.authoring_jobs).load_only(AuthoringJob.created_at, AuthoringJob.task_payload),
+            )
+            .where(
+                Assignment.teacher_id == legacy_user.id,
+                Assignment.status == "published",
+                or_(Assignment.deadline.is_(None), Assignment.deadline >= now),
+            )
+            .order_by(Assignment.deadline.asc(), Assignment.id.asc())
         )
-        .where(
-            Assignment.teacher_id == legacy_user.id,
-            Assignment.status == "published",
-            or_(Assignment.deadline.is_(None), Assignment.deadline >= now),
-        )
-        .order_by(Assignment.deadline.asc(), Assignment.id.asc())
-    ).all()
+        .unique()
+        .scalars()
+        .all()
+    )
 
     items: list[TeacherCaseItem] = []
     for assignment in assignments:
@@ -344,12 +396,13 @@ def list_teacher_active_cases(
         canonical_title = canonical_output.get("title")
         title = canonical_title if isinstance(canonical_title, str) and canonical_title.strip() else assignment.title
         course_codes = [assignment.course.code] if assignment.course and assignment.course.code else []
+        available_from, deadline = resolve_assignment_schedule_values(assignment)
         items.append(
             TeacherCaseItem(
                 id=assignment.id,
                 title=title,
-                available_from=assignment.available_from,
-                deadline=assignment.deadline,
+                available_from=available_from,
+                deadline=deadline,
                 status=assignment.status,
                 course_codes=course_codes,
             )

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -41,6 +41,7 @@ class TeacherCoursesResponse(BaseModel):
 class TeacherCaseItem:
     id: str
     title: str
+    available_from: datetime | None
     deadline: datetime | None
     status: str
     course_codes: list[str]
@@ -321,6 +322,8 @@ def list_teacher_active_cases(
             load_only(
                 Assignment.id,
                 Assignment.title,
+                Assignment.canonical_output,
+                Assignment.available_from,
                 Assignment.deadline,
                 Assignment.status,
             )
@@ -333,13 +336,20 @@ def list_teacher_active_cases(
         .order_by(Assignment.deadline.asc(), Assignment.id.asc())
     ).all()
 
-    return [
-        TeacherCaseItem(
-            id=assignment.id,
-            title=assignment.title,
-            deadline=assignment.deadline,
-            status=assignment.status,
-            course_codes=[],
+    items: list[TeacherCaseItem] = []
+    for assignment in assignments:
+        canonical_output = assignment.canonical_output if isinstance(assignment.canonical_output, dict) else {}
+        canonical_title = canonical_output.get("title")
+        title = canonical_title if isinstance(canonical_title, str) and canonical_title.strip() else assignment.title
+        items.append(
+            TeacherCaseItem(
+                id=assignment.id,
+                title=title,
+                available_from=assignment.available_from,
+                deadline=assignment.deadline,
+                status=assignment.status,
+                course_codes=[],
+            )
         )
-        for assignment in assignments
-    ]
+
+    return items

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -321,6 +321,22 @@ def _normalize_schedule_value(raw_value: Any) -> datetime | None:
     return localized_value.astimezone(timezone.utc)
 
 
+def _resolve_schedule_values_from_payload(
+    *,
+    available_from: datetime | None,
+    deadline: datetime | None,
+    task_payload: dict[str, Any] | None,
+) -> tuple[datetime | None, datetime | None]:
+    normalized_payload = task_payload if isinstance(task_payload, dict) else {}
+
+    if available_from is None:
+        available_from = _normalize_schedule_value(normalized_payload.get("availableFrom"))
+    if deadline is None:
+        deadline = _normalize_schedule_value(normalized_payload.get("dueAt"))
+
+    return available_from, deadline
+
+
 def resolve_assignment_schedule_values(assignment: Assignment) -> tuple[datetime | None, datetime | None]:
     available_from = assignment.available_from
     deadline = assignment.deadline
@@ -333,13 +349,11 @@ def resolve_assignment_schedule_values(assignment: Assignment) -> tuple[datetime
 
     latest_job = max(assignment.authoring_jobs, key=lambda job: job.created_at)
     task_payload = latest_job.task_payload if isinstance(latest_job.task_payload, dict) else {}
-
-    if available_from is None:
-        available_from = _normalize_schedule_value(task_payload.get("availableFrom"))
-    if deadline is None:
-        deadline = _normalize_schedule_value(task_payload.get("dueAt"))
-
-    return available_from, deadline
+    return _resolve_schedule_values_from_payload(
+        available_from=available_from,
+        deadline=deadline,
+        task_payload=task_payload,
+    )
 
 
 def list_teacher_active_cases(
@@ -376,7 +390,6 @@ def list_teacher_active_cases(
                     Assignment.status,
                 ),
                 joinedload(Assignment.course).load_only(Course.code),
-                joinedload(Assignment.authoring_jobs).load_only(AuthoringJob.created_at, AuthoringJob.task_payload),
             )
             .where(
                 Assignment.teacher_id == legacy_user.id,
@@ -385,10 +398,32 @@ def list_teacher_active_cases(
             )
             .order_by(Assignment.deadline.asc(), Assignment.id.asc())
         )
-        .unique()
         .scalars()
         .all()
     )
+
+    legacy_assignment_ids = [
+        assignment.id
+        for assignment in assignments
+        if assignment.available_from is None or assignment.deadline is None
+    ]
+    legacy_schedule_payloads: dict[str, dict[str, Any]] = {}
+    if legacy_assignment_ids:
+        # Legacy-only bridge: records created before the #175 schedule persistence fix
+        # may still carry dates only inside authoring_jobs.task_payload. Remove this
+        # fallback in a future release once no assignments remain with null available_from.
+        legacy_schedule_rows = db.execute(
+            select(
+                AuthoringJob.assignment_id,
+                AuthoringJob.created_at,
+                AuthoringJob.task_payload,
+            )
+            .where(AuthoringJob.assignment_id.in_(legacy_assignment_ids))
+            .order_by(AuthoringJob.assignment_id.asc(), AuthoringJob.created_at.desc())
+        ).all()
+        for assignment_id, _created_at, task_payload in legacy_schedule_rows:
+            if assignment_id not in legacy_schedule_payloads and isinstance(task_payload, dict):
+                legacy_schedule_payloads[assignment_id] = task_payload
 
     items: list[TeacherCaseItem] = []
     for assignment in assignments:
@@ -396,7 +431,11 @@ def list_teacher_active_cases(
         canonical_title = canonical_output.get("title")
         title = canonical_title if isinstance(canonical_title, str) and canonical_title.strip() else assignment.title
         course_codes = [assignment.course.code] if assignment.course and assignment.course.code else []
-        available_from, deadline = resolve_assignment_schedule_values(assignment)
+        available_from, deadline = _resolve_schedule_values_from_payload(
+            available_from=assignment.available_from,
+            deadline=assignment.deadline,
+            task_payload=legacy_schedule_payloads.get(assignment.id),
+        )
         items.append(
             TeacherCaseItem(
                 id=assignment.id,

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from fastapi import HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import and_, func, or_, select
-from sqlalchemy.orm import Session, load_only
+from sqlalchemy.orm import Session, joinedload, load_only
 
 from shared.auth import CurrentActor, ensure_legacy_teacher_bridge
 from shared.models import Assignment, Course, CourseAccessLink, CourseMembership, Membership, Syllabus
@@ -321,12 +321,14 @@ def list_teacher_active_cases(
         .options(
             load_only(
                 Assignment.id,
+                Assignment.course_id,
                 Assignment.title,
                 Assignment.canonical_output,
                 Assignment.available_from,
                 Assignment.deadline,
                 Assignment.status,
-            )
+            ),
+            joinedload(Assignment.course).load_only(Course.code),
         )
         .where(
             Assignment.teacher_id == legacy_user.id,
@@ -341,6 +343,7 @@ def list_teacher_active_cases(
         canonical_output = assignment.canonical_output if isinstance(assignment.canonical_output, dict) else {}
         canonical_title = canonical_output.get("title")
         title = canonical_title if isinstance(canonical_title, str) and canonical_title.strip() else assignment.title
+        course_codes = [assignment.course.code] if assignment.course and assignment.course.code else []
         items.append(
             TeacherCaseItem(
                 id=assignment.id,
@@ -348,7 +351,7 @@ def list_teacher_active_cases(
                 available_from=assignment.available_from,
                 deadline=assignment.deadline,
                 status=assignment.status,
-                course_codes=[],
+                course_codes=course_codes,
             )
         )
 

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -15,7 +15,13 @@ from shared.database import get_db
 from shared.models import Assignment
 from shared.syllabus_schema import TeacherCourseDetailResponse, TeacherSyllabusSaveRequest
 from shared.teacher_context import TeacherContext, require_teacher_context
-from shared.teacher_reads import TeacherCoursesResponse, get_teacher_course_detail, list_teacher_active_cases, list_teacher_courses
+from shared.teacher_reads import (
+    TeacherCoursesResponse,
+    get_teacher_course_detail,
+    list_teacher_active_cases,
+    list_teacher_courses,
+    resolve_assignment_schedule_values,
+)
 from shared.teacher_writes import save_teacher_course_syllabus
 
 router = APIRouter(prefix="/api/teacher", tags=["teacher"])
@@ -124,12 +130,13 @@ def get_teacher_cases(
 
 def _to_case_detail(assignment: Assignment) -> TeacherCaseDetailResponse:
     """Build a TeacherCaseDetailResponse from an Assignment ORM instance."""
+    available_from, deadline = resolve_assignment_schedule_values(assignment)
     return TeacherCaseDetailResponse(
         id=assignment.id,
         title=assignment.title,
         status=assignment.status,
-        available_from=assignment.available_from,
-        deadline=assignment.deadline,
+        available_from=available_from,
+        deadline=deadline,
         course_id=assignment.course_id,
         canonical_output=assignment.canonical_output,
     )

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -23,6 +23,7 @@ router = APIRouter(prefix="/api/teacher", tags=["teacher"])
 class TeacherCaseItemResponse(BaseModel):
     id: str
     title: str
+    available_from: datetime | None
     deadline: datetime | None
     status: str
     course_codes: list[str]
@@ -100,6 +101,7 @@ def get_teacher_cases(
         TeacherCaseItemResponse(
             id=item.id,
             title=item.title,
+            available_from=item.available_from,
             deadline=item.deadline,
             status=item.status,
             course_codes=item.course_codes,

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import math
 from typing import Annotated, Any
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -18,6 +19,7 @@ from shared.teacher_reads import TeacherCoursesResponse, get_teacher_course_deta
 from shared.teacher_writes import save_teacher_course_syllabus
 
 router = APIRouter(prefix="/api/teacher", tags=["teacher"])
+_BOGOTA_TZ = ZoneInfo("America/Bogota")
 
 
 class TeacherCaseItemResponse(BaseModel):
@@ -54,12 +56,16 @@ def _days_remaining(deadline: datetime | None, now: datetime) -> int | None:
     if deadline is None:
         return None
 
-    remaining_seconds = (deadline - now).total_seconds()
-    if remaining_seconds <= 0:
+    if deadline <= now:
         return 0
-    if remaining_seconds < 86400:
+
+    deadline_local = deadline.astimezone(_BOGOTA_TZ)
+    now_local = now.astimezone(_BOGOTA_TZ)
+    remaining_days = (deadline_local.date() - now_local.date()).days
+
+    if remaining_days <= 0:
         return 0
-    return math.ceil(remaining_seconds / 86400)
+    return remaining_days
 
 
 @router.get("/courses", response_model=TeacherCoursesResponse)

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -1274,9 +1274,12 @@ async def test_run_job_same_thread_retry_preserves_checkpoint_lineage_and_rebuil
     db.expire_all()
     refreshed = db.get(AuthoringJob, job.id)
     assert refreshed is not None
+    assignment = db.get(Assignment, refreshed.assignment_id)
+    assert assignment is not None
 
     payload = dict(refreshed.task_payload or {})
     assert refreshed.status == "completed"
+    assert assignment.status == "draft"
     assert refreshed.retry_count == 2
     assert payload.get("current_step") == "completed"
     assert corrupt_graph.calls == 1

--- a/backend/tests/test_issue90_teacher_cases.py
+++ b/backend/tests/test_issue90_teacher_cases.py
@@ -11,7 +11,7 @@ def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str
     return auth_headers_factory(sub=user_id, email=email)
 
 
-def test_issue90_authoring_job_persists_deadline_and_normalizes_due_at(
+def test_issue90_authoring_job_persists_assignment_dates_and_normalizes_intake_datetimes(
     client,
     db,
     seed_identity,
@@ -37,6 +37,7 @@ def test_issue90_authoring_job_persists_deadline_and_normalizes_due_at(
                 "syllabus_module": "m1",
                 "topic_unit": "u1",
                 "target_groups": ["Grupo 01"],
+                "available_from": "2026-04-14T08:15",
                 "due_at": "2026-04-15T09:30",
             },
             headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
@@ -45,7 +46,10 @@ def test_issue90_authoring_job_persists_deadline_and_normalizes_due_at(
     assert response.status_code == 202, response.text
     assignment = db.query(Assignment).order_by(Assignment.created_at.desc()).first()
     assert assignment is not None
+    assert assignment.available_from == datetime(2026, 4, 14, 13, 15, tzinfo=timezone.utc)
     assert assignment.deadline == datetime(2026, 4, 15, 14, 30, tzinfo=timezone.utc)
+    assert assignment.authoring_jobs[0].task_payload["availableFrom"] == "2026-04-14T13:15:00+00:00"
+    assert assignment.authoring_jobs[0].task_payload["dueAt"] == "2026-04-15T14:30:00+00:00"
 
 
 def test_issue90_authoring_job_preserves_string_payload_shape_and_allows_null_deadline(

--- a/backend/tests/test_issue90_teacher_cases.py
+++ b/backend/tests/test_issue90_teacher_cases.py
@@ -128,18 +128,26 @@ def test_issue90_teacher_cases_returns_only_future_published_assignments_sorted(
     teacher_email = "teacher-cases@example.edu"
     seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
     now = datetime.now(timezone.utc)
+    sooner_available_from = now + timedelta(hours=1)
+    later_available_from = now + timedelta(hours=2)
+    sooner_available_from_response = sooner_available_from.isoformat().replace("+00:00", "Z")
+    later_available_from_response = later_available_from.isoformat().replace("+00:00", "Z")
 
     later_assignment = Assignment(
         teacher_id=teacher_id,
         title="Later",
         status="published",
+        available_from=later_available_from,
         deadline=now + timedelta(hours=25),
+        canonical_output={"title": "Canonical Later"},
     )
     sooner_assignment = Assignment(
         teacher_id=teacher_id,
         title="Sooner",
         status="published",
+        available_from=sooner_available_from,
         deadline=now + timedelta(hours=3),
+        canonical_output={"title": "Canonical Sooner"},
     )
     draft_assignment = Assignment(
         teacher_id=teacher_id,
@@ -164,6 +172,7 @@ def test_issue90_teacher_cases_returns_only_future_published_assignments_sorted(
         title="No Deadline",
         status="published",
         deadline=None,
+        canonical_output={"title": "Canonical No Deadline"},
     )
     db.add_all(
         [
@@ -186,11 +195,50 @@ def test_issue90_teacher_cases_returns_only_future_published_assignments_sorted(
     body = response.json()
     # After fix: null-deadline published assignment is now visible (sorts LAST with PG ASC NULLS LAST)
     assert body["total"] == 3
-    assert [item["title"] for item in body["cases"]] == ["Sooner", "Later", "No Deadline"]
+    assert [item["title"] for item in body["cases"]] == [
+        "Canonical Sooner",
+        "Canonical Later",
+        "Canonical No Deadline",
+    ]
     assert body["cases"][0]["days_remaining"] == 0
     assert body["cases"][1]["days_remaining"] == 2
     assert body["cases"][2]["days_remaining"] is None
+    assert body["cases"][0]["available_from"] == sooner_available_from_response
+    assert body["cases"][1]["available_from"] == later_available_from_response
+    assert body["cases"][2]["available_from"] is None
     assert body["cases"][0]["course_codes"] == []
+
+
+def test_issue90_teacher_cases_falls_back_to_assignment_title_when_canonical_title_missing(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-cases-title-fallback@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    now = datetime.now(timezone.utc)
+
+    fallback_assignment = Assignment(
+        teacher_id=teacher_id,
+        title="Assignment Title Fallback",
+        status="published",
+        deadline=now + timedelta(hours=6),
+        canonical_output={"summary": "missing title"},
+    )
+    db.add(fallback_assignment)
+    db.commit()
+
+    response = client.get(
+        "/api/teacher/cases",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 1
+    assert body["cases"][0]["title"] == "Assignment Title Fallback"
 
 
 def test_issue90_teacher_cases_returns_empty_when_teacher_has_no_active_cases(

--- a/backend/tests/test_issue90_teacher_cases.py
+++ b/backend/tests/test_issue90_teacher_cases.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 import uuid
 
-from shared.models import Assignment, Membership
+from shared.models import Assignment, AuthoringJob, Membership
 
 
 def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
@@ -120,6 +120,48 @@ def test_issue90_authoring_job_rejects_invalid_due_at(
 
     assert response.status_code == 422
     assert response.json()["detail"] == "invalid_due_at"
+
+
+def test_issue90_teacher_cases_fall_back_to_authoring_payload_available_from(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-fallback-available-from@example.edu"
+    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+
+    assignment = Assignment(
+        teacher_id=teacher_id,
+        title="Fallback Available From",
+        status="published",
+        available_from=None,
+        deadline=datetime(2026, 4, 30, 14, 30, tzinfo=timezone.utc),
+    )
+    db.add(assignment)
+    db.flush()
+    db.add(
+        AuthoringJob(
+            assignment_id=assignment.id,
+            idempotency_key=f"fallback-available-from-{assignment.id}",
+            status="completed",
+            task_payload={
+                "availableFrom": "2026-04-14T08:15",
+                "dueAt": "2026-04-30T14:30:00+00:00",
+            },
+        )
+    )
+    db.commit()
+
+    response = client.get(
+        "/api/teacher/cases",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["cases"][0]["available_from"] == "2026-04-14T13:15:00Z"
 
 
 def test_issue90_teacher_cases_returns_only_future_published_assignments_sorted(

--- a/backend/tests/test_issue90_teacher_cases.py
+++ b/backend/tests/test_issue90_teacher_cases.py
@@ -123,49 +123,64 @@ def test_issue90_teacher_cases_returns_only_future_published_assignments_sorted(
     db,
     seed_identity,
     auth_headers_factory,
+    seed_course,
 ) -> None:
     teacher_id = str(uuid.uuid4())
     teacher_email = "teacher-cases@example.edu"
-    seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
-    now = datetime.now(timezone.utc)
-    sooner_available_from = now + timedelta(hours=1)
-    later_available_from = now + timedelta(hours=2)
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    fixed_now = datetime(2026, 4, 22, 20, 30, tzinfo=timezone.utc)
+    sooner_available_from = fixed_now + timedelta(hours=1)
+    later_available_from = fixed_now + timedelta(hours=2)
     sooner_available_from_response = sooner_available_from.isoformat().replace("+00:00", "Z")
     later_available_from_response = later_available_from.isoformat().replace("+00:00", "Z")
+    sooner_course = seed_course(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Sooner Course",
+        code="OPS-101",
+    )
+    later_course = seed_course(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Later Course",
+        code="DS-202",
+    )
 
     later_assignment = Assignment(
         teacher_id=teacher_id,
+        course_id=later_course.id,
         title="Later",
         status="published",
         available_from=later_available_from,
-        deadline=now + timedelta(hours=25),
+        deadline=fixed_now + timedelta(hours=50),
         canonical_output={"title": "Canonical Later"},
     )
     sooner_assignment = Assignment(
         teacher_id=teacher_id,
+        course_id=sooner_course.id,
         title="Sooner",
         status="published",
         available_from=sooner_available_from,
-        deadline=now + timedelta(hours=3),
+        deadline=fixed_now + timedelta(hours=18),
         canonical_output={"title": "Canonical Sooner"},
     )
     draft_assignment = Assignment(
         teacher_id=teacher_id,
         title="Draft",
         status="draft",
-        deadline=now + timedelta(days=2),
+        deadline=fixed_now + timedelta(days=2),
     )
     failed_assignment = Assignment(
         teacher_id=teacher_id,
         title="Failed",
         status="failed",
-        deadline=now + timedelta(days=3),
+        deadline=fixed_now + timedelta(days=3),
     )
     expired_assignment = Assignment(
         teacher_id=teacher_id,
         title="Expired",
         status="published",
-        deadline=now - timedelta(seconds=1),
+        deadline=fixed_now - timedelta(seconds=1),
     )
     null_deadline_assignment = Assignment(
         teacher_id=teacher_id,
@@ -186,10 +201,12 @@ def test_issue90_teacher_cases_returns_only_future_published_assignments_sorted(
     )
     db.commit()
 
-    response = client.get(
-        "/api/teacher/cases",
-        headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
-    )
+    with patch("shared.teacher_router.datetime") as mock_datetime:
+        mock_datetime.now.return_value = fixed_now
+        response = client.get(
+            "/api/teacher/cases",
+            headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+        )
 
     assert response.status_code == 200, response.text
     body = response.json()
@@ -200,13 +217,15 @@ def test_issue90_teacher_cases_returns_only_future_published_assignments_sorted(
         "Canonical Later",
         "Canonical No Deadline",
     ]
-    assert body["cases"][0]["days_remaining"] == 0
+    assert body["cases"][0]["days_remaining"] == 1
     assert body["cases"][1]["days_remaining"] == 2
     assert body["cases"][2]["days_remaining"] is None
     assert body["cases"][0]["available_from"] == sooner_available_from_response
     assert body["cases"][1]["available_from"] == later_available_from_response
     assert body["cases"][2]["available_from"] is None
-    assert body["cases"][0]["course_codes"] == []
+    assert body["cases"][0]["course_codes"] == ["OPS-101"]
+    assert body["cases"][1]["course_codes"] == ["DS-202"]
+    assert body["cases"][2]["course_codes"] == []
 
 
 def test_issue90_teacher_cases_falls_back_to_assignment_title_when_canonical_title_missing(

--- a/backend/tests/test_phase1b_integration.py
+++ b/backend/tests/test_phase1b_integration.py
@@ -69,7 +69,7 @@ def test_phase1b_intake_and_authoring_stubbed(client, db, auth_headers_factory, 
 
         assignment = db.query(Assignment).filter(Assignment.id == job.assignment_id).first()
         assert assignment is not None
-        assert assignment.status == "published"
+        assert assignment.status == "draft"
 
         blueprint = assignment.blueprint
         assert blueprint is not None

--- a/backend/tests/test_phase1b_real.py
+++ b/backend/tests/test_phase1b_real.py
@@ -43,7 +43,7 @@ def test_real_success_and_idempotency(client, auth_headers_factory, seed_identit
 
         assignment = db.query(Assignment).filter(Assignment.id == job.assignment_id).first()
         print(f"Assignment Status: {assignment.status}")
-        assert assignment.status == "published", f"Expected published, got {assignment.status}"
+        assert assignment.status == "draft", f"Expected draft, got {assignment.status}"
 
         blueprint = assignment.blueprint
         print(f"Blueprint version: {blueprint.get('version')}")

--- a/backend/tests/test_phase1b_real.py
+++ b/backend/tests/test_phase1b_real.py
@@ -1,11 +1,39 @@
 import os
 import uuid
+import time
 
 import pytest
 from shared.database import SessionLocal
 from shared.models import AuthoringJob, Assignment
 
 pytestmark = pytest.mark.live_llm
+
+_TERMINAL_JOB_STATUSES = {"completed", "failed", "failed_resumable"}
+
+
+def _wait_for_terminal_job_status(
+    client,
+    job_id: str,
+    headers: dict[str, str],
+    *,
+    timeout_seconds: float = 240.0,
+    poll_interval_seconds: float = 1.0,
+) -> dict[str, str | None]:
+    deadline = time.monotonic() + timeout_seconds
+    last_status_payload: dict[str, str | None] | None = None
+
+    while time.monotonic() < deadline:
+        response = client.get(f"/api/authoring/jobs/{job_id}", headers=headers)
+        assert response.status_code == 200, response.text
+        last_status_payload = response.json()
+        if last_status_payload.get("status") in _TERMINAL_JOB_STATUSES:
+            return last_status_payload
+        time.sleep(poll_interval_seconds)
+
+    pytest.fail(
+        "Timed out waiting for authoring job to reach a terminal state. "
+        f"Last status payload: {last_status_payload}"
+    )
 
 def test_real_success_and_idempotency(client, auth_headers_factory, seed_identity, seed_course_with_syllabus):
     print("\n--- Testing Real Success ---")
@@ -34,6 +62,8 @@ def test_real_success_and_idempotency(client, auth_headers_factory, seed_identit
 
     # Because we use TestClient, BackgroundTasks runs synchronously after the response is generated.
     # Therefore, by this point, the LangGraph execution has already completed.
+    status_payload = _wait_for_terminal_job_status(client, job_id, headers)
+    print(f"Job Status via API: {status_payload['status']}")
 
     db = SessionLocal()
     try:
@@ -88,23 +118,15 @@ def test_real_failure_handling(client, auth_headers_factory, seed_identity, seed
         "target_groups": ["Grupo 01"],
     }
 
-    # Patch the environment variable to an invalid key during the run
-    original_key = os.getenv("GEMINI_API_KEY")
-    os.environ["GEMINI_API_KEY"] = "INVALID_KEY_12345"
+    monkeypatch.setenv("GEMINI_API_KEY", "INVALID_KEY_12345")
 
-    try:
-        resp = client.post("/api/authoring/jobs", json=payload, headers=headers)
-        assert resp.status_code == 202
-        job_id = resp.json().get("job_id")
-        print(f"Intake Response 202 OK. Job ID: {job_id}")
-    finally:
-        # Restore key
-        if original_key is not None:
-            os.environ["GEMINI_API_KEY"] = original_key
-        else:
-            del os.environ["GEMINI_API_KEY"]
-
+    resp = client.post("/api/authoring/jobs", json=payload, headers=headers)
+    assert resp.status_code == 202
+    job_id = resp.json().get("job_id")
+    print(f"Intake Response 202 OK. Job ID: {job_id}")
     db = SessionLocal()
+    status_payload = _wait_for_terminal_job_status(client, job_id, headers)
+    print(f"Job Status via API (Expected Failed): {status_payload['status']}")
     try:
         job = db.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
         print(f"Job Status in DB (Expected Failed): {job.status}")

--- a/frontend/src/features/teacher-authoring/TeacherCaseViewPage.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherCaseViewPage.tsx
@@ -49,8 +49,8 @@ function CaseViewSkeleton() {
 //   isLoading  → skeleton
 //   isError    → error section (404-aware: "Caso no encontrado" vs generic)
 //   !canonical_output → empty state (no crash)
-//   happy path → CasePreview read-only (no onEditParams)
-//               isAlreadyPublished passed when status === "published"
+//   happy path → CasePreview detail view (no onEditParams)
+//               publish CTA stays available unless status === "published"
 // ════════════════════════════════════════════════════════════════════════════
 export function TeacherCaseViewPage() {
     const { assignmentId = "" } = useParams<{ assignmentId: string }>();

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
@@ -27,6 +27,7 @@ function createCase(index: number, overrides?: Partial<TeacherCaseItem>): Teache
     return {
         id: `case-${index}`,
         title: `Caso ${index}`,
+        available_from: null,
         deadline: "2026-12-01T00:00:00Z",
         status: "published",
         course_codes: ["GTD-GEME-01"],

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
@@ -23,6 +23,12 @@ vi.mock("./useTeacherDashboard", () => ({
 
 import { CasosActivosSection } from "./CasosActivosSection";
 
+const SPANISH_DEADLINE_FORMATTER = new Intl.DateTimeFormat("es-CO", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "America/Bogota",
+});
+
 function createCase(index: number, overrides?: Partial<TeacherCaseItem>): TeacherCaseItem {
     return {
         id: `case-${index}`,
@@ -34,6 +40,14 @@ function createCase(index: number, overrides?: Partial<TeacherCaseItem>): Teache
         days_remaining: 12,
         ...overrides,
     };
+}
+
+function formatDeadline(deadline: string): string {
+    return SPANISH_DEADLINE_FORMATTER.format(new Date(deadline));
+}
+
+function normalizeText(value: string): string {
+    return value.replace(/[\u00a0\u202f]/g, " ").replace(/\s+/g, " ").trim();
 }
 
 describe("CasosActivosSection", () => {
@@ -64,6 +78,13 @@ describe("CasosActivosSection", () => {
             "scope",
             "col",
         );
+        const expectedDeadline = normalizeText(formatDeadline("2026-12-01T00:00:00Z"));
+        expect(
+            screen.getAllByText((_, node) => {
+                const textContent = node?.textContent;
+                return textContent !== null && normalizeText(textContent) === expectedDeadline;
+            }).length,
+        ).toBeGreaterThan(0);
         expect(screen.getByText("Mostrando 3 de 3 casos activos")).toBeTruthy();
         expect(screen.getByText("—")).toBeTruthy();
         expect(document.getElementById("cases-section")).toBeTruthy();
@@ -126,7 +147,7 @@ describe("CasosActivosSection", () => {
                 cases: [
                     createCase(1, { days_remaining: null }),
                     createCase(2, { days_remaining: 0 }),
-                    createCase(3, { days_remaining: 4 }),
+                    createCase(3, { days_remaining: 1 }),
                     createCase(4, { days_remaining: 6 }),
                 ],
                 total: 4,
@@ -139,7 +160,7 @@ describe("CasosActivosSection", () => {
 
         const noDate = screen.getByText("Sin fecha");
         const today = screen.getByText("Hoy");
-        const urgent = screen.getByText("4 días");
+        const urgent = screen.getByText("1 día");
         const normal = screen.getByText("6 días");
 
         expect(noDate.className).toContain("text-slate-400");

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
@@ -200,7 +200,12 @@ describe("CasosActivosSection", () => {
     it("click 'Editar' renders DeadlineEditModal with correct props", () => {
         useTeacherCases.mockReturnValue({
             data: {
-                cases: [createCase(1, { available_from: "2026-06-01T10:00:00Z" })],
+                cases: [
+                    createCase(1, {
+                        available_from: "2026-06-01T15:00:00Z",
+                        deadline: "2026-12-02T04:59:00Z",
+                    }),
+                ],
                 total: 1,
             },
             isLoading: false,
@@ -213,7 +218,9 @@ describe("CasosActivosSection", () => {
 
         expect(screen.getByRole("heading", { name: "Editar fechas" })).toBeTruthy();
         const availableFromInput = screen.getByLabelText("Disponible desde") as HTMLInputElement;
+        const deadlineInput = screen.getByLabelText("Fecha límite") as HTMLInputElement;
         expect(availableFromInput.value).toBe("2026-06-01T10:00");
+        expect(deadlineInput.value).toBe("2026-12-01T23:59");
     });
 
     it("handles client-side pagination and button boundaries", () => {

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
@@ -82,7 +82,7 @@ describe("CasosActivosSection", () => {
         expect(
             screen.getAllByText((_, node) => {
                 const textContent = node?.textContent;
-                return textContent !== null && normalizeText(textContent) === expectedDeadline;
+                return typeof textContent === "string" && normalizeText(textContent) === expectedDeadline;
             }).length,
         ).toBeGreaterThan(0);
         expect(screen.getByText("Mostrando 3 de 3 casos activos")).toBeTruthy();

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.tsx
@@ -10,6 +10,11 @@ import { useTeacherCases } from "./useTeacherDashboard";
 const PAGE_SIZE = 10;
 const CASES_LOAD_ERROR_MSG = "Error al cargar casos. Intenta refrescar la página.";
 const EMPTY_CASES: TeacherCaseItem[] = [];
+const SPANISH_DEADLINE_FORMATTER = new Intl.DateTimeFormat("es-CO", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "America/Bogota",
+});
 
 function buildCasesSignature(cases: TeacherCaseItem[]): string {
     return JSON.stringify(
@@ -46,6 +51,19 @@ function DeadlineBadge({ days }: { days: number | null }) {
     );
 }
 
+function formatDeadline(deadline: string | null): string | null {
+    if (!deadline) {
+        return null;
+    }
+
+    const parsedDeadline = new Date(deadline);
+    if (Number.isNaN(parsedDeadline.getTime())) {
+        return deadline;
+    }
+
+    return SPANISH_DEADLINE_FORMATTER.format(parsedDeadline);
+}
+
 interface CasoRowProps {
     caso: TeacherCaseItem;
     onEdit: (caso: TeacherCaseItem) => void;
@@ -77,7 +95,16 @@ function CasoRow({ caso, onEdit }: CasoRowProps) {
                 )}
             </td>
             <td className="px-6 py-5 align-middle">
-                <DeadlineBadge days={caso.days_remaining} />
+                {caso.deadline ? (
+                    <div className="flex flex-col items-start gap-2">
+                        <span className="text-[13px] font-semibold text-slate-700">
+                            {formatDeadline(caso.deadline)}
+                        </span>
+                        <DeadlineBadge days={caso.days_remaining} />
+                    </div>
+                ) : (
+                    <DeadlineBadge days={caso.days_remaining} />
+                )}
             </td>
             <td className="px-6 py-5 align-middle">
                 <div className="flex items-center justify-end gap-2.5 opacity-90 transition-opacity group-hover:opacity-100">

--- a/frontend/src/features/teacher-dashboard/DeadlineEditModal.test.tsx
+++ b/frontend/src/features/teacher-dashboard/DeadlineEditModal.test.tsx
@@ -21,8 +21,8 @@ const onClose = vi.fn();
 
 const BASE_PROPS = {
     caseId: "case-1",
-    currentAvailableFrom: "2026-06-01T10:00:00Z",
-    currentDeadline: "2026-12-01T23:59:00Z",
+    currentAvailableFrom: "2026-06-01T15:00:00Z",
+    currentDeadline: "2026-12-02T04:59:00Z",
     onClose,
 };
 
@@ -95,7 +95,10 @@ describe("DeadlineEditModal", () => {
         expect(mutateFn).toHaveBeenCalledWith(
             {
                 assignmentId: "case-1",
-                body: { available_from: "2026-06-01T10:00", deadline: "2027-01-15T12:00" },
+                body: {
+                    available_from: "2026-06-01T15:00:00Z",
+                    deadline: "2027-01-15T17:00:00Z",
+                },
             },
             expect.objectContaining({
                 onSuccess: expect.any(Function),

--- a/frontend/src/features/teacher-dashboard/DeadlineEditModal.test.tsx
+++ b/frontend/src/features/teacher-dashboard/DeadlineEditModal.test.tsx
@@ -43,6 +43,23 @@ describe("DeadlineEditModal", () => {
         expect(deadlineInput.value).toBe("2026-12-01T23:59");
     });
 
+    it("keeps inputs empty when currentAvailableFrom and currentDeadline are null", () => {
+        renderWithProviders(
+            <DeadlineEditModal
+                caseId="case-2"
+                currentAvailableFrom={null}
+                currentDeadline={null}
+                onClose={onClose}
+            />,
+        );
+
+        const availableFromInput = screen.getByLabelText("Disponible desde") as HTMLInputElement;
+        const deadlineInput = screen.getByLabelText("Fecha límite") as HTMLInputElement;
+
+        expect(availableFromInput.value).toBe("");
+        expect(deadlineInput.value).toBe("");
+    });
+
     it("shows inline error and disables submit when deadline is not after available_from", () => {
         renderWithProviders(<DeadlineEditModal {...BASE_PROPS} />);
 

--- a/frontend/src/features/teacher-dashboard/DeadlineEditModal.tsx
+++ b/frontend/src/features/teacher-dashboard/DeadlineEditModal.tsx
@@ -5,6 +5,18 @@ import { useToast } from "@/shared/Toast";
 
 import { useUpdateDeadline } from "./useTeacherDashboard";
 
+const BOGOTA_TIME_ZONE = "America/Bogota";
+const BOGOTA_OFFSET = "-05:00";
+const BOGOTA_DATETIME_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+    timeZone: BOGOTA_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+});
+
 interface DeadlineEditModalProps {
     caseId: string;
     currentAvailableFrom: string | null;
@@ -12,9 +24,39 @@ interface DeadlineEditModalProps {
     onClose: () => void;
 }
 
+function extractPart(parts: Intl.DateTimeFormatPart[], type: Intl.DateTimeFormatPartTypes): string {
+    return parts.find((part) => part.type === type)?.value ?? "";
+}
+
 function toDatetimeLocalValue(iso: string | null): string {
     if (!iso) return "";
-    return iso.slice(0, 16);
+
+    const parsed = new Date(iso);
+    if (Number.isNaN(parsed.getTime())) {
+        return "";
+    }
+
+    const parts = BOGOTA_DATETIME_FORMATTER.formatToParts(parsed);
+    const year = extractPart(parts, "year");
+    const month = extractPart(parts, "month");
+    const day = extractPart(parts, "day");
+    const hour = extractPart(parts, "hour");
+    const minute = extractPart(parts, "minute");
+
+    return `${year}-${month}-${day}T${hour}:${minute}`;
+}
+
+function toBogotaUtcIsoValue(value: string): string | null {
+    if (!value) {
+        return null;
+    }
+
+    const parsed = new Date(`${value}:00${BOGOTA_OFFSET}`);
+    if (Number.isNaN(parsed.getTime())) {
+        return null;
+    }
+
+    return parsed.toISOString().replace(".000Z", "Z");
 }
 
 export function DeadlineEditModal({
@@ -43,8 +85,8 @@ export function DeadlineEditModal({
             {
                 assignmentId: caseId,
                 body: {
-                    available_from: availableFrom || null,
-                    deadline: deadline || null,
+                    available_from: toBogotaUtcIsoValue(availableFrom),
+                    deadline: toBogotaUtcIsoValue(deadline),
                 },
             },
             {


### PR DESCRIPTION
Closes #175.

## Summary
- keep generated assignments in `draft` after authoring completion instead of implicitly publishing them
- return canonical list titles and `available_from` from `GET /api/teacher/cases`
- align backend and frontend regression tests for dashboard edit prefill and teacher case flows
- mark `TODO-025` as resolved by this fix

## Validation
- `uv run --directory backend pytest -q tests/test_authoring_progress_resilience.py tests/test_phase1b_integration.py tests/test_issue90_teacher_cases.py tests/test_teacher_case_actions.py`
- `npm --prefix frontend run test -- --run`