### PR TITLE
fix: refresh teacher active course counters

### DIFF
--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -77,6 +77,45 @@ def _build_student_counts_subquery(context: TeacherContext):
     )
 
 
+def _resolve_reference_now(now: datetime | None = None) -> datetime:
+    return now if now is not None else datetime.now(timezone.utc)
+
+
+def _active_assignment_predicate(*, now: datetime):
+    return and_(
+        Assignment.status == "published",
+        or_(Assignment.deadline.is_(None), Assignment.deadline >= now),
+    )
+
+
+def _build_active_case_counts_subquery(
+    context: TeacherContext,
+    *,
+    now: datetime,
+):
+    return (
+        select(
+            Assignment.course_id.label("course_id"),
+            func.count(Assignment.id).label("active_cases_count"),
+        )
+        .select_from(Assignment)
+        .join(
+            Course,
+            and_(
+                Assignment.course_id == Course.id,
+                Course.university_id == context.university_id,
+                Course.teacher_membership_id == context.teacher_membership_id,
+            ),
+        )
+        .where(
+            Assignment.course_id.is_not(None),
+            _active_assignment_predicate(now=now),
+        )
+        .group_by(Assignment.course_id)
+        .subquery()
+    )
+
+
 def _serialize_syllabus_response(syllabus: Syllabus | None) -> TeacherSyllabusResponse | None:
     if syllabus is None:
         return None
@@ -102,9 +141,16 @@ def _serialize_syllabus_response(syllabus: Syllabus | None) -> TeacherSyllabusRe
     )
 
 
-def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCoursesResponse:
+def list_teacher_courses(
+    db: Session,
+    context: TeacherContext,
+    *,
+    now: datetime | None = None,
+) -> TeacherCoursesResponse:
     """Return the teacher-scoped course directory for the authenticated membership."""
+    reference_now = _resolve_reference_now(now)
     student_counts = _build_student_counts_subquery(context)
+    active_case_counts = _build_active_case_counts_subquery(context, now=reference_now)
 
     rows = (
         db.execute(
@@ -116,9 +162,11 @@ def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCourses
                 Course.academic_level.label("academic_level"),
                 Course.status.label("status"),
                 func.coalesce(student_counts.c.students_count, 0).label("students_count"),
+                func.coalesce(active_case_counts.c.active_cases_count, 0).label("active_cases_count"),
             )
             .select_from(Course)
             .outerjoin(student_counts, student_counts.c.course_id == Course.id)
+            .outerjoin(active_case_counts, active_case_counts.c.course_id == Course.id)
             .where(
                 Course.university_id == context.university_id,
                 Course.teacher_membership_id == context.teacher_membership_id,
@@ -138,7 +186,7 @@ def list_teacher_courses(db: Session, context: TeacherContext) -> TeacherCourses
             academic_level=row["academic_level"],
             status=row["status"],
             students_count=int(row["students_count"]),
-            active_cases_count=0,  # TODO(#90): populate once Assignment gains course_id FK
+            active_cases_count=int(row["active_cases_count"]),
         )
         for row in rows
     ]
@@ -150,9 +198,13 @@ def get_teacher_course_detail(
     db: Session,
     context: TeacherContext,
     course_id: str,
+    *,
+    now: datetime | None = None,
 ) -> TeacherCourseDetailResponse:
     """Return the teacher-owned composed course detail payload."""
+    reference_now = _resolve_reference_now(now)
     student_counts = _build_student_counts_subquery(context)
+    active_case_counts = _build_active_case_counts_subquery(context, now=reference_now)
 
     row = (
         db.execute(
@@ -165,12 +217,14 @@ def get_teacher_course_detail(
                 Course.status.label("status"),
                 Course.max_students.label("max_students"),
                 func.coalesce(student_counts.c.students_count, 0).label("students_count"),
+                func.coalesce(active_case_counts.c.active_cases_count, 0).label("active_cases_count"),
                 CourseAccessLink.id.label("access_link_id"),
                 CourseAccessLink.status.label("access_link_status"),
                 CourseAccessLink.created_at.label("access_link_created_at"),
             )
             .select_from(Course)
             .outerjoin(student_counts, student_counts.c.course_id == Course.id)
+            .outerjoin(active_case_counts, active_case_counts.c.course_id == Course.id)
             .outerjoin(
                 CourseAccessLink,
                 and_(
@@ -207,7 +261,7 @@ def get_teacher_course_detail(
             status=row["status"],
             max_students=int(row["max_students"]),
             students_count=int(row["students_count"]),
-            active_cases_count=0,
+            active_cases_count=int(row["active_cases_count"]),
         ),
         syllabus=_serialize_syllabus_response(syllabus),
         revision_metadata=TeacherSyllabusRevisionMetadataResponse(
@@ -393,8 +447,7 @@ def list_teacher_active_cases(
             )
             .where(
                 Assignment.teacher_id == legacy_user.id,
-                Assignment.status == "published",
-                or_(Assignment.deadline.is_(None), Assignment.deadline >= now),
+                _active_assignment_predicate(now=now),
             )
             .order_by(Assignment.deadline.asc(), Assignment.id.asc())
         )

--- a/backend/tests/test_issue88_teacher_courses.py
+++ b/backend/tests/test_issue88_teacher_courses.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import uuid
 
 from sqlalchemy import select
 
-from shared.models import Membership
+from shared.models import Assignment, Membership
 from shared.models import Syllabus, SyllabusRevision
 from shared.syllabus_schema import TeacherSyllabusPayload, derive_syllabus_grounding_context
 
@@ -195,6 +195,100 @@ def test_issue88_teacher_courses_returns_assigned_courses_with_student_counts(
             },
         ],
         "total": 2,
+    }
+
+
+def test_issue88_teacher_courses_counts_only_active_published_assignments_per_course(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000981"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-course-counts@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Counts",
+    )
+    course_a = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Analitica Avanzada",
+        code="AA-101",
+    )
+    course_b = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Business Strategy",
+        code="BS-202",
+    )
+    reference_now = datetime.now(timezone.utc)
+    db.add_all(
+        [
+            Assignment(
+                teacher_id=teacher_user_id,
+                course_id=course_a.id,
+                title="Course A Active Future",
+                status="published",
+                deadline=reference_now + timedelta(days=3),
+            ),
+            Assignment(
+                teacher_id=teacher_user_id,
+                course_id=course_a.id,
+                title="Course A Active Null Deadline",
+                status="published",
+                deadline=None,
+            ),
+            Assignment(
+                teacher_id=teacher_user_id,
+                course_id=course_a.id,
+                title="Course A Draft",
+                status="draft",
+                deadline=reference_now + timedelta(days=5),
+            ),
+            Assignment(
+                teacher_id=teacher_user_id,
+                course_id=course_a.id,
+                title="Course A Expired",
+                status="published",
+                deadline=reference_now - timedelta(minutes=1),
+            ),
+            Assignment(
+                teacher_id=teacher_user_id,
+                course_id=course_b.id,
+                title="Course B Active Future",
+                status="published",
+                deadline=reference_now + timedelta(days=1),
+            ),
+            Assignment(
+                teacher_id=teacher_user_id,
+                course_id=None,
+                title="Unassigned Published",
+                status="published",
+                deadline=reference_now + timedelta(days=2),
+            ),
+        ]
+    )
+    db.commit()
+
+    response = client.get(
+        "/api/teacher/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    counts_by_course_id = {
+        course["id"]: course["active_cases_count"]
+        for course in response.json()["courses"]
+    }
+    assert counts_by_course_id == {
+        course_a.id: 2,
+        course_b.id: 1,
     }
 
 
@@ -509,6 +603,79 @@ def test_issue88_teacher_course_detail_returns_composed_payload(
     }
     assert payload["syllabus"]["ai_grounding_context"]["metadata"]["syllabus_revision"] == 1
     assert raw_token not in response.text
+
+
+def test_issue88_teacher_course_detail_returns_active_case_count_for_owned_course(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000990"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-detail-count@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Detail Count",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Decision Science",
+        code="DS-330",
+    )
+    _insert_syllabus(
+        db,
+        course=course,
+        membership_id=teacher["membership"].id,
+        payload=_syllabus_payload(),
+    )
+    reference_now = datetime.now(timezone.utc)
+    db.add_all(
+        [
+            Assignment(
+                teacher_id=teacher_user_id,
+                course_id=course.id,
+                title="Published Future",
+                status="published",
+                deadline=reference_now + timedelta(days=4),
+            ),
+            Assignment(
+                teacher_id=teacher_user_id,
+                course_id=course.id,
+                title="Published No Deadline",
+                status="published",
+                deadline=None,
+            ),
+            Assignment(
+                teacher_id=teacher_user_id,
+                course_id=course.id,
+                title="Draft Not Counted",
+                status="draft",
+                deadline=reference_now + timedelta(days=4),
+            ),
+            Assignment(
+                teacher_id=teacher_user_id,
+                course_id=course.id,
+                title="Expired Not Counted",
+                status="published",
+                deadline=reference_now - timedelta(minutes=1),
+            ),
+        ]
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/courses/{course.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["course"]["active_cases_count"] == 2
 
 
 def test_issue88_teacher_course_detail_student_token_returns_403(

--- a/frontend/src/features/teacher-dashboard/useTeacherDashboard.test.tsx
+++ b/frontend/src/features/teacher-dashboard/useTeacherDashboard.test.tsx
@@ -131,7 +131,7 @@ describe("usePublishCase", () => {
         vi.clearAllMocks();
     });
 
-    it("onSuccess sets cache data and invalidates cases list", () => {
+    it("onSuccess sets cache data and invalidates cases and courses lists", () => {
         const setQueryData = vi.fn();
         const invalidateQueries = vi.fn().mockResolvedValue(undefined);
         vi.mocked(useQueryClient).mockReturnValue({ setQueryData, invalidateQueries } as never);
@@ -146,6 +146,7 @@ describe("usePublishCase", () => {
 
         expect(setQueryData).toHaveBeenCalledWith(queryKeys.teacher.case("case-abc"), { id: "case-abc" });
         expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.teacher.cases() });
+        expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.teacher.courses() });
     });
 
     it("mutationFn calls api.teacher.publishCase with the given assignmentId", async () => {
@@ -155,9 +156,6 @@ describe("usePublishCase", () => {
 
         usePublishCase();
 
-        // NOTE: onSuccess invalidates teacher.cases() only, NOT teacher.courses() —
-        // issue #160 spec included courses() invalidation but actual code does not.
-        // Testing real code behavior here.
         const options = vi.mocked(useMutation).mock.calls[0]?.[0] as unknown as {
             mutationFn: (assignmentId: string) => Promise<unknown>;
         };
@@ -185,7 +183,7 @@ describe("useUpdateDeadline", () => {
         vi.clearAllMocks();
     });
 
-    it("onSuccess sets cache data and invalidates cases list", () => {
+    it("onSuccess sets cache data and invalidates cases and courses lists", () => {
         const setQueryData = vi.fn();
         const invalidateQueries = vi.fn().mockResolvedValue(undefined);
         vi.mocked(useQueryClient).mockReturnValue({ setQueryData, invalidateQueries } as never);
@@ -200,6 +198,7 @@ describe("useUpdateDeadline", () => {
 
         expect(setQueryData).toHaveBeenCalledWith(queryKeys.teacher.case("case-abc"), { id: "case-abc" });
         expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.teacher.cases() });
+        expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.teacher.courses() });
     });
 
     it("mutationFn calls api.teacher.updateDeadline with assignmentId and body", async () => {

--- a/frontend/src/features/teacher-dashboard/useTeacherDashboard.ts
+++ b/frontend/src/features/teacher-dashboard/useTeacherDashboard.ts
@@ -41,6 +41,7 @@ export function usePublishCase() {
         onSuccess: (detail) => {
             queryClient.setQueryData(queryKeys.teacher.case(detail.id), detail);
             void queryClient.invalidateQueries({ queryKey: queryKeys.teacher.cases() });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.teacher.courses() });
         },
     });
 }
@@ -53,6 +54,7 @@ export function useUpdateDeadline() {
         onSuccess: (detail) => {
             queryClient.setQueryData(queryKeys.teacher.case(detail.id), detail);
             void queryClient.invalidateQueries({ queryKey: queryKeys.teacher.cases() });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.teacher.courses() });
         },
     });
 }


### PR DESCRIPTION
## Summary
- Populate ctive_cases_count for teacher course list and detail from published, non-expired assignments.
- Refresh teacher course counters after publish and deadline mutations by invalidating 	eacher.courses().
- Add backend and frontend regressions for the counter aggregation and cache invalidation paths.

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Eval Results
No prompt-related files changed — evals skipped.

## Test Plan
- [x] uv run --directory backend pytest -q tests/test_issue88_teacher_courses.py (26 passed)
- [x] uv run --directory backend mypy src
- [x] 
pm --prefix frontend run test -- --run src/features/teacher-dashboard/useTeacherDashboard.test.tsx (11 passed)
- [x] 
pm --prefix frontend run lint
- [x] 
pm --prefix frontend run build

## Notes
- This repository does not use root VERSION or CHANGELOG.md files, so no version bump or changelog update was applicable for this ship run.

🤖 Generated with GitHub Copilot