### PR TITLE
feat: support real multi-course destinations

### DIFF
--- a/backend/alembic/versions/b7c8d9e0f1a2_issue180_assignment_courses.py
+++ b/backend/alembic/versions/b7c8d9e0f1a2_issue180_assignment_courses.py
@@ -1,0 +1,67 @@
+"""Issue 180 assignment target-course links
+
+Revision ID: b7c8d9e0f1a2
+Revises: f2a3b4c5d6e7
+Create Date: 2026-04-22 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c8d9e0f1a2"
+down_revision: Union[str, Sequence[str], None] = "f2a3b4c5d6e7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "assignment_courses",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("assignment_id", sa.String(length=36), nullable=False),
+        sa.Column("course_id", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["assignment_id"], ["assignments.id"]),
+        sa.ForeignKeyConstraint(["course_id"], ["courses.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("assignment_id", "course_id", name="uix_assignment_course"),
+    )
+    op.create_index(
+        "ix_assignment_courses_assignment_id",
+        "assignment_courses",
+        ["assignment_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_assignment_courses_course_id",
+        "assignment_courses",
+        ["course_id"],
+        unique=False,
+    )
+
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+            INSERT INTO assignment_courses (id, assignment_id, course_id, created_at)
+            SELECT assignments.id || ':' || assignments.course_id,
+                   assignments.id,
+                   assignments.course_id,
+                   COALESCE(assignments.created_at, NOW())
+            FROM assignments
+            WHERE assignments.course_id IS NOT NULL
+            ON CONFLICT (assignment_id, course_id) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_assignment_courses_course_id", table_name="assignment_courses")
+    op.drop_index("ix_assignment_courses_assignment_id", table_name="assignment_courses")
+    op.drop_table("assignment_courses")

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -83,6 +83,7 @@ from shared.models import (
     AUTHORING_JOB_STATUS_PENDING,
     AUTHORING_JOB_STATUS_PROCESSING,
     Assignment,
+    AssignmentCourse,
     AuthoringJob,
     Course,
     CourseMembership,
@@ -265,6 +266,45 @@ def _normalize_available_from_input(raw_available_from: str | None) -> tuple[dat
         raw_available_from,
         invalid_detail="invalid_available_from",
     )
+
+
+def _dedupe_course_ids(course_ids: list[str]) -> list[str]:
+    deduped_course_ids: list[str] = []
+    seen_course_ids: set[str] = set()
+    for course_id in course_ids:
+        normalized_course_id = course_id.strip()
+        if not normalized_course_id or normalized_course_id in seen_course_ids:
+            continue
+        deduped_course_ids.append(normalized_course_id)
+        seen_course_ids.add(normalized_course_id)
+    return deduped_course_ids
+
+
+def _resolve_target_courses_or_404(db: Session, context, target_course_ids: list[str]) -> list[Course]:
+    deduped_course_ids = _dedupe_course_ids(target_course_ids)
+    if not deduped_course_ids:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="target_courses_required",
+        )
+
+    target_courses = db.scalars(
+        select(Course).where(
+            Course.id.in_(deduped_course_ids),
+            Course.university_id == context.university_id,
+            Course.teacher_membership_id == context.teacher_membership_id,
+        )
+    ).all()
+    target_courses_by_id = {course.id: course for course in target_courses}
+    missing_course_ids = [course_id for course_id in deduped_course_ids if course_id not in target_courses_by_id]
+    if missing_course_ids:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="course_not_found")
+
+    return [target_courses_by_id[course_id] for course_id in deduped_course_ids]
+
+
+def _course_target_group_label(course: Course) -> str:
+    return f"{course.title} ({course.code})" if course.code else course.title
 
 
 def get_legacy_teacher_or_500(db: Session, actor: CurrentActor) -> User:
@@ -573,6 +613,7 @@ class IntakeRequest(BaseModel):
     guiding_question: str = ""
     topic_unit: str = ""
     target_groups: list[str] = []
+    target_course_ids: list[str] = []
     eda_depth: str | None = None
     include_python_code: bool = False
     suggested_techniques: list[str] = []
@@ -609,6 +650,13 @@ def create_authoring_job(
         context = resolve_teacher_context(actor)
         teacher = get_legacy_teacher_or_500(db, actor)
         owned_course = get_teacher_owned_course_with_syllabus(db, context, req.course_id, lock=True)
+        target_course_ids = req.target_course_ids or [req.course_id]
+        target_courses = _resolve_target_courses_or_404(db, context, target_course_ids)
+        target_groups = (
+            [_course_target_group_label(course) for course in target_courses]
+            if req.target_course_ids
+            else list(req.target_groups)
+        )
         SyllabusGroundingContext.model_validate(owned_course.syllabus.ai_grounding_context)
         available_from, normalized_available_from = _normalize_available_from_input(req.available_from)
         deadline, normalized_due_at = _normalize_deadline_input(req.due_at)
@@ -632,6 +680,7 @@ def create_authoring_job(
             status="draft",
             available_from=available_from,
             deadline=deadline,
+            assignment_courses=[AssignmentCourse(course_id=course.id) for course in target_courses],
         )
         db.add(assignment)
         db.commit()
@@ -657,7 +706,8 @@ def create_authoring_job(
                 "escenario": req.scenario_description,
                 "pregunta_guia": req.guiding_question,
                 "topicUnit": unit_title,
-                "targetGroups": req.target_groups,
+                "targetCourseIds": [course.id for course in target_courses],
+                "targetGroups": target_groups,
                 "edaDepth": req.eda_depth,
                 "includePythonCode": req.include_python_code,
                 "algoritmos": req.suggested_techniques,

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -204,6 +204,7 @@ class Course(Base):
     course_memberships: Mapped[list["CourseMembership"]] = relationship(back_populates="course")
     syllabus: Mapped["Syllabus | None"] = relationship(back_populates="course", uselist=False)
     assignments: Mapped[list["Assignment"]] = relationship(back_populates="course")
+    assignment_courses: Mapped[list["AssignmentCourse"]] = relationship(back_populates="course")
 
 
 class Invite(Base):
@@ -348,8 +349,32 @@ class Assignment(Base):
 
     teacher: Mapped["User"] = relationship(back_populates="assignments")
     course: Mapped["Course | None"] = relationship(back_populates="assignments")
+    assignment_courses: Mapped[list["AssignmentCourse"]] = relationship(
+        back_populates="assignment",
+        cascade="all, delete-orphan",
+    )
     authoring_jobs: Mapped[list["AuthoringJob"]] = relationship(back_populates="assignment")
     artifacts: Mapped[list["ArtifactManifest"]] = relationship(back_populates="assignment")
+
+
+class AssignmentCourse(Base):
+    """Links a teacher assignment to every target course that receives it."""
+
+    __tablename__ = "assignment_courses"
+    __table_args__ = (
+        UniqueConstraint("assignment_id", "course_id", name="uix_assignment_course"),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=generate_uuid)
+    assignment_id: Mapped[str] = mapped_column(String(36), ForeignKey("assignments.id"), nullable=False, index=True)
+    course_id: Mapped[str] = mapped_column(Text, ForeignKey("courses.id"), nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    assignment: Mapped["Assignment"] = relationship(back_populates="assignment_courses")
+    course: Mapped["Course"] = relationship(back_populates="assignment_courses")
 
 
 class Syllabus(Base):

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -7,11 +7,11 @@ from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, exists, func, or_, select
 from sqlalchemy.orm import Session, joinedload, load_only
 
 from shared.auth import CurrentActor, ensure_legacy_teacher_bridge
-from shared.models import Assignment, AuthoringJob, Course, CourseAccessLink, CourseMembership, Membership, Syllabus
+from shared.models import Assignment, AssignmentCourse, AuthoringJob, Course, CourseAccessLink, CourseMembership, Membership, Syllabus
 from shared.syllabus_schema import (
     TeacherCourseConfigurationResponse,
     TeacherCourseDetailResponse,
@@ -93,27 +93,64 @@ def _build_active_case_counts_subquery(
     *,
     now: datetime,
 ):
+    assignment_target_courses = _build_assignment_target_courses_subquery()
     return (
         select(
-            Assignment.course_id.label("course_id"),
-            func.count(Assignment.id).label("active_cases_count"),
+            assignment_target_courses.c.course_id.label("course_id"),
+            func.count(func.distinct(Assignment.id)).label("active_cases_count"),
         )
-        .select_from(Assignment)
+        .select_from(assignment_target_courses)
+        .join(Assignment, assignment_target_courses.c.assignment_id == Assignment.id)
         .join(
             Course,
             and_(
-                Assignment.course_id == Course.id,
+                assignment_target_courses.c.course_id == Course.id,
                 Course.university_id == context.university_id,
                 Course.teacher_membership_id == context.teacher_membership_id,
             ),
         )
         .where(
-            Assignment.course_id.is_not(None),
             _active_assignment_predicate(now=now),
         )
-        .group_by(Assignment.course_id)
+        .group_by(assignment_target_courses.c.course_id)
         .subquery()
     )
+
+
+def _build_assignment_target_courses_subquery():
+    persisted_targets = select(
+        AssignmentCourse.assignment_id.label("assignment_id"),
+        AssignmentCourse.course_id.label("course_id"),
+    )
+    legacy_targets = (
+        select(
+            Assignment.id.label("assignment_id"),
+            Assignment.course_id.label("course_id"),
+        )
+        .where(
+            Assignment.course_id.is_not(None),
+            ~exists(select(1).where(AssignmentCourse.assignment_id == Assignment.id)),
+        )
+    )
+    return persisted_targets.union_all(legacy_targets).subquery()
+
+
+def _assignment_course_codes(assignment: Assignment) -> list[str]:
+    if assignment.assignment_courses:
+        course_codes = sorted(
+            {
+                link.course.code
+                for link in assignment.assignment_courses
+                if link.course is not None and link.course.code
+            }
+        )
+        if course_codes:
+            return course_codes
+
+    if assignment.course is not None and assignment.course.code:
+        return [assignment.course.code]
+
+    return []
 
 
 def _serialize_syllabus_response(syllabus: Syllabus | None) -> TeacherSyllabusResponse | None:
@@ -444,6 +481,9 @@ def list_teacher_active_cases(
                     Assignment.status,
                 ),
                 joinedload(Assignment.course).load_only(Course.code),
+                joinedload(Assignment.assignment_courses)
+                .joinedload(AssignmentCourse.course)
+                .load_only(Course.code),
             )
             .where(
                 Assignment.teacher_id == legacy_user.id,
@@ -451,6 +491,7 @@ def list_teacher_active_cases(
             )
             .order_by(Assignment.deadline.asc(), Assignment.id.asc())
         )
+        .unique()
         .scalars()
         .all()
     )
@@ -483,7 +524,7 @@ def list_teacher_active_cases(
         canonical_output = assignment.canonical_output if isinstance(assignment.canonical_output, dict) else {}
         canonical_title = canonical_output.get("title")
         title = canonical_title if isinstance(canonical_title, str) and canonical_title.strip() else assignment.title
-        course_codes = [assignment.course.code] if assignment.course and assignment.course.code else []
+        course_codes = _assignment_course_codes(assignment)
         available_from, deadline = _resolve_schedule_values_from_payload(
             available_from=assignment.available_from,
             deadline=assignment.deadline,

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -8,11 +8,11 @@ from zoneinfo import ZoneInfo
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from shared.auth import CurrentActor, require_current_actor_password_ready
 from shared.database import get_db
-from shared.models import Assignment
+from shared.models import Assignment, AssignmentCourse, Course
 from shared.syllabus_schema import TeacherCourseDetailResponse, TeacherSyllabusSaveRequest
 from shared.teacher_context import TeacherContext, require_teacher_context
 from shared.teacher_reads import (
@@ -50,6 +50,8 @@ class TeacherCaseDetailResponse(BaseModel):
     available_from: datetime | None
     deadline: datetime | None
     course_id: str | None
+    target_course_ids: list[str] = []
+    course_codes: list[str] = []
     canonical_output: dict[str, Any] | None
 
 
@@ -128,9 +130,29 @@ def get_teacher_cases(
 # Internal helpers — not endpoints
 # ---------------------------------------------------------------------------
 
+def _assignment_target_course_metadata(assignment: Assignment) -> tuple[list[str], list[str]]:
+    if assignment.assignment_courses:
+        course_pairs = sorted(
+            {
+                (link.course_id, link.course.code if link.course is not None else None)
+                for link in assignment.assignment_courses
+                if link.course_id
+            },
+            key=lambda pair: ((pair[1] or ""), pair[0]),
+        )
+        course_ids = [course_id for course_id, _code in course_pairs]
+        course_codes = [code for _course_id, code in course_pairs if code]
+        if course_ids:
+            return course_ids, course_codes
+
+    course_ids = [assignment.course_id] if assignment.course_id else []
+    course_codes = [assignment.course.code] if assignment.course is not None and assignment.course.code else []
+    return course_ids, course_codes
+
 def _to_case_detail(assignment: Assignment) -> TeacherCaseDetailResponse:
     """Build a TeacherCaseDetailResponse from an Assignment ORM instance."""
     available_from, deadline = resolve_assignment_schedule_values(assignment)
+    target_course_ids, course_codes = _assignment_target_course_metadata(assignment)
     return TeacherCaseDetailResponse(
         id=assignment.id,
         title=assignment.title,
@@ -138,6 +160,8 @@ def _to_case_detail(assignment: Assignment) -> TeacherCaseDetailResponse:
         available_from=available_from,
         deadline=deadline,
         course_id=assignment.course_id,
+        target_course_ids=target_course_ids,
+        course_codes=course_codes,
         canonical_output=assignment.canonical_output,
     )
 
@@ -148,11 +172,20 @@ def _get_owned_assignment_or_404(
     actor: CurrentActor,
 ) -> Assignment:
     """Return the assignment owned by this actor or raise 404."""
-    stmt = select(Assignment).where(
-        Assignment.id == assignment_id,
-        Assignment.teacher_id == actor.auth_user_id,
+    stmt = (
+        select(Assignment)
+        .options(
+            joinedload(Assignment.course).load_only(Course.code),
+            joinedload(Assignment.assignment_courses)
+            .joinedload(AssignmentCourse.course)
+            .load_only(Course.code),
+        )
+        .where(
+            Assignment.id == assignment_id,
+            Assignment.teacher_id == actor.auth_user_id,
+        )
     )
-    assignment = db.scalar(stmt)
+    assignment = db.execute(stmt).unique().scalar_one_or_none()
     if assignment is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/tests/test_issue139_authoring_grounding.py
+++ b/backend/tests/test_issue139_authoring_grounding.py
@@ -145,6 +145,57 @@ def test_issue139_authoring_intake_rejects_client_grounding_injection(
     assert any(item.get("loc") == ["body", "ai_grounding_context"] for item in detail)
 
 
+def test_issue180_authoring_intake_persists_real_target_courses(
+    client,
+    db,
+    seed_identity,
+    seed_course_with_syllabus,
+    auth_headers_factory,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-multi-course@example.edu"
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    anchor_course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Anchor Course",
+    )
+    secondary_course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Secondary Course",
+    )
+    anchor_course.code = "ANCH-101"
+    secondary_course.code = "SEC-202"
+    db.flush()
+    db.commit()
+
+    payload = _build_authoring_payload(course_id=anchor_course.id)
+    payload["target_course_ids"] = [anchor_course.id, secondary_course.id]
+    payload["target_groups"] = ["Legacy Label"]
+
+    with patch("fastapi.BackgroundTasks.add_task"):
+        response = client.post(
+            "/api/authoring/jobs",
+            json=payload,
+            headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+        )
+
+    assert response.status_code == 202, response.text
+    assignment = db.query(Assignment).order_by(Assignment.created_at.desc()).first()
+    assert assignment is not None
+    assert assignment.course_id == anchor_course.id
+    assert {link.course_id for link in assignment.assignment_courses} == {anchor_course.id, secondary_course.id}
+
+    task_payload = dict(assignment.authoring_jobs[0].task_payload or {})
+    assert task_payload["course_id"] == anchor_course.id
+    assert task_payload["targetCourseIds"] == [anchor_course.id, secondary_course.id]
+    assert task_payload["targetGroups"] == [
+        "Anchor Course (ANCH-101)",
+        "Secondary Course (SEC-202)",
+    ]
+
+
 def test_issue139_authoring_runtime_fails_closed_on_invalid_persisted_selection(
     db,
     seed_identity,

--- a/backend/tests/test_issue88_teacher_courses.py
+++ b/backend/tests/test_issue88_teacher_courses.py
@@ -6,7 +6,7 @@ import uuid
 
 from sqlalchemy import select
 
-from shared.models import Assignment, Membership
+from shared.models import Assignment, AssignmentCourse, Membership
 from shared.models import Syllabus, SyllabusRevision
 from shared.syllabus_schema import TeacherSyllabusPayload, derive_syllabus_grounding_context
 
@@ -289,6 +289,67 @@ def test_issue88_teacher_courses_counts_only_active_published_assignments_per_co
     assert counts_by_course_id == {
         course_a.id: 2,
         course_b.id: 1,
+    }
+
+
+def test_issue180_teacher_courses_counts_multi_course_targets(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000180"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-multi-target-counts@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Multi Target Counts",
+    )
+    anchor_course = seed_course(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Anchor Course",
+        code="ANCH-101",
+    )
+    secondary_course = seed_course(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Secondary Course",
+        code="SEC-202",
+    )
+
+    db.add(
+        Assignment(
+            teacher_id=teacher_user_id,
+            course_id=anchor_course.id,
+            title="Multi Target Published",
+            status="published",
+            deadline=datetime.now(timezone.utc) + timedelta(days=1),
+            assignment_courses=[
+                AssignmentCourse(course_id=anchor_course.id),
+                AssignmentCourse(course_id=secondary_course.id),
+            ],
+        )
+    )
+    db.commit()
+
+    response = client.get(
+        "/api/teacher/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    counts_by_course_id = {
+        course["id"]: course["active_cases_count"]
+        for course in response.json()["courses"]
+    }
+    assert counts_by_course_id == {
+        anchor_course.id: 1,
+        secondary_course.id: 1,
     }
 
 

--- a/backend/tests/test_issue90_teacher_cases.py
+++ b/backend/tests/test_issue90_teacher_cases.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 import uuid
 
-from shared.models import Assignment, AuthoringJob, Membership
+from shared.models import Assignment, AssignmentCourse, AuthoringJob, Membership
 
 
 def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
@@ -272,6 +272,106 @@ def test_issue90_teacher_cases_returns_only_future_published_assignments_sorted(
     assert body["cases"][0]["course_codes"] == ["OPS-101"]
     assert body["cases"][1]["course_codes"] == ["DS-202"]
     assert body["cases"][2]["course_codes"] == []
+
+
+def test_issue180_teacher_cases_returns_all_target_course_codes(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+    seed_course,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-target-codes@example.edu"
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    fixed_now = datetime(2026, 4, 22, 20, 30, tzinfo=timezone.utc)
+    anchor_course = seed_course(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Anchor Course",
+        code="ANCH-101",
+    )
+    secondary_course = seed_course(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Secondary Course",
+        code="SEC-202",
+    )
+
+    assignment = Assignment(
+        teacher_id=teacher_id,
+        course_id=anchor_course.id,
+        title="Multi-course Case",
+        status="published",
+        available_from=fixed_now + timedelta(hours=1),
+        deadline=fixed_now + timedelta(days=1),
+        assignment_courses=[
+            AssignmentCourse(course_id=anchor_course.id),
+            AssignmentCourse(course_id=secondary_course.id),
+        ],
+    )
+    db.add(assignment)
+    db.commit()
+
+    with patch("shared.teacher_router.datetime") as mock_datetime:
+        mock_datetime.now.return_value = fixed_now
+        response = client.get(
+            "/api/teacher/cases",
+            headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 1
+    assert body["cases"][0]["course_codes"] == ["ANCH-101", "SEC-202"]
+
+
+def test_issue180_teacher_case_detail_returns_all_target_courses(
+    client,
+    db,
+    seed_identity,
+    auth_headers_factory,
+    seed_course,
+) -> None:
+    teacher_id = str(uuid.uuid4())
+    teacher_email = "teacher-case-detail-targets@example.edu"
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    anchor_course = seed_course(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Anchor Course",
+        code="ANCH-101",
+    )
+    secondary_course = seed_course(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Secondary Course",
+        code="SEC-203",
+    )
+
+    assignment = Assignment(
+        teacher_id=teacher_id,
+        course_id=anchor_course.id,
+        title="Detailed Multi-course Case",
+        status="published",
+        assignment_courses=[
+            AssignmentCourse(course_id=anchor_course.id),
+            AssignmentCourse(course_id=secondary_course.id),
+        ],
+    )
+    db.add(assignment)
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["course_id"] == anchor_course.id
+    assert body["target_course_ids"] == [anchor_course.id, secondary_course.id]
+    assert body["course_codes"] == ["ANCH-101", "SEC-203"]
 
 
 def test_issue90_teacher_cases_falls_back_to_assignment_title_when_canonical_title_missing(

--- a/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
@@ -34,7 +34,7 @@ async function selectOption(
 async function enableSuggestions(user: ReturnType<typeof userEvent.setup>) {
     await selectOption(user, /asignatura/i, /gerencia/i);
     await user.click(screen.getByLabelText(/grupos destino/i));
-    await user.click(await screen.findByRole("button", { name: "Gerencia de Operaciones (GO-101)" }));
+    await user.click(await screen.findByRole("button", { name: "Agregar grupo Gerencia de Operaciones (GO-101)" }));
     await selectOption(user, /m[oó]dulo del syllabus/i, /fundamentos/i);
 }
 
@@ -420,7 +420,7 @@ describe("GroupsCombobox (within AuthoringForm)", () => {
 
         await user.click(screen.getByLabelText(/grupos destino/i));
 
-        expect(await screen.findByRole("button", { name: "Gerencia de Operaciones (GO-101)" })).toBeInTheDocument();
+        expect(await screen.findByRole("button", { name: "Agregar grupo Gerencia de Operaciones (GO-101)" })).toBeInTheDocument();
     });
 
     it("shows empty state when teacher has no courses", async () => {
@@ -441,7 +441,7 @@ describe("GroupsCombobox (within AuthoringForm)", () => {
         renderWithProviders(<AuthoringForm onSubmit={onSubmit} />);
 
         await user.click(screen.getByLabelText(/grupos destino/i));
-        await user.click(await screen.findByRole("button", { name: "Gerencia de Operaciones (GO-101)" }));
+        await user.click(await screen.findByRole("button", { name: "Agregar grupo Gerencia de Operaciones (GO-101)" }));
 
         expect(screen.getByText("Gerencia de Operaciones (GO-101)")).toBeInTheDocument();
         expect(onSubmit).not.toHaveBeenCalled();
@@ -452,17 +452,16 @@ describe("GroupsCombobox (within AuthoringForm)", () => {
         renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
 
         await user.click(screen.getByLabelText(/grupos destino/i));
-        await user.click(await screen.findByRole("button", { name: "Gerencia de Operaciones (GO-101)" }));
+        await user.click(await screen.findByRole("button", { name: "Agregar grupo Gerencia de Operaciones (GO-101)" }));
 
         // Trigger reflects the selection
         expect(screen.getByText(/1 grupo seleccionado/i)).toBeInTheDocument();
 
         // Re-open: the course now appears in the selected section only, not as an addable option
         await user.click(screen.getByLabelText(/grupos destino/i));
-        // Available section is empty; selected section shows the course with checkmark
-        const allMatchingButtons = screen.getAllByRole("button", { name: "Gerencia de Operaciones (GO-101)" });
-        // One inside popover (selected item, removable), one chip below
-        expect(allMatchingButtons).toHaveLength(2);
+        expect(screen.queryByRole("button", { name: "Agregar grupo Gerencia de Operaciones (GO-101)" })).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Quitar selección Gerencia de Operaciones (GO-101)" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Quitar grupo Gerencia de Operaciones (GO-101)" })).toBeInTheDocument();
     });
 
     it("clicking the chip removes the selection", async () => {
@@ -471,10 +470,10 @@ describe("GroupsCombobox (within AuthoringForm)", () => {
 
         // Add the course
         await user.click(screen.getByLabelText(/grupos destino/i));
-        await user.click(await screen.findByRole("button", { name: "Gerencia de Operaciones (GO-101)" }));
+        await user.click(await screen.findByRole("button", { name: "Agregar grupo Gerencia de Operaciones (GO-101)" }));
 
         // Chip should now be visible (popover closed after selection)
-        const chip = screen.getByRole("button", { name: "Gerencia de Operaciones (GO-101)" });
+        const chip = screen.getByRole("button", { name: "Quitar grupo Gerencia de Operaciones (GO-101)" });
         await user.click(chip);
 
         expect(screen.queryByText("Gerencia de Operaciones (GO-101)")).not.toBeInTheDocument();
@@ -795,7 +794,7 @@ describe("Task 3 — sessionStorage persistence", () => {
                 targetGroups: [],
                 studentProfile: "business",
                 industry: "fintech",
-                caseType: "harvard_only",
+                caseType: "harvard_with_eda",
                 notebookToggle: false,
                 suggestedTechniques: [],
                 algoInput: "",
@@ -808,6 +807,7 @@ describe("Task 3 — sessionStorage persistence", () => {
 
         expect(await screen.findByDisplayValue("Escenario restaurado desde storage")).toBeInTheDocument();
         expect(screen.getByDisplayValue("Pregunta restaurada desde storage")).toBeInTheDocument();
+        expect(screen.getByRole("radio", { name: /caso .*an[aá]lisis de datos/i })).toHaveAttribute("aria-checked", "true");
     });
 
     it("writes form state to sessionStorage within 1 second of a field change", async () => {

--- a/frontend/src/features/teacher-authoring/AuthoringForm.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useCallback, useEffect, useRef, type KeyboardEvent, type FormEvent } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import type { CaseFormData, CaseType, EDADepth, StudentProfile, SuggestRequest } from "@/shared/adam-types";
+import type { CaseFormData, CaseType, EDADepth, StudentProfile, SuggestRequest, TeacherCourseItem } from "@/shared/adam-types";
 import {
     Select, SelectContent, SelectGroup,
     SelectItem, SelectTrigger, SelectValue,
@@ -25,6 +25,24 @@ interface Props {
     onCancelEdit?: () => void;
 }
 
+function formatCourseTargetGroupLabel(course: Pick<TeacherCourseItem, "title" | "code">): string {
+    return course.code ? `${course.title} (${course.code})` : course.title;
+}
+
+function resolveCourseIdsFromTargetGroupLabels(courses: TeacherCourseItem[], labels: string[]): string[] {
+    const normalizedLabels = new Set(
+        labels
+            .map((label) => label.trim().toLowerCase())
+            .filter((label) => label.length > 0),
+    );
+
+    return courses
+        .filter((course) => normalizedLabels.has(formatCourseTargetGroupLabel(course).trim().toLowerCase()))
+        .map((course) => course.id);
+}
+
+    const EMPTY_TEACHER_COURSES: TeacherCourseItem[] = [];
+
 export function AuthoringForm({
     initialData,
     onSubmit,
@@ -35,7 +53,10 @@ export function AuthoringForm({
     const [subject, setSubject] = useState(initialData?.courseId ?? "");
     const [syllabusModule, setSyllabusModule] = useState(initialData?.syllabusModule ?? "");
     const [topicUnit, setTopicUnit] = useState(initialData?.topicUnit ?? "");
-    const [targetGroups, setTargetGroups] = useState<string[]>(initialData?.targetGroups ?? []);
+    const restoredTargetGroupLabelsRef = useRef<string[]>(
+        initialData?.targetCourseIds?.length ? [] : (initialData?.targetGroups ?? []),
+    );
+    const [targetCourseIds, setTargetCourseIds] = useState<string[]>(initialData?.targetCourseIds ?? []);
     const [studentProfile, setStudentProfile] = useState<StudentProfile>(initialData?.studentProfile ?? "business");
 
     const initialIndustry = INDUSTRIAS_OPTIONS.find((o) => o.label === initialData?.industry)?.value ?? "fintech";
@@ -56,7 +77,6 @@ export function AuthoringForm({
     // ── Estados IA ──
     const [formAlertError, setFormAlertError] = useState<string | null>(null);
     const [areTechniquesStale, setAreTechniquesStale] = useState(false);
-
     // ── Validation ──
     const [errors, setErrors] = useState<Record<string, boolean>>({});
 
@@ -72,10 +92,13 @@ export function AuthoringForm({
             if (typeof saved.subject === "string") setSubject(saved.subject);
             if (typeof saved.syllabusModule === "string") setSyllabusModule(saved.syllabusModule);
             if (typeof saved.topicUnit === "string") setTopicUnit(saved.topicUnit);
-            if (Array.isArray(saved.targetGroups)) setTargetGroups(saved.targetGroups as string[]);
+            if (Array.isArray(saved.targetCourseIds)) {
+                setTargetCourseIds(saved.targetCourseIds.filter((value): value is string => typeof value === "string"));
+            } else if (Array.isArray(saved.targetGroups)) {
+                restoredTargetGroupLabelsRef.current = saved.targetGroups.filter((value): value is string => typeof value === "string");
+            }
             if (saved.studentProfile === "business" || saved.studentProfile === "ml_ds") setStudentProfile(saved.studentProfile);
             if (typeof saved.industry === "string") setIndustry(saved.industry);
-            if (saved.caseType === "harvard_only" || saved.caseType === "harvard_with_eda") setCaseType(saved.caseType as CaseType);
             if (typeof saved.notebookToggle === "boolean") setNotebookToggle(saved.notebookToggle);
             if (typeof saved.scenarioDescription === "string") setScenarioDescription(saved.scenarioDescription);
             if (typeof saved.guidingQuestion === "string") setGuidingQuestion(saved.guidingQuestion);
@@ -101,19 +124,39 @@ export function AuthoringForm({
     });
 
     // ── Derived data ──
-    const teacherCourses = teacherCoursesQuery.data?.courses ?? [];
+    const teacherCourses = teacherCoursesQuery.data?.courses ?? EMPTY_TEACHER_COURSES;
+    const teacherCoursesById = new Map(teacherCourses.map((course) => [course.id, course]));
     const selectedCourse = teacherCourses.find((course) => course.id === selectedCourseId);
     const academicLevel = selectedCourse?.academic_level ?? "";
     const modules = selectedCourseDetailQuery.data?.syllabus?.modules ?? [];
     const selectedModule = modules.find((module) => module.module_id === syllabusModule);
     const units = selectedModule?.units ?? [];
     const selectedUnit = units.find((unit) => unit.unit_id === topicUnit);
+    const targetGroups = targetCourseIds
+        .map((courseId) => teacherCoursesById.get(courseId))
+        .filter((course): course is TeacherCourseItem => Boolean(course))
+        .map((course) => formatCourseTargetGroupLabel(course));
     const selectedIndustry = INDUSTRIAS_OPTIONS.find((option) => option.value === industry);
     const availableProfiles = caseType === "harvard_only"
         ? STUDENT_PROFILES.filter((p) => p.value !== "ml_ds")
         : STUDENT_PROFILES;
     const suggestionGenerationRef = useRef({ scenario: 0, techniques: 0 });
     const hasPersistedSyllabus = !!selectedCourseDetailQuery.data?.syllabus;
+
+    useEffect(() => {
+        if (targetCourseIds.length > 0 || restoredTargetGroupLabelsRef.current.length === 0 || teacherCourses.length === 0) {
+            return;
+        }
+
+        const resolvedTargetCourseIds = resolveCourseIdsFromTargetGroupLabels(
+            teacherCourses,
+            restoredTargetGroupLabelsRef.current,
+        );
+        if (resolvedTargetCourseIds.length > 0) {
+            setTargetCourseIds(resolvedTargetCourseIds);
+        }
+        restoredTargetGroupLabelsRef.current = [];
+    }, [targetCourseIds.length, teacherCourses]);
 
     // ── EDA depth + notebook toggle logic ──
     // business + harvard_with_eda → edaDepth="charts_plus_explanation", no UI
@@ -142,7 +185,7 @@ export function AuthoringForm({
         persistTimerRef.current = setTimeout(() => {
             try {
                 sessionStorage.setItem(FORM_STATE_SESSION_KEY, JSON.stringify({
-                    subject, syllabusModule, topicUnit, targetGroups, studentProfile,
+                    subject, syllabusModule, topicUnit, targetGroups, targetCourseIds, studentProfile,
                     industry, caseType, notebookToggle,
                     scenarioDescription, guidingQuestion, suggestedTechniques, algoInput,
                     availableFrom, dueAt,
@@ -154,7 +197,7 @@ export function AuthoringForm({
         return () => {
             if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
         };
-    }, [subject, syllabusModule, topicUnit, targetGroups, studentProfile, industry, caseType,
+    }, [subject, syllabusModule, topicUnit, targetGroups, targetCourseIds, studentProfile, industry, caseType,
         notebookToggle, scenarioDescription, guidingQuestion, suggestedTechniques, algoInput,
         availableFrom, dueAt]);
 
@@ -172,6 +215,7 @@ export function AuthoringForm({
     // ── Validation CanSuggest ──
     const canSuggest =
         !!subject &&
+        targetCourseIds.length > 0 &&
         targetGroups.length > 0 &&
         !!syllabusModule &&
         !!industry;
@@ -183,7 +227,7 @@ export function AuthoringForm({
         !!subject &&
         !!syllabusModule &&
         hasValidTopicUnit &&
-        targetGroups.length > 0 &&
+        targetCourseIds.length > 0 &&
         !!industry &&
         !!scenarioDescription.trim() &&
         !!guidingQuestion.trim() &&
@@ -300,7 +344,7 @@ export function AuthoringForm({
         setSubject(id);
         setSyllabusModule("");
         setTopicUnit("");
-        setTargetGroups([]);
+        setTargetCourseIds([]);
         setErrors((prev) => ({ ...prev, asignatura: false, modulo: false, topicUnit: false }));
     };
 
@@ -318,17 +362,17 @@ export function AuthoringForm({
     };
 
     const addTargetGroup = useCallback((value: string) => {
-        const trimmed = value.trim();
-        if (!trimmed) return;
-        if (targetGroups.some((group) => group.toLowerCase() === trimmed.toLowerCase())) return;
+        const normalizedCourseId = value.trim();
+        if (!normalizedCourseId) return;
+        if (targetCourseIds.includes(normalizedCourseId)) return;
         invalidateSuggestionResponses();
-        setTargetGroups((prev) => [...prev, trimmed]);
+        setTargetCourseIds((prev) => [...prev, normalizedCourseId]);
         setErrors((prev) => ({ ...prev, targetGroups: false }));
-    }, [invalidateSuggestionResponses, targetGroups]);
+    }, [invalidateSuggestionResponses, targetCourseIds]);
 
     const removeTargetGroup = useCallback((group: string) => {
         invalidateSuggestionResponses();
-        setTargetGroups((prev) => prev.filter((value) => value !== group));
+        setTargetCourseIds((prev) => prev.filter((value) => value !== group));
     }, [invalidateSuggestionResponses]);
 
     // ── Chips Orchestration ──
@@ -405,7 +449,7 @@ export function AuthoringForm({
             if (!subject) newErrors.asignatura = true;
             if (!syllabusModule) newErrors.modulo = true;
             if (units.length > 0 && !topicUnit) newErrors.topicUnit = true;
-            if (targetGroups.length === 0) newErrors.targetGroups = true;
+            if (targetCourseIds.length === 0) newErrors.targetGroups = true;
             if (!industry) newErrors.industria = true;
             if (!scenarioDescription.trim()) newErrors.scenario = true;
             if (!guidingQuestion.trim()) newErrors.guidingQuestion = true;
@@ -439,6 +483,7 @@ export function AuthoringForm({
                 subject: selectedCourse?.title ?? "",
                 academicLevel,
                 targetGroups,
+                targetCourseIds,
                 syllabusModule,
                 topicUnit,
                 industry: selectedIndustry?.label ?? industry,
@@ -465,7 +510,7 @@ export function AuthoringForm({
         setTopicUnit("");
         setIndustry("fintech");
         setStudentProfile("business");
-        setTargetGroups([]);
+        setTargetCourseIds([]);
         setScenarioDescription("");
         setGuidingQuestion("");
         setSuggestedTechniques([]);
@@ -575,7 +620,7 @@ export function AuthoringForm({
                                         </label>
                                         <GroupsCombobox
                                             courses={teacherCourses}
-                                            value={targetGroups}
+                                            value={targetCourseIds}
                                             onAdd={addTargetGroup}
                                             onRemove={removeTargetGroup}
                                             hasError={!!errors.targetGroups}

--- a/frontend/src/features/teacher-authoring/AuthoringForm.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.tsx
@@ -99,6 +99,7 @@ export function AuthoringForm({
             }
             if (saved.studentProfile === "business" || saved.studentProfile === "ml_ds") setStudentProfile(saved.studentProfile);
             if (typeof saved.industry === "string") setIndustry(saved.industry);
+            if (saved.caseType === "harvard_only" || saved.caseType === "harvard_with_eda") setCaseType(saved.caseType as CaseType);
             if (typeof saved.notebookToggle === "boolean") setNotebookToggle(saved.notebookToggle);
             if (typeof saved.scenarioDescription === "string") setScenarioDescription(saved.scenarioDescription);
             if (typeof saved.guidingQuestion === "string") setGuidingQuestion(saved.guidingQuestion);

--- a/frontend/src/features/teacher-authoring/GroupsCombobox.tsx
+++ b/frontend/src/features/teacher-authoring/GroupsCombobox.tsx
@@ -7,13 +7,13 @@ import type { TeacherCourseItem } from "@/shared/adam-types";
 interface GroupsComboboxProps {
     courses: TeacherCourseItem[];
     value: string[];
-    onAdd: (label: string) => void;
-    onRemove: (label: string) => void;
+    onAdd: (courseId: string) => void;
+    onRemove: (courseId: string) => void;
     hasError?: boolean;
 }
 
 function courseLabel(course: TeacherCourseItem): string {
-    return `${course.title} (${course.code})`;
+    return course.code ? `${course.title} (${course.code})` : course.title;
 }
 
 export function GroupsCombobox({ courses, value, onAdd, onRemove, hasError }: GroupsComboboxProps) {
@@ -21,10 +21,10 @@ export function GroupsCombobox({ courses, value, onAdd, onRemove, hasError }: Gr
     const [filter, setFilter] = useState("");
 
     const filterLower = filter.toLowerCase();
-    const selected = courses.filter((c) => value.includes(courseLabel(c)));
+    const selected = courses.filter((c) => value.includes(c.id));
     const available = courses.filter(
         (c) =>
-            !value.includes(courseLabel(c)) &&
+            !value.includes(c.id) &&
             (!filter || courseLabel(c).toLowerCase().includes(filterLower)),
     );
 
@@ -86,7 +86,7 @@ export function GroupsCombobox({ courses, value, onAdd, onRemove, hasError }: Gr
                                         <button
                                             key={c.id}
                                             type="button"
-                                            onClick={() => onRemove(label)}
+                                            onClick={() => onRemove(c.id)}
                                             className="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 text-left"
                                         >
                                             <span className="flex items-center gap-2">
@@ -109,7 +109,7 @@ export function GroupsCombobox({ courses, value, onAdd, onRemove, hasError }: Gr
                                             key={c.id}
                                             type="button"
                                             onClick={() => {
-                                                onAdd(label);
+                                                onAdd(c.id);
                                                 setOpen(false);
                                             }}
                                             className="w-full flex items-center gap-2 px-3 py-2 text-sm text-slate-700 hover:bg-blue-50 text-left"
@@ -126,17 +126,21 @@ export function GroupsCombobox({ courses, value, onAdd, onRemove, hasError }: Gr
             </Popover>
             {value.length > 0 && (
                 <div className="flex flex-wrap gap-2 mt-2">
-                    {value.map((label) => (
+                    {value.map((courseId) => {
+                        const course = courses.find((item) => item.id === courseId);
+                        const label = course ? courseLabel(course) : courseId;
+                        return (
                         <button
-                            key={label}
+                            key={courseId}
                             type="button"
-                            onClick={() => onRemove(label)}
+                            onClick={() => onRemove(courseId)}
                             className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:border-[#0144a0] hover:text-[#0144a0]"
                         >
                             <span>{label}</span>
                             <span aria-hidden="true" className="text-base leading-none">×</span>
                         </button>
-                    ))}
+                        );
+                    })}
                 </div>
             )}
         </div>

--- a/frontend/src/features/teacher-authoring/GroupsCombobox.tsx
+++ b/frontend/src/features/teacher-authoring/GroupsCombobox.tsx
@@ -86,6 +86,7 @@ export function GroupsCombobox({ courses, value, onAdd, onRemove, hasError }: Gr
                                         <button
                                             key={c.id}
                                             type="button"
+                                            aria-label={`Quitar selección ${label}`}
                                             onClick={() => onRemove(c.id)}
                                             className="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 text-left"
                                         >
@@ -108,6 +109,7 @@ export function GroupsCombobox({ courses, value, onAdd, onRemove, hasError }: Gr
                                         <button
                                             key={c.id}
                                             type="button"
+                                            aria-label={`Agregar grupo ${label}`}
                                             onClick={() => {
                                                 onAdd(c.id);
                                                 setOpen(false);
@@ -133,6 +135,7 @@ export function GroupsCombobox({ courses, value, onAdd, onRemove, hasError }: Gr
                         <button
                             key={courseId}
                             type="button"
+                            aria-label={`Quitar grupo ${label}`}
                             onClick={() => onRemove(courseId)}
                             className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:border-[#0144a0] hover:text-[#0144a0]"
                         >

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.test.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.test.ts
@@ -19,6 +19,7 @@ describe("buildAuthoringJobCreateRequest", () => {
             guidingQuestion: "Question",
             topicUnit: "Unit",
             targetGroups: ["Grupo A"],
+                targetCourseIds: ["course-1"],
             suggestedTechniques: ["SWOT"],
         });
 
@@ -26,6 +27,7 @@ describe("buildAuthoringJobCreateRequest", () => {
         expect(request).toEqual({
             assignment_title: "Decision Analysis",
             course_id: "course-1",
+                target_course_ids: ["course-1"],
             subject: "Decision Analysis",
             academic_level: "MBA",
             industry: "Retail",

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
@@ -127,6 +127,7 @@ export function buildAuthoringJobCreateRequest(formData: CaseFormData): Authorin
     return {
         assignment_title: formData.subject || "Untitled Case",
         course_id: formData.courseId,
+        target_course_ids: formData.targetCourseIds,
         subject: formData.subject,
         academic_level: formData.academicLevel,
         industry: formData.industry,

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -67,6 +67,7 @@ export interface CaseFormData {
     subject: string;
     academicLevel: string;
     targetGroups: string[];
+    targetCourseIds: string[];
     syllabusModule: string;
     topicUnit: string;
     industry: string;
@@ -139,6 +140,7 @@ export interface CanonicalCaseOutput {
 export interface AuthoringJobCreateRequest {
     assignment_title: string;
     course_id: string;
+    target_course_ids: string[];
     subject: string;
     academic_level: string;
     industry: string;
@@ -684,6 +686,8 @@ export interface TeacherCaseDetailResponse {
     available_from: string | null;
     deadline: string | null;
     course_id: string | null;
+    target_course_ids?: string[];
+    course_codes?: string[];
     canonical_output: CanonicalCaseOutput | null;
 }
 
@@ -697,6 +701,7 @@ export const EMPTY_FORM: CaseFormData = {
     subject: "",
     academicLevel: "Pregrado",
     targetGroups: [],
+    targetCourseIds: [],
     syllabusModule: "",
     topicUnit: "",
     industry: "FinTech",

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -73,6 +73,7 @@ describe("api auth + stream glue", () => {
         await api.authoring.submitJob({
             assignment_title: "Case",
             course_id: "course-1",
+                target_course_ids: ["course-1"],
             subject: "Case",
             academic_level: "MBA",
             industry: "FinTech",


### PR DESCRIPTION
## Summary
- Modelo final: `assignment_courses` es la fuente de verdad multi-curso y `assignments.course_id` se mantiene como curso ancla para grounding y compatibilidad.
- Autorización: `get_owned_job_or_404` sigue resolviendo ownership por el ancla únicamente, sin ampliar el perímetro de acceso.
- Migración: se agrega `backend/alembic/versions/b7c8d9e0f1a2_issue180_assignment_courses.py` como migración aditiva con backfill idempotente desde `assignments.course_id`.
- Backend: intake de authoring persiste `target_course_ids`, crea `assignment_courses`, y teacher list/detail/counts leen destinos reales con fallback para filas legacy sin links persistidos.
- Frontend: el formulario de authoring y el request builder usan IDs reales de cursos destino y mantienen `targetGroups` como labels derivados para compatibilidad de UX y payloads existentes.

## Validation Evidence
- `uv run --directory backend pytest -q tests/test_issue139_authoring_grounding.py tests/test_issue88_teacher_courses.py tests/test_issue90_teacher_cases.py tests/test_teacher_case_actions.py tests/test_issue90_assignment_deadline_migration.py tests/test_phase3_status_api.py`
  - `80 passed, 4 warnings in 6.65s`
- `npm --prefix frontend run test -- --run src/features/teacher-authoring/AuthoringForm.test.tsx src/features/teacher-authoring/useAuthoringJobProgress.test.ts src/features/teacher-dashboard/CasosActivosSection.test.tsx`
  - `35 passed in 32.26s`
- `uv run --directory backend mypy src`
  - `Success: no issues found in 38 source files`
- `uv run --directory backend pytest -q`
  - `310 passed, 12 skipped, 4 warnings in 42.57s`
- `npm --prefix frontend run lint`
  - `0 errors, 1 warning` in `frontend/src/shared/Toast.tsx` (`react-refresh/only-export-components`, pre-existing)
- `npm --prefix frontend run test -- --run`
  - `312 passed in 18.39s` on the final tree state
- `npm --prefix frontend run build`
  - `tsc -b && vite build` succeeded, `3629 modules transformed`

## Real Follow-ups
- Non-blocking backend deprecation warning still exists around `HTTP_422_UNPROCESSABLE_ENTITY` in `backend/src/shared/teacher_router.py` during deadline validation tests.
- Non-blocking frontend lint warning still exists in `frontend/src/shared/Toast.tsx` for `react-refresh/only-export-components`.
- Vitest still emits the existing non-blocking `test.poolOptions` deprecation notice and `MaxListenersExceededWarning` during frontend test runs.
