### PR TITLE
fix(case-preview): strip duplicate exhibit sections from narrative when dedicated exhibit fields are present

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -261,6 +261,22 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
+## TODO-027: Hardening del `CASE_WRITER_PROMPT` para prohibir exhibits completos en `doc1_narrativa`
+
+**What:** Ajustar `backend/src/case_generator/prompts.py` para que `CASE_WRITER_PROMPT` prohíba explícitamente reproducir tablas completas de `Exhibit 1`, `Exhibit 2` o `Exhibit 3` dentro de `doc1_narrativa`, limitando su uso a citas y referencias narrativas.
+
+**Why:** El fix frontend del issue de duplicación en M1 ya evita que el preview muestre exhibits repetidos, pero el payload todavía puede contaminarse si el LLM vuelve a incrustar anexos completos dentro de la narrativa. Endurecer el prompt reduce la probabilidad de reintroducir el problema aguas arriba.
+
+**Pros:** Refuerza el contrato semántico entre narrativa y exhibits, reduce ruido en payloads generados y baja la dependencia de guardrails correctivos en frontend.
+
+**Cons:** Toca una superficie sensible de `backend/src/case_generator/prompts.py`, puede requerir recalibrar ejemplos/instrucciones del writer y debería validarse con suites/evals antes de aterrizarlo.
+
+**Context:** Detectado durante el gap analysis del bug de duplicación visual de exhibits en M1 después del cambio de `sanitizeExhibitMarkdown` del issue #173. La investigación mostró que el frontend renderiza exhibits por un canal dedicado (`financialExhibit` / `operatingExhibit` / `stakeholdersExhibit`) y que la duplicación visible puede reaparecer si `doc1_narrativa` vuelve a incluir secciones `### Exhibit ...` completas. Se decidió mantener el fix actual frontend-only y registrar este hardening como follow-up separado.
+
+**Depends on / blocked by:** Mantener verde el baseline actual del preview M1. Requiere definir el alcance de validación de prompts/evals antes de tocar `CASE_WRITER_PROMPT`.
+
+---
+
 ## TODO-014: Lifecycle explícito para el singleton async de checkpoints
 
 **What:** Evaluar si el singleton async lazy de `AsyncConnectionPool` + `AsyncPostgresSaver` + grafo compilado debe migrarse a ownership explícito por `lifespan` en `shared.app` y `shared.worker_app`.

--- a/frontend/src/features/case-preview/CasePreview.m1-exhibit-dedup.test.tsx
+++ b/frontend/src/features/case-preview/CasePreview.m1-exhibit-dedup.test.tsx
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+
+import type { CanonicalCaseOutput } from "@/shared/adam-types";
+import { renderWithProviders } from "@/shared/test-utils";
+
+const mockMutate = vi.fn();
+vi.mock("@/features/teacher-dashboard/useTeacherDashboard", () => ({
+    usePublishCase: () => ({ mutate: mockMutate }),
+}));
+
+import { CasePreview } from "./CasePreview";
+
+const duplicatedExhibitNarrative = [
+    "### Apertura",
+    "",
+    "BioDigital enfrenta presión en el consejo mientras el churn sigue subiendo.",
+    "",
+    "### Exhibit 1 — Datos Financieros",
+    "",
+    "| Métrica | Año N-1 | Año N (Estimado) |",
+    "|---|---|---|",
+    "| Ingresos Totales | $3,800,000 | $5,000,000 |",
+    "| EBITDA | $650,000 | $900,000 |",
+    "",
+    "### Exhibit 2 — Indicadores Operativos",
+    "",
+    "| Indicador | Año N-1 | Año N (Estimado) |",
+    "|---|---|---|",
+    "| Usuarios Activos Mensuales | 12,500 | 28,000 |",
+    "| Tasa de Abandono (Churn) | 12.5% | 22.4% |",
+    "",
+    "### Exhibit 3 — Mapa de Stakeholders",
+    "",
+    "| Actor | Interés | Incentivo | Riesgo | Postura |",
+    "|---|---|---|---|---|",
+    "| Elena Rivas (CEO) | Alta | Bonos | Baja | A |",
+    "",
+    "### Dilema Final",
+    "",
+    "La CEO debe decidir sin margen de error.",
+].join("\n");
+
+const caseData: CanonicalCaseOutput = {
+    caseId: "assignment-biodigital-1",
+    title: "BioDigital — El desafío de la retención predictiva en HealthTech",
+    subject: "Analítica de Negocios",
+    syllabusModule: "Retención y crecimiento",
+    guidingQuestion: "¿Cómo priorizar la inversión en retención?",
+    industry: "HealthTech",
+    academicLevel: "MBA",
+    caseType: "harvard_only",
+    studentProfile: "business",
+    generatedAt: "2026-04-22T00:00:00Z",
+    content: {
+        narrative: duplicatedExhibitNarrative,
+        financialExhibit: "### Exhibit 1 — Datos Financieros | Métrica | Año N-1 | Año N (Estimado) | |---|---|---| | Ingresos Totales | $3,800,000 | $5,000,000 | | EBITDA | $650,000 | $900,000 |",
+        operatingExhibit: [
+            "### Exhibit 2 — Indicadores Operativos",
+            "",
+            "| Indicador | Año N-1 | Año N (Estimado) |",
+            "|---|---|---|",
+            "| Usuarios Activos Mensuales | 12,500 | 28,000 |",
+            "| Tasa de Abandono (Churn) | 12.5% | 22.4% |",
+        ].join("\n"),
+        stakeholdersExhibit: [
+            "### Exhibit 3 — Mapa de Stakeholders",
+            "",
+            "| Actor | Interés | Incentivo | Riesgo | Postura |",
+            "|---|---|---|---|---|",
+            "| Elena Rivas (CEO) | Alta | Bonos | Baja | A |",
+        ].join("\n"),
+    },
+};
+
+describe("CasePreview M1 exhibit dedupe", () => {
+    beforeEach(() => {
+        Object.defineProperty(window.HTMLElement.prototype, "scrollTo", {
+            configurable: true,
+            value: vi.fn(),
+            writable: true,
+        });
+        mockMutate.mockReset();
+    });
+
+    it("renders duplicated inline exhibits only once when dedicated exhibit fields are present", () => {
+        renderWithProviders(<CasePreview caseData={caseData} />);
+
+        expect(screen.getByText("BioDigital enfrenta presión en el consejo mientras el churn sigue subiendo.")).toBeTruthy();
+        expect(screen.getByText("La CEO debe decidir sin margen de error.")).toBeTruthy();
+        expect(screen.getAllByText("Exhibit 1 — Datos Financieros")).toHaveLength(1);
+        expect(screen.getAllByText("Exhibit 2 — Indicadores Operativos")).toHaveLength(1);
+        expect(screen.getAllByText("Exhibit 3 — Mapa de Stakeholders")).toHaveLength(1);
+    });
+});

--- a/frontend/src/features/case-preview/CasePreview.m1-exhibit-dedup.test.tsx
+++ b/frontend/src/features/case-preview/CasePreview.m1-exhibit-dedup.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 
 import type { CanonicalCaseOutput } from "@/shared/adam-types";
 import { renderWithProviders } from "@/shared/test-utils";
@@ -85,11 +85,16 @@ describe("CasePreview M1 exhibit dedupe", () => {
 
     it("renders duplicated inline exhibits only once when dedicated exhibit fields are present", () => {
         renderWithProviders(<CasePreview caseData={caseData} />);
+        const moduleContentPanel = document.getElementById("module-content-panel");
+
+        expect(moduleContentPanel).toBeTruthy();
+
+        const contentPanel = within(moduleContentPanel as HTMLElement);
 
         expect(screen.getByText("BioDigital enfrenta presión en el consejo mientras el churn sigue subiendo.")).toBeTruthy();
         expect(screen.getByText("La CEO debe decidir sin margen de error.")).toBeTruthy();
-        expect(screen.getAllByText("Exhibit 1 — Datos Financieros")).toHaveLength(1);
-        expect(screen.getAllByText("Exhibit 2 — Indicadores Operativos")).toHaveLength(1);
-        expect(screen.getAllByText("Exhibit 3 — Mapa de Stakeholders")).toHaveLength(1);
+        expect(contentPanel.getAllByText("Exhibit 1 — Datos Financieros")).toHaveLength(1);
+        expect(contentPanel.getAllByText("Exhibit 2 — Indicadores Operativos")).toHaveLength(1);
+        expect(contentPanel.getAllByText("Exhibit 3 — Mapa de Stakeholders")).toHaveLength(1);
     });
 });

--- a/frontend/src/features/case-preview/CasePreview.tsx
+++ b/frontend/src/features/case-preview/CasePreview.tsx
@@ -16,6 +16,7 @@ import { Suspense, lazy, useState, useRef, useCallback, useMemo, useEffect, type
 import { usePublishCase } from "@/features/teacher-dashboard/useTeacherDashboard"; // TODO: move usePublishCase to shared/ — cross-feature import accepted per #154
 import { useToast } from "@/shared/Toast";
 import { marked, type Tokens } from "marked";
+import { isMarkdownTableRow } from "./markdownTable";
 
 marked.setOptions({ gfm: true, breaks: false });
 
@@ -118,11 +119,10 @@ const M1_EXHIBIT_SECTIONS: Array<{ key: M1DedicatedExhibitKey; heading: RegExp }
     { key: "stakeholdersExhibit", heading: /^\s*#{1,6}\s*Exhibit\s*3\b/i },
 ];
 
-const MARKDOWN_TABLE_ROW = /^\s*\|.+\|\s*$/;
 const INLINE_TABLE_SEPARATOR = /\|(\s*:?-+:?\s*\|)+/;
 
 function lineLooksLikeMarkdownTable(line: string): boolean {
-    return MARKDOWN_TABLE_ROW.test(line);
+    return isMarkdownTableRow(line);
 }
 
 function normalizeMarkdownAfterExhibitRemoval(markdown: string): string {

--- a/frontend/src/features/case-preview/CasePreview.tsx
+++ b/frontend/src/features/case-preview/CasePreview.tsx
@@ -109,6 +109,111 @@ function renderMarkdownWithIds(markdown: string): string {
     );
 }
 
+type M1DedicatedExhibitKey = "financialExhibit" | "operatingExhibit" | "stakeholdersExhibit";
+type M1DedicatedExhibits = Pick<CanonicalCaseOutput["content"], M1DedicatedExhibitKey>;
+
+const M1_EXHIBIT_SECTIONS: Array<{ key: M1DedicatedExhibitKey; heading: RegExp }> = [
+    { key: "financialExhibit", heading: /^\s*#{1,6}\s*Exhibit\s*1\b/i },
+    { key: "operatingExhibit", heading: /^\s*#{1,6}\s*Exhibit\s*2\b/i },
+    { key: "stakeholdersExhibit", heading: /^\s*#{1,6}\s*Exhibit\s*3\b/i },
+];
+
+const MARKDOWN_TABLE_ROW = /^\s*\|.+\|\s*$/;
+const INLINE_TABLE_SEPARATOR = /\|(\s*:?-+:?\s*\|)+/;
+
+function lineLooksLikeMarkdownTable(line: string): boolean {
+    return MARKDOWN_TABLE_ROW.test(line);
+}
+
+function normalizeMarkdownAfterExhibitRemoval(markdown: string): string {
+    const lines = markdown.split("\n");
+    const normalized: string[] = [];
+    let blankRun = 0;
+
+    for (const line of lines) {
+        if (line.trim() === "") {
+            blankRun += 1;
+            if (blankRun > 2) {
+                continue;
+            }
+        } else {
+            blankRun = 0;
+        }
+
+        normalized.push(line);
+    }
+
+    return normalized.join("\n").trim();
+}
+
+function stripDuplicatedM1ExhibitSections(
+    markdown: string | undefined,
+    dedicatedExhibits: M1DedicatedExhibits,
+): string | undefined {
+    if (!markdown?.trim()) {
+        return markdown;
+    }
+
+    const lines = markdown.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+    const output: string[] = [];
+    let removedAnySection = false;
+
+    for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index];
+        const matchedSection = M1_EXHIBIT_SECTIONS.find(
+            ({ key, heading }) => dedicatedExhibits[key]?.trim() && heading.test(line),
+        );
+
+        if (!matchedSection) {
+            output.push(line);
+            continue;
+        }
+
+        if (INLINE_TABLE_SEPARATOR.test(line)) {
+            removedAnySection = true;
+            continue;
+        }
+
+        let cursor = index + 1;
+        while (cursor < lines.length && lines[cursor].trim() === "") {
+            cursor += 1;
+        }
+
+        if (cursor >= lines.length || !lineLooksLikeMarkdownTable(lines[cursor])) {
+            output.push(line);
+            continue;
+        }
+
+        removedAnySection = true;
+        index = cursor;
+
+        while (index + 1 < lines.length) {
+            const nextLine = lines[index + 1];
+
+            if (nextLine.trim() === "") {
+                const afterBlank = lines[index + 2];
+                if (afterBlank && lineLooksLikeMarkdownTable(afterBlank)) {
+                    index += 1;
+                    continue;
+                }
+
+                index += 1;
+                break;
+            }
+
+            if (!lineLooksLikeMarkdownTable(nextLine)) {
+                break;
+            }
+
+            index += 1;
+        }
+    }
+
+    return removedAnySection
+        ? normalizeMarkdownAfterExhibitRemoval(output.join("\n"))
+        : markdown;
+}
+
 // ── Helper: type guard para EDASocraticQuestion ──────────────────────────────
 function isEDASocraticQuestion(p: PreguntaMinimalista | EDASocraticQuestion): p is EDASocraticQuestion {
     return typeof p.solucion_esperada === "object" && p.solucion_esperada !== null && "teoria" in p.solucion_esperada;
@@ -521,12 +626,17 @@ export function CasePreview({ caseData, onEditParams, isPausedWaitingForApproval
     // renderMarkdownWithIds: para secciones que necesitan anclas de heading (rail)
     // marked simple: para secciones auxiliares (sin nav)
     const md = useMemo(() => {
+        const m1DedicatedExhibits: M1DedicatedExhibits = {
+            financialExhibit: content.financialExhibit,
+            operatingExhibit: content.operatingExhibit,
+            stakeholdersExhibit: content.stakeholdersExhibit,
+        };
         const rich = (s: string | undefined) => s?.trim() ? renderMarkdownWithIds(s) : null;
         const plain = (s: string | undefined) => s?.trim() ? marked(s) as string : null;
         return {
             // Rich: heading IDs inyectados para scroll-spy
-            instructions: rich(content.instructions),
-            narrative: rich(content.narrative),
+            instructions: rich(stripDuplicatedM1ExhibitSections(content.instructions, m1DedicatedExhibits)),
+            narrative: rich(stripDuplicatedM1ExhibitSections(content.narrative, m1DedicatedExhibits)),
             edaReport: rich(content.edaReport),
             m3Content: rich(content.m3Content),
             m4Content: rich(content.m4Content),

--- a/frontend/src/features/case-preview/markdownTable.ts
+++ b/frontend/src/features/case-preview/markdownTable.ts
@@ -1,0 +1,3 @@
+export function isMarkdownTableRow(line: string): boolean {
+    return /^\s*\|.+\|/.test(line);
+}

--- a/frontend/src/features/case-preview/sanitizeExhibit.ts
+++ b/frontend/src/features/case-preview/sanitizeExhibit.ts
@@ -13,7 +13,7 @@
  *   [6] Heading immediately adjacent to table (### Exhibit\n| col |)
  *   [7] Blank line(s) trapped between two table rows (premature </table> close)
  */
-const isTableRow = (line: string) => /^\s*\|.+\|/.test(line);
+import { isMarkdownTableRow } from "./markdownTable";
 
 // GFM separator: starts with |, each cell is (optional spaces, optional colon,
 // one or more dashes, optional colon, optional spaces), ends with |
@@ -40,7 +40,7 @@ function expandInlineTable(line: string): string {
 
     const heading = beforeSep.slice(0, firstPipe).trim();
     const headerRow = beforeSep.slice(firstPipe).trim();
-    if (!isTableRow(headerRow)) {
+    if (!isMarkdownTableRow(headerRow)) {
         return line;
     }
 
@@ -115,7 +115,7 @@ export function sanitizeExhibitMarkdown(raw: string): string {
                 if (rawLines[f].trim() !== "") { next = rawLines[f]; break; }
             }
             // Drop the blank line if both neighbours are table rows
-            if (isTableRow(prev) && isTableRow(next)) continue;
+            if (isMarkdownTableRow(prev) && isMarkdownTableRow(next)) continue;
         }
         purged.push(rawLines[i]);
     }
@@ -129,7 +129,7 @@ export function sanitizeExhibitMarkdown(raw: string): string {
         const next = lines[i + 1] ?? "";
 
         // [6] Heading immediately followed by a table row — inject blank line between
-        if (isHeading(line) && isTableRow(next)) {
+        if (isHeading(line) && isMarkdownTableRow(next)) {
             out.push(line);
             out.push("");
             continue;
@@ -139,7 +139,7 @@ export function sanitizeExhibitMarkdown(raw: string): string {
         //     Guard !isTableRow(prev) ensures we only fire at the START of a table
         //     block, not for data rows that follow a separator or another data row
         //     (which would be adjacent after the table-glue pre-pass).
-        if (isTableRow(line) && !isSeparator(line) && prev.trim() !== "" && !isTableRow(prev)) {
+        if (isMarkdownTableRow(line) && !isSeparator(line) && prev.trim() !== "" && !isMarkdownTableRow(prev)) {
             out.push("");
         }
 
@@ -149,11 +149,11 @@ export function sanitizeExhibitMarkdown(raw: string): string {
         //     block; after the table-glue pass adjacent data rows must not trigger
         //     a spurious separator injection.
         if (
-            isTableRow(line) &&
+            isMarkdownTableRow(line) &&
             !isSeparator(line) &&
-            isTableRow(next) &&
+            isMarkdownTableRow(next) &&
             !isSeparator(next) &&
-            !isTableRow(prev)
+            !isMarkdownTableRow(prev)
         ) {
             out.push(line);
             const cols = (line.match(/\|/g) ?? []).length - 1;
@@ -163,7 +163,7 @@ export function sanitizeExhibitMarkdown(raw: string): string {
         }
 
         // [5] Last table row followed by non-table, non-blank content — append blank line
-        if (isTableRow(line) && !isTableRow(next) && next.trim() !== "") {
+        if (isMarkdownTableRow(line) && !isMarkdownTableRow(next) && next.trim() !== "") {
             out.push(line);
             out.push("");
             continue;
@@ -184,7 +184,7 @@ export function sanitizeExhibitMarkdown(raw: string): string {
  */
 export function isRenderableAsTable(text: string): boolean {
     const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
-    const tableLike = lines.filter((l) => /^\|.+\|/.test(l));
+    const tableLike = lines.filter(isMarkdownTableRow);
     const hasSeparator = tableLike.some((l) => /^\|(\s*:?-+:?\s*\|)+$/.test(l));
     return tableLike.length >= 2 && hasSeparator;
 }


### PR DESCRIPTION
## Summary
- strip duplicate inline M1 exhibit sections from rendered narrative/instructions when dedicated exhibit fields are present
- add a DOM regression test covering duplicated inline exhibits plus dedicated exhibit fields
- record a follow-up TODO to harden CASE_WRITER_PROMPT against embedding full exhibit tables in doc1_narrativa

## Pre-Landing Review
No issues found.

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] npm --prefix frontend run lint
- [x] npm --prefix frontend run test -- --run
- [x] npm --prefix frontend run build
- [x] 41 test files passed
- [x] 313 tests passed

🤖 Generated with GitHub Copilot