### PR TITLE
feat(case-preview): update post-send CTA and navigation to dashboard

### DIFF
--- a/frontend/src/features/case-preview/CasePreview.test.tsx
+++ b/frontend/src/features/case-preview/CasePreview.test.tsx
@@ -4,6 +4,15 @@ import { fireEvent, screen } from "@testing-library/react";
 import type { CanonicalCaseOutput } from "@/shared/adam-types";
 import { renderWithProviders } from "@/shared/test-utils";
 
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+    };
+});
+
 // ── usePublishCase mock ──────────────────────────────────────────────────────
 const mockMutate = vi.fn();
 vi.mock("@/features/teacher-dashboard/useTeacherDashboard", () => ({
@@ -80,6 +89,7 @@ describe("CasePreview Enviar Caso button", () => {
             writable: true,
         });
         mockMutate.mockReset();
+        mockNavigate.mockReset();
     });
 
     const caseDataWithId: CanonicalCaseOutput = {
@@ -153,5 +163,28 @@ describe("CasePreview Enviar Caso button", () => {
         expect(screen.queryByRole("button", { name: /enviar caso/i })).toBeNull();
         expect(screen.queryByText("¿Confirmar envío?")).toBeNull();
         expect(screen.queryByText(/✓ Caso enviado/)).toBeNull();
+    });
+
+    it("[T8] onSuccess: sidebar CTA changes to 'Volver a Inicio' and navigates to dashboard", () => {
+        mockMutate.mockImplementation((_id: string, { onSuccess }: { onSuccess: () => void }) => {
+            onSuccess();
+        });
+
+        renderWithProviders(
+            <CasePreview caseData={caseDataWithId} onEditParams={vi.fn()} />,
+        );
+
+        expect(screen.getByRole("button", { name: /volver y rehacer/i })).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: /enviar caso/i }));
+        fireEvent.click(screen.getByRole("button", { name: /sí, enviar/i }));
+
+        const backToHomeButton = screen.getByRole("button", { name: /volver a inicio/i });
+        expect(backToHomeButton).toBeTruthy();
+        expect(screen.queryByRole("button", { name: /volver y rehacer/i })).toBeNull();
+
+        fireEvent.click(backToHomeButton);
+
+        expect(mockNavigate).toHaveBeenCalledWith("/teacher/dashboard", { replace: true });
     });
 });

--- a/frontend/src/features/case-preview/CasePreview.tsx
+++ b/frontend/src/features/case-preview/CasePreview.tsx
@@ -13,6 +13,7 @@
  */
 
 import { Suspense, lazy, useState, useRef, useCallback, useMemo, useEffect, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
 import { usePublishCase } from "@/features/teacher-dashboard/useTeacherDashboard"; // TODO: move usePublishCase to shared/ — cross-feature import accepted per #154
 import { useToast } from "@/shared/Toast";
 import { marked, type Tokens } from "marked";
@@ -582,6 +583,7 @@ export function CasePreview({ caseData, onEditParams, isPausedWaitingForApproval
     const content = result.content;
     const isEDA = result.caseType === "harvard_with_eda";
     const isMLDS = result.studentProfile === "ml_ds";
+    const navigate = useNavigate();
 
     // ── Módulos visibles según caseType + studentProfile (ISSUE-17) ─────────
     //   harvard_only     → M1, M4(→#2), M5(→#3), M6(→#4)
@@ -795,6 +797,13 @@ export function CasePreview({ caseData, onEditParams, isPausedWaitingForApproval
         onResumeEDA?.();
     }, [onResumeEDA]);
 
+    const handleGoToTeacherDashboard = useCallback(() => {
+        navigate("/teacher/dashboard", { replace: true });
+    }, [navigate]);
+
+    const showEditParamsButton = Boolean(onEditParams) && sendState !== "sent";
+    const showBackToDashboardButton = sendState === "sent";
+
     // ════════════════════════════════════════════════════════════════════════
     // RENDER DE MÓDULOS
     // ════════════════════════════════════════════════════════════════════════
@@ -826,7 +835,15 @@ export function CasePreview({ caseData, onEditParams, isPausedWaitingForApproval
 
                     {/* Header sidebar */}
                     <div className="h-16 flex items-center px-5 border-b border-slate-800 flex-shrink-0">
-                        {onEditParams ? (
+                        {showBackToDashboardButton ? (
+                            <button type="button" onClick={handleGoToTeacherDashboard}
+                                className="w-full flex items-center justify-center gap-2 bg-slate-800/80 hover:bg-[#0144a0] border border-slate-700 hover:border-[#0144a0] text-slate-300 hover:text-white py-2 px-4 rounded-lg text-sm font-semibold transition-all">
+                                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6l-6 6m0 0l6 6m-6-6h16" />
+                                </svg>
+                                Volver a Inicio
+                            </button>
+                        ) : showEditParamsButton ? (
                             <button type="button" onClick={onEditParams}
                                 className="w-full flex items-center justify-center gap-2 bg-slate-800/80 hover:bg-[#0144a0] border border-slate-700 hover:border-[#0144a0] text-slate-300 hover:text-white py-2 px-4 rounded-lg text-sm font-semibold transition-all">
                                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
Summary: Sidebar CTA changes from 'Volver y rehacer' to 'Volver a Inicio' after successful publish, navigation to /teacher/dashboard, added regression test, and validation run (npx vitest run src/features/case-preview/CasePreview.test.tsx, npm --prefix frontend run lint).