### PR TITLE
feat: implement teacher course access-link flow

### DIFF
--- a/backend/src/shared/admin_router.py
+++ b/backend/src/shared/admin_router.py
@@ -17,12 +17,12 @@ from shared.admin_reads import (
     list_admin_courses,
     list_teacher_options,
 )
+from shared.course_access_schema import CourseAccessLinkRegenerateResponse
 from shared.admin_writes import (
     AdminRemoveTeacherResponse,
     AdminResendInviteResponse,
     AdminRevokeInviteResponse,
     AdminCourseMutationRequest,
-    CourseAccessLinkRegenerateResponse,
     CreateTeacherInviteRequest,
     TeacherInviteResponse,
     create_admin_course,

--- a/backend/src/shared/admin_writes.py
+++ b/backend/src/shared/admin_writes.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from shared.admin_context import AdminContext
 from shared.admin_reads import CourseListItemResponse, get_admin_course_item
 from shared.auth import audit_log, hash_invite_token, normalize_email
+from shared.course_access_schema import CourseAccessLinkRegenerateResponse
 from shared.course_access_links import (
     GeneratedCourseAccessLink,
     create_course_access_link,
@@ -110,12 +111,6 @@ class TeacherInviteResponse(BaseModel):
     email: str
     status: Literal["pending"]
     activation_link: str
-
-
-class CourseAccessLinkRegenerateResponse(BaseModel):
-    course_id: str
-    access_link: str
-    access_link_status: Literal["active"]
 
 
 class AdminResendInviteResponse(BaseModel):

--- a/backend/src/shared/course_access_schema.py
+++ b/backend/src/shared/course_access_schema.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+from shared.syllabus_schema import TeacherCourseConfigurationResponse
+
+
+class CourseAccessLinkRegenerateResponse(BaseModel):
+    course_id: str
+    access_link: str
+    access_link_status: Literal["active"]
+
+
+class TeacherCourseAccessLinkResponse(TeacherCourseConfigurationResponse):
+    course_id: str

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -11,6 +11,7 @@ from sqlalchemy import and_, exists, func, or_, select
 from sqlalchemy.orm import Session, joinedload, load_only
 
 from shared.auth import CurrentActor, ensure_legacy_teacher_bridge
+from shared.course_access_schema import TeacherCourseAccessLinkResponse
 from shared.models import Assignment, AssignmentCourse, AuthoringJob, Course, CourseAccessLink, CourseMembership, Membership, Syllabus
 from shared.syllabus_schema import (
     TeacherCourseConfigurationResponse,
@@ -151,6 +152,19 @@ def _assignment_course_codes(assignment: Assignment) -> list[str]:
         return [assignment.course.code]
 
     return []
+
+
+def _serialize_teacher_course_configuration(
+    *,
+    access_link_status: str | None,
+    access_link_id: str | None,
+    access_link_created_at: datetime | None,
+) -> TeacherCourseConfigurationResponse:
+    return TeacherCourseConfigurationResponse(
+        access_link_status="active" if access_link_status == "active" else "missing",
+        access_link_id=access_link_id,
+        access_link_created_at=access_link_created_at,
+    )
 
 
 def _serialize_syllabus_response(syllabus: Syllabus | None) -> TeacherSyllabusResponse | None:
@@ -306,11 +320,57 @@ def get_teacher_course_detail(
             saved_at=saved_at,
             saved_by_membership_id=saved_by_membership_id,
         ),
-        configuration=TeacherCourseConfigurationResponse(
-            access_link_status="active" if row["access_link_status"] == "active" else "missing",
+        configuration=_serialize_teacher_course_configuration(
+            access_link_status=row["access_link_status"],
             access_link_id=row["access_link_id"],
             access_link_created_at=row["access_link_created_at"],
         ),
+    )
+
+
+def get_teacher_course_access_link(
+    db: Session,
+    context: TeacherContext,
+    course_id: str,
+) -> TeacherCourseAccessLinkResponse:
+    row = (
+        db.execute(
+            select(
+                Course.id.label("course_id"),
+                CourseAccessLink.id.label("access_link_id"),
+                CourseAccessLink.status.label("access_link_status"),
+                CourseAccessLink.created_at.label("access_link_created_at"),
+            )
+            .select_from(Course)
+            .outerjoin(
+                CourseAccessLink,
+                and_(
+                    CourseAccessLink.course_id == Course.id,
+                    CourseAccessLink.status == "active",
+                ),
+            )
+            .where(
+                Course.id == course_id,
+                Course.university_id == context.university_id,
+                Course.teacher_membership_id == context.teacher_membership_id,
+            )
+            .limit(1)
+        )
+        .mappings()
+        .first()
+    )
+
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="course_not_found")
+
+    configuration = _serialize_teacher_course_configuration(
+        access_link_status=row["access_link_status"],
+        access_link_id=row["access_link_id"],
+        access_link_created_at=row["access_link_created_at"],
+    )
+    return TeacherCourseAccessLinkResponse(
+        course_id=row["course_id"],
+        **configuration.model_dump(),
     )
 
 

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -11,18 +11,20 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
 from shared.auth import CurrentActor, require_current_actor_password_ready
+from shared.course_access_schema import CourseAccessLinkRegenerateResponse, TeacherCourseAccessLinkResponse
 from shared.database import get_db
 from shared.models import Assignment, AssignmentCourse, Course
 from shared.syllabus_schema import TeacherCourseDetailResponse, TeacherSyllabusSaveRequest
 from shared.teacher_context import TeacherContext, require_teacher_context
 from shared.teacher_reads import (
     TeacherCoursesResponse,
+    get_teacher_course_access_link,
     get_teacher_course_detail,
     list_teacher_active_cases,
     list_teacher_courses,
     resolve_assignment_schedule_values,
 )
-from shared.teacher_writes import save_teacher_course_syllabus
+from shared.teacher_writes import regenerate_teacher_course_access_link, save_teacher_course_syllabus
 
 router = APIRouter(prefix="/api/teacher", tags=["teacher"])
 _BOGOTA_TZ = ZoneInfo("America/Bogota")
@@ -91,6 +93,27 @@ def get_teacher_course(
     db: Session = Depends(get_db),
 ) -> TeacherCourseDetailResponse:
     return get_teacher_course_detail(db, context, course_id)
+
+
+@router.get("/courses/{course_id}/access-link", response_model=TeacherCourseAccessLinkResponse)
+def get_teacher_course_access_link_view(
+    course_id: str,
+    context: Annotated[TeacherContext, Depends(require_teacher_context)],
+    db: Session = Depends(get_db),
+) -> TeacherCourseAccessLinkResponse:
+    return get_teacher_course_access_link(db, context, course_id)
+
+
+@router.post(
+    "/courses/{course_id}/access-link/regenerate",
+    response_model=CourseAccessLinkRegenerateResponse,
+)
+def post_teacher_course_access_link_regenerate(
+    course_id: str,
+    context: Annotated[TeacherContext, Depends(require_teacher_context)],
+    db: Session = Depends(get_db),
+) -> CourseAccessLinkRegenerateResponse:
+    return regenerate_teacher_course_access_link(db, context, course_id)
 
 
 @router.put("/courses/{course_id}/syllabus", response_model=TeacherCourseDetailResponse)

--- a/backend/src/shared/teacher_writes.py
+++ b/backend/src/shared/teacher_writes.py
@@ -9,6 +9,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from shared.auth import audit_log
+from shared.course_access_links import regenerate_course_access_link, try_acquire_course_regeneration_lock
+from shared.course_access_schema import CourseAccessLinkRegenerateResponse
 from shared.models import Course, Syllabus, SyllabusRevision
 from shared.syllabus_schema import (
     TeacherCourseDetailResponse,
@@ -183,3 +185,60 @@ def save_teacher_course_syllabus(
         revision=next_revision,
     )
     return get_teacher_course_detail(db, context, course.id)
+
+
+def regenerate_teacher_course_access_link(
+    db: Session,
+    context: TeacherContext,
+    course_id: str,
+) -> CourseAccessLinkRegenerateResponse:
+    course = db.scalar(
+        select(Course)
+        .where(
+            Course.id == course_id,
+            Course.university_id == context.university_id,
+            Course.teacher_membership_id == context.teacher_membership_id,
+        )
+        .with_for_update()
+    )
+    if course is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="course_not_found")
+    if course.status != "active":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="course_inactive",
+        )
+
+    try:
+        if not try_acquire_course_regeneration_lock(db, course.id):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="course_link_regeneration_in_progress",
+            )
+        generated_link = regenerate_course_access_link(db, course.id)
+        db.commit()
+    except HTTPException:
+        db.rollback()
+        raise
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="course_link_regeneration_failed",
+        ) from exc
+
+    audit_log(
+        "teacher.course_link.regenerated",
+        "success",
+        auth_user_id=context.auth_user_id,
+        university_id=context.university_id,
+        membership_id=context.teacher_membership_id,
+        course_id=course.id,
+        link_id=generated_link.link_id,
+        http_status=status.HTTP_200_OK,
+    )
+    return CourseAccessLinkRegenerateResponse(
+        course_id=course.id,
+        access_link=generated_link.access_link,
+        access_link_status="active",
+    )

--- a/backend/tests/test_issue88_teacher_courses.py
+++ b/backend/tests/test_issue88_teacher_courses.py
@@ -6,7 +6,7 @@ import uuid
 
 from sqlalchemy import select
 
-from shared.models import Assignment, AssignmentCourse, Membership
+from shared.models import Assignment, AssignmentCourse, CourseMembership, Membership
 from shared.models import Syllabus, SyllabusRevision
 from shared.syllabus_schema import TeacherSyllabusPayload, derive_syllabus_grounding_context
 
@@ -905,6 +905,247 @@ def test_issue88_teacher_course_detail_multiple_teacher_memberships_returns_409(
 
     assert response.status_code == 409
     assert response.json()["detail"] == "teacher_membership_context_required"
+
+
+def test_issue185_teacher_course_access_link_view_returns_active_metadata(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000001850"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-access-link-view@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Access Link View",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Course Access Link View",
+        code="TCH-ACCESS-001",
+    )
+    access_link, raw_token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.get(
+        f"/api/teacher/courses/{course.id}/access-link",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "course_id": course.id,
+        "access_link_status": "active",
+        "access_link_id": access_link.id,
+        "access_link_created_at": access_link.created_at.isoformat().replace("+00:00", "Z"),
+        "join_path": "/app/join",
+    }
+    assert raw_token not in response.text
+
+
+def test_issue185_teacher_course_access_link_view_returns_missing_without_active_link(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000001851"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-access-link-missing@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Access Link Missing",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Course Access Link Missing",
+        code="TCH-ACCESS-002",
+    )
+
+    response = client.get(
+        f"/api/teacher/courses/{course.id}/access-link",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "course_id": course.id,
+        "access_link_status": "missing",
+        "access_link_id": None,
+        "access_link_created_at": None,
+        "join_path": "/app/join",
+    }
+
+
+def test_issue185_teacher_regenerate_course_access_link_requires_owned_course(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000001852"
+    owner = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-owner-access@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Owner Access",
+    )
+    other_teacher_user_id = str(uuid.uuid4())
+    other_teacher_email = "teacher-other-access@example.edu"
+    seed_identity(
+        user_id=other_teacher_user_id,
+        email=other_teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Other Access",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=owner["membership"].id,
+        title="Owned Teacher Access Course",
+        code="TCH-ACCESS-003",
+    )
+
+    response = client.post(
+        f"/api/teacher/courses/{course.id}/access-link/regenerate",
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=other_teacher_user_id,
+            email=other_teacher_email,
+        ),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "course_not_found"
+
+
+def test_issue185_teacher_regenerate_course_access_link_rejects_inactive_course(
+    client,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000001853"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-access-inactive@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Inactive Access",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        status="inactive",
+        title="Inactive Teacher Access Course",
+        code="TCH-ACCESS-004",
+    )
+
+    response = client.post(
+        f"/api/teacher/courses/{course.id}/access-link/regenerate",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "course_inactive"
+
+
+def test_issue185_teacher_regenerate_course_access_link_supports_password_runtime_end_to_end(
+    client,
+    db,
+    fake_admin_client,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000001854"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-access-runtime@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Runtime Access",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Teacher Runtime Access Course",
+        code="TCH-ACCESS-005",
+    )
+    _, original_raw = seed_course_access_link(course_id=course.id, status="active")
+
+    regenerate_response = client.post(
+        f"/api/teacher/courses/{course.id}/access-link/regenerate",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert regenerate_response.status_code == 200, regenerate_response.text
+    payload = regenerate_response.json()
+    assert payload["course_id"] == course.id
+    assert payload["access_link_status"] == "active"
+    assert payload["access_link"].startswith("/app/join#course_access_token=")
+
+    new_raw = payload["access_link"].split("=", maxsplit=1)[1]
+    assert original_raw != new_raw
+
+    old_resolve = client.post(
+        "/api/course-access/resolve",
+        json={"course_access_token": original_raw},
+    )
+    assert old_resolve.status_code == 410
+    assert old_resolve.json()["detail"] == "course_access_link_rotated"
+
+    new_resolve = client.post(
+        "/api/course-access/resolve",
+        json={"course_access_token": new_raw},
+    )
+    assert new_resolve.status_code == 200
+    assert new_resolve.json()["course_id"] == course.id
+
+    activate_response = client.post(
+        "/api/course-access/activate/password",
+        json={
+            "course_access_token": new_raw,
+            "email": "student.teacher.runtime@example.edu",
+            "full_name": "Student Teacher Runtime",
+            "password": "Secure1234!",
+            "confirm_password": "Secure1234!",
+        },
+    )
+    assert activate_response.status_code == 201, activate_response.text
+
+    auth_user = fake_admin_client.find_user_by_email("student.teacher.runtime@example.edu")
+    assert auth_user is not None
+    membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == auth_user.id,
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    )
+    assert membership is not None
+    enrollment = db.scalar(
+        select(CourseMembership).where(
+            CourseMembership.course_id == course.id,
+            CourseMembership.membership_id == membership.id,
+        )
+    )
+    assert enrollment is not None
 
 
 def test_issue88_teacher_course_syllabus_save_happy_path_creates_initial_syllabus(

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
@@ -43,8 +43,9 @@ import type {
     AdminTeacherOptionsResponse,
 } from "@/shared/adam-types";
 import { ApiError, api } from "@/shared/api";
+import { copyToClipboard } from "@/shared/clipboard";
 import { queryKeys, type CourseFilters } from "@/shared/queryKeys";
-import { useToast } from "@/shared/Toast";
+import { useToast } from "@/shared/toast-context";
 import {
     Select,
     SelectContent,
@@ -64,7 +65,6 @@ import {
     buildCourseFormFromItem,
     buildCoursePayload,
     buildLinkPresentation,
-    copyToClipboard,
     createEmptyCourseForm,
     encodeTeacherOptionValue,
     getAdminErrorMessage,

--- a/frontend/src/features/admin-dashboard/TeacherDirectoryModal.tsx
+++ b/frontend/src/features/admin-dashboard/TeacherDirectoryModal.tsx
@@ -8,11 +8,12 @@ import type {
     AdminTeacherDirectoryResponse,
 } from "@/shared/adam-types";
 import { api } from "@/shared/api";
+import { copyToClipboard } from "@/shared/clipboard";
 import { queryKeys } from "@/shared/queryKeys";
-import { useToast } from "@/shared/Toast";
+import { useToast } from "@/shared/toast-context";
 
 import { ConfirmationModal } from "./AdminDashboardModals";
-import { copyToClipboard, getAdminErrorMessage, getInitials } from "./adminDashboardModel";
+import { getAdminErrorMessage, getInitials } from "./adminDashboardModel";
 
 interface Props {
     isOpen: boolean;

--- a/frontend/src/features/admin-dashboard/adminDashboardModel.ts
+++ b/frontend/src/features/admin-dashboard/adminDashboardModel.ts
@@ -291,17 +291,6 @@ export function buildLinkPresentation(
     };
 }
 
-export async function copyToClipboard(value: string): Promise<boolean> {
-    if (!navigator.clipboard?.writeText) return false;
-
-    try {
-        await navigator.clipboard.writeText(value);
-        return true;
-    } catch {
-        return false;
-    }
-}
-
 export function summarizePageRange(response: AdminCourseListResponse | null): string {
     if (!response || response.total === 0) return "Mostrando 0 cursos";
 

--- a/frontend/src/features/case-preview/CasePreview.tsx
+++ b/frontend/src/features/case-preview/CasePreview.tsx
@@ -15,7 +15,7 @@
 import { Suspense, lazy, useState, useRef, useCallback, useMemo, useEffect, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { usePublishCase } from "@/features/teacher-dashboard/useTeacherDashboard"; // TODO: move usePublishCase to shared/ — cross-feature import accepted per #154
-import { useToast } from "@/shared/Toast";
+import { useToast } from "@/shared/toast-context";
 import { marked, type Tokens } from "marked";
 import { isMarkdownTableRow } from "./markdownTable";
 

--- a/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
@@ -257,12 +257,12 @@ describe("TeacherCoursePage", () => {
             await screen.findByRole("heading", { name: /Syllabus de la asignatura/i }),
         ).toBeTruthy();
         expect(api.teacher.getCourseDetail).toHaveBeenCalledWith("course-1");
-            expect(await screen.findByDisplayValue("GTD-GEME-01-2026")).toBeTruthy();
-            await waitFor(() => {
-                expect(
-                    screen.getByLabelText(/Departamento que la ofrece/i),
-                ).toHaveValue("Gestión de las Organizaciones");
-            });
+        expect(await screen.findByDisplayValue("GTD-GEME-01-2026")).toBeTruthy();
+        await waitFor(() => {
+            expect(
+                screen.getByLabelText(/Departamento que la ofrece/i),
+            ).toHaveValue("Gestión de las Organizaciones");
+        });
     });
 
     it("persists the active tab in the URL", async () => {

--- a/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
@@ -425,7 +425,7 @@ describe("TeacherCoursePage", () => {
             ),
         ).toBeTruthy();
         expect(
-            screen.getByText("Enlace activo. Regenerado el 16/04/2026, 5:00 a. m.."),
+            screen.getByText((content) => content.startsWith("Enlace activo. Regenerado el ")),
         ).toBeTruthy();
         expect(screen.queryByLabelText("Estado del enlace")).toBeNull();
         expect(screen.queryByLabelText("Access link ID")).toBeNull();

--- a/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
@@ -476,6 +476,9 @@ describe("TeacherCoursePage", () => {
         await waitFor(() => {
             expect(api.teacher.regenerateCourseAccessLink).toHaveBeenCalledWith("course-1");
         });
+        await waitFor(() => {
+            expect(api.teacher.getCourseAccessLink).toHaveBeenCalledTimes(2);
+        });
 
         await waitFor(() => {
             expect(screen.getByLabelText(/Enlace para compartir/i)).toHaveValue(

--- a/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
@@ -257,10 +257,12 @@ describe("TeacherCoursePage", () => {
             await screen.findByRole("heading", { name: /Syllabus de la asignatura/i }),
         ).toBeTruthy();
         expect(api.teacher.getCourseDetail).toHaveBeenCalledWith("course-1");
-        expect(screen.getByDisplayValue("GTD-GEME-01-2026")).toBeTruthy();
-        expect(
-            screen.getByLabelText(/Departamento que la ofrece/i),
-        ).toHaveValue("Gestión de las Organizaciones");
+            expect(await screen.findByDisplayValue("GTD-GEME-01-2026")).toBeTruthy();
+            await waitFor(() => {
+                expect(
+                    screen.getByLabelText(/Departamento que la ofrece/i),
+                ).toHaveValue("Gestión de las Organizaciones");
+            });
     });
 
     it("persists the active tab in the URL", async () => {

--- a/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthContextValue } from "@/app/auth/auth-types";
 import { ApiError, api } from "@/shared/api";
-import type { TeacherCourseDetailResponse } from "@/shared/adam-types";
+import type {
+    TeacherCourseAccessLinkRegenerateResponse,
+    TeacherCourseAccessLinkResponse,
+    TeacherCourseDetailResponse,
+} from "@/shared/adam-types";
 import { renderWithProviders } from "@/shared/test-utils";
 
 import { TeacherCoursePage } from "./TeacherCoursePage";
@@ -19,6 +23,8 @@ vi.mock("@/shared/api", async () => {
             teacher: {
                 ...actual.api.teacher,
                 getCourseDetail: vi.fn(),
+                getCourseAccessLink: vi.fn(),
+                regenerateCourseAccessLink: vi.fn(),
                 saveCourseSyllabus: vi.fn(),
             },
         },
@@ -184,6 +190,30 @@ function createCourseDetailResponse(
     };
 }
 
+function createCourseAccessLinkResponse(
+    overrides?: Partial<TeacherCourseAccessLinkResponse>,
+): TeacherCourseAccessLinkResponse {
+    return {
+        course_id: "course-1",
+        access_link_status: "active",
+        access_link_id: "access-link-1",
+        access_link_created_at: "2026-04-16T10:00:00Z",
+        join_path: "/app/join",
+        ...overrides,
+    };
+}
+
+function createCourseAccessLinkRegenerateResponse(
+    overrides?: Partial<TeacherCourseAccessLinkRegenerateResponse>,
+): TeacherCourseAccessLinkRegenerateResponse {
+    return {
+        course_id: "course-1",
+        access_link: "/app/join#course_access_token=fresh-token-123",
+        access_link_status: "active",
+        ...overrides,
+    };
+}
+
 function renderTeacherCoursePage(initialEntry = "/teacher/courses/course-1") {
     return renderWithProviders(
         <>
@@ -205,6 +235,15 @@ function renderTeacherCoursePage(initialEntry = "/teacher/courses/course-1") {
 describe("TeacherCoursePage", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.mocked(api.teacher.getCourseAccessLink).mockResolvedValue(
+            createCourseAccessLinkResponse(),
+        );
+        Object.defineProperty(window.navigator, "clipboard", {
+            configurable: true,
+            value: {
+                writeText: vi.fn().mockResolvedValue(undefined),
+            },
+        });
     });
 
     it("loads the composed teacher course detail route", async () => {
@@ -372,7 +411,7 @@ describe("TeacherCoursePage", () => {
         expect(screen.getByDisplayValue("1.3 — 19/04/2026")).toBeTruthy();
     });
 
-    it("renders configuration metadata without fake raw-link actions", async () => {
+    it("renders configuration metadata and explains when the raw link is not visible", async () => {
         vi.mocked(api.teacher.getCourseDetail).mockResolvedValueOnce(
             createCourseDetailResponse(),
         );
@@ -380,10 +419,144 @@ describe("TeacherCoursePage", () => {
         renderTeacherCoursePage("/teacher/courses/course-1?tab=configuracion");
 
         expect(await screen.findByRole("heading", { name: /Configuración del Curso/i })).toBeTruthy();
-        expect(screen.getByDisplayValue("access-link-1")).toBeTruthy();
-        expect(screen.getByDisplayValue("/app/join")).toBeTruthy();
-        expect(screen.queryByRole("button", { name: /copiar/i })).toBeNull();
-        expect(screen.queryByRole("button", { name: /regenerar/i })).toBeNull();
+        expect(
+            screen.getByDisplayValue(
+                "Existe un enlace activo, pero el token completo solo puede verse al regenerarlo.",
+            ),
+        ).toBeTruthy();
+        expect(
+            screen.getByText("Enlace activo. Regenerado el 16/04/2026, 5:00 a. m.."),
+        ).toBeTruthy();
+        expect(screen.queryByLabelText("Estado del enlace")).toBeNull();
+        expect(screen.queryByLabelText("Access link ID")).toBeNull();
+        expect(screen.queryByLabelText("Creado en")).toBeNull();
+        expect(screen.queryByLabelText("Join path")).toBeNull();
+        expect(screen.getByRole("button", { name: /Copiar enlace/i })).toBeDisabled();
+        expect(screen.getByRole("button", { name: /Regenerar enlace/i })).toBeEnabled();
+    });
+
+    it("keeps the section usable when the metadata refresh query fails", async () => {
+        vi.mocked(api.teacher.getCourseDetail).mockResolvedValueOnce(
+            createCourseDetailResponse(),
+        );
+        vi.mocked(api.teacher.getCourseAccessLink).mockRejectedValueOnce(
+            new Error("Not Found"),
+        );
+
+        renderTeacherCoursePage("/teacher/courses/course-1?tab=configuracion");
+
+        expect(await screen.findByRole("heading", { name: /Configuración del Curso/i })).toBeTruthy();
+        expect(screen.queryByRole("alert")).toBeNull();
+        expect(screen.queryByRole("button", { name: /Reintentar metadata/i })).toBeNull();
+        expect(
+            screen.getByDisplayValue(
+                "Existe un enlace activo, pero el token completo solo puede verse al regenerarlo.",
+            ),
+        ).toBeTruthy();
+        expect(screen.getByRole("button", { name: /Regenerar enlace/i })).toBeEnabled();
+    });
+
+    it("regenerates and copies a functional access link from the configuration tab", async () => {
+        vi.mocked(api.teacher.getCourseDetail).mockResolvedValueOnce(
+            createCourseDetailResponse(),
+        );
+        vi.mocked(api.teacher.regenerateCourseAccessLink).mockResolvedValueOnce(
+            createCourseAccessLinkRegenerateResponse(),
+        );
+        const expectedAccessLink = new URL(
+            "/app/join#course_access_token=fresh-token-123",
+            window.location.origin,
+        ).toString();
+
+        renderTeacherCoursePage("/teacher/courses/course-1?tab=configuracion");
+
+        await screen.findByRole("heading", { name: /Configuración del Curso/i });
+        fireEvent.click(screen.getByRole("button", { name: /Regenerar enlace/i }));
+
+        await waitFor(() => {
+            expect(api.teacher.regenerateCourseAccessLink).toHaveBeenCalledWith("course-1");
+        });
+
+        await waitFor(() => {
+            expect(screen.getByLabelText(/Enlace para compartir/i)).toHaveValue(
+                expectedAccessLink,
+            );
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: /Copiar enlace/i }));
+
+        await waitFor(() => {
+            expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+                expectedAccessLink,
+            );
+        });
+        expect(await screen.findByText(
+            "Access link copiado al portapapeles.",
+        )).toBeTruthy();
+    });
+
+    it("keeps unsaved syllabus draft edits when the access link is regenerated", async () => {
+        vi.mocked(api.teacher.getCourseDetail).mockResolvedValueOnce(
+            createCourseDetailResponse(),
+        );
+        vi.mocked(api.teacher.regenerateCourseAccessLink).mockResolvedValueOnce(
+            createCourseAccessLinkRegenerateResponse({
+                access_link: "/app/join#course_access_token=fresh-token-draft",
+            }),
+        );
+
+        renderTeacherCoursePage();
+
+        await screen.findByRole("heading", { name: /Syllabus de la asignatura/i });
+        fireEvent.change(screen.getByLabelText("Departamento que la ofrece"), {
+            target: { value: "Departamento en borrador" },
+        });
+
+        fireEvent.click(screen.getByRole("tab", { name: "Configuración" }));
+        await screen.findByRole("heading", { name: /Configuración del Curso/i });
+        fireEvent.click(screen.getByRole("button", { name: /Regenerar enlace/i }));
+
+        await waitFor(() => {
+            expect(api.teacher.regenerateCourseAccessLink).toHaveBeenCalledWith("course-1");
+        });
+        await waitFor(() => {
+            expect(api.teacher.getCourseDetail).toHaveBeenCalledTimes(1);
+        });
+
+        fireEvent.click(screen.getByRole("tab", { name: /Syllabus/i }));
+
+        expect(await screen.findByLabelText("Departamento que la ofrece")).toHaveValue(
+            "Departamento en borrador",
+        );
+    });
+
+    it("shows a teacher-facing error when access link regeneration fails", async () => {
+        vi.mocked(api.teacher.getCourseDetail).mockResolvedValueOnce(
+            createCourseDetailResponse(),
+        );
+        vi.mocked(api.teacher.regenerateCourseAccessLink).mockRejectedValueOnce(
+            new ApiError(
+                409,
+                "regeneration already running",
+                "course_link_regeneration_in_progress",
+            ),
+        );
+
+        renderTeacherCoursePage("/teacher/courses/course-1?tab=configuracion");
+
+        await screen.findByRole("heading", { name: /Configuración del Curso/i });
+        fireEvent.click(screen.getByRole("button", { name: /Regenerar enlace/i }));
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+            "Ya hay una regeneración en curso para este access link. Intenta nuevamente en unos segundos.",
+        );
+        await waitFor(() => {
+            expect(
+                screen.getAllByText(
+                    "Ya hay una regeneración en curso para este access link. Intenta nuevamente en unos segundos.",
+                ).length,
+            ).toBeGreaterThanOrEqual(2);
+        });
     });
 
     it("shows a page-level error when the detail query fails", async () => {

--- a/frontend/src/features/teacher-course/TeacherCoursePage.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.tsx
@@ -4,6 +4,7 @@ import {
     AlertCircle,
     BookOpen,
     ChevronRight,
+    Copy,
     LoaderCircle,
     Plus,
     RefreshCcw,
@@ -26,18 +27,21 @@ import {
     createEmptyTeacherSyllabusModule,
     createEmptyTeacherSyllabusPayload,
     createEmptyTeacherSyllabusUnit,
-    formatAccessLinkStatus,
     formatTeacherCourseStatus,
+    getTeacherCourseAccessLinkErrorMessage,
     formatTeacherCourseTimestamp,
     getTeacherCoursePageErrorMessage,
     getTeacherCourseSaveErrorMessage,
     getTeacherCourseTab,
     isStaleSyllabusRevisionError,
+    useRegenerateTeacherCourseAccessLink,
     useSaveTeacherCourseSyllabus,
+    useTeacherCourseAccessLink,
     useTeacherCourseDetail,
     validateTeacherCourseDraft,
 } from "@/features/teacher-course/teacherCourseModel";
-import { useToast } from "@/shared/Toast";
+import { copyToClipboard } from "@/shared/clipboard";
+import { useToast } from "@/shared/toast-context";
 
 const SYLLABUS_TAB_ID = "teacher-course-tab-syllabus";
 const CONFIG_TAB_ID = "teacher-course-tab-configuracion";
@@ -125,11 +129,15 @@ export function TeacherCoursePage() {
     const [searchParams, setSearchParams] = useSearchParams();
     const activeTab = getTeacherCourseTab(searchParams.get("tab"));
     const courseDetailQuery = useTeacherCourseDetail(courseId);
+    const accessLinkQuery = useTeacherCourseAccessLink(courseId);
+    const regenerateAccessLinkMutation = useRegenerateTeacherCourseAccessLink(courseId);
     const saveSyllabusMutation = useSaveTeacherCourseSyllabus(courseId);
     const [draft, setDraft] = useState<TeacherCourseDraft>(
         createEmptyTeacherSyllabusPayload(),
     );
     const [formError, setFormError] = useState<string | null>(null);
+    const [accessLinkActionError, setAccessLinkActionError] = useState<string | null>(null);
+    const [transientAccessLink, setTransientAccessLink] = useState<string | null>(null);
 
     useEffect(() => {
         if (courseDetailQuery.data) {
@@ -137,6 +145,11 @@ export function TeacherCoursePage() {
             setFormError(null);
         }
     }, [courseDetailQuery.data]);
+
+    useEffect(() => {
+        setAccessLinkActionError(null);
+        setTransientAccessLink(null);
+    }, [courseId]);
 
     const detail = courseDetailQuery.data;
     const pageErrorMessage = courseDetailQuery.error
@@ -152,6 +165,34 @@ export function TeacherCoursePage() {
     );
 
     const revisionLabel = detail?.revision_metadata.current_revision ?? 0;
+    const accessLinkState = detail
+        ? accessLinkQuery.data ?? {
+              course_id: detail.course.id,
+              ...detail.configuration,
+          }
+        : null;
+    const visibleAccessLink = transientAccessLink
+        ? new URL(transientAccessLink, window.location.origin).toString()
+        : null;
+    const accessLinkDisplayValue = visibleAccessLink
+        ? visibleAccessLink
+        : accessLinkState?.access_link_status === "active"
+          ? "Existe un enlace activo, pero el token completo solo puede verse al regenerarlo."
+          : "Aún no existe un enlace activo para estudiantes.";
+    const accessLinkHelperText = visibleAccessLink
+        ? "Este es el enlace recién generado. Cópialo ahora; si recargas la página necesitarás regenerarlo de nuevo porque el token completo no se almacena."
+        : accessLinkState?.access_link_status === "active"
+          ? "Ya existe un enlace activo para estudiantes, pero por seguridad solo puedes ver y copiar un token nuevo en el momento de regenerarlo."
+          : "Regenera el access link para crear el primer enlace de acceso para tus estudiantes.";
+    const accessLinkMetadataText = accessLinkState?.access_link_status === "active"
+        ? accessLinkState.access_link_created_at
+            ? `Enlace activo. Regenerado el ${formatTeacherCourseTimestamp(accessLinkState.access_link_created_at)}.`
+            : "Enlace activo y listo para compartir con estudiantes."
+        : `Aún no existe un enlace activo. Se usará ${accessLinkState?.join_path ?? detail?.configuration.join_path ?? "/app/join"} cuando regeneres uno nuevo.`;
+    const accessLinkErrorMessage = accessLinkActionError;
+    const isRegeneratingAccessLink = regenerateAccessLinkMutation.isPending;
+    const isRefreshingAccessLink = accessLinkQuery.isFetching && !accessLinkQuery.isLoading;
+    const canRegenerateAccessLink = detail?.course.status === "active";
 
     function setTab(tab: TeacherCourseTab) {
         const nextParams = new URLSearchParams(searchParams);
@@ -369,6 +410,46 @@ export function TeacherCoursePage() {
 
             showToast(message, "error");
         }
+    }
+
+    async function handleRegenerateAccessLink() {
+        setAccessLinkActionError(null);
+
+        try {
+            const response = await regenerateAccessLinkMutation.mutateAsync();
+            setTransientAccessLink(response.access_link);
+            showToast(
+                "Nuevo access link generado. Cópialo y compártelo con tus estudiantes.",
+                "success",
+            );
+            void accessLinkQuery.refetch();
+        } catch (error) {
+            const message = getTeacherCourseAccessLinkErrorMessage(
+                error,
+                "No se pudo regenerar el access link. Intenta nuevamente.",
+            );
+            setAccessLinkActionError(message);
+            showToast(message, "error");
+        }
+    }
+
+    async function handleCopyAccessLink() {
+        if (!visibleAccessLink) {
+            return;
+        }
+
+        setAccessLinkActionError(null);
+
+        const copied = await copyToClipboard(visibleAccessLink);
+        if (!copied) {
+            const message =
+                "No se pudo copiar el enlace. Puedes copiarlo manualmente desde el campo visible.";
+            setAccessLinkActionError(message);
+            showToast(message, "error");
+            return;
+        }
+
+        showToast("Access link copiado al portapapeles.", "success");
     }
 
     if (courseDetailQuery.isLoading) {
@@ -1342,58 +1423,67 @@ export function TeacherCoursePage() {
                                 <div className="alert-strip alert-info mb-6">
                                     <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
                                     <span>
-                                        Esta vista solo muestra la metadata entregada por el backend. El contrato actual no expone un raw invite link reutilizable, por eso aquí no aparecen acciones de copiar o regenerar tokens.
+                                        El token completo solo se muestra inmediatamente después de regenerar el enlace. Si vuelves a entrar a la página, deberás crear uno nuevo para copiarlo otra vez.
                                     </span>
                                 </div>
 
-                                <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
-                                    <div>
-                                        <label className="form-label" htmlFor="configuration-access-status">
-                                            Estado del enlace
-                                        </label>
-                                        <input
-                                            id="configuration-access-status"
-                                            className="form-input"
-                                            readOnly
-                                            value={formatAccessLinkStatus(
-                                                detail.configuration.access_link_status,
-                                            )}
-                                        />
+                                {accessLinkErrorMessage ? (
+                                    <div className="alert-strip alert-warn mb-6" role="alert">
+                                        <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+                                        <span>{accessLinkErrorMessage}</span>
                                     </div>
-                                    <div>
-                                        <label className="form-label" htmlFor="configuration-access-id">
-                                            Access link ID
-                                        </label>
-                                        <input
-                                            id="configuration-access-id"
-                                            className="form-input font-mono text-sm"
-                                            readOnly
-                                            value={detail.configuration.access_link_id ?? "No disponible"}
-                                        />
+                                ) : null}
+
+                                <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-5 shadow-sm">
+                                    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                                        <div>
+                                            <label className="form-label" htmlFor="configuration-visible-access-link">
+                                                Enlace para compartir
+                                            </label>
+                                            <p className="max-w-3xl text-sm text-slate-500">
+                                                Regenera un enlace funcional para estudiantes usando el mismo flujo seguro del join real.
+                                            </p>
+                                        </div>
+                                        <div className="flex flex-wrap items-center gap-3">
+                                            <button
+                                                type="button"
+                                                onClick={() => void handleCopyAccessLink()}
+                                                disabled={!visibleAccessLink}
+                                                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+                                            >
+                                                <Copy className="h-4 w-4" />
+                                                Copiar enlace
+                                            </button>
+                                            <button
+                                                type="button"
+                                                onClick={() => void handleRegenerateAccessLink()}
+                                                disabled={!canRegenerateAccessLink || isRegeneratingAccessLink}
+                                                className="inline-flex items-center gap-2 rounded-xl bg-[#0144a0] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#00337a] disabled:cursor-not-allowed disabled:opacity-70"
+                                            >
+                                                {isRegeneratingAccessLink ? (
+                                                    <LoaderCircle className="h-4 w-4 animate-spin" />
+                                                ) : (
+                                                    <RefreshCcw className="h-4 w-4" />
+                                                )}
+                                                {isRegeneratingAccessLink ? "Regenerando..." : "Regenerar enlace"}
+                                            </button>
+                                        </div>
                                     </div>
-                                    <div>
-                                        <label className="form-label" htmlFor="configuration-created-at">
-                                            Creado en
-                                        </label>
-                                        <input
-                                            id="configuration-created-at"
-                                            className="form-input"
+
+                                    <div className="mt-4">
+                                        <textarea
+                                            id="configuration-visible-access-link"
+                                            className="form-input min-h-[112px] font-mono text-sm"
                                             readOnly
-                                            value={formatTeacherCourseTimestamp(
-                                                detail.configuration.access_link_created_at,
-                                            )}
+                                            value={accessLinkDisplayValue}
                                         />
-                                    </div>
-                                    <div>
-                                        <label className="form-label" htmlFor="configuration-join-path">
-                                            Join path
-                                        </label>
-                                        <input
-                                            id="configuration-join-path"
-                                            className="form-input font-mono text-sm"
-                                            readOnly
-                                            value={detail.configuration.join_path}
-                                        />
+                                        <p className="form-hint">{accessLinkHelperText}</p>
+                                        <p className="mt-2 text-sm text-slate-500">{accessLinkMetadataText}</p>
+                                        {isRefreshingAccessLink ? (
+                                            <p className="mt-2 text-xs font-semibold text-slate-400">
+                                                Actualizando metadata del enlace...
+                                            </p>
+                                        ) : null}
                                     </div>
                                 </div>
                             </SectionCard>

--- a/frontend/src/features/teacher-course/TeacherCoursePage.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.tsx
@@ -422,7 +422,6 @@ export function TeacherCoursePage() {
                 "Nuevo access link generado. Cópialo y compártelo con tus estudiantes.",
                 "success",
             );
-            void accessLinkQuery.refetch();
         } catch (error) {
             const message = getTeacherCourseAccessLinkErrorMessage(
                 error,

--- a/frontend/src/features/teacher-course/teacherCourseModel.ts
+++ b/frontend/src/features/teacher-course/teacherCourseModel.ts
@@ -327,6 +327,34 @@ export function getTeacherCourseSaveErrorMessage(
     }
 }
 
+export function getTeacherCourseAccessLinkErrorMessage(
+    error: unknown,
+    fallback: string,
+): string {
+    if (!(error instanceof ApiError)) {
+        return error instanceof Error ? error.message : fallback;
+    }
+
+    switch (error.detail) {
+        case "course_inactive":
+            return "No se puede regenerar el access link de un curso inactivo.";
+        case "course_link_regeneration_in_progress":
+            return "Ya hay una regeneración en curso para este access link. Intenta nuevamente en unos segundos.";
+        case "course_link_regeneration_failed":
+            return "No se pudo regenerar el access link por un error interno. Intenta nuevamente.";
+        case "course_not_found":
+            return "El curso ya no existe o no pertenece a tu cuenta docente.";
+        case "invalid_token":
+            return "Tu sesión expiró. Vuelve a iniciar sesión para continuar.";
+        case "profile_incomplete":
+            return "Tu perfil docente todavía no está listo para usar esta vista.";
+        case "membership_required":
+            return "Tu cuenta no tiene una membresía docente activa para este curso.";
+        default:
+            return error.message || fallback;
+    }
+}
+
 export function validateTeacherCourseDraft(draft: TeacherCourseDraft): string | null {
     const payload = sanitizeTeacherSyllabusPayload(draft);
 
@@ -375,6 +403,16 @@ export function useTeacherCourseDetail(courseId: string) {
     });
 }
 
+export function useTeacherCourseAccessLink(courseId: string) {
+    return useQuery({
+        queryKey: queryKeys.teacher.accessLink(courseId),
+        queryFn: () => api.teacher.getCourseAccessLink(courseId),
+        enabled: Boolean(courseId),
+        staleTime: 30_000,
+        refetchOnWindowFocus: false,
+    });
+}
+
 export function useSaveTeacherCourseSyllabus(courseId: string) {
     const queryClient = useQueryClient();
 
@@ -383,6 +421,19 @@ export function useSaveTeacherCourseSyllabus(courseId: string) {
             api.teacher.saveCourseSyllabus(courseId, request),
         onSuccess: (detail) => {
             queryClient.setQueryData(queryKeys.teacher.course(courseId), detail);
+        },
+    });
+}
+
+export function useRegenerateTeacherCourseAccessLink(courseId: string) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: () => api.teacher.regenerateCourseAccessLink(courseId),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({
+                queryKey: queryKeys.teacher.accessLink(courseId),
+            });
         },
     });
 }

--- a/frontend/src/features/teacher-dashboard/DeadlineEditModal.test.tsx
+++ b/frontend/src/features/teacher-dashboard/DeadlineEditModal.test.tsx
@@ -10,8 +10,10 @@ vi.mock("./useTeacherDashboard", () => ({
     useUpdateDeadline: () => ({ mutate: mutateFn, isPending: false }),
 }));
 
-vi.mock("@/shared/Toast", async () => {
-    const actual = await vi.importActual<typeof import("@/shared/Toast")>("@/shared/Toast");
+vi.mock("@/shared/toast-context", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/toast-context")>(
+        "@/shared/toast-context",
+    );
     return { ...actual, useToast: () => ({ showToast: showToastFn }) };
 });
 

--- a/frontend/src/features/teacher-dashboard/DeadlineEditModal.tsx
+++ b/frontend/src/features/teacher-dashboard/DeadlineEditModal.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import type { FormEvent } from "react";
 
-import { useToast } from "@/shared/Toast";
+import { useToast } from "@/shared/toast-context";
 
 import { useUpdateDeadline } from "./useTeacherDashboard";
 

--- a/frontend/src/features/teacher-dashboard/QuickActionsSection.tsx
+++ b/frontend/src/features/teacher-dashboard/QuickActionsSection.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 
-import { useToast } from "@/shared/Toast";
+import { useToast } from "@/shared/toast-context";
 import { DashboardActionCard } from "@/shared/ui/DashboardActionCard";
 
 function SparklesIcon() {

--- a/frontend/src/shared/Toast.test.tsx
+++ b/frontend/src/shared/Toast.test.tsx
@@ -4,7 +4,8 @@ import { describe, expect, it, vi } from "vitest";
 import { render } from "@testing-library/react";
 import type { ReactNode } from "react";
 
-import { ToastProvider, useToast } from "./Toast";
+import { ToastProvider } from "./Toast";
+import { useToast } from "./toast-context";
 
 function wrapper({ children }: { children: ReactNode }) {
     return <ToastProvider>{children}</ToastProvider>;

--- a/frontend/src/shared/Toast.tsx
+++ b/frontend/src/shared/Toast.tsx
@@ -1,27 +1,18 @@
 import {
-    createContext,
     useCallback,
-    useContext,
     useEffect,
     useMemo,
     useRef,
     useState,
 } from "react";
 import type { ReactNode } from "react";
-
-export type ToastType = "success" | "error" | "info";
+import { ToastContext, type ToastType } from "@/shared/toast-context";
 
 interface ToastItem {
     id: number;
     message: string;
     type: ToastType;
 }
-
-export interface ToastContextValue {
-    showToast: (message: string, type?: ToastType) => void;
-}
-
-const ToastContext = createContext<ToastContextValue | null>(null);
 
 export function ToastProvider({ children }: { children: ReactNode }) {
     const [toasts, setToasts] = useState<ToastItem[]>([]);
@@ -76,12 +67,4 @@ export function ToastProvider({ children }: { children: ReactNode }) {
             </div>
         </ToastContext.Provider>
     );
-}
-
-export function useToast(): ToastContextValue {
-    const ctx = useContext(ToastContext);
-    if (!ctx) {
-        throw new Error("useToast must be used inside ToastProvider");
-    }
-    return ctx;
 }

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -464,11 +464,13 @@ export interface AdminTeacherInviteResponse {
     activation_link: string;
 }
 
-export interface AdminCourseAccessLinkRegenerateResponse {
+export interface CourseAccessLinkRegenerateResponse {
     course_id: string;
     access_link: string;
     access_link_status: "active";
 }
+
+export type AdminCourseAccessLinkRegenerateResponse = CourseAccessLinkRegenerateResponse;
 
 export interface AdminCourseRef {
     course_id: string;
@@ -651,6 +653,12 @@ export interface TeacherCourseConfiguration {
     access_link_created_at: string | null;
     join_path: string;
 }
+
+export interface TeacherCourseAccessLinkResponse extends TeacherCourseConfiguration {
+    course_id: string;
+}
+
+export type TeacherCourseAccessLinkRegenerateResponse = CourseAccessLinkRegenerateResponse;
 
 export interface TeacherCourseDetailResponse {
     course: TeacherCourseInstitutionalDetail;

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -39,6 +39,8 @@ import type {
     SuggestRequest,
     SuggestResponse,
     TeacherCaseDetailResponse,
+    TeacherCourseAccessLinkRegenerateResponse,
+    TeacherCourseAccessLinkResponse,
     TeacherCourseDetailResponse,
     TeacherCasesResponse,
     TeacherCoursesResponse,
@@ -1022,6 +1024,11 @@ export const api = {
         async getCourseDetail(courseId: string): Promise<TeacherCourseDetailResponse> {
             return parseJsonResponse<TeacherCourseDetailResponse>(`/teacher/courses/${courseId}`);
         },
+        async getCourseAccessLink(courseId: string): Promise<TeacherCourseAccessLinkResponse> {
+            return parseJsonResponse<TeacherCourseAccessLinkResponse>(
+                `/teacher/courses/${courseId}/access-link`,
+            );
+        },
         async getCases(): Promise<TeacherCasesResponse> {
             return parseJsonResponse<TeacherCasesResponse>("/teacher/cases");
         },
@@ -1035,6 +1042,16 @@ export const api = {
                     method: "PUT",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify(req),
+                },
+            );
+        },
+        async regenerateCourseAccessLink(
+            courseId: string,
+        ): Promise<TeacherCourseAccessLinkRegenerateResponse> {
+            return parseJsonResponse<TeacherCourseAccessLinkRegenerateResponse>(
+                `/teacher/courses/${courseId}/access-link/regenerate`,
+                {
+                    method: "POST",
                 },
             );
         },

--- a/frontend/src/shared/clipboard.ts
+++ b/frontend/src/shared/clipboard.ts
@@ -1,0 +1,12 @@
+export async function copyToClipboard(value: string): Promise<boolean> {
+    if (!navigator.clipboard?.writeText) {
+        return false;
+    }
+
+    try {
+        await navigator.clipboard.writeText(value);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -68,6 +68,8 @@ export const queryKeys = {
         courses: () => ["teacher", "courses"] as const,
         /** ["teacher", "course", courseId] — detalle compuesto de un curso docente */
         course: (courseId: string) => ["teacher", "course", courseId] as const,
+        /** ["teacher", "course-access-link", courseId] — metadata aislada del access link docente */
+        accessLink: (courseId: string) => ["teacher", "course-access-link", courseId] as const,
         /** ["teacher", "cases"] — casos activos del docente autenticado */
         cases: () => ["teacher", "cases"] as const,
         /** ["teacher", "case", id] — detalle de un caso del docente */

--- a/frontend/src/shared/toast-context.ts
+++ b/frontend/src/shared/toast-context.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+
+export type ToastType = "success" | "error" | "info";
+
+export interface ToastContextValue {
+    showToast: (message: string, type?: ToastType) => void;
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function useToast(): ToastContextValue {
+    const ctx = useContext(ToastContext);
+    if (!ctx) {
+        throw new Error("useToast must be used inside ToastProvider");
+    }
+    return ctx;
+}


### PR DESCRIPTION
## Summary
- add teacher-scoped access-link metadata and regeneration endpoints that reuse the secure backend core
- add the teacher regenerate and copy workflow with isolated query state so unsaved syllabus drafts are preserved
- simplify the teacher access-link panel UX and extract shared frontend clipboard and toast utilities
- validate the real student join runtime with the regenerated access link and keep the full backend/frontend matrix green

Closes #185

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] `uv run --directory backend pytest -q` (315 passed, 12 skipped)
- [x] `uv run --directory backend mypy src`
- [x] `npm --prefix frontend run lint`
- [x] `npm --prefix frontend run test` (42 files, 319 tests)
- [x] `npm --prefix frontend run build`