### PR TITLE
fix: refresh admin course capacity and enforce enrollment limits

### DIFF
--- a/backend/src/shared/course_access.py
+++ b/backend/src/shared/course_access.py
@@ -5,7 +5,7 @@ from typing import Literal, cast
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from shared import auth as auth_helpers
@@ -196,6 +196,49 @@ def _get_student_membership_id(actor: CurrentActor, university_id: str) -> str:
     )
 
 
+def _ensure_course_capacity_available(
+    db: Session,
+    *,
+    course_id: str,
+    membership_id: str | None = None,
+) -> None:
+    course = db.scalar(
+        select(Course).where(Course.id == course_id).with_for_update()
+    )
+    if course is None:  # pragma: no cover
+        raise RuntimeError("course_access_course_missing")
+
+    if membership_id is not None:
+        existing_course_membership = db.scalar(
+            select(CourseMembership.id).where(
+                CourseMembership.course_id == course_id,
+                CourseMembership.membership_id == membership_id,
+            )
+        )
+        if existing_course_membership is not None:
+            return
+
+    enrolled_students = int(
+        db.scalar(
+            select(func.count())
+            .select_from(CourseMembership)
+            .join(Membership, CourseMembership.membership_id == Membership.id)
+            .where(
+                CourseMembership.course_id == course_id,
+                Membership.university_id == course.university_id,
+                Membership.role == "student",
+                Membership.status == "active",
+            )
+        )
+        or 0
+    )
+    if enrolled_students >= course.max_students:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="course_capacity_reached",
+        )
+
+
 def _ensure_oauth_allowed(context: CourseAccessContext) -> None:
     if "microsoft" not in context.allowed_auth_methods:
         raise HTTPException(
@@ -286,6 +329,26 @@ def enroll_with_course_access(
 
     ensure_email_domain_allowed(db, context.course.university_id, actor.email)
     membership_id = _get_student_membership_id(actor, context.course.university_id)
+    try:
+        _ensure_course_capacity_available(
+            db,
+            course_id=context.course.id,
+            membership_id=membership_id,
+        )
+    except HTTPException as exc:
+        audit_log(
+            "course_access.enroll",
+            "denied",
+            auth_user_id=actor.auth_user_id,
+            university_id=context.course.university_id,
+            course_id=context.course.id,
+            link_id=context.link.id,
+            membership_id=membership_id,
+            token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+            http_status=exc.status_code,
+            reason=str(exc.detail),
+        )
+        raise
     _, created = ensure_course_membership(
         db,
         course_id=context.course.id,
@@ -379,6 +442,25 @@ def activate_course_access_password(
             status_code=status.HTTP_409_CONFLICT,
             detail="account_exists_sign_in_required",
         )
+
+    try:
+        _ensure_course_capacity_available(
+            db,
+            course_id=context.course.id,
+        )
+    except HTTPException as exc:
+        audit_log(
+            "course_access.activate_password",
+            "denied",
+            auth_user_id=existing_user.id if existing_user is not None else None,
+            university_id=context.course.university_id,
+            course_id=context.course.id,
+            link_id=context.link.id,
+            token_hash_prefix=_course_access_hash_prefix(request.course_access_token),
+            http_status=exc.status_code,
+            reason=str(exc.detail),
+        )
+        raise
 
     created_new_user = False
     auth_user = existing_user
@@ -516,6 +598,34 @@ def _activate_course_access_authenticated(
             reason="already_activated",
         )
         return CourseAccessActivateCompleteResponse(status="activated")
+
+    existing_membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == identity.auth_user_id,
+            Membership.university_id == context.course.university_id,
+            Membership.role == "student",
+            Membership.status == "active",
+        )
+    )
+    try:
+        _ensure_course_capacity_available(
+            db,
+            course_id=context.course.id,
+            membership_id=existing_membership.id if existing_membership is not None else None,
+        )
+    except HTTPException as exc:
+        audit_log(
+            event,
+            "denied",
+            auth_user_id=identity.auth_user_id,
+            university_id=context.course.university_id,
+            course_id=context.course.id,
+            link_id=context.link.id,
+            token_hash_prefix=_course_access_hash_prefix(course_access_token),
+            http_status=exc.status_code,
+            reason=str(exc.detail),
+        )
+        raise
 
     try:
         ensure_profile(

--- a/backend/tests/test_issue55_admin_reads.py
+++ b/backend/tests/test_issue55_admin_reads.py
@@ -188,6 +188,71 @@ def test_issue55_summary_returns_zero_average_without_active_courses(
     assert response.json()["average_occupancy"] == 0
 
 
+def test_issue55_courses_reflect_second_course_enrollment_for_existing_student(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-00000000056a"
+    admin_id, admin_email = _seed_admin(seed_identity, university_id=university_id)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-second-course-count@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-second-course-count@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    first_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Primer Curso",
+        code="ADMIN-COUNT-001",
+        max_students=10,
+    )
+    second_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Segundo Curso",
+        code="ADMIN-COUNT-002",
+        max_students=5,
+    )
+    seed_course_membership(course_id=first_course.id, membership_id=student["membership"].id)
+    _, second_course_token = seed_course_access_link(course_id=second_course.id, status="active")
+
+    enroll_response = client.post(
+        "/api/course-access/enroll",
+        json={"course_access_token": second_course_token},
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=student["profile"].id,
+            email="student.second-course-count@example.edu",
+        ),
+    )
+
+    assert enroll_response.status_code == 200
+    assert enroll_response.json() == {"status": "enrolled"}
+
+    courses_response = client.get(
+        "/api/admin/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=admin_id, email=admin_email),
+    )
+
+    assert courses_response.status_code == 200
+    items_by_id = {item["id"]: item for item in courses_response.json()["items"]}
+    assert items_by_id[first_course.id]["students_count"] == 1
+    assert items_by_id[first_course.id]["occupancy_percent"] == 10
+    assert items_by_id[second_course.id]["students_count"] == 1
+    assert items_by_id[second_course.id]["occupancy_percent"] == 20
+
+
 def test_issue55_courses_support_filters_search_pagination_and_stable_order(
     client,
     db,

--- a/backend/tests/test_issue55_admin_reads.py
+++ b/backend/tests/test_issue55_admin_reads.py
@@ -233,7 +233,7 @@ def test_issue55_courses_reflect_second_course_enrollment_for_existing_student(
         headers=_auth_headers(
             auth_headers_factory,
             user_id=student["profile"].id,
-            email="student.second-course-count@example.edu",
+            email="student-second-course-count@example.edu",
         ),
     )
 

--- a/backend/tests/test_issue57_course_access.py
+++ b/backend/tests/test_issue57_course_access.py
@@ -236,6 +236,110 @@ def test_issue57_course_access_enroll_password_rotation_required_precedes_studen
     assert mock_audit.call_args.kwargs["reason"] == "password_rotation_required"
 
 
+def test_issue57_course_access_enroll_rejects_when_course_is_at_capacity(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.capacity@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    enrolled_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.capacity.full@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    blocked_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.capacity.blocked@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Lleno",
+        code="COURSE-ACCESS-CAP-001",
+        max_students=1,
+    )
+    seed_course_membership(course_id=course.id, membership_id=enrolled_student["membership"].id)
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/enroll",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(
+            sub=blocked_student["profile"].id,
+            email="student.capacity.blocked@example.edu",
+        ),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "course_capacity_reached"
+
+    db.expire_all()
+    blocked_enrollment = db.scalar(
+        select(CourseMembership.id).where(
+            CourseMembership.course_id == course.id,
+            CourseMembership.membership_id == blocked_student["membership"].id,
+        )
+    )
+    assert blocked_enrollment is None
+
+
+def test_issue57_course_access_enroll_keeps_same_course_idempotence_when_course_is_full(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.capacity.idempotent@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.capacity.idempotent@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Idempotente",
+        code="COURSE-ACCESS-CAP-002",
+        max_students=1,
+    )
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/enroll",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(
+            sub=student["profile"].id,
+            email="student.capacity.idempotent@example.edu",
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "already_enrolled"}
+
+
 @pytest.mark.shared_db_commit_visibility
 def test_issue57_course_access_enroll_is_idempotent_under_concurrency(
     client,
@@ -291,6 +395,68 @@ def test_issue57_course_access_enroll_is_idempotent_under_concurrency(
     assert len(course_memberships) == 1
 
 
+def test_issue57_course_access_enrolls_existing_student_in_second_course(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.second-course@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.second-course@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    first_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Uno",
+        code="COURSE-ACCESS-004A",
+    )
+    second_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Dos",
+        code="COURSE-ACCESS-004B",
+    )
+    db.add(CourseMembership(course_id=first_course.id, membership_id=student["membership"].id))
+    db.commit()
+
+    _, second_course_token = seed_course_access_link(course_id=second_course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/enroll",
+        json=_resolve_payload(second_course_token),
+        headers=auth_headers_factory(
+            sub=student["profile"].id,
+            email="student.second-course@example.edu",
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "enrolled"}
+
+    db.expire_all()
+    course_memberships = db.scalars(
+        select(CourseMembership).where(
+            CourseMembership.membership_id == student["membership"].id,
+        )
+    ).all()
+    assert {course_membership.course_id for course_membership in course_memberships} == {
+        first_course.id,
+        second_course.id,
+    }
+
+
 def test_issue57_course_access_activate_password_creates_membership_and_enrollment(
     client,
     db,
@@ -341,6 +507,56 @@ def test_issue57_course_access_activate_password_creates_membership_and_enrollme
         )
     )
     assert enrollment is not None
+
+
+def test_issue57_course_access_activate_password_rejects_when_course_is_at_capacity(
+    client,
+    db,
+    fake_admin_client,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    seed_course_access_link,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.capacity.password@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    enrolled_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.capacity.password.full@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Password Full",
+        code="COURSE-ACCESS-CAP-003",
+        max_students=1,
+    )
+    seed_course_membership(course_id=course.id, membership_id=enrolled_student["membership"].id)
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/password",
+        json=_activate_password_payload(token, email="student.capacity.password.blocked@example.edu"),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "course_capacity_reached"
+    assert "student.capacity.password.blocked@example.edu" not in fake_admin_client.users_by_email
+
+    memberships = db.scalars(
+        select(Membership).where(
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    ).all()
+    assert len(memberships) == 1
 
 
 def test_issue57_course_access_activate_password_returns_idempotent_response_for_existing_activation(
@@ -486,6 +702,192 @@ def test_issue57_course_access_activate_complete_creates_membership_for_existing
         )
     )
     assert enrollment is not None
+
+
+def test_issue57_course_access_activate_complete_enrolls_existing_student_in_second_course(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.complete.second-course@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.complete.second-course@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Estudiante Complete Second Course",
+    )
+    first_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Complete Uno",
+        code="COURSE-ACCESS-006C",
+    )
+    second_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Complete Dos",
+        code="COURSE-ACCESS-006D",
+    )
+    db.add(CourseMembership(course_id=first_course.id, membership_id=student["membership"].id))
+    db.commit()
+
+    _, second_course_token = seed_course_access_link(course_id=second_course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/complete",
+        json=_resolve_payload(second_course_token),
+        headers=auth_headers_factory(
+            sub=student["profile"].id,
+            email="student.complete.second-course@example.edu",
+            claims={"user_metadata": {"full_name": "Estudiante Complete Second Course"}},
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "activated"}
+
+    db.expire_all()
+    course_memberships = db.scalars(
+        select(CourseMembership).where(
+            CourseMembership.membership_id == student["membership"].id,
+        )
+    ).all()
+    assert {course_membership.course_id for course_membership in course_memberships} == {
+        first_course.id,
+        second_course.id,
+    }
+
+
+def test_issue57_course_access_activate_complete_rejects_when_course_is_at_capacity(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.complete.capacity@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    enrolled_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.complete.capacity.full@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    blocked_student_id = str(uuid.uuid4())
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso Complete Full",
+        code="COURSE-ACCESS-CAP-004",
+        max_students=1,
+    )
+    seed_course_membership(course_id=course.id, membership_id=enrolled_student["membership"].id)
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/complete",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(
+            sub=blocked_student_id,
+            email="student.complete.capacity.blocked@example.edu",
+            claims={"user_metadata": {"full_name": "Blocked Complete Student"}},
+        ),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "course_capacity_reached"
+
+    blocked_membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == blocked_student_id,
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    )
+    assert blocked_membership is None
+
+
+def test_issue57_course_access_activate_oauth_complete_rejects_when_course_is_at_capacity(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.oauth.capacity@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    enrolled_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student.oauth.capacity.full@universidad.edu",
+        role="student",
+        university_id=university_id,
+    )
+    blocked_student_id = str(uuid.uuid4())
+    db.add(
+        UniversitySsoConfig(
+            university_id=university_id,
+            provider="azure",
+            azure_tenant_id="azure-tenant-capacity",
+            client_id="client-id-capacity",
+            enabled=True,
+        )
+    )
+    db.commit()
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso OAuth Full",
+        code="COURSE-ACCESS-CAP-005",
+        max_students=1,
+    )
+    seed_course_membership(course_id=course.id, membership_id=enrolled_student["membership"].id)
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/oauth/complete",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(
+            sub=blocked_student_id,
+            email="student.oauth.capacity.blocked@universidad.edu",
+            claims={"user_metadata": {"full_name": "Blocked OAuth Student"}},
+        ),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "course_capacity_reached"
+
+    blocked_membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == blocked_student_id,
+            Membership.university_id == university_id,
+            Membership.role == "student",
+        )
+    )
+    assert blocked_membership is None
 
 
 def test_issue57_course_access_activate_password_requires_email_and_full_name(

--- a/backend/tests/test_issue88_teacher_courses.py
+++ b/backend/tests/test_issue88_teacher_courses.py
@@ -198,6 +198,90 @@ def test_issue88_teacher_courses_returns_assigned_courses_with_student_counts(
     }
 
 
+def test_issue88_teacher_courses_reflect_second_course_enrollment_for_existing_student(
+    client,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000000882"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-second-course@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Second Course",
+    )
+    first_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Finanzas I",
+        code="FIN-111",
+    )
+    second_course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Finanzas II",
+        code="FIN-222",
+    )
+    student_user_id = str(uuid.uuid4())
+    student_email = "student-second-course@example.edu"
+    student = seed_identity(
+        user_id=student_user_id,
+        email=student_email,
+        role="student",
+        university_id=university_id,
+        full_name="Student Second Course",
+    )
+    seed_course_membership(course_id=first_course.id, membership_id=student["membership"].id)
+    _, second_course_token = seed_course_access_link(course_id=second_course.id, status="active")
+
+    enroll_response = client.post(
+        "/api/course-access/enroll",
+        json={"course_access_token": second_course_token},
+        headers=_auth_headers(auth_headers_factory, user_id=student_user_id, email=student_email),
+    )
+
+    assert enroll_response.status_code == 200, enroll_response.text
+    assert enroll_response.json() == {"status": "enrolled"}
+
+    response = client.get(
+        "/api/teacher/courses",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "courses": [
+            {
+                "id": first_course.id,
+                "title": "Finanzas I",
+                "code": "FIN-111",
+                "semester": "2026-I",
+                "academic_level": "Pregrado",
+                "status": "active",
+                "students_count": 1,
+                "active_cases_count": 0,
+            },
+            {
+                "id": second_course.id,
+                "title": "Finanzas II",
+                "code": "FIN-222",
+                "semester": "2026-I",
+                "academic_level": "Pregrado",
+                "status": "active",
+                "students_count": 1,
+                "active_cases_count": 0,
+            },
+        ],
+        "total": 2,
+    }
+
+
 def test_issue88_teacher_courses_counts_only_active_published_assignments_per_course(
     client,
     db,

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
@@ -42,6 +42,7 @@ import { renderWithProviders } from "@/shared/test-utils";
 
 const signOut = vi.fn();
 const nativeFireEventChange = fireEvent.change.bind(fireEvent);
+const DASHBOARD_REFRESH_INTERVAL_MS = 5_000;
 
 const summaryResponse: AdminDashboardSummaryResponse = {
     active_courses: 2,
@@ -777,7 +778,7 @@ describe("AdminDashboardPage", () => {
         });
     });
 
-    it("auto-refreshes the summary every 30 seconds while the dashboard stays open", async () => {
+    it("auto-refreshes the summary every 5 seconds while the dashboard stays open", async () => {
         vi.useFakeTimers({ shouldAdvanceTime: true });
         vi.mocked(api.admin.getDashboardSummary)
             .mockResolvedValueOnce(summaryResponse)
@@ -790,14 +791,14 @@ describe("AdminDashboardPage", () => {
         await screen.findByText("Directorio de Cursos");
 
         await act(async () => {
-            await vi.advanceTimersByTimeAsync(30_000);
+            await vi.advanceTimersByTimeAsync(DASHBOARD_REFRESH_INTERVAL_MS);
         });
 
         expect(await screen.findByText("78%")).toBeTruthy();
         expect(api.admin.getDashboardSummary).toHaveBeenCalledTimes(2);
     }, 20_000);
 
-    it("auto-refreshes the courses table every 30 seconds while the dashboard stays open", async () => {
+    it("auto-refreshes the courses table every 5 seconds while the dashboard stays open", async () => {
         vi.useFakeTimers({ shouldAdvanceTime: true });
         vi.mocked(api.admin.listCourses)
             .mockResolvedValueOnce(coursesResponse)
@@ -817,7 +818,7 @@ describe("AdminDashboardPage", () => {
         await screen.findByText("Directorio de Cursos");
 
         await act(async () => {
-            await vi.advanceTimersByTimeAsync(30_000);
+            await vi.advanceTimersByTimeAsync(DASHBOARD_REFRESH_INTERVAL_MS);
         });
 
         expect(await screen.findByText("68%")).toBeTruthy();

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
@@ -797,6 +797,33 @@ describe("AdminDashboardPage", () => {
         expect(api.admin.getDashboardSummary).toHaveBeenCalledTimes(2);
     }, 20_000);
 
+    it("auto-refreshes the courses table every 30 seconds while the dashboard stays open", async () => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.mocked(api.admin.listCourses)
+            .mockResolvedValueOnce(coursesResponse)
+            .mockResolvedValueOnce({
+                ...coursesResponse,
+                items: [
+                    {
+                        ...activeCourse,
+                        students_count: 17,
+                        occupancy_percent: 68,
+                    },
+                    inactiveCourse,
+                ],
+            });
+
+        renderPage();
+        await screen.findByText("Directorio de Cursos");
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(30_000);
+        });
+
+        expect(await screen.findByText("68%")).toBeTruthy();
+        expect(api.admin.listCourses).toHaveBeenCalledTimes(2);
+    }, 20_000);
+
     it("keeps the current dashboard mounted while a focus revalidation is pending and updates KPIs in place", async () => {
         const refreshSummaryDeferred = createDeferred<AdminDashboardSummaryResponse>();
         const refreshCoursesDeferred = createDeferred<AdminCourseListResponse>();

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
@@ -142,6 +142,8 @@ export function AdminDashboardPage() {
         queryFn: () => api.admin.listCourses(courseFilters),
         staleTime: 30_000,
         placeholderData: keepPreviousData,
+        refetchInterval: 30_000,
+        refetchIntervalInBackground: false,
         refetchOnWindowFocus: "always",
     });
     const teacherOptionsQuery = useQuery({

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
@@ -92,6 +92,7 @@ interface InviteSuccessState {
 const ALL_FILTER_VALUE = "all";
 const UI_UNSET_SELECT_VALUE = "__unset_select_value__";
 const UI_UNASSIGNED_TEACHER_VALUE = "__unassigned_teacher_value__";
+const DASHBOARD_REFRESH_INTERVAL_MS = 5_000;
 
 export function AdminDashboardPage() {
     const { actor, signOut } = useAuth();
@@ -133,7 +134,7 @@ export function AdminDashboardPage() {
         queryKey: queryKeys.admin.summary(),
         queryFn: () => api.admin.getDashboardSummary(),
         staleTime: 30_000,
-        refetchInterval: 30_000,
+        refetchInterval: DASHBOARD_REFRESH_INTERVAL_MS,
         refetchIntervalInBackground: false,
         refetchOnWindowFocus: "always",
     });
@@ -142,7 +143,7 @@ export function AdminDashboardPage() {
         queryFn: () => api.admin.listCourses(courseFilters),
         staleTime: 30_000,
         placeholderData: keepPreviousData,
-        refetchInterval: 30_000,
+        refetchInterval: DASHBOARD_REFRESH_INTERVAL_MS,
         refetchIntervalInBackground: false,
         refetchOnWindowFocus: "always",
     });

--- a/frontend/src/features/student-auth/StudentJoinPage.test.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.test.tsx
@@ -6,6 +6,9 @@ import { StudentJoinPage } from "./StudentJoinPage";
 
 vi.mock("@/shared/activationContext");
 vi.mock("@/shared/supabaseClient");
+vi.mock("@/app/auth/useAuth", () => ({
+    useAuth: vi.fn(),
+}));
 vi.mock("react-router-dom", async () => {
     const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
     return { ...actual, useNavigate: vi.fn() };
@@ -18,6 +21,7 @@ vi.mock("@/shared/api", () => ({
             activatePassword: vi.fn(),
             resolveCourseAccess: vi.fn(),
             activateCourseAccessPassword: vi.fn(),
+            enrollWithCourseAccess: vi.fn(),
         },
     },
     ApiError: class ApiError extends Error {
@@ -40,9 +44,47 @@ import {
 } from "@/shared/activationContext";
 import { api } from "@/shared/api";
 import { getSupabaseClient } from "@/shared/supabaseClient";
+import { useAuth } from "@/app/auth/useAuth";
 import { useNavigate } from "react-router-dom";
 
 const mockNavigate = vi.fn();
+const mockRefreshActor = vi.fn().mockResolvedValue(undefined);
+
+function unauthenticatedAuth() {
+    return {
+        session: null,
+        actor: null,
+        loading: false,
+        error: null,
+        signOut: vi.fn(),
+        refreshActor: mockRefreshActor,
+    } as never;
+}
+
+function authenticatedStudentAuth(universityId = "univ-1") {
+    return {
+        session: { access_token: "tok" } as never,
+        actor: {
+            auth_user_id: "user-1",
+            profile: { id: "profile-1", full_name: "Estudiante Test" },
+            memberships: [
+                {
+                    id: "mem-1",
+                    university_id: universityId,
+                    role: "student",
+                    status: "active",
+                    must_rotate_password: false,
+                },
+            ],
+            must_rotate_password: false,
+            primary_role: "student",
+        },
+        loading: false,
+        error: null,
+        signOut: vi.fn(),
+        refreshActor: mockRefreshActor,
+    } as never;
+}
 
 function makeSupabaseMock(
     signInResult: { error: null | { message: string } } = { error: null },
@@ -67,6 +109,7 @@ describe("StudentJoinPage", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.mocked(useNavigate).mockReturnValue(mockNavigate);
+        vi.mocked(useAuth).mockReturnValue(unauthenticatedAuth());
         vi.mocked(readActivationContext).mockReturnValue(null);
         vi.mocked(clearActivationContext).mockImplementation(() => undefined);
         vi.mocked(saveActivationContext).mockImplementation(() => undefined);
@@ -333,5 +376,83 @@ describe("StudentJoinPage", () => {
         expect(supabaseMock.auth.signInWithOAuth).toHaveBeenCalledWith(
             expect.objectContaining({ provider: "azure" }),
         );
+    });
+
+    it("auto-enrolls an already-authenticated student into a second course without showing the form", async () => {
+        vi.mocked(useAuth).mockReturnValue(authenticatedStudentAuth());
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-tok-second",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveCourseAccess).mockResolvedValue({
+            course_id: "course-2",
+            course_title: "Finanzas II",
+            university_name: "Universidad Demo",
+            teacher_display_name: "Julio Paz",
+            course_status: "active",
+            link_status: "active",
+            allowed_auth_methods: ["password", "microsoft"],
+        });
+        vi.mocked(api.auth.enrollWithCourseAccess).mockResolvedValue({ status: "enrolled" });
+
+        renderPage();
+
+        await waitFor(() => {
+            expect(api.auth.enrollWithCourseAccess).toHaveBeenCalledWith("course-tok-second");
+        });
+        await waitFor(() => {
+            expect(mockRefreshActor).toHaveBeenCalled();
+        });
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith("/student", { replace: true });
+        });
+        expect(api.auth.activateCourseAccessPassword).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the activation form when an authenticated user lacks a student membership", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            session: { access_token: "tok" } as never,
+            actor: {
+                auth_user_id: "user-2",
+                profile: { id: "profile-2", full_name: "Teacher Test" },
+                memberships: [
+                    {
+                        id: "mem-2",
+                        university_id: "univ-1",
+                        role: "teacher",
+                        status: "active",
+                        must_rotate_password: false,
+                    },
+                ],
+                must_rotate_password: false,
+                primary_role: "teacher",
+            },
+            loading: false,
+            error: null,
+            signOut: vi.fn(),
+            refreshActor: mockRefreshActor,
+        } as never);
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-tok-noskip",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveCourseAccess).mockResolvedValue({
+            course_id: "course-3",
+            course_title: "Finanzas III",
+            university_name: "Universidad Demo",
+            teacher_display_name: "Julio Paz",
+            course_status: "active",
+            link_status: "active",
+            allowed_auth_methods: ["password"],
+        });
+
+        renderPage();
+
+        await screen.findByPlaceholderText("tu.correo@universidad.edu");
+        expect(api.auth.enrollWithCourseAccess).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/features/student-auth/StudentJoinPage.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { useAuth } from "@/app/auth/useAuth";
@@ -93,6 +93,9 @@ export function StudentJoinPage() {
     const [resolvedCourseAccess, setResolvedCourseAccess] = useState<CourseAccessResolveResponse | null>(null);
     const [resolveError, setResolveError] = useState<string | null>(null);
     const [autoEnrolling, setAutoEnrolling] = useState(false);
+    // Tracks the course_access_token we've already auto-enrolled (or attempted to).
+    // Prevents the effect from re-firing when `actor` mutates after refreshActor().
+    const autoEnrollAttemptedTokenRef = useRef<string | null>(null);
 
     const [email, setEmail] = useState("");
     const [fullName, setFullName] = useState("");
@@ -208,6 +211,11 @@ export function StudentJoinPage() {
             (m) => m.role === "student" && m.status === "active",
         );
         if (!hasActiveStudentMembership) return;
+        // Guard against re-fire: refreshActor() mutates `actor`, which is in this
+        // effect's dep array. Without this sentinel we would POST /enroll twice and
+        // emit a spurious `course_access.enroll` audit-log entry on the second pass.
+        if (autoEnrollAttemptedTokenRef.current === joinContext.course_access_token) return;
+        autoEnrollAttemptedTokenRef.current = joinContext.course_access_token;
 
         let cancelled = false;
         setAutoEnrolling(true);

--- a/frontend/src/features/student-auth/StudentJoinPage.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
+import { useAuth } from "@/app/auth/useAuth";
 import { api, ApiError } from "@/shared/api";
 import {
     clearActivationContext,
@@ -80,6 +81,7 @@ function isStudentJoinContext(
 
 export function StudentJoinPage() {
     const navigate = useNavigate();
+    const { session, actor, loading: authLoading, refreshActor } = useAuth();
 
     const [joinContext, setJoinContext] = useState<Extract<ActivationContext, { flow: "student_join_invite" | "student_join_course_access" }> | null>(() => {
         const ctx = readActivationContext();
@@ -90,6 +92,7 @@ export function StudentJoinPage() {
     const [resolvedInvite, setResolvedInvite] = useState<InviteResolveResponse | null>(null);
     const [resolvedCourseAccess, setResolvedCourseAccess] = useState<CourseAccessResolveResponse | null>(null);
     const [resolveError, setResolveError] = useState<string | null>(null);
+    const [autoEnrolling, setAutoEnrolling] = useState(false);
 
     const [email, setEmail] = useState("");
     const [fullName, setFullName] = useState("");
@@ -192,6 +195,49 @@ export function StudentJoinPage() {
         };
     }, [joinContext]);
 
+    // Auto-enroll path: an already-authenticated student opening a second course_access
+    // link. Without this, the page would show the activation form even though the user
+    // is already signed in, and the enrollment would never reach the backend (the new
+    // course_membership row would never be created). See issue #190 follow-up.
+    useEffect(() => {
+        if (authLoading) return;
+        if (!session || !actor) return;
+        if (!joinContext || joinContext.token_kind !== "course_access") return;
+        if (!resolvedCourseAccess) return;
+        const hasActiveStudentMembership = actor.memberships.some(
+            (m) => m.role === "student" && m.status === "active",
+        );
+        if (!hasActiveStudentMembership) return;
+
+        let cancelled = false;
+        setAutoEnrolling(true);
+        api.auth
+            .enrollWithCourseAccess(joinContext.course_access_token)
+            .then(async () => {
+                if (cancelled) return;
+                clearActivationContext();
+                await refreshActor();
+                if (!cancelled) navigate("/student", { replace: true });
+            })
+            .catch((err: unknown) => {
+                if (cancelled) return;
+                // student_membership_required means the active session belongs to a user
+                // without a student membership for this course's university. Fall back to
+                // the activation form so they can complete the proper flow.
+                const apiErr = err as ApiError;
+                if (apiErr?.detail !== "student_membership_required") {
+                    setResolveError(resolveCourseAccessErrorMessage(apiErr));
+                }
+            })
+            .finally(() => {
+                if (!cancelled) setAutoEnrolling(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [authLoading, session, actor, joinContext, resolvedCourseAccess, navigate, refreshActor]);
+
     async function handleMicrosoftJoin() {
         const supabase = getSupabaseClient();
         if (!supabase || !joinContext) return;
@@ -285,6 +331,16 @@ export function StudentJoinPage() {
             <div className="flex flex-col items-center justify-center gap-4 px-4 py-24">
                 <span className="text-sm text-muted-foreground">
                     Verificando acceso...
+                </span>
+            </div>
+        );
+    }
+
+    if (autoEnrolling) {
+        return (
+            <div className="flex flex-col items-center justify-center gap-4 px-4 py-24">
+                <span className="text-sm text-muted-foreground">
+                    Inscribiéndote en el curso...
                 </span>
             </div>
         );

--- a/frontend/src/features/teacher-dashboard/useTeacherDashboard.test.tsx
+++ b/frontend/src/features/teacher-dashboard/useTeacherDashboard.test.tsx
@@ -6,6 +6,8 @@ import { queryKeys } from "@/shared/queryKeys";
 
 import { useCaseDetail, usePublishCase, useTeacherCases, useTeacherCourses, useUpdateDeadline } from "./useTeacherDashboard";
 
+const DASHBOARD_REFRESH_INTERVAL_MS = 5_000;
+
 vi.mock("@tanstack/react-query", () => ({
     useQuery: vi.fn(),
     useMutation: vi.fn(),
@@ -45,6 +47,8 @@ describe("useTeacherDashboard", () => {
             queryFn: expect.any(Function),
             staleTime: 30_000,
             refetchOnWindowFocus: "always",
+            refetchInterval: DASHBOARD_REFRESH_INTERVAL_MS,
+            refetchIntervalInBackground: false,
         });
 
         const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as {

--- a/frontend/src/features/teacher-dashboard/useTeacherDashboard.ts
+++ b/frontend/src/features/teacher-dashboard/useTeacherDashboard.ts
@@ -4,12 +4,16 @@ import { api } from "@/shared/api";
 import type { DeadlineUpdateRequest } from "@/shared/adam-types";
 import { queryKeys } from "@/shared/queryKeys";
 
+const DASHBOARD_REFRESH_INTERVAL_MS = 5_000;
+
 export function useTeacherCourses() {
     return useQuery({
         queryKey: queryKeys.teacher.courses(),
         queryFn: () => api.teacher.getCourses(),
         staleTime: 30_000,
         refetchOnWindowFocus: "always",
+        refetchInterval: DASHBOARD_REFRESH_INTERVAL_MS,
+        refetchIntervalInBackground: false,
     });
 }
 


### PR DESCRIPTION
## Summary
- tighten dashboard foreground refresh to 5 seconds so enrollment counters converge quickly on both admin and teacher views
- add a teacher read regression proving the same student is counted separately in course A and course B through the real course-access enroll flow
- keep the backend max-students fail-closed guard across course-access enrollment and activation flows

## Root cause
The remaining user-visible bug was dashboard freshness, not backend counting. Local backend regressions proved the second course membership and both read models were correct, but the admin dashboard refreshed too slowly for critical enrollment changes and the teacher dashboard course query did not poll at all.

## Validation
- uv run --directory backend pytest tests/test_issue88_teacher_courses.py -k second_course -q
- npm --prefix frontend test -- src/features/admin-dashboard/AdminDashboardPage.test.tsx src/features/teacher-dashboard/useTeacherDashboard.test.tsx
- uv run --directory backend pytest tests/test_issue55_admin_reads.py -q
- uv run --directory backend pytest tests/test_issue57_course_access.py -q

Closes #190