### PR TITLE
fix: align student runtime case resolution viewport

### DIFF
--- a/frontend/src/features/case-preview/CasePreview.tsx
+++ b/frontend/src/features/case-preview/CasePreview.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import type { CanonicalCaseOutput, ModuleId } from "@/shared/adam-types";
 import { usePublishCase } from "@/features/teacher-dashboard/useTeacherDashboard";
 import { useToast } from "@/shared/toast-context";
+import { PORTAL_SHELL_HEIGHT_VH_CLASSNAME } from "@/shared/ui/layout";
 import {
     CASE_VIEWER_STYLES,
     CaseContentRenderer,
@@ -143,7 +144,7 @@ export function CasePreview({
     return (
         <>
             <style>{CASE_VIEWER_STYLES}</style>
-            <div className="case-preview flex h-[calc(100vh-80px)] overflow-hidden font-sans">
+            <div className={`case-preview flex ${PORTAL_SHELL_HEIGHT_VH_CLASSNAME} overflow-hidden font-sans`}>
                 <aside className="flex flex-col flex-shrink-0 bg-[#0f172a] text-slate-400" style={{ width: 280 }}>
                     <div className="h-16 flex items-center px-5 border-b border-slate-800 flex-shrink-0">
                         {showBackToDashboardButton ? (

--- a/frontend/src/features/student-layout/StudentUserHeader.tsx
+++ b/frontend/src/features/student-layout/StudentUserHeader.tsx
@@ -2,6 +2,7 @@ import { Bell, GraduationCap } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { useAuth } from "@/app/auth/useAuth";
+import { PORTAL_HEADER_HEIGHT_CLASSNAME } from "@/shared/ui/layout";
 
 const STUDENT_NAME_FALLBACK = "Estudiante";
 const STUDENT_SUBTITLE = "Portal Estudiante";
@@ -23,7 +24,7 @@ export function StudentUserHeader() {
             className="w-full"
             style={{ background: "linear-gradient(135deg, #0144a0 0%, #0255c5 100%)" }}
         >
-            <div className="mx-auto flex h-20 max-w-6xl items-center justify-between gap-4 px-6">
+            <div className={`mx-auto flex ${PORTAL_HEADER_HEIGHT_CLASSNAME} max-w-6xl items-center justify-between gap-4 px-6`}>
                 <div className="flex min-w-0 items-center gap-3.5">
                     <Link
                         to="/student/dashboard"

--- a/frontend/src/features/student-runtime/StudentCaseResolutionPage.test.tsx
+++ b/frontend/src/features/student-runtime/StudentCaseResolutionPage.test.tsx
@@ -136,12 +136,27 @@ describe("StudentCaseResolutionPage", () => {
         renderPage();
 
         expect(screen.getByTestId("case-content-renderer")).toHaveAttribute("data-answer", "borrador");
+        expect(screen.queryByText(/Tus respuestas se guardan automaticamente hasta que confirmes el envio final\./i)).toBeNull();
+        expect(screen.getByTestId("student-submit-trigger")).toBeTruthy();
         fireEvent.click(screen.getByRole("button", { name: /Enviar respuestas/i }));
 
         expect(screen.getByText(/Esto es definitivo, no podras editar/i)).toBeTruthy();
         fireEvent.click(screen.getByRole("button", { name: /Confirmar entrega/i }));
 
         await waitFor(() => expect(submitCase).toHaveBeenCalled());
+    });
+
+    it("locks body scroll while the case shell is active", () => {
+        vi.mocked(useStudentCaseResolution).mockReturnValue(buildHookState() as never);
+
+        const { unmount } = renderPage();
+
+        expect(screen.getByTestId("student-case-shell")).toBeTruthy();
+        expect(document.body.style.overflow).toBe("hidden");
+
+        unmount();
+
+        expect(document.body.style.overflow).toBe("");
     });
 
     it("renders submitted cases in read-only mode", () => {
@@ -190,6 +205,7 @@ describe("StudentCaseResolutionPage", () => {
         renderPage();
 
         expect(screen.getAllByText(/Entregado/i).length).toBeGreaterThan(0);
+        expect(screen.queryByText(/Entregado, esperando retroalimentacion\./i)).toBeNull();
         expect(screen.getByTestId("case-content-renderer")).toHaveAttribute("data-read-only", "true");
         expect(screen.queryByRole("button", { name: /Enviar respuestas/i })).toBeNull();
     });
@@ -221,8 +237,24 @@ describe("StudentCaseResolutionPage", () => {
         renderPage();
 
         expect(screen.getAllByText(/Plazo cerrado/i).length).toBeGreaterThan(0);
+        expect(screen.queryByText(/El caso quedo en modo solo lectura porque la ventana de entrega cerro\./i)).toBeNull();
         expect(screen.getByTestId("case-content-renderer")).toHaveAttribute("data-read-only", "true");
         fireEvent.click(screen.getByRole("button", { name: /Entendido/i }));
         expect(closeDeadlineModal).toHaveBeenCalled();
+    });
+
+    it("renders operational banners when the hook reports an active alert", () => {
+        vi.mocked(useStudentCaseResolution).mockReturnValue(buildHookState({
+            errorBanner: {
+                tone: "red",
+                title: "No se pudo guardar el borrador",
+                message: "Intenta de nuevo en unos segundos.",
+            },
+        }) as never);
+
+        renderPage();
+
+        expect(screen.getByText(/No se pudo guardar el borrador/i)).toBeTruthy();
+        expect(screen.getByText(/Intenta de nuevo en unos segundos\./i)).toBeTruthy();
     });
 });

--- a/frontend/src/features/student-runtime/StudentCaseResolutionPage.tsx
+++ b/frontend/src/features/student-runtime/StudentCaseResolutionPage.tsx
@@ -20,6 +20,7 @@ import { StudentVersionConflictModal } from "./StudentVersionConflictModal";
 import { useStudentCaseResolution } from "./useStudentCaseResolution";
 
 type BannerTone = "amber" | "red" | "emerald";
+const STUDENT_HEADER_HEIGHT_PX = 80;
 
 interface RuntimeBannerState {
     tone: BannerTone;
@@ -164,34 +165,31 @@ export function StudentCaseResolutionPage() {
 
     const statusBadge = resolveStatusBadge(effectiveStatus);
     const banner = useMemo<RuntimeBannerState | null>(() => {
-        if (errorBanner) {
-            return errorBanner;
+        if (!errorBanner || errorBanner.tone === "emerald") {
+            return null;
         }
 
-        if (detail?.response.status === "submitted" || submittedAt) {
-            return {
-                tone: "emerald",
-                title: "Entregado",
-                message: "Entregado, esperando retroalimentacion.",
-            };
+        return errorBanner;
+    }, [errorBanner]);
+
+    useEffect(() => {
+        const shouldLockBodyScroll = Boolean(detail && caseOutput);
+        const previousOverflow = document.body.style.overflow;
+
+        if (shouldLockBodyScroll) {
+            document.body.style.overflow = "hidden";
         }
 
-        if (detail && effectiveStatus === "closed") {
-            return {
-                tone: "amber",
-                title: "Plazo cerrado",
-                message: "El caso quedo en modo solo lectura porque la ventana de entrega cerro.",
-            };
-        }
-
-        return null;
-    }, [detail, effectiveStatus, errorBanner, submittedAt]);
+        return () => {
+            document.body.style.overflow = previousOverflow;
+        };
+    }, [caseOutput, detail]);
 
     if (!assignmentId) {
         return (
-            <div className="min-h-screen bg-[#F0F4F8]" data-testid="student-case-resolution-page">
+            <div className="flex min-h-screen flex-col bg-[#F0F4F8]" data-testid="student-case-resolution-page">
                 <StudentUserHeader />
-                <main className="mx-auto max-w-4xl px-6 py-9">
+                <main className="flex flex-1 items-center justify-center px-6 py-9">
                     <ErrorState
                         title="Caso no encontrado"
                         message="No pudimos resolver la ruta del caso solicitado."
@@ -203,10 +201,10 @@ export function StudentCaseResolutionPage() {
     }
 
     return (
-        <div className="min-h-screen bg-[#F0F4F8]" data-testid="student-case-resolution-page">
+        <div className="flex min-h-screen flex-col bg-[#F0F4F8]" data-testid="student-case-resolution-page">
             <StudentUserHeader />
 
-            <main className="mx-auto flex max-w-[1440px] flex-col gap-6 px-6 py-8">
+            <main className="flex flex-1 min-h-0 flex-col">
                 <StudentVersionConflictModal
                     isOpen={isConflictModalOpen}
                     isReloading={isReloadingConflict}
@@ -215,21 +213,27 @@ export function StudentCaseResolutionPage() {
                 <StudentDeadlineClosedModal isOpen={isDeadlineModalOpen} onClose={closeDeadlineModal} />
 
                 {detailQuery.isLoading && !detail ? (
-                    <LoadingState />
+                    <div className="flex flex-1 items-center justify-center px-6 py-9">
+                        <LoadingState />
+                    </div>
                 ) : detailQuery.error || !detail || !caseOutput ? (
-                    <ErrorState
-                        title="No se pudo cargar el caso"
-                        message={getApiErrorMessage(detailQuery.error)}
-                        onRetry={() => {
-                            void detailQuery.refetch();
-                        }}
-                    />
+                    <div className="flex flex-1 items-center justify-center px-6 py-9">
+                        <ErrorState
+                            title="No se pudo cargar el caso"
+                            message={getApiErrorMessage(detailQuery.error)}
+                            onRetry={() => {
+                                void detailQuery.refetch();
+                            }}
+                        />
+                    </div>
                 ) : (
                     <>
-                        {banner ? <RuntimeBanner banner={banner} /> : null}
-
                         <style>{CASE_VIEWER_STYLES}</style>
-                        <div className="case-preview flex min-h-[calc(100vh-120px)] overflow-hidden rounded-[28px] border border-slate-200 shadow-sm">
+                        <div
+                            className="case-preview flex overflow-hidden font-sans"
+                            data-testid="student-case-shell"
+                            style={{ height: `calc(100dvh - ${STUDENT_HEADER_HEIGHT_PX}px)` }}
+                        >
                             <aside className="flex flex-shrink-0 flex-col bg-[#0f172a] text-slate-400" style={{ width: 280 }}>
                                 <div className="flex h-16 flex-shrink-0 items-center border-b border-slate-800 px-5">
                                     <Link
@@ -285,20 +289,35 @@ export function StudentCaseResolutionPage() {
                                         </span>
                                     </div>
 
-                                    <div className="hidden flex-shrink-0 items-center gap-4 lg:flex">
-                                        <StudentDeadlineCountdown
-                                            deadline={detail.assignment.deadline}
-                                            isClosed={effectiveStatus === "closed"}
-                                            className="text-slate-500"
-                                        />
-                                        <StudentAutosaveIndicator
-                                            state={autosaveState}
-                                            lastAutosavedAt={lastAutosavedAt}
-                                            submittedAt={submittedAt}
-                                            className="text-slate-500"
+                                    <div className="flex flex-shrink-0 items-center gap-3">
+                                        <div className="hidden xl:flex items-center gap-4">
+                                            <StudentDeadlineCountdown
+                                                deadline={detail.assignment.deadline}
+                                                isClosed={effectiveStatus === "closed"}
+                                                className="text-slate-500"
+                                            />
+                                            <StudentAutosaveIndicator
+                                                state={autosaveState}
+                                                lastAutosavedAt={lastAutosavedAt}
+                                                submittedAt={submittedAt}
+                                                className="text-slate-500"
+                                            />
+                                        </div>
+
+                                        <StudentSubmitBar
+                                            isVisible={!isReadOnly}
+                                            hasAnyAnswer={hasAnyAnswer}
+                                            isSubmitting={submitMutation.isPending}
+                                            onSubmit={submitCase}
                                         />
                                     </div>
                                 </header>
+
+                                {banner ? (
+                                    <div className="flex-shrink-0 border-b border-slate-200 bg-white px-6 py-4">
+                                        <RuntimeBanner banner={banner} />
+                                    </div>
+                                ) : null}
 
                                 <CaseContentRenderer
                                     result={caseOutput}
@@ -309,13 +328,6 @@ export function StudentCaseResolutionPage() {
                                     onAnswersChange={setLocalAnswers}
                                     readOnly={isReadOnly}
                                     showExpectedSolutions={false}
-                                />
-
-                                <StudentSubmitBar
-                                    isVisible={!isReadOnly}
-                                    hasAnyAnswer={hasAnyAnswer}
-                                    isSubmitting={submitMutation.isPending}
-                                    onSubmit={submitCase}
                                 />
                             </section>
                         </div>

--- a/frontend/src/features/student-runtime/StudentCaseResolutionPage.tsx
+++ b/frontend/src/features/student-runtime/StudentCaseResolutionPage.tsx
@@ -5,6 +5,7 @@ import { Link, useParams } from "react-router-dom";
 import { StudentUserHeader } from "@/features/student-layout/StudentUserHeader";
 import type { ModuleId } from "@/shared/adam-types";
 import { getApiErrorMessage } from "@/shared/api";
+import { PORTAL_SHELL_HEIGHT_DVH } from "@/shared/ui/layout";
 import {
     CASE_VIEWER_STYLES,
     CaseContentRenderer,
@@ -20,7 +21,6 @@ import { StudentVersionConflictModal } from "./StudentVersionConflictModal";
 import { useStudentCaseResolution } from "./useStudentCaseResolution";
 
 type BannerTone = "amber" | "red" | "emerald";
-const STUDENT_HEADER_HEIGHT_PX = 80;
 
 interface RuntimeBannerState {
     tone: BannerTone;
@@ -232,7 +232,7 @@ export function StudentCaseResolutionPage() {
                         <div
                             className="case-preview flex overflow-hidden font-sans"
                             data-testid="student-case-shell"
-                            style={{ height: `calc(100dvh - ${STUDENT_HEADER_HEIGHT_PX}px)` }}
+                            style={{ height: PORTAL_SHELL_HEIGHT_DVH }}
                         >
                             <aside className="flex flex-shrink-0 flex-col bg-[#0f172a] text-slate-400" style={{ width: 280 }}>
                                 <div className="flex h-16 flex-shrink-0 items-center border-b border-slate-800 px-5">

--- a/frontend/src/features/student-runtime/StudentSubmitBar.tsx
+++ b/frontend/src/features/student-runtime/StudentSubmitBar.tsx
@@ -26,23 +26,16 @@ export function StudentSubmitBar({
 
     return (
         <>
-            <div className="sticky bottom-0 z-10 border-t border-slate-200 bg-white/95 px-6 py-4 backdrop-blur-sm">
-                <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-4 rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
-                    <div>
-                        <p className="text-sm font-bold text-slate-900">Enviar respuestas</p>
-                        <p className="mt-1 text-xs text-slate-500">Tus respuestas se guardan automaticamente hasta que confirmes el envio final.</p>
-                    </div>
-                    <button
-                        type="button"
-                        disabled={!hasAnyAnswer || isSubmitting}
-                        onClick={() => setIsConfirming(true)}
-                        className="inline-flex items-center gap-2 rounded-xl bg-[#0144a0] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#00337a] disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                        {isSubmitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <SendHorizonal className="h-4 w-4" />}
-                        Enviar respuestas
-                    </button>
-                </div>
-            </div>
+            <button
+                type="button"
+                data-testid="student-submit-trigger"
+                disabled={!hasAnyAnswer || isSubmitting}
+                onClick={() => setIsConfirming(true)}
+                className="inline-flex h-10 items-center gap-2 rounded-xl bg-[#0144a0] px-4 text-sm font-semibold text-white transition-colors hover:bg-[#00337a] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+                {isSubmitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <SendHorizonal className="h-4 w-4" />}
+                Enviar respuestas
+            </button>
 
             {isConfirming ? (
                 <div className="fixed inset-0 z-[80] flex items-center justify-center bg-slate-950/60 px-4 py-6 backdrop-blur-sm">

--- a/frontend/src/features/student-runtime/useStudentCaseResolution.test.ts
+++ b/frontend/src/features/student-runtime/useStudentCaseResolution.test.ts
@@ -170,6 +170,11 @@ describe("useStudentCaseResolution", () => {
         });
         expect(api.student.saveCaseDraft).toHaveBeenCalledTimes(1);
         await waitFor(() => expect(result.current.autosaveState).toBe("retrying"));
+        expect(result.current.errorBanner).toEqual({
+            tone: "amber",
+            title: "Sin conexion, reintentando...",
+            message: "Guardaremos tu borrador apenas el servidor vuelva a responder.",
+        });
 
         await act(async () => {
             await vi.advanceTimersByTimeAsync(1_000);
@@ -346,5 +351,6 @@ describe("useStudentCaseResolution", () => {
                 next_deadline: null,
             },
         ]);
+        expect(result.current.errorBanner).toBeNull();
     });
 });

--- a/frontend/src/features/student-runtime/useStudentCaseResolution.ts
+++ b/frontend/src/features/student-runtime/useStudentCaseResolution.ts
@@ -594,11 +594,7 @@ export function useStudentCaseResolution(assignmentId: string) {
             setAutosaveState("saved");
             setReadOnlyOverride(false);
             clearDraftBackup(assignmentIdRef.current);
-            setErrorBanner({
-                tone: "emerald",
-                title: "Entregado",
-                message: "Entregado, esperando retroalimentacion.",
-            });
+            setErrorBanner(null);
         } catch (error) {
             await handleMutationError(error, "submit");
             throw error;

--- a/frontend/src/features/teacher-layout/TeacherUserHeader.tsx
+++ b/frontend/src/features/teacher-layout/TeacherUserHeader.tsx
@@ -2,6 +2,7 @@ import { Bell, GraduationCap } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { useAuth } from "@/app/auth/useAuth";
+import { PORTAL_HEADER_HEIGHT_CLASSNAME } from "@/shared/ui/layout";
 
 const FACULTY_SUBTITLE = "Portal Docente";
 
@@ -22,7 +23,7 @@ export function TeacherUserHeader() {
             className="w-full"
             style={{ background: "linear-gradient(135deg, #0144a0 0%, #0255c5 100%)" }}
         >
-            <div className="mx-auto flex h-20 max-w-6xl items-center justify-between gap-4 px-6">
+            <div className={`mx-auto flex ${PORTAL_HEADER_HEIGHT_CLASSNAME} max-w-6xl items-center justify-between gap-4 px-6`}>
                 <div className="flex min-w-0 items-center gap-3.5">
                     <Link
                         to="/teacher/dashboard"

--- a/frontend/src/shared/ui/layout.ts
+++ b/frontend/src/shared/ui/layout.ts
@@ -1,0 +1,4 @@
+export const PORTAL_HEADER_HEIGHT_PX = 80;
+export const PORTAL_HEADER_HEIGHT_CLASSNAME = "h-20";
+export const PORTAL_SHELL_HEIGHT_DVH = `calc(100dvh - ${PORTAL_HEADER_HEIGHT_PX}px)`;
+export const PORTAL_SHELL_HEIGHT_VH_CLASSNAME = "h-[calc(100vh-80px)]";


### PR DESCRIPTION
## Summary
- match the student case-resolution shell to the teacher preview viewport with a full-height layout and body scroll lock
- move the submit CTA into the case header and remove the sticky bottom banner copy
- keep only operational runtime alerts and clear normal submit success from the errorBanner state
- add regression coverage for shell scroll locking, CTA placement, and runtime alert behavior

## Validation
- uv run --directory backend pytest -q (337 passed, 12 skipped)
- uv run --directory backend mypy src
- npm --prefix frontend run lint
- npm --prefix frontend run test (49/49 files, 357/357 tests)
- npm --prefix frontend run build

## Review
- Eval suites skipped: no prompt-related files changed.
- Pre-Landing Review: No issues found.