### PR TITLE
feat(teacher-course): add search bar to gradebook students table

### DIFF
--- a/frontend/src/features/teacher-course/TeacherCourseStudentsTab.tsx
+++ b/frontend/src/features/teacher-course/TeacherCourseStudentsTab.tsx
@@ -1,10 +1,14 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
 import {
     AlertCircle,
     BarChart3,
     BookOpen,
     LoaderCircle,
     RefreshCcw,
+    Search,
     Users,
+    X,
 } from "lucide-react";
 
 import type {
@@ -82,6 +86,73 @@ export function TeacherCourseStudentsTab({
     const caseById = new Map(gradebook?.cases.map((item) => [item.assignment_id, item]) ?? []);
     const refreshLabel = isFetching && !isLoading ? "Actualizando gradebook" : "Actualizar gradebook";
 
+    const tableRef = useRef<HTMLTableElement | null>(null);
+    const topScrollRef = useRef<HTMLDivElement | null>(null);
+    const bottomScrollRef = useRef<HTMLDivElement | null>(null);
+    const [tableWidth, setTableWidth] = useState(0);
+    const [searchQuery, setSearchQuery] = useState("");
+
+    const normalizedQuery = searchQuery.trim().toLocaleLowerCase();
+    const filteredStudents = useMemo(() => {
+        if (!gradebook) return [];
+        if (!normalizedQuery) return gradebook.students;
+        return gradebook.students.filter((student) => {
+            const name = student.full_name.toLocaleLowerCase();
+            const email = student.email.toLocaleLowerCase();
+            return name.includes(normalizedQuery) || email.includes(normalizedQuery);
+        });
+    }, [gradebook, normalizedQuery]);
+
+    const hasMatrix = Boolean(
+        !isLoading && gradebook && gradebook.students.length > 0 && gradebook.cases.length > 0,
+    );
+    const hasSearchResults = filteredStudents.length > 0;
+
+    useEffect(() => {
+        const node = tableRef.current;
+        if (!node || typeof ResizeObserver === "undefined") {
+            return;
+        }
+        const observer = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                setTableWidth(entry.contentRect.width);
+            }
+        });
+        observer.observe(node);
+        return () => observer.disconnect();
+    }, [hasMatrix, gradebook?.cases.length, gradebook?.students.length]);
+
+    useEffect(() => {
+        const top = topScrollRef.current;
+        const bottom = bottomScrollRef.current;
+        if (!top || !bottom) {
+            return;
+        }
+        let lockedBy: "top" | "bottom" | null = null;
+        const handleTop = () => {
+            if (lockedBy === "bottom") return;
+            lockedBy = "top";
+            bottom.scrollLeft = top.scrollLeft;
+            requestAnimationFrame(() => {
+                lockedBy = null;
+            });
+        };
+        const handleBottom = () => {
+            if (lockedBy === "top") return;
+            lockedBy = "bottom";
+            top.scrollLeft = bottom.scrollLeft;
+            requestAnimationFrame(() => {
+                lockedBy = null;
+            });
+        };
+        top.addEventListener("scroll", handleTop, { passive: true });
+        bottom.addEventListener("scroll", handleBottom, { passive: true });
+        return () => {
+            top.removeEventListener("scroll", handleTop);
+            bottom.removeEventListener("scroll", handleBottom);
+        };
+    }, [hasMatrix]);
+
     return (
         <div
             id="teacher-course-students-panel"
@@ -90,35 +161,16 @@ export function TeacherCourseStudentsTab({
             className="space-y-6"
         >
             <section className="rounded-[24px] border border-slate-200 bg-white p-6 shadow-sm md:p-8">
-                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                    <div>
-                        <h1 className="text-2xl font-bold tracking-tight text-slate-900 md:text-[32px]">
-                            Estudiantes y calificaciones
-                        </h1>
-                        <p className="mt-2 max-w-3xl text-sm text-slate-500 md:text-base">
-                            Consulta el progreso real por caso publicado sin salir de la vista del curso.
-                        </p>
-                    </div>
-                    <div className="teacher-gradebook-header-actions">
-                        {gradebook ? (
-                            <div className="teacher-gradebook-metrics">
-                                <MetricCard
-                                    icon={<Users className="h-4 w-4" />}
-                                    label="Estudiantes activos"
-                                    value={String(gradebook.course.students_count)}
-                                />
-                                <MetricCard
-                                    icon={<BookOpen className="h-4 w-4" />}
-                                    label="Casos publicados"
-                                    value={String(gradebook.course.cases_count)}
-                                />
-                                <MetricCard
-                                    icon={<BarChart3 className="h-4 w-4" />}
-                                    label="Curso"
-                                    value={gradebook.course.code}
-                                />
-                            </div>
-                        ) : null}
+                <div className="teacher-gradebook-header">
+                    <div className="teacher-gradebook-header-row">
+                        <div className="min-w-0">
+                            <h1 className="text-2xl font-bold tracking-tight text-slate-900 md:text-[32px]">
+                                Estudiantes y calificaciones
+                            </h1>
+                            <p className="mt-2 max-w-3xl text-sm text-slate-500 md:text-base">
+                                Consulta el progreso real por caso publicado sin salir de la vista del curso.
+                            </p>
+                        </div>
                         <div className="teacher-gradebook-refresh-group">
                             <button
                                 type="button"
@@ -137,6 +189,25 @@ export function TeacherCourseStudentsTab({
                             ) : null}
                         </div>
                     </div>
+                    {gradebook ? (
+                        <div className="teacher-gradebook-metrics">
+                            <MetricCard
+                                icon={<Users className="h-4 w-4" />}
+                                label="Estudiantes activos"
+                                value={String(gradebook.course.students_count)}
+                            />
+                            <MetricCard
+                                icon={<BookOpen className="h-4 w-4" />}
+                                label="Casos publicados"
+                                value={String(gradebook.course.cases_count)}
+                            />
+                            <MetricCard
+                                icon={<BarChart3 className="h-4 w-4" />}
+                                label="Curso"
+                                value={gradebook.course.code}
+                            />
+                        </div>
+                    ) : null}
                 </div>
             </section>
 
@@ -185,10 +256,59 @@ export function TeacherCourseStudentsTab({
                 </section>
             ) : null}
 
-            {!isLoading && gradebook && gradebook.students.length > 0 && gradebook.cases.length > 0 ? (
+            {hasMatrix && gradebook ? (
                 <section className="teacher-gradebook-shell" aria-busy={isFetching}>
-                    <div className="teacher-gradebook-scroll">
-                        <table className="teacher-gradebook-table">
+                    <div className="teacher-gradebook-toolbar">
+                        <label
+                            htmlFor="teacher-gradebook-search"
+                            className="teacher-gradebook-search"
+                        >
+                            <Search
+                                className="teacher-gradebook-search-icon"
+                                aria-hidden="true"
+                            />
+                            <input
+                                id="teacher-gradebook-search"
+                                type="search"
+                                value={searchQuery}
+                                onChange={(event) => setSearchQuery(event.target.value)}
+                                placeholder="Buscar estudiante por nombre o correo"
+                                className="teacher-gradebook-search-input"
+                                autoComplete="off"
+                                spellCheck={false}
+                            />
+                            {searchQuery ? (
+                                <button
+                                    type="button"
+                                    onClick={() => setSearchQuery("")}
+                                    className="teacher-gradebook-search-clear"
+                                    aria-label="Limpiar búsqueda"
+                                >
+                                    <X className="h-4 w-4" aria-hidden="true" />
+                                </button>
+                            ) : null}
+                        </label>
+                        <p
+                            className="teacher-gradebook-search-count"
+                            aria-live="polite"
+                        >
+                            {normalizedQuery
+                                ? `${filteredStudents.length} de ${gradebook.students.length} estudiantes`
+                                : `${gradebook.students.length} estudiantes`}
+                        </p>
+                    </div>
+                    <div
+                        ref={topScrollRef}
+                        className="teacher-gradebook-scroll-top"
+                        aria-hidden="true"
+                    >
+                        <div
+                            className="teacher-gradebook-scroll-top-spacer"
+                            style={{ width: tableWidth || "100%" }}
+                        />
+                    </div>
+                    <div ref={bottomScrollRef} className="teacher-gradebook-scroll">
+                        <table ref={tableRef} className="teacher-gradebook-table">
                             <caption className="sr-only">
                                 Gradebook del curso {gradebook.course.title} con {gradebook.course.students_count} estudiantes activos y {gradebook.course.cases_count} casos publicados.
                             </caption>
@@ -197,44 +317,53 @@ export function TeacherCourseStudentsTab({
                                     <th scope="col" className="teacher-gradebook-sticky teacher-gradebook-sticky-name">
                                         Estudiante
                                     </th>
-                                    <th scope="col" className="teacher-gradebook-sticky teacher-gradebook-sticky-email">
+                                    <th scope="col" className="teacher-gradebook-email-col">
                                         Correo
                                     </th>
-                                    <th scope="col" className="teacher-gradebook-sticky teacher-gradebook-sticky-average">
-                                        Promedio / {formatTeacherGradebookScore(gradebook.course.average_score_scale)}
-                                    </th>
                                     {gradebook.cases.map((item) => (
-                                        <th key={item.assignment_id} scope="col">
+                                        <th key={item.assignment_id} scope="col" className="teacher-gradebook-case-col">
                                             <div className="teacher-gradebook-case-heading">
-                                                <span className="teacher-gradebook-case-title">{item.title}</span>
-                                                <span className="teacher-gradebook-case-meta">
-                                                    Fecha límite: {formatTeacherGradebookDeadline(item.deadline)}
+                                                <span
+                                                    className="teacher-gradebook-case-title"
+                                                    title={item.title}
+                                                >
+                                                    {item.title}
                                                 </span>
                                                 <span className="teacher-gradebook-case-meta">
-                                                    Máximo: {formatTeacherGradebookScore(item.max_score)}
+                                                    <span>Vence {formatTeacherGradebookDeadline(item.deadline)}</span>
+                                                    <span aria-hidden="true" className="teacher-gradebook-case-meta-sep">·</span>
+                                                    <span>Máx {formatTeacherGradebookScore(item.max_score)}</span>
                                                 </span>
                                             </div>
                                         </th>
                                     ))}
+                                    <th scope="col" className="teacher-gradebook-average-col">
+                                        Promedio / {formatTeacherGradebookScore(gradebook.course.average_score_scale)}
+                                    </th>
                                 </tr>
                             </thead>
                             <tbody>
-                                {gradebook.students.map((student) => (
+                                {filteredStudents.map((student) => (
                                     <tr key={student.membership_id}>
                                         <th
                                             scope="row"
                                             className="teacher-gradebook-sticky teacher-gradebook-sticky-name teacher-gradebook-student-cell"
                                         >
-                                            <div className="teacher-gradebook-student-name">{student.full_name}</div>
+                                            <div
+                                                className="teacher-gradebook-student-name"
+                                                title={student.full_name}
+                                            >
+                                                {student.full_name}
+                                            </div>
                                             <div className="teacher-gradebook-student-meta">
                                                 Ingresó: {formatTeacherCourseTimestamp(student.enrolled_at)}
                                             </div>
                                         </th>
-                                        <td className="teacher-gradebook-sticky teacher-gradebook-sticky-email teacher-gradebook-email-cell">
+                                        <td
+                                            className="teacher-gradebook-email-cell"
+                                            title={student.email}
+                                        >
                                             {student.email}
-                                        </td>
-                                        <td className="teacher-gradebook-sticky teacher-gradebook-sticky-average teacher-gradebook-average-cell">
-                                            {formatTeacherGradebookAverage(student.average_score)}
                                         </td>
                                         {student.grades.map((cell) => (
                                             <td key={`${student.membership_id}-${cell.assignment_id}`}>
@@ -244,10 +373,30 @@ export function TeacherCourseStudentsTab({
                                                 )}
                                             </td>
                                         ))}
+                                        <td className="teacher-gradebook-average-cell">
+                                            {formatTeacherGradebookAverage(student.average_score)}
+                                        </td>
                                     </tr>
                                 ))}
                             </tbody>
                         </table>
+                        {!hasSearchResults ? (
+                            <div
+                                className="teacher-gradebook-search-empty"
+                                role="status"
+                                aria-live="polite"
+                            >
+                                <AlertCircle className="h-5 w-5 text-slate-400" aria-hidden="true" />
+                                <div>
+                                    <p className="teacher-gradebook-empty-title">
+                                        Sin coincidencias
+                                    </p>
+                                    <p className="teacher-gradebook-empty-copy">
+                                        Ningún estudiante coincide con “{searchQuery}”. Prueba con otro nombre o correo.
+                                    </p>
+                                </div>
+                            </div>
+                        ) : null}
                     </div>
                 </section>
             ) : null}

--- a/frontend/src/features/teacher-course/teacherCoursePage.css
+++ b/frontend/src/features/teacher-course/teacherCoursePage.css
@@ -171,11 +171,26 @@
   transition: transform 0.18s ease;
 }
 
+.teacher-course-page .teacher-gradebook-header {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
+.teacher-course-page .teacher-gradebook-header-row {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: flex-start;
+  min-width: 0;
+}
+
 .teacher-course-page .teacher-gradebook-metrics {
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   gap: 12px;
   width: 100%;
-  max-width: 520px;
 }
 
 .teacher-course-page .teacher-gradebook-header-actions {
@@ -183,6 +198,7 @@
   flex-direction: column;
   gap: 16px;
   width: 100%;
+  min-width: 0;
 }
 
 .teacher-course-page .teacher-gradebook-refresh-group {
@@ -195,15 +211,17 @@
 .teacher-course-page .teacher-gradebook-refresh-button {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 10px;
   min-height: 44px;
   border: 1px solid #cbd5e1;
   border-radius: 14px;
-  padding: 10px 14px;
+  padding: 10px 16px;
   background: #fff;
   color: #0f172a;
   font-size: 14px;
   font-weight: 700;
+  white-space: nowrap;
   transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease;
 }
 
@@ -232,6 +250,8 @@
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
   gap: 12px;
+  flex: 1 1 170px;
+  min-width: 0;
   border: 1px solid #dbeafe;
   border-radius: 18px;
   padding: 14px 16px;
@@ -247,15 +267,19 @@
   border-radius: 14px;
   background: #0144a0;
   color: #fff;
+  flex-shrink: 0;
 }
 
 .teacher-course-page .teacher-gradebook-metric-label {
   margin: 0;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: #64748b;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .teacher-course-page .teacher-gradebook-metric-value {
@@ -263,6 +287,9 @@
   font-size: 18px;
   font-weight: 800;
   color: #0f172a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .teacher-course-page .teacher-gradebook-empty-state {
@@ -297,8 +324,126 @@
   overflow: hidden;
 }
 
+.teacher-course-page .teacher-gradebook-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid #e2e8f0;
+  background: #f8fafc;
+}
+
+.teacher-course-page .teacher-gradebook-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1 1 320px;
+  min-width: 0;
+  max-width: 480px;
+  background: #ffffff;
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 0 10px 0 38px;
+  height: 40px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.teacher-course-page .teacher-gradebook-search:focus-within {
+  border-color: #0144a0;
+  box-shadow: 0 0 0 3px rgba(1, 68, 160, 0.15);
+}
+
+.teacher-course-page .teacher-gradebook-search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  color: #64748b;
+  pointer-events: none;
+}
+
+.teacher-course-page .teacher-gradebook-search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 14px;
+  color: #0f172a;
+  height: 100%;
+}
+
+.teacher-course-page .teacher-gradebook-search-input::placeholder {
+  color: #94a3b8;
+}
+
+.teacher-course-page .teacher-gradebook-search-input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.teacher-course-page .teacher-gradebook-search-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: #64748b;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.teacher-course-page .teacher-gradebook-search-clear:hover {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.teacher-course-page .teacher-gradebook-search-clear:focus-visible {
+  outline: 2px solid #0144a0;
+  outline-offset: 2px;
+}
+
+.teacher-course-page .teacher-gradebook-search-count {
+  font-size: 13px;
+  color: #475569;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.teacher-course-page .teacher-gradebook-search-empty {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 32px 24px;
+  background: #ffffff;
+  border-top: 1px solid #eef1f6;
+}
+
+.teacher-course-page .teacher-gradebook-scroll-top {
+  overflow-x: auto;
+  overflow-y: hidden;
+  border-bottom: 1px solid #e2e8f0;
+  background: #f8fafc;
+  /* Reserve a small height so the native scrollbar is always visible. */
+  height: 14px;
+  scrollbar-width: thin;
+}
+
+.teacher-course-page .teacher-gradebook-scroll-top-spacer {
+  height: 1px;
+}
+
 .teacher-course-page .teacher-gradebook-scroll {
   overflow: auto;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
 }
 
 .teacher-course-page .teacher-gradebook-table {
@@ -310,9 +455,9 @@
 
 .teacher-course-page .teacher-gradebook-table th,
 .teacher-course-page .teacher-gradebook-table td {
-  padding: 16px;
-  border-bottom: 1px solid #e2e8f0;
-  vertical-align: top;
+  padding: 12px 14px;
+  border-bottom: 1px solid #eef1f6;
+  vertical-align: middle;
   background: #fff;
 }
 
@@ -320,9 +465,23 @@
   position: sticky;
   top: 0;
   z-index: 3;
-  min-width: 210px;
+  min-width: 200px;
+  padding: 12px 14px;
   text-align: left;
+  vertical-align: middle;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #475569;
+  background: #f1f5f9;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.teacher-course-page .teacher-gradebook-table thead th.teacher-gradebook-case-col {
   background: #f8fafc;
+  text-transform: none;
+  letter-spacing: normal;
+  vertical-align: top;
 }
 
 .teacher-course-page .teacher-gradebook-table tbody tr:nth-child(even) td {
@@ -335,35 +494,30 @@
 
 .teacher-course-page .teacher-gradebook-sticky {
   position: sticky;
-  z-index: 2;
-  background: inherit;
+  z-index: 4;
 }
 
 .teacher-course-page .teacher-gradebook-sticky-name {
   left: 0;
   min-width: 240px;
-  max-width: 240px;
-  box-shadow: 8px 0 18px -18px rgba(15, 23, 42, 0.35);
+  max-width: 260px;
+  width: 250px;
+  background: #ffffff;
+  box-shadow: 14px 0 18px -14px rgba(15, 23, 42, 0.28);
+  clip-path: inset(0 -22px 0 0);
 }
 
-.teacher-course-page .teacher-gradebook-sticky-email {
-  left: 240px;
-  min-width: 240px;
-  max-width: 240px;
-  box-shadow: 8px 0 18px -18px rgba(15, 23, 42, 0.35);
+.teacher-course-page .teacher-gradebook-table thead th.teacher-gradebook-sticky-name {
+  z-index: 5;
+  background: #f1f5f9;
 }
 
-.teacher-course-page .teacher-gradebook-sticky-average {
-  right: 0;
-  min-width: 140px;
-  max-width: 140px;
-  box-shadow: -8px 0 18px -18px rgba(15, 23, 42, 0.35);
+.teacher-course-page .teacher-gradebook-table tbody tr:nth-child(even) th.teacher-gradebook-sticky-name {
+  background: #fcfdff;
 }
 
-.teacher-course-page .teacher-gradebook-student-cell,
-.teacher-course-page .teacher-gradebook-email-cell,
-.teacher-course-page .teacher-gradebook-average-cell {
-  background: #f8fafc !important;
+.teacher-course-page .teacher-gradebook-table tbody tr:hover th.teacher-gradebook-sticky-name {
+  background: #f8fbff;
 }
 
 .teacher-course-page .teacher-gradebook-student-cell {
@@ -371,28 +525,63 @@
 }
 
 .teacher-course-page .teacher-gradebook-student-name {
+  display: block;
   font-size: 15px;
   font-weight: 800;
   color: #0f172a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
 }
 
 .teacher-course-page .teacher-gradebook-student-meta,
 .teacher-course-page .teacher-gradebook-case-meta {
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
   margin-top: 4px;
-  font-size: 12px;
+  font-size: 11px;
+  font-weight: 500;
   color: #64748b;
+  letter-spacing: 0;
+  text-transform: none;
+  line-height: 1.35;
+}
+
+.teacher-course-page .teacher-gradebook-case-meta-sep {
+  color: #cbd5f5;
 }
 
 .teacher-course-page .teacher-gradebook-case-heading {
-  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 220px;
 }
 
 .teacher-course-page .teacher-gradebook-case-title {
-  display: block;
-  font-size: 14px;
-  font-weight: 800;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 700;
   color: #0f172a;
+  line-height: 1.3;
+  letter-spacing: 0;
+  text-transform: none;
+  word-break: normal;
+  overflow-wrap: anywhere;
+}
+
+.teacher-course-page .teacher-gradebook-email-cell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: #475569;
 }
 
 .teacher-course-page .teacher-gradebook-email-cell,
@@ -406,7 +595,7 @@
   display: inline-flex;
   flex-direction: column;
   gap: 4px;
-  min-width: 160px;
+  min-width: 140px;
   border: 1px solid #e2e8f0;
   border-radius: 18px;
   padding: 12px 14px;
@@ -465,46 +654,75 @@
   color: #15803d;
 }
 
-@media (min-width: 1024px) {
-  .teacher-course-page .teacher-gradebook-header-actions {
+@media (min-width: 640px) {
+  .teacher-course-page .teacher-gradebook-header-row {
     flex-direction: row;
     align-items: flex-start;
     justify-content: space-between;
+    gap: 24px;
   }
 
   .teacher-course-page .teacher-gradebook-refresh-group {
     align-items: flex-end;
-  }
-
-  .teacher-course-page .teacher-gradebook-metrics {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    flex-shrink: 0;
   }
 }
 
-@media (max-width: 1023px) {
-  .teacher-course-page .teacher-gradebook-metrics {
-    grid-template-columns: 1fr;
+@media (min-width: 1280px) {
+  .teacher-course-page .teacher-gradebook-header-actions {
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+
+  .teacher-course-page .teacher-gradebook-header-actions .teacher-gradebook-refresh-group {
+    align-items: flex-end;
+    flex-shrink: 0;
+  }
+
+  .teacher-course-page .teacher-gradebook-header-actions .teacher-gradebook-metrics {
+    flex: 1 1 auto;
+    min-width: 0;
   }
 }
 
 @media (max-width: 767px) {
   .teacher-course-page .teacher-gradebook-table th,
   .teacher-course-page .teacher-gradebook-table td {
-    padding: 14px;
+    padding: 12px;
   }
 
   .teacher-course-page .teacher-gradebook-sticky-name {
     min-width: 200px;
-    max-width: 200px;
+    max-width: 220px;
+    width: 210px;
   }
 
-  .teacher-course-page .teacher-gradebook-sticky-email {
-    left: 200px;
-    min-width: 220px;
+  /* Drop the email column entirely on small screens to keep the matrix readable. */
+  .teacher-course-page .teacher-gradebook-email-col,
+  .teacher-course-page .teacher-gradebook-email-cell {
+    display: none;
+  }
+
+  .teacher-course-page .teacher-gradebook-table thead th {
+    min-width: 170px;
+  }
+
+  .teacher-course-page .teacher-gradebook-case-heading {
+    min-width: 170px;
     max-width: 220px;
   }
 
-  .teacher-course-page .teacher-gradebook-sticky-average {
-    left: 420px;
+  .teacher-course-page .teacher-gradebook-chip {
+    min-width: 120px;
+    padding: 10px 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .teacher-course-page .teacher-gradebook-scroll-top {
+    /* Save vertical space on phones; the bottom scrollbar is enough. */
+    display: none;
   }
 }


### PR DESCRIPTION
﻿## Summary

Polish final del gradebook docente: anade una barra de busqueda sobre la tabla de estudiantes para filtrar filas por **nombre** o **correo**.

### Added
- Toolbar con `<input type="search">` (icono lupa + boton X para limpiar) sobre la tabla del gradebook.
- Contador en vivo (`aria-live="polite"`): "N de M estudiantes" mientras se filtra; "M estudiantes" sin query.
- Empty state amigable cuando no hay coincidencias ("Sin coincidencias / Ningun estudiante coincide con ...").

### Changed
- `tbody` itera `filteredStudents` (memoizado) en lugar de `gradebook.students` directamente.
- Estilos `.teacher-gradebook-toolbar`, `.teacher-gradebook-search*` y `.teacher-gradebook-search-empty` anadidos a `teacherCoursePage.css`.

### Detalles tecnicos
- Filtrado client-side, case-insensitive (`toLocaleLowerCase().includes(...)`), `useMemo` con deps `[gradebook, normalizedQuery]`.
- A11y: `<label htmlFor>`, `aria-label` en boton clear, focus ring brand `#0144a0`, `:focus-visible` en clear.
- Native cancel button del `type="search"` ocultado via `::-webkit-search-cancel-button { display: none }` para evitar duplicado con la X custom.
- Sin nuevas dependencias (`Search`, `X` ya vienen en `lucide-react`).
- Comportamiento sticky de la primera columna y scrollbars sincronizados se mantienen intactos.

## Test plan
- [x] `npm --prefix frontend run lint` - pasa.
- [x] `npm --prefix frontend run test -- --run TeacherCourseStudentsTab` - 4/4 verdes.
- [x] Suite completa frontend: 365/366; el unico fallo (`useStudentCaseResolution > debounces draft autosave`) es un flake de timers preexistente, NO relacionado con este diff (pasa en aislamiento 2x consecutivas).
- [x] `npm --prefix frontend run build` - exitoso.

## Notas
- Diff acotado a `frontend/src/features/teacher-course/`. No toca backend, rutas, esquemas ni APIs.
