### PR TITLE
feat: add teacher case submissions list

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -261,6 +261,22 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
+## TODO-014: Paginación o virtualización para el listado docente de entregas por caso
+
+**What:** Evaluar y aplicar paginación server-side o virtualización de filas en la vista docente `GET /api/teacher/cases/{assignment_id}/submissions` y su tabla en frontend cuando el volumen por caso crezca más allá del rango cómodo del render actual.
+
+**Why:** La implementación de Issue #210 entrega el listado completo en una sola respuesta y lo renderiza íntegro en el cliente. Eso mantiene el diff mínimo y cubre el caso actual, pero en cursos grandes puede degradar tiempo de respuesta, costo de serialización y rendimiento del DOM.
+
+**Pros:** Mejor escalabilidad para cursos grandes, menor costo de render en frontend y un contrato más explícito para navegación incremental del docente.
+
+**Cons:** Añade complejidad de contrato compartido (cursor o page params), estados extra en TanStack Query y decisiones de UX sobre búsqueda local vs remota, ordenamiento y preservación de filtros.
+
+**Context:** Diferido explícitamente durante la implementación de Issue #210 para cerrar primero la vista read-only con el contrato mínimo reutilizando la capa de gradebook de Issue #205. Antes de implementarlo conviene medir tamaños reales por curso y decidir si basta con virtualización en frontend o si hace falta paginación backend.
+
+**Depends on / blocked by:** Señales reales de volumen en producción o staging, decisión de producto sobre búsqueda/ordenamiento cross-page y definición del contrato incremental compartido entre backend y frontend.
+
+---
+
 ## TODO-027: Hardening del `CASE_WRITER_PROMPT` para prohibir exhibits completos en `doc1_narrativa`
 
 **What:** Ajustar `backend/src/case_generator/prompts.py` para que `CASE_WRITER_PROMPT` prohíba explícitamente reproducir tablas completas de `Exhibit 1`, `Exhibit 2` o `Exhibit 3` dentro de `doc1_narrativa`, limitando su uso a citas y referencias narrativas.

--- a/backend/src/shared/teacher_gradebook_schema.py
+++ b/backend/src/shared/teacher_gradebook_schema.py
@@ -28,9 +28,12 @@ class TeacherCourseGradebookCase(StrictModel):
     max_score: float = Field(ge=0)
 
 
+TeacherCourseGradebookStatus = Literal["not_started", "in_progress", "submitted", "graded"]
+
+
 class TeacherCourseGradebookCell(StrictModel):
     assignment_id: str
-    status: Literal["not_started", "in_progress", "submitted", "graded"]
+    status: TeacherCourseGradebookStatus
     score: float | None = Field(default=None, ge=0)
     graded_at: datetime | None
 
@@ -48,3 +51,22 @@ class TeacherCourseGradebookResponse(StrictModel):
     course: TeacherCourseGradebookCourse
     cases: list[TeacherCourseGradebookCase]
     students: list[TeacherCourseGradebookStudent]
+
+
+class TeacherCaseSubmissionRow(StrictModel):
+    membership_id: str
+    full_name: str
+    email: str
+    course_id: str
+    course_code: str
+    enrolled_at: datetime
+    status: TeacherCourseGradebookStatus
+    submitted_at: datetime | None
+    score: float | None = Field(default=None, ge=0)
+    max_score: float = Field(ge=0)
+    graded_at: datetime | None
+
+
+class TeacherCaseSubmissionsResponse(StrictModel):
+    case: TeacherCourseGradebookCase
+    submissions: list[TeacherCaseSubmissionRow]

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -958,13 +958,28 @@ def get_teacher_case_submissions(
         )
     )
 
+    available_from = assignment.available_from
+    deadline = assignment.deadline
+    if available_from is None or deadline is None:
+        latest_task_payload = db.scalar(
+            select(AuthoringJob.task_payload)
+            .where(AuthoringJob.assignment_id == assignment.id)
+            .order_by(AuthoringJob.created_at.desc())
+            .limit(1)
+        )
+        available_from, deadline = _resolve_schedule_values_from_payload(
+            available_from=available_from,
+            deadline=deadline,
+            task_payload=latest_task_payload if isinstance(latest_task_payload, dict) else None,
+        )
+
     return TeacherCaseSubmissionsResponse(
         case=TeacherCourseGradebookCase(
             assignment_id=assignment.id,
             title=_resolve_assignment_title(assignment),
             status="published",
-            available_from=assignment.available_from,
-            deadline=assignment.deadline,
+            available_from=available_from,
+            deadline=deadline,
             max_score=assignment_max_score,
         ),
         submissions=submissions,

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -39,10 +39,13 @@ from shared.syllabus_schema import (
 )
 from shared.teacher_context import TeacherContext
 from shared.teacher_gradebook_schema import (
+    TeacherCaseSubmissionRow,
+    TeacherCaseSubmissionsResponse,
     TeacherCourseGradebookCase,
     TeacherCourseGradebookCell,
     TeacherCourseGradebookCourse,
     TeacherCourseGradebookResponse,
+    TeacherCourseGradebookStatus,
     TeacherCourseGradebookStudent,
 )
 
@@ -94,8 +97,21 @@ def _display_name(*, profile_full_name: str | None, email: str) -> str:
     return candidate or email
 
 
+def _derive_grade_cell_status(
+    student_case_status: str | None,
+    case_grade_status: str | None,
+) -> Literal["not_started", "in_progress", "submitted", "graded"]:
+    if case_grade_status == "graded":
+        return "graded"
+    if case_grade_status == "submitted" or student_case_status == "submitted":
+        return "submitted"
+    if case_grade_status == "in_progress" or student_case_status == "draft":
+        return "in_progress"
+    return "not_started"
+
+
 def _map_student_case_status(status_value: str) -> Literal["in_progress", "submitted"]:
-    if status_value == "submitted":
+    if _derive_grade_cell_status(status_value, None) == "submitted":
         return "submitted"
     return "in_progress"
 
@@ -366,6 +382,26 @@ def _assignment_course_codes(assignment: Assignment) -> list[str]:
         return [assignment.course.code]
 
     return []
+
+
+def _assignment_target_course_metadata(assignment: Assignment) -> tuple[list[str], list[str]]:
+    if assignment.assignment_courses:
+        course_pairs = sorted(
+            {
+                (link.course_id, link.course.code if link.course is not None else None)
+                for link in assignment.assignment_courses
+                if link.course_id
+            },
+            key=lambda pair: ((pair[1] or ""), pair[0]),
+        )
+        course_ids = [course_id for course_id, _code in course_pairs]
+        course_codes = [code for _course_id, code in course_pairs if code]
+        if course_ids:
+            return course_ids, course_codes
+
+    course_ids = [assignment.course_id] if assignment.course_id else []
+    course_codes = [assignment.course.code] if assignment.course is not None and assignment.course.code else []
+    return course_ids, course_codes
 
 
 def _serialize_teacher_course_configuration(
@@ -644,7 +680,7 @@ def get_teacher_course_gradebook(
         student_membership_ids=student_membership_ids,
     )
 
-    progress_by_key: dict[tuple[str, str], Literal["in_progress", "submitted"]] = {}
+    progress_by_key: dict[tuple[str, str], str] = {}
     if student_membership_ids and assignment_ids:
         progress_rows = (
             db.execute(
@@ -662,7 +698,7 @@ def get_teacher_course_gradebook(
             .all()
         )
         progress_by_key = {
-            (row["membership_id"], row["assignment_id"]): _map_student_case_status(row["status"])
+            (row["membership_id"], row["assignment_id"]): row["status"]
             for row in progress_rows
         }
 
@@ -737,14 +773,17 @@ def get_teacher_course_gradebook(
                 grades.append(
                     TeacherCourseGradebookCell(
                         assignment_id=assignment.id,
-                        status=grade["status"],
+                        status=_derive_grade_cell_status(None, grade["status"]),
                         score=score,
                         graded_at=grade["graded_at"],
                     )
                 )
                 continue
 
-            progress_status = progress_by_key.get((membership_id, assignment.id), "not_started")
+            progress_status = _derive_grade_cell_status(
+                progress_by_key.get((membership_id, assignment.id)),
+                None,
+            )
             grades.append(
                 TeacherCourseGradebookCell(
                     assignment_id=assignment.id,
@@ -780,6 +819,155 @@ def get_teacher_course_gradebook(
         ),
         cases=cases,
         students=students,
+    )
+
+
+def get_teacher_case_submissions(
+    db: Session,
+    context: TeacherContext,
+    assignment: Assignment,
+) -> TeacherCaseSubmissionsResponse:
+    if assignment.status != "published":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Assignment not found",
+        )
+
+    target_course_ids, _course_codes = _assignment_target_course_metadata(assignment)
+    if not target_course_ids:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Assignment not found",
+        )
+
+    submission_row_records = (
+        db.execute(
+            select(
+                Membership.id.label("membership_id"),
+                Membership.user_id.label("user_id"),
+                CourseMembership.created_at.label("enrolled_at"),
+                Profile.full_name.label("profile_full_name"),
+                User.email.label("email"),
+                CourseMembership.course_id.label("course_id"),
+                Course.code.label("course_code"),
+                StudentCaseResponse.status.label("student_case_status"),
+                StudentCaseResponse.submitted_at.label("submitted_at"),
+                CaseGrade.status.label("case_grade_status"),
+                CaseGrade.score.label("score"),
+                CaseGrade.max_score.label("max_score"),
+                CaseGrade.graded_at.label("graded_at"),
+            )
+            .select_from(CourseMembership)
+            .join(
+                Membership,
+                and_(
+                    CourseMembership.membership_id == Membership.id,
+                    Membership.university_id == context.university_id,
+                    Membership.role == "student",
+                    Membership.status == "active",
+                ),
+            )
+            .join(
+                Course,
+                and_(
+                    CourseMembership.course_id == Course.id,
+                    Course.university_id == context.university_id,
+                    Course.teacher_membership_id == context.teacher_membership_id,
+                ),
+            )
+            .outerjoin(User, User.id == Membership.user_id)
+            .outerjoin(Profile, Profile.id == Membership.user_id)
+            .outerjoin(
+                StudentCaseResponse,
+                and_(
+                    StudentCaseResponse.membership_id == Membership.id,
+                    StudentCaseResponse.assignment_id == assignment.id,
+                ),
+            )
+            .outerjoin(
+                CaseGrade,
+                and_(
+                    CaseGrade.membership_id == Membership.id,
+                    CaseGrade.assignment_id == assignment.id,
+                ),
+            )
+            .where(CourseMembership.course_id.in_(target_course_ids))
+        )
+        .mappings()
+        .all()
+    )
+
+    submission_rows = _repair_gradebook_student_rows(
+        db,
+        context,
+        student_rows=submission_row_records,
+    )
+
+    student_membership_ids = [row["membership_id"] for row in submission_rows]
+    _ensure_supported_gradebook_topology(
+        db,
+        context,
+        assignments=[assignment],
+        student_membership_ids=student_membership_ids,
+    )
+
+    assignment_max_score = _DEFAULT_CASE_MAX_SCORE
+    for row in submission_rows:
+        max_score = _decimal_to_float(row["max_score"])
+        if max_score is None:
+            continue
+        if assignment_max_score != _DEFAULT_CASE_MAX_SCORE and assignment_max_score != max_score:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="course_gradebook_inconsistent_max_score",
+            )
+        assignment_max_score = max_score
+
+    submissions: list[TeacherCaseSubmissionRow] = []
+    for row in submission_rows:
+        derived_status: TeacherCourseGradebookStatus = _derive_grade_cell_status(
+            row["student_case_status"],
+            row["case_grade_status"],
+        )
+        score = _decimal_to_float(row["score"])
+        submissions.append(
+            TeacherCaseSubmissionRow(
+                membership_id=row["membership_id"],
+                full_name=_display_name(
+                    profile_full_name=row["profile_full_name"],
+                    email=row["email"],
+                ),
+                email=row["email"],
+                course_id=row["course_id"],
+                course_code=row["course_code"],
+                enrolled_at=row["enrolled_at"],
+                status=derived_status,
+                submitted_at=row["submitted_at"],
+                score=score if derived_status == "graded" else None,
+                max_score=assignment_max_score,
+                graded_at=row["graded_at"],
+            )
+        )
+
+    submissions.sort(
+        key=lambda row: (
+            row.course_code.lower(),
+            row.full_name.lower(),
+            row.email.lower(),
+            row.membership_id,
+        )
+    )
+
+    return TeacherCaseSubmissionsResponse(
+        case=TeacherCourseGradebookCase(
+            assignment_id=assignment.id,
+            title=_resolve_assignment_title(assignment),
+            status="published",
+            available_from=assignment.available_from,
+            deadline=assignment.deadline,
+            max_score=assignment_max_score,
+        ),
+        submissions=submissions,
     )
 
 

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -14,14 +14,16 @@ from shared.auth import CurrentActor, require_current_actor_password_ready
 from shared.course_access_schema import CourseAccessLinkRegenerateResponse, TeacherCourseAccessLinkResponse
 from shared.database import get_db
 from shared.models import Assignment, AssignmentCourse, Course
-from shared.teacher_gradebook_schema import TeacherCourseGradebookResponse
+from shared.teacher_gradebook_schema import TeacherCaseSubmissionsResponse, TeacherCourseGradebookResponse
 from shared.syllabus_schema import TeacherCourseDetailResponse, TeacherSyllabusSaveRequest
 from shared.teacher_context import TeacherContext, require_teacher_context
 from shared.teacher_reads import (
+    _assignment_target_course_metadata,
     TeacherCoursesResponse,
     get_teacher_course_access_link,
     get_teacher_course_detail,
     get_teacher_course_gradebook,
+    get_teacher_case_submissions,
     list_teacher_active_cases,
     list_teacher_courses,
     resolve_assignment_schedule_values,
@@ -164,25 +166,6 @@ def get_teacher_cases(
 # Internal helpers — not endpoints
 # ---------------------------------------------------------------------------
 
-def _assignment_target_course_metadata(assignment: Assignment) -> tuple[list[str], list[str]]:
-    if assignment.assignment_courses:
-        course_pairs = sorted(
-            {
-                (link.course_id, link.course.code if link.course is not None else None)
-                for link in assignment.assignment_courses
-                if link.course_id
-            },
-            key=lambda pair: ((pair[1] or ""), pair[0]),
-        )
-        course_ids = [course_id for course_id, _code in course_pairs]
-        course_codes = [code for _course_id, code in course_pairs if code]
-        if course_ids:
-            return course_ids, course_codes
-
-    course_ids = [assignment.course_id] if assignment.course_id else []
-    course_codes = [assignment.course.code] if assignment.course is not None and assignment.course.code else []
-    return course_ids, course_codes
-
 def _to_case_detail(assignment: Assignment) -> TeacherCaseDetailResponse:
     """Build a TeacherCaseDetailResponse from an Assignment ORM instance."""
     available_from, deadline = resolve_assignment_schedule_values(assignment)
@@ -265,6 +248,17 @@ def get_teacher_case_detail(
 ) -> TeacherCaseDetailResponse:
     assignment = _get_owned_assignment_or_404(db, assignment_id, actor)
     return _to_case_detail(assignment)
+
+
+@router.get("/cases/{assignment_id}/submissions", response_model=TeacherCaseSubmissionsResponse)
+def get_teacher_case_submissions_view(
+    assignment_id: str,
+    context: Annotated[TeacherContext, Depends(require_teacher_context)],
+    actor: CurrentActor = Depends(require_current_actor_password_ready),
+    db: Session = Depends(get_db),
+) -> TeacherCaseSubmissionsResponse:
+    assignment = _get_owned_assignment_or_404(db, assignment_id, actor)
+    return get_teacher_case_submissions(db, context, assignment)
 
 
 @router.patch("/cases/{assignment_id}/publish", response_model=TeacherCaseDetailResponse)

--- a/backend/tests/test_teacher_case_submissions.py
+++ b/backend/tests/test_teacher_case_submissions.py
@@ -1,0 +1,692 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Generator
+import uuid
+
+from sqlalchemy import event
+
+from shared.models import Assignment, AssignmentCourse, CaseGrade, StudentCaseResponse, User
+from shared.teacher_context import TeacherContext
+from shared.teacher_reads import get_teacher_case_submissions
+
+
+def _iso_z(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
+    return auth_headers_factory(sub=user_id, email=email)
+
+
+def _seed_case_grade(
+    db,
+    *,
+    membership_id: str,
+    assignment_id: str,
+    course_id: str,
+    status: str,
+    score: Decimal | None = None,
+    max_score: Decimal = Decimal("5.00"),
+    graded_at: datetime | None = None,
+) -> CaseGrade:
+    grade = CaseGrade(
+        membership_id=membership_id,
+        assignment_id=assignment_id,
+        course_id=course_id,
+        status=status,
+        score=score,
+        max_score=max_score,
+        graded_at=graded_at,
+    )
+    db.add(grade)
+    db.flush()
+    return grade
+
+
+def _seed_student_case_response(
+    db,
+    *,
+    membership_id: str,
+    assignment_id: str,
+    status: str,
+    opened_at: datetime,
+) -> StudentCaseResponse:
+    response = StudentCaseResponse(
+        membership_id=membership_id,
+        assignment_id=assignment_id,
+        status=status,
+        answers={"q1": "answer"},
+        version=0,
+        first_opened_at=opened_at,
+        last_autosaved_at=opened_at if status == "draft" else None,
+        submitted_at=opened_at if status == "submitted" else None,
+    )
+    db.add(response)
+    db.flush()
+    return response
+
+
+@contextmanager
+def _count_queries(bind) -> Generator[dict[str, int], None, None]:
+    counter = {"value": 0}
+
+    def _before_cursor_execute(*_args, **_kwargs) -> None:
+        counter["value"] += 1
+
+    event.listen(bind, "before_cursor_execute", _before_cursor_execute)
+    try:
+        yield counter
+    finally:
+        event.remove(bind, "before_cursor_execute", _before_cursor_execute)
+
+
+def test_teacher_case_submissions_returns_single_course_rows_and_statuses(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002101"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-submissions@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Submissions",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Casos",
+        code="CASE-210",
+    )
+
+    not_started_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="ana@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Ana Student",
+    )
+    in_progress_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="bruno@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Bruno Student",
+    )
+    submitted_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="carla@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Carla Student",
+    )
+    graded_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="diego@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Diego Student",
+    )
+    for student in (not_started_student, in_progress_student, submitted_student, graded_student):
+        seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+
+    reference_now = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        course_id=course.id,
+        title="Teacher Assignment Title",
+        canonical_output={"title": "Canonical Case Title"},
+        status="published",
+        available_from=reference_now - timedelta(days=3),
+        deadline=reference_now + timedelta(days=7),
+    )
+    db.add(assignment)
+    db.flush()
+
+    _seed_student_case_response(
+        db,
+        membership_id=in_progress_student["membership"].id,
+        assignment_id=assignment.id,
+        status="draft",
+        opened_at=reference_now - timedelta(hours=8),
+    )
+    _seed_student_case_response(
+        db,
+        membership_id=submitted_student["membership"].id,
+        assignment_id=assignment.id,
+        status="submitted",
+        opened_at=reference_now - timedelta(hours=6),
+    )
+    _seed_case_grade(
+        db,
+        membership_id=graded_student["membership"].id,
+        assignment_id=assignment.id,
+        course_id=course.id,
+        status="graded",
+        score=Decimal("4.50"),
+        graded_at=reference_now - timedelta(hours=1),
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["case"] == {
+        "assignment_id": assignment.id,
+        "title": "Canonical Case Title",
+        "status": "published",
+        "available_from": _iso_z(assignment.available_from),
+        "deadline": _iso_z(assignment.deadline),
+        "max_score": 5.0,
+    }
+
+    rows = {row["email"]: row for row in payload["submissions"]}
+    assert rows["ana@example.edu"]["status"] == "not_started"
+    assert rows["ana@example.edu"]["score"] is None
+    assert rows["bruno@example.edu"]["status"] == "in_progress"
+    assert rows["bruno@example.edu"]["submitted_at"] is None
+    assert rows["carla@example.edu"]["status"] == "submitted"
+    assert rows["carla@example.edu"]["submitted_at"] == _iso_z(reference_now - timedelta(hours=6))
+    assert rows["carla@example.edu"]["score"] is None
+    assert rows["diego@example.edu"]["status"] == "graded"
+    assert rows["diego@example.edu"]["score"] == 4.5
+    assert rows["diego@example.edu"]["graded_at"] == _iso_z(reference_now - timedelta(hours=1))
+    assert all(row["course_code"] == "CASE-210" for row in payload["submissions"])
+
+
+def test_teacher_case_submissions_returns_multicourse_rows_sorted_deterministically(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002102"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-multicourse@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course_a = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso A",
+        code="A-210",
+    )
+    course_b = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso B",
+        code="B-210",
+    )
+    first_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="zeta@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Zeta Student",
+    )
+    second_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="alfa@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Alfa Student",
+    )
+    third_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="beta@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Beta Student",
+    )
+    seed_course_membership(course_id=course_b.id, membership_id=first_student["membership"].id)
+    seed_course_membership(course_id=course_a.id, membership_id=second_student["membership"].id)
+    seed_course_membership(course_id=course_b.id, membership_id=third_student["membership"].id)
+
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        title="Shared Assignment",
+        status="published",
+        available_from=datetime(2026, 6, 2, 12, 0, tzinfo=timezone.utc),
+        deadline=datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc),
+    )
+    db.add(assignment)
+    db.flush()
+    db.add_all(
+        [
+            AssignmentCourse(assignment_id=assignment.id, course_id=course_b.id),
+            AssignmentCourse(assignment_id=assignment.id, course_id=course_a.id),
+        ]
+    )
+    db.commit()
+
+    first_response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+    second_response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert first_response.status_code == 200, first_response.text
+    assert second_response.status_code == 200, second_response.text
+    first_rows = first_response.json()["submissions"]
+    second_rows = second_response.json()["submissions"]
+    assert [(row["course_code"], row["full_name"], row["email"]) for row in first_rows] == [
+        ("A-210", "Alfa Student", "alfa@example.edu"),
+        ("B-210", "Beta Student", "beta@example.edu"),
+        ("B-210", "Zeta Student", "zeta@example.edu"),
+    ]
+    assert first_rows == second_rows
+
+
+def test_teacher_case_submissions_non_owner_returns_404(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002103"
+    owner = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="owner@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    other_teacher_user_id = str(uuid.uuid4())
+    other_teacher_email = "other@example.edu"
+    seed_identity(
+        user_id=other_teacher_user_id,
+        email=other_teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=owner["membership"].id,
+    )
+    assignment = Assignment(
+        teacher_id=owner["membership"].user_id,
+        course_id=course.id,
+        title="Owned Assignment",
+        status="published",
+    )
+    db.add(assignment)
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=other_teacher_user_id, email=other_teacher_email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Assignment not found"
+
+
+def test_teacher_case_submissions_missing_assignment_returns_404(
+    client,
+    seed_identity,
+    auth_headers_factory,
+) -> None:
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-missing-assignment@example.edu"
+    seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id="10000000-0000-0000-0000-000000002104",
+    )
+
+    response = client.get(
+        "/api/teacher/cases/does-not-exist/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Assignment not found"
+
+
+def test_teacher_case_submissions_student_token_returns_403(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002105"
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-role@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student_user_id = str(uuid.uuid4())
+    student_email = "student-role@example.edu"
+    seed_identity(
+        user_id=student_user_id,
+        email=student_email,
+        role="student",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+    assignment = Assignment(
+        teacher_id=teacher["membership"].user_id,
+        course_id=course.id,
+        title="Protected Assignment",
+        status="published",
+    )
+    db.add(assignment)
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=student_user_id, email=student_email),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "teacher_role_required"
+
+
+def test_teacher_case_submissions_excludes_suspended_students(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002106"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-suspended@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+    active_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="active@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Active Student",
+    )
+    suspended_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="suspended@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Suspended Student",
+        membership_status="suspended",
+    )
+    seed_course_membership(course_id=course.id, membership_id=active_student["membership"].id)
+    seed_course_membership(course_id=course.id, membership_id=suspended_student["membership"].id)
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        course_id=course.id,
+        title="Suspended Filter",
+        status="published",
+    )
+    db.add(assignment)
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200
+    emails = [row["email"] for row in response.json()["submissions"]]
+    assert emails == ["active@example.edu"]
+
+
+def test_teacher_case_submissions_falls_back_to_repaired_email_for_blank_name(
+    client,
+    db,
+    fake_admin_client,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002107"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-fallback@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+    auth_user = fake_admin_client.create_password_user("fallback@example.edu", "Secure1234!")
+    fallback_student = seed_identity(
+        user_id=auth_user.id,
+        email="fallback@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="   ",
+        create_legacy_user=False,
+    )
+    seed_course_membership(course_id=course.id, membership_id=fallback_student["membership"].id)
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        course_id=course.id,
+        title="Fallback Assignment",
+        status="published",
+    )
+    db.add(assignment)
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200
+    row = response.json()["submissions"][0]
+    assert row["email"] == "fallback@example.edu"
+    assert row["full_name"] == "fallback@example.edu"
+    repaired_user = db.get(User, auth_user.id)
+    assert repaired_user is not None
+    assert repaired_user.email == "fallback@example.edu"
+
+
+def test_teacher_case_submissions_degrades_missing_auth_identity(
+    client,
+    db,
+    fake_admin_client,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002108"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-degraded@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id)
+    missing_auth_user = fake_admin_client.create_password_user("missing-auth@example.edu", "Secure1234!")
+    fake_admin_client.delete_user(missing_auth_user.id)
+    degraded_student = seed_identity(
+        user_id=missing_auth_user.id,
+        email="missing-auth@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="   ",
+        create_legacy_user=False,
+    )
+    seed_course_membership(course_id=course.id, membership_id=degraded_student["membership"].id)
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        course_id=course.id,
+        title="Degraded Assignment",
+        status="published",
+    )
+    db.add(assignment)
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200
+    row = response.json()["submissions"][0]
+    assert row["email"].startswith("Correo no disponible (")
+    assert row["full_name"] == row["email"]
+    assert db.get(User, missing_auth_user.id) is None
+
+
+def test_teacher_case_submissions_rejects_cross_enrollment_topology(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002109"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-cross@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course_a = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, code="CR-A")
+    course_b = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, code="CR-B")
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="cross@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Cross Student",
+    )
+    seed_course_membership(course_id=course_a.id, membership_id=student["membership"].id)
+    seed_course_membership(course_id=course_b.id, membership_id=student["membership"].id)
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        title="Cross Assignment",
+        status="published",
+    )
+    db.add(assignment)
+    db.flush()
+    db.add_all(
+        [
+            AssignmentCourse(assignment_id=assignment.id, course_id=course_a.id),
+            AssignmentCourse(assignment_id=assignment.id, course_id=course_b.id),
+        ]
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "course_gradebook_cross_enrollment_unsupported"
+
+
+def test_teacher_case_submissions_runs_in_bounded_query_count(
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002110"
+    teacher_user_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email="teacher-query@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        code="Q-210",
+    )
+    first_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="query-one@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Query One",
+    )
+    second_student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="query-two@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Query Two",
+    )
+    seed_course_membership(course_id=course.id, membership_id=first_student["membership"].id)
+    seed_course_membership(course_id=course.id, membership_id=second_student["membership"].id)
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        course_id=course.id,
+        title="Query Budget",
+        status="published",
+        available_from=datetime(2026, 6, 3, 12, 0, tzinfo=timezone.utc),
+    )
+    db.add(assignment)
+    db.flush()
+    _seed_student_case_response(
+        db,
+        membership_id=first_student["membership"].id,
+        assignment_id=assignment.id,
+        status="submitted",
+        opened_at=datetime(2026, 6, 4, 12, 0, tzinfo=timezone.utc),
+    )
+    _seed_case_grade(
+        db,
+        membership_id=second_student["membership"].id,
+        assignment_id=assignment.id,
+        course_id=course.id,
+        status="graded",
+        score=Decimal("5.00"),
+        graded_at=datetime(2026, 6, 5, 12, 0, tzinfo=timezone.utc),
+    )
+
+    context = TeacherContext(
+        auth_user_id=teacher_user_id,
+        teacher_membership_id=teacher["membership"].id,
+        university_id=university_id,
+    )
+
+    with _count_queries(db.bind) as counter:
+        response = get_teacher_case_submissions(db, context, assignment)
+
+    assert len(response.submissions) == 2
+    assert counter["value"] <= 4

--- a/backend/tests/test_teacher_case_submissions.py
+++ b/backend/tests/test_teacher_case_submissions.py
@@ -8,7 +8,7 @@ import uuid
 
 from sqlalchemy import event
 
-from shared.models import Assignment, AssignmentCourse, CaseGrade, StudentCaseResponse, User
+from shared.models import Assignment, AssignmentCourse, AuthoringJob, CaseGrade, StudentCaseResponse, User
 from shared.teacher_context import TeacherContext
 from shared.teacher_reads import get_teacher_case_submissions
 
@@ -208,6 +208,85 @@ def test_teacher_case_submissions_returns_single_course_rows_and_statuses(
     assert rows["diego@example.edu"]["graded_at"] == _iso_z(reference_now - timedelta(hours=1))
     assert all(row["course_code"] == "CASE-210" for row in payload["submissions"])
 
+def test_teacher_case_submissions_falls_back_to_latest_authoring_payload_schedule(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002111"
+    teacher_user_id = str(uuid.uuid4())
+    teacher_email = "teacher-legacy-schedule@example.edu"
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email=teacher_email,
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Legacy Schedule",
+        code="LEG-210",
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="legacy-student@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Legacy Student",
+    )
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+
+    persisted_available_from = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    latest_deadline = datetime(2026, 6, 10, 18, 30, tzinfo=timezone.utc)
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        course_id=course.id,
+        title="Legacy Schedule Assignment",
+        status="published",
+        available_from=persisted_available_from,
+        deadline=None,
+    )
+    db.add(assignment)
+    db.flush()
+    db.add_all(
+        [
+            AuthoringJob(
+                assignment_id=assignment.id,
+                idempotency_key=f"legacy-schedule-old-{assignment.id}",
+                status="completed",
+                created_at=datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc),
+                task_payload={
+                    "availableFrom": "2026-05-20T10:00:00+00:00",
+                    "dueAt": "2026-06-07T17:00:00+00:00",
+                },
+            ),
+            AuthoringJob(
+                assignment_id=assignment.id,
+                idempotency_key=f"legacy-schedule-new-{assignment.id}",
+                status="completed",
+                created_at=datetime(2026, 5, 21, 12, 0, tzinfo=timezone.utc),
+                task_payload={
+                    "availableFrom": "2026-05-21T10:00:00+00:00",
+                    "dueAt": _iso_z(latest_deadline),
+                },
+            ),
+        ]
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_user_id, email=teacher_email),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["case"]["available_from"] == _iso_z(persisted_available_from)
+    assert payload["case"]["deadline"] == _iso_z(latest_deadline)
 
 def test_teacher_case_submissions_returns_multicourse_rows_sorted_deterministically(
     client,
@@ -690,3 +769,74 @@ def test_teacher_case_submissions_runs_in_bounded_query_count(
 
     assert len(response.submissions) == 2
     assert counter["value"] <= 4
+
+
+def test_teacher_case_submissions_legacy_schedule_fallback_adds_only_one_query(
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002112"
+    teacher_user_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=teacher_user_id,
+        email="teacher-query-legacy@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        code="QL-210",
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="query-legacy@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Query Legacy",
+    )
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        course_id=course.id,
+        title="Query Budget Legacy",
+        status="published",
+        available_from=None,
+        deadline=None,
+    )
+    db.add(assignment)
+    db.flush()
+    db.add(
+        AuthoringJob(
+            assignment_id=assignment.id,
+            idempotency_key=f"legacy-query-budget-{assignment.id}",
+            status="completed",
+            task_payload={
+                "availableFrom": "2026-06-03T12:00:00+00:00",
+                "dueAt": "2026-06-08T12:00:00+00:00",
+            },
+        )
+    )
+    _seed_student_case_response(
+        db,
+        membership_id=student["membership"].id,
+        assignment_id=assignment.id,
+        status="submitted",
+        opened_at=datetime(2026, 6, 4, 12, 0, tzinfo=timezone.utc),
+    )
+
+    context = TeacherContext(
+        auth_user_id=teacher_user_id,
+        teacher_membership_id=teacher["membership"].id,
+        university_id=university_id,
+    )
+
+    with _count_queries(db.bind) as counter:
+        response = get_teacher_case_submissions(db, context, assignment)
+
+    assert response.case.available_from == datetime(2026, 6, 3, 12, 0, tzinfo=timezone.utc)
+    assert response.case.deadline == datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+    assert len(response.submissions) == 1
+    assert counter["value"] <= 5

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -19,6 +19,11 @@ vi.mock("@/features/teacher-course/TeacherCoursePage", () => ({
         <div data-testid="teacher-course-page">Teacher course page</div>
     ),
 }));
+vi.mock("@/features/teacher-case-submissions/TeacherCaseSubmissionsPage", () => ({
+    TeacherCaseSubmissionsPage: () => (
+        <div data-testid="teacher-case-submissions-page">Teacher case submissions page</div>
+    ),
+}));
 vi.mock("@/features/admin-dashboard/AdminDashboardPage", () => ({
     AdminDashboardPage: () => <div data-testid="admin-dashboard-page">Dashboard admin</div>,
 }));
@@ -257,6 +262,37 @@ describe("App admin shell layout", () => {
         });
 
         expect(await screen.findByTestId("teacher-course-page")).toBeTruthy();
+        expect(screen.queryByTestId("site-header")).toBeNull();
+    });
+
+    it("resolves the teacher case submissions route before the authoring catch-all", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseContext,
+            session: { access_token: "jwt" } as never,
+            actor: teacherActor,
+        });
+
+        renderWithProviders(<App />, {
+            initialEntries: ["/teacher/cases/case-1/entregas"],
+        });
+
+        expect(await screen.findByTestId("teacher-case-submissions-page")).toBeTruthy();
+        expect(screen.queryByTestId("teacher-authoring-page")).toBeNull();
+        expect(screen.queryByTestId("site-header")).toBeNull();
+    });
+
+    it("resolves the teacher submission detail placeholder route without a SPA 404", async () => {
+        vi.mocked(useAuth).mockReturnValue({
+            ...baseContext,
+            session: { access_token: "jwt" } as never,
+            actor: teacherActor,
+        });
+
+        renderWithProviders(<App />, {
+            initialEntries: ["/teacher/cases/case-1/entregas/membership-1"],
+        });
+
+        expect(await screen.findByRole("heading", { name: /Ver entrega y calificar/i })).toBeTruthy();
         expect(screen.queryByTestId("site-header")).toBeNull();
     });
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -28,6 +28,11 @@ const TeacherCaseViewPage = lazy(() =>
         (module) => ({ default: module.TeacherCaseViewPage }),
     ),
 );
+const TeacherCaseSubmissionsPage = lazy(() =>
+    import("@/features/teacher-case-submissions/TeacherCaseSubmissionsPage").then(
+        (module) => ({ default: module.TeacherCaseSubmissionsPage }),
+    ),
+);
 const AuthCallbackPage = lazy(() =>
     import("@/features/auth-callback/AuthCallbackPage").then((module) => ({
         default: module.AuthCallbackPage,
@@ -151,10 +156,18 @@ function App() {
                             path="/teacher/cases/:assignmentId/entregas"
                             element={
                                 <RequireRole role="teacher">
+                                    <TeacherCaseSubmissionsPage />
+                                </RequireRole>
+                            }
+                        />
+                        <Route
+                            path="/teacher/cases/:assignmentId/entregas/:membershipId"
+                            element={
+                                <RequireRole role="teacher">
                                     <div className="flex flex-col items-center justify-center gap-4 px-4 py-24 text-center">
-                                        <h1 className="text-xl font-semibold">Entregas del caso</h1>
+                                        <h1 className="text-xl font-semibold">Ver entrega y calificar</h1>
                                         <p className="max-w-xs text-sm text-muted-foreground">
-                                            El listado de entregas estará disponible en la próxima versión.
+                                            Esta vista estará disponible en la próxima versión.
                                         </p>
                                     </div>
                                 </RequireRole>

--- a/frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.test.tsx
+++ b/frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.test.tsx
@@ -1,0 +1,231 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/shared/test-utils";
+import { api, ApiError } from "@/shared/api";
+import type { TeacherCaseSubmissionsResponse } from "@/shared/adam-types";
+
+import { TeacherCaseSubmissionsPage } from "./TeacherCaseSubmissionsPage";
+
+vi.mock("@/features/teacher-layout/TeacherLayout", () => ({
+    TeacherLayout: ({ children, testId }: { children: React.ReactNode; testId?: string }) => (
+        <div data-testid={testId ?? "teacher-layout"}>{children}</div>
+    ),
+}));
+
+vi.mock("@/shared/api", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/api")>("@/shared/api");
+
+    return {
+        ...actual,
+        api: {
+            ...actual.api,
+            teacher: {
+                ...actual.api.teacher,
+                getCaseSubmissions: vi.fn(),
+            },
+        },
+    };
+});
+
+function createCaseSubmissionsResponse(
+    overrides?: Partial<TeacherCaseSubmissionsResponse>,
+): TeacherCaseSubmissionsResponse {
+    return {
+        case: {
+            assignment_id: "assignment-1",
+            title: "Caso Plataforma",
+            status: "published",
+            available_from: "2026-06-01T15:00:00Z",
+            deadline: "2026-06-08T15:00:00Z",
+            max_score: 5,
+            ...overrides?.case,
+        },
+        submissions: overrides?.submissions ?? [
+            {
+                membership_id: "membership-1",
+                full_name: "Ana Student",
+                email: "ana.student@example.edu",
+                course_id: "course-1",
+                course_code: "A-210",
+                enrolled_at: "2026-05-20T15:00:00Z",
+                status: "not_started",
+                submitted_at: null,
+                score: null,
+                max_score: 5,
+                graded_at: null,
+            },
+            {
+                membership_id: "membership-2",
+                full_name: "Bruno Student",
+                email: "bruno.student@example.edu",
+                course_id: "course-1",
+                course_code: "A-210",
+                enrolled_at: "2026-05-21T15:00:00Z",
+                status: "submitted",
+                submitted_at: "2026-06-05T15:00:00Z",
+                score: null,
+                max_score: 5,
+                graded_at: null,
+            },
+            {
+                membership_id: "membership-3",
+                full_name: "Carla Student",
+                email: "carla.student@example.edu",
+                course_id: "course-2",
+                course_code: "B-210",
+                enrolled_at: "2026-05-22T15:00:00Z",
+                status: "graded",
+                submitted_at: "2026-06-06T15:00:00Z",
+                score: 4.5,
+                max_score: 5,
+                graded_at: "2026-06-07T15:00:00Z",
+            },
+        ],
+    };
+}
+
+function renderPage(initialEntries = ["/teacher/cases/assignment-1/entregas"]) {
+    return renderWithProviders(
+        <Routes>
+            <Route path="/teacher/cases/:assignmentId/entregas" element={<TeacherCaseSubmissionsPage />} />
+            <Route
+                path="/teacher/cases/:assignmentId/entregas/:membershipId"
+                element={<div data-testid="teacher-case-submission-detail-placeholder">Detalle placeholder</div>}
+            />
+        </Routes>,
+        { initialEntries },
+    );
+}
+
+describe("TeacherCaseSubmissionsPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("renders a loading state while the submissions query is pending", () => {
+        vi.mocked(api.teacher.getCaseSubmissions).mockReturnValue(new Promise(() => undefined));
+
+        renderPage();
+
+        expect(screen.getByText("Cargando entregas del caso")).toBeTruthy();
+    });
+
+    it("renders the submissions table with one row per student", async () => {
+        vi.mocked(api.teacher.getCaseSubmissions).mockResolvedValue(createCaseSubmissionsResponse());
+
+        renderPage();
+
+        expect(await screen.findByRole("table", { name: /Listado de entregas del caso Caso Plataforma/i })).toBeTruthy();
+        expect(screen.getByText("Ana Student")).toBeTruthy();
+        expect(screen.getByText("Bruno Student")).toBeTruthy();
+        expect(screen.getByText("Carla Student")).toBeTruthy();
+    });
+
+    it("disables the action button for not_started and enables it for the other states", async () => {
+        vi.mocked(api.teacher.getCaseSubmissions).mockResolvedValue(createCaseSubmissionsResponse());
+
+        renderPage();
+
+        expect(await screen.findByRole("button", { name: "Ver entrega y calificar: Ana Student" })).toBeDisabled();
+        expect(screen.getByRole("button", { name: "Ver entrega y calificar: Bruno Student" })).toBeEnabled();
+        expect(screen.getByRole("button", { name: "Ver calificación: Carla Student" })).toBeEnabled();
+        expect(screen.getByRole("button", { name: "Ver entrega y calificar: Ana Student" })).toHaveAttribute(
+            "title",
+            "El estudiante aún no ha abierto el caso.",
+        );
+    });
+
+    it("shows the score only when the submission is graded", async () => {
+        vi.mocked(api.teacher.getCaseSubmissions).mockResolvedValue(createCaseSubmissionsResponse());
+
+        renderPage();
+
+        expect(await screen.findByText(/4[,.]5\s*\/\s*5/)).toBeTruthy();
+        expect(screen.getAllByText("-").length).toBeGreaterThan(0);
+    });
+
+    it("filters the list by full name and email", async () => {
+        vi.mocked(api.teacher.getCaseSubmissions).mockResolvedValue(createCaseSubmissionsResponse());
+
+        renderPage();
+
+        const searchInput = await screen.findByLabelText("Buscar estudiante por nombre o correo");
+        fireEvent.change(searchInput, { target: { value: "carla" } });
+        expect(screen.getByText("Carla Student")).toBeTruthy();
+        expect(screen.queryByText("Ana Student")).toBeNull();
+
+        fireEvent.change(searchInput, { target: { value: "bruno.student@example.edu" } });
+        expect(screen.getByText("Bruno Student")).toBeTruthy();
+        expect(screen.queryByText("Carla Student")).toBeNull();
+    });
+
+    it("renders an empty state when the case has no assigned students", async () => {
+        vi.mocked(api.teacher.getCaseSubmissions).mockResolvedValue(
+            createCaseSubmissionsResponse({ submissions: [] }),
+        );
+
+        renderPage();
+
+        expect(await screen.findByTestId("teacher-case-submissions-empty")).toBeTruthy();
+    });
+
+    it("renders an error state and retries the query", async () => {
+        vi.mocked(api.teacher.getCaseSubmissions)
+            .mockRejectedValueOnce(new ApiError(404, "Not found", "Assignment not found"))
+            .mockResolvedValueOnce(createCaseSubmissionsResponse());
+
+        renderPage();
+
+        expect(await screen.findByText("No encontramos este caso o no tienes acceso.")).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: /Reintentar/i }));
+
+        expect(await screen.findByText("Ana Student")).toBeTruthy();
+        expect(api.teacher.getCaseSubmissions).toHaveBeenCalledTimes(2);
+    });
+
+    it("navigates to the placeholder submission detail route for enabled rows", async () => {
+        vi.mocked(api.teacher.getCaseSubmissions).mockResolvedValue(createCaseSubmissionsResponse());
+
+        renderPage();
+
+        fireEvent.click(await screen.findByRole("button", { name: "Ver calificación: Carla Student" }));
+
+        expect(await screen.findByTestId("teacher-case-submission-detail-placeholder")).toBeTruthy();
+    });
+
+    it("shows a local empty-search state when no rows match the filter", async () => {
+        vi.mocked(api.teacher.getCaseSubmissions).mockResolvedValue(createCaseSubmissionsResponse());
+
+        renderPage();
+
+        fireEvent.change(await screen.findByLabelText("Buscar estudiante por nombre o correo"), {
+            target: { value: "nadie" },
+        });
+
+        expect(screen.getByTestId("teacher-case-submissions-search-empty")).toBeTruthy();
+    });
+
+    it("refetches submissions when the refresh button is pressed", async () => {
+        vi.mocked(api.teacher.getCaseSubmissions)
+            .mockResolvedValueOnce(createCaseSubmissionsResponse())
+            .mockResolvedValueOnce(createCaseSubmissionsResponse());
+
+        renderPage();
+
+        expect(await screen.findByText("Ana Student")).toBeTruthy();
+        expect(api.teacher.getCaseSubmissions).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole("button", { name: /Actualizar entregas/i }));
+
+        await waitFor(() => {
+            expect(api.teacher.getCaseSubmissions).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.test.tsx
+++ b/frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.test.tsx
@@ -122,6 +122,7 @@ describe("TeacherCaseSubmissionsPage", () => {
         renderPage();
 
         expect(await screen.findByRole("table", { name: /Listado de entregas del caso Caso Plataforma/i })).toBeTruthy();
+        expect(screen.getByText(/Fecha límite:/i)).toBeTruthy();
         expect(screen.getByText("Ana Student")).toBeTruthy();
         expect(screen.getByText("Bruno Student")).toBeTruthy();
         expect(screen.getByText("Carla Student")).toBeTruthy();

--- a/frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.tsx
+++ b/frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.tsx
@@ -1,0 +1,324 @@
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+    AlertCircle,
+    ArrowLeft,
+    BookOpen,
+    LoaderCircle,
+    RefreshCcw,
+    Search,
+    Users,
+    X,
+} from "lucide-react";
+
+import "@/features/teacher-course/teacherCoursePage.css";
+
+import { TeacherLayout } from "@/features/teacher-layout/TeacherLayout";
+import {
+    formatTeacherCourseTimestamp,
+    formatTeacherGradebookCellStatus,
+    formatTeacherGradebookScore,
+} from "@/features/teacher-course/teacherCourseModel";
+
+import {
+    getTeacherCaseSubmissionsErrorMessage,
+    useTeacherCaseSubmissions,
+} from "./useTeacherCaseSubmissions";
+
+interface MetricCardProps {
+    icon: React.ReactNode;
+    label: string;
+    value: string;
+}
+
+function MetricCard({ icon, label, value }: MetricCardProps) {
+    return (
+        <div className="teacher-gradebook-metric-card">
+            <span className="teacher-gradebook-metric-icon" aria-hidden="true">{icon}</span>
+            <div>
+                <p className="teacher-gradebook-metric-label">{label}</p>
+                <p className="teacher-gradebook-metric-value">{value}</p>
+            </div>
+        </div>
+    );
+}
+
+function renderStatusChip(status: string) {
+    return (
+        <div className={`teacher-gradebook-chip teacher-gradebook-chip--${status}`}>
+            <span className="teacher-gradebook-chip-label">
+                {formatTeacherGradebookCellStatus(status)}
+            </span>
+        </div>
+    );
+}
+
+export function TeacherCaseSubmissionsPage() {
+    const navigate = useNavigate();
+    const { assignmentId = "" } = useParams<{ assignmentId: string }>();
+    const submissionsQuery = useTeacherCaseSubmissions(assignmentId);
+    const [searchQuery, setSearchQuery] = useState("");
+
+    const caseDetail = submissionsQuery.data?.case;
+    const submissions = submissionsQuery.data?.submissions ?? [];
+    const normalizedQuery = searchQuery.trim().toLocaleLowerCase();
+    const filteredSubmissions = (() => {
+        if (!normalizedQuery) {
+            return submissions;
+        }
+
+        return submissions.filter((submission) => {
+            const fullName = submission.full_name.toLocaleLowerCase();
+            const email = submission.email.toLocaleLowerCase();
+            return fullName.includes(normalizedQuery) || email.includes(normalizedQuery);
+        });
+    })();
+
+    const refreshLabel = submissionsQuery.isFetching && !submissionsQuery.isLoading
+        ? "Actualizando entregas"
+        : "Actualizar entregas";
+    const errorMessage = submissionsQuery.error
+        ? getTeacherCaseSubmissionsErrorMessage(
+            submissionsQuery.error,
+            "No se pudo cargar el listado de entregas. Intenta nuevamente.",
+        )
+        : null;
+
+    return (
+        <TeacherLayout contentClassName="teacher-course-page mx-auto w-full max-w-6xl px-6 py-9" testId="teacher-case-submissions-page">
+            <div className="space-y-6">
+                <section className="rounded-[24px] border border-slate-200 bg-white p-6 shadow-sm md:p-8">
+                    <div className="teacher-gradebook-header">
+                        <div className="teacher-gradebook-header-row">
+                            <div className="min-w-0">
+                                <button
+                                    type="button"
+                                    onClick={() => navigate(-1)}
+                                    className="mb-4 inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                                >
+                                    <ArrowLeft className="h-4 w-4" />
+                                    Volver
+                                </button>
+                                <h1 className="text-2xl font-bold tracking-tight text-slate-900 md:text-[32px]">
+                                    Entregas del caso
+                                </h1>
+                                <p className="mt-2 max-w-3xl text-sm text-slate-500 md:text-base">
+                                    {caseDetail
+                                        ? `Revisa quién ya abrió, entregó o recibió calificación en ${caseDetail.title}.`
+                                        : "Consulta el estado de entrega por estudiante para este caso publicado."}
+                                </p>
+                                {caseDetail ? (
+                                    <div className="mt-4 flex flex-wrap items-center gap-3 text-sm text-slate-500">
+                                        <span className="rounded-full bg-slate-100 px-3 py-1 font-semibold text-slate-700">
+                                            Deadline: {caseDetail.deadline ? formatTeacherCourseTimestamp(caseDetail.deadline) : "Sin fecha"}
+                                        </span>
+                                        <span className="rounded-full bg-blue-50 px-3 py-1 font-semibold text-blue-700">
+                                            Puntaje máximo: {formatTeacherGradebookScore(caseDetail.max_score)}
+                                        </span>
+                                    </div>
+                                ) : null}
+                            </div>
+                            <div className="teacher-gradebook-refresh-group">
+                                <button
+                                    type="button"
+                                    onClick={() => void submissionsQuery.refetch()}
+                                    disabled={submissionsQuery.isFetching}
+                                    className="teacher-gradebook-refresh-button"
+                                    aria-label={refreshLabel}
+                                >
+                                    <RefreshCcw className={`h-4 w-4${submissionsQuery.isFetching ? " animate-spin" : ""}`} />
+                                    {refreshLabel}
+                                </button>
+                                {submissionsQuery.isFetching && !submissionsQuery.isLoading ? (
+                                    <p className="teacher-gradebook-refresh-status" aria-live="polite">
+                                        Sincronizando entregas recientes del caso.
+                                    </p>
+                                ) : null}
+                            </div>
+                        </div>
+                        {caseDetail ? (
+                            <div className="teacher-gradebook-metrics">
+                                <MetricCard
+                                    icon={<Users className="h-4 w-4" />}
+                                    label="Estudiantes asignados"
+                                    value={String(submissions.length)}
+                                />
+                                <MetricCard
+                                    icon={<BookOpen className="h-4 w-4" />}
+                                    label="Caso publicado"
+                                    value={caseDetail.status === "published" ? "Sí" : "No"}
+                                />
+                                <MetricCard
+                                    icon={<RefreshCcw className="h-4 w-4" />}
+                                    label="Entregas visibles"
+                                    value={String(filteredSubmissions.length)}
+                                />
+                            </div>
+                        ) : null}
+                    </div>
+                </section>
+
+                {errorMessage ? (
+                    <div className="alert-strip alert-warn" role="alert">
+                        <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+                        <div className="flex min-w-0 flex-1 flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                            <span>{errorMessage}</span>
+                            <button
+                                type="button"
+                                onClick={() => void submissionsQuery.refetch()}
+                                className="inline-flex items-center gap-2 self-start rounded-xl border border-amber-300 bg-white px-4 py-2 text-sm font-semibold text-amber-900 transition hover:bg-amber-50"
+                            >
+                                <RefreshCcw className="h-4 w-4" />
+                                Reintentar
+                            </button>
+                        </div>
+                    </div>
+                ) : null}
+
+                {submissionsQuery.isLoading && !submissionsQuery.data ? (
+                    <section className="teacher-gradebook-empty-state" aria-live="polite">
+                        <LoaderCircle className="h-6 w-6 animate-spin text-[#0144a0]" />
+                        <div>
+                            <p className="teacher-gradebook-empty-title">Cargando entregas del caso</p>
+                            <p className="teacher-gradebook-empty-copy">
+                                ADAM está consultando el estado de cada estudiante asignado.
+                            </p>
+                        </div>
+                    </section>
+                ) : null}
+
+                {!submissionsQuery.isLoading && !errorMessage && submissions.length === 0 ? (
+                    <section className="teacher-gradebook-empty-state" data-testid="teacher-case-submissions-empty">
+                        <AlertCircle className="h-6 w-6 text-slate-400" />
+                        <div>
+                            <p className="teacher-gradebook-empty-title">Aún no hay estudiantes asignados</p>
+                            <p className="teacher-gradebook-empty-copy">
+                                Este caso todavía no tiene estudiantes activos asociados a sus cursos publicados.
+                            </p>
+                        </div>
+                    </section>
+                ) : null}
+
+                {!submissionsQuery.isLoading && !errorMessage && submissions.length > 0 ? (
+                    <section className="teacher-gradebook-shell" aria-busy={submissionsQuery.isFetching}>
+                        <div className="teacher-gradebook-toolbar">
+                            <label htmlFor="teacher-case-submissions-search" className="teacher-gradebook-search">
+                                <Search className="teacher-gradebook-search-icon" aria-hidden="true" />
+                                <input
+                                    id="teacher-case-submissions-search"
+                                    type="search"
+                                    aria-label="Buscar estudiante por nombre o correo"
+                                    value={searchQuery}
+                                    onChange={(event) => setSearchQuery(event.target.value)}
+                                    placeholder="Buscar estudiante por nombre o correo"
+                                    className="teacher-gradebook-search-input"
+                                    autoComplete="off"
+                                    spellCheck={false}
+                                />
+                                {searchQuery ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => setSearchQuery("")}
+                                        className="teacher-gradebook-search-clear"
+                                        aria-label="Limpiar búsqueda"
+                                    >
+                                        <X className="h-4 w-4" />
+                                    </button>
+                                ) : null}
+                            </label>
+                            <p className="teacher-gradebook-search-count">
+                                {filteredSubmissions.length} de {submissions.length} estudiantes visibles
+                            </p>
+                        </div>
+
+                        {filteredSubmissions.length === 0 ? (
+                            <div className="teacher-gradebook-search-empty" data-testid="teacher-case-submissions-search-empty">
+                                <AlertCircle className="h-5 w-5 text-slate-400" />
+                                <div>
+                                    <p className="teacher-gradebook-empty-title">No encontramos coincidencias</p>
+                                    <p className="teacher-gradebook-empty-copy">
+                                        Ajusta la búsqueda para encontrar al estudiante por nombre o correo.
+                                    </p>
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="overflow-x-auto">
+                                <table
+                                    className="min-w-full border-collapse"
+                                    aria-label={`Listado de entregas del caso ${caseDetail?.title ?? "seleccionado"} con ${filteredSubmissions.length} estudiantes visibles.`}
+                                >
+                                    <thead className="bg-slate-50 text-left text-xs uppercase tracking-[0.08em] text-slate-500">
+                                        <tr>
+                                            <th scope="col" className="px-6 py-4 font-semibold">Estudiante</th>
+                                            <th scope="col" className="px-6 py-4 font-semibold">Correo</th>
+                                            <th scope="col" className="px-6 py-4 font-semibold">Curso</th>
+                                            <th scope="col" className="px-6 py-4 font-semibold">Estado</th>
+                                            <th scope="col" className="px-6 py-4 font-semibold">Enviado</th>
+                                            <th scope="col" className="px-6 py-4 font-semibold">Nota</th>
+                                            <th scope="col" className="px-6 py-4 font-semibold">Acciones</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody className="divide-y divide-slate-100 bg-white text-sm text-slate-700">
+                                        {filteredSubmissions.map((submission) => {
+                                            const fullName = submission.full_name.trim() || "(sin nombre)";
+                                            const canOpenDetail = submission.status !== "not_started";
+                                            const actionLabel = submission.status === "graded"
+                                                ? "Ver calificación"
+                                                : "Ver entrega y calificar";
+
+                                            return (
+                                                <tr key={`${submission.membership_id}:${submission.course_id}`}>
+                                                    <th scope="row" className="px-6 py-5 align-top font-semibold text-slate-900">
+                                                        <div className="space-y-1">
+                                                            <p title={fullName}>{fullName}</p>
+                                                            <p className="text-xs font-normal text-slate-500">
+                                                                Ingresó: {formatTeacherCourseTimestamp(submission.enrolled_at)}
+                                                            </p>
+                                                        </div>
+                                                    </th>
+                                                    <td className="px-6 py-5 align-top text-slate-600" title={submission.email}>
+                                                        {submission.email}
+                                                    </td>
+                                                    <td className="px-6 py-5 align-top">
+                                                        <span className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+                                                            {submission.course_code}
+                                                        </span>
+                                                    </td>
+                                                    <td className="px-6 py-5 align-top">{renderStatusChip(submission.status)}</td>
+                                                    <td className="px-6 py-5 align-top text-slate-600">
+                                                        {submission.submitted_at ? formatTeacherCourseTimestamp(submission.submitted_at) : "-"}
+                                                    </td>
+                                                    <td className="px-6 py-5 align-top text-slate-600">
+                                                        {submission.score !== null
+                                                            ? `${formatTeacherGradebookScore(submission.score)} / ${formatTeacherGradebookScore(submission.max_score)}`
+                                                            : "-"}
+                                                    </td>
+                                                    <td className="px-6 py-5 align-top">
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => navigate(`/teacher/cases/${assignmentId}/entregas/${submission.membership_id}`)}
+                                                            disabled={!canOpenDetail}
+                                                            aria-disabled={canOpenDetail ? undefined : "true"}
+                                                            aria-label={`${actionLabel}: ${fullName}`}
+                                                            title={canOpenDetail ? actionLabel : "El estudiante aún no ha abierto el caso."}
+                                                            className={canOpenDetail
+                                                                ? "inline-flex h-9 items-center justify-center gap-1.5 rounded-[9px] border-none bg-gradient-to-r from-blue-600 to-indigo-600 px-3.5 py-2 text-[13px] font-bold text-white shadow-md shadow-blue-500/20 transition-all hover:scale-[1.02] hover:shadow-lg hover:shadow-blue-500/30"
+                                                                : "inline-flex h-9 cursor-not-allowed items-center justify-center gap-1.5 rounded-[9px] border border-slate-200 bg-slate-100 px-3.5 py-2 text-[13px] font-semibold text-slate-500 shadow-none"
+                                                            }
+                                                        >
+                                                            {actionLabel}
+                                                        </button>
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+                    </section>
+                ) : null}
+            </div>
+        </TeacherLayout>
+    );
+}

--- a/frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.tsx
+++ b/frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.tsx
@@ -110,7 +110,7 @@ export function TeacherCaseSubmissionsPage() {
                                 {caseDetail ? (
                                     <div className="mt-4 flex flex-wrap items-center gap-3 text-sm text-slate-500">
                                         <span className="rounded-full bg-slate-100 px-3 py-1 font-semibold text-slate-700">
-                                            Deadline: {caseDetail.deadline ? formatTeacherCourseTimestamp(caseDetail.deadline) : "Sin fecha"}
+                                            Fecha límite: {caseDetail.deadline ? formatTeacherCourseTimestamp(caseDetail.deadline) : "Sin fecha"}
                                         </span>
                                         <span className="rounded-full bg-blue-50 px-3 py-1 font-semibold text-blue-700">
                                             Puntaje máximo: {formatTeacherGradebookScore(caseDetail.max_score)}

--- a/frontend/src/features/teacher-case-submissions/useTeacherCaseSubmissions.test.ts
+++ b/frontend/src/features/teacher-case-submissions/useTeacherCaseSubmissions.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/shared/api";
+import { queryKeys } from "@/shared/queryKeys";
+
+import { useTeacherCaseSubmissions } from "./useTeacherCaseSubmissions";
+
+vi.mock("@tanstack/react-query", () => ({
+    useQuery: vi.fn(),
+}));
+
+vi.mock("@/shared/api", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/api")>("@/shared/api");
+
+    return {
+        ...actual,
+        api: {
+            ...actual.api,
+            teacher: {
+                ...actual.api.teacher,
+                getCaseSubmissions: vi.fn(),
+            },
+        },
+    };
+});
+
+describe("useTeacherCaseSubmissions", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("configures the submissions query with the expected cache policy", async () => {
+        vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+
+        useTeacherCaseSubmissions("assignment-1");
+
+        expect(useQuery).toHaveBeenCalledWith({
+            queryKey: queryKeys.teacher.caseSubmissions("assignment-1"),
+            queryFn: expect.any(Function),
+            enabled: true,
+            staleTime: 30_000,
+            refetchOnMount: true,
+            refetchOnWindowFocus: true,
+        });
+
+        const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as {
+            queryFn: () => Promise<unknown>;
+        };
+        await options.queryFn();
+        expect(api.teacher.getCaseSubmissions).toHaveBeenCalledWith("assignment-1");
+    });
+
+    it("disables the submissions query when the assignment id is empty", () => {
+        vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+
+        useTeacherCaseSubmissions("");
+
+        const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+        expect(options.enabled).toBe(false);
+    });
+});

--- a/frontend/src/features/teacher-case-submissions/useTeacherCaseSubmissions.ts
+++ b/frontend/src/features/teacher-case-submissions/useTeacherCaseSubmissions.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api, ApiError } from "@/shared/api";
+import type { TeacherCaseSubmissionsResponse } from "@/shared/adam-types";
+import { queryKeys } from "@/shared/queryKeys";
+
+export function getTeacherCaseSubmissionsErrorMessage(
+    error: unknown,
+    fallback: string,
+): string {
+    if (!(error instanceof ApiError)) {
+        return error instanceof Error ? error.message : fallback;
+    }
+
+    if (error.status === 404) {
+        return "No encontramos este caso o no tienes acceso.";
+    }
+
+    switch (error.detail) {
+        case "course_gradebook_cross_enrollment_unsupported":
+            return "Este caso está publicado en varios cursos con estudiantes superpuestos. Corrige esa configuración antes de abrir las entregas.";
+        case "course_gradebook_inconsistent_max_score":
+        case "course_gradebook_invalid_max_score":
+            return "Este caso tiene calificaciones inválidas o inconsistentes. Corrige esos registros antes de abrir las entregas.";
+        case "student_identity_unavailable":
+            return "No se pudo recuperar la identidad de uno o más estudiantes asignados a este caso.";
+        case "invalid_token":
+            return "Tu sesión expiró. Vuelve a iniciar sesión para continuar.";
+        case "profile_incomplete":
+            return "Tu perfil docente todavía no está listo para usar esta vista.";
+        case "membership_required":
+            return "Tu cuenta no tiene una membresía docente activa para este caso.";
+        default:
+            return error.message || fallback;
+    }
+}
+
+export function useTeacherCaseSubmissions(assignmentId: string) {
+    return useQuery<TeacherCaseSubmissionsResponse>({
+        queryKey: queryKeys.teacher.caseSubmissions(assignmentId),
+        queryFn: () => api.teacher.getCaseSubmissions(assignmentId),
+        enabled: Boolean(assignmentId),
+        staleTime: 30_000,
+        refetchOnMount: true,
+        refetchOnWindowFocus: true,
+    });
+}

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -825,6 +825,25 @@ export interface TeacherCaseDetailResponse {
     canonical_output: CanonicalCaseOutput | null;
 }
 
+export interface TeacherCaseSubmissionRow {
+    membership_id: string;
+    full_name: string;
+    email: string;
+    course_id: string;
+    course_code: string;
+    enrolled_at: string;
+    status: TeacherCourseGradebookStatus;
+    submitted_at: string | null;
+    score: number | null;
+    max_score: number;
+    graded_at: string | null;
+}
+
+export interface TeacherCaseSubmissionsResponse {
+    case: TeacherCourseGradebookCase;
+    submissions: TeacherCaseSubmissionRow[];
+}
+
 export interface DeadlineUpdateRequest {
     available_from?: string | null;
     deadline?: string | null;

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -974,6 +974,41 @@ describe("api auth + stream glue", () => {
         expect(new Headers(options.headers).get("Authorization")).toBe("Bearer teacher-token");
     });
 
+    it("fetches teacher case submissions with bearer auth", async () => {
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+        getSessionMock.mockResolvedValue({
+            data: { session: { access_token: "teacher-token" } },
+            error: null,
+        });
+
+        const payload = {
+            case: {
+                assignment_id: "case-1",
+                title: "Caso Test",
+                status: "published",
+                available_from: null,
+                deadline: null,
+                max_score: 5,
+            },
+            submissions: [],
+        };
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(payload), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await api.teacher.getCaseSubmissions("case-1");
+
+        expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/teacher/cases/case-1/submissions");
+        const options = fetchMock.mock.calls[0]?.[1] as RequestInit;
+        expect(options.method).toBeUndefined();
+        expect(new Headers(options.headers).get("Authorization")).toBe("Bearer teacher-token");
+    });
+
     it("publishes a teacher case with PATCH and bearer auth", async () => {
         vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
         vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -46,6 +46,7 @@ import type {
     SuggestRequest,
     SuggestResponse,
     TeacherCaseDetailResponse,
+    TeacherCaseSubmissionsResponse,
     TeacherCourseAccessLinkRegenerateResponse,
     TeacherCourseAccessLinkResponse,
     TeacherCourseDetailResponse,
@@ -1185,6 +1186,11 @@ export const api = {
         async getCaseDetail(assignmentId: string): Promise<TeacherCaseDetailResponse> {
             return parseJsonResponse<TeacherCaseDetailResponse>(
                 `/teacher/cases/${assignmentId}`,
+            );
+        },
+        async getCaseSubmissions(assignmentId: string): Promise<TeacherCaseSubmissionsResponse> {
+            return parseJsonResponse<TeacherCaseSubmissionsResponse>(
+                `/teacher/cases/${assignmentId}/submissions`,
             );
         },
         async publishCase(assignmentId: string): Promise<TeacherCaseDetailResponse> {

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -88,5 +88,7 @@ export const queryKeys = {
         cases: () => ["teacher", "cases"] as const,
         /** ["teacher", "case", id] — detalle de un caso del docente */
         case: (id: string) => ["teacher", "case", id] as const,
+        /** ["teacher", "case-submissions", id] — entregas por caso del docente */
+        caseSubmissions: (id: string) => ["teacher", "case-submissions", id] as const,
     },
 } as const;


### PR DESCRIPTION
## Summary
- Add the teacher case submissions backend endpoint, shared gradebook status derivation, and focused backend coverage for published case submission listings.
- Add the teacher case submissions page, query hook, shared frontend contracts, route wiring, and targeted frontend tests for the new teacher flow.
- Record the deferred pagination or virtualization follow-up for large submission lists in TODOS.md.

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Eval Results
No prompt-related files changed ��� evals skipped.

## Test plan
- [x] `uv run --directory backend pytest -q` (372 passed, 12 skipped)
- [x] `npm --prefix frontend run test` (381 passed)
- [x] `uv run --directory backend mypy src`
- [x] `npm --prefix frontend run lint`
- [x] `npm --prefix frontend run build`

���� Generated with [Claude Code](https://claude.com/claude-code)




Closes #210
