### PR TITLE
feat: add teacher case submission detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ADAM EDU es un Teacher Authoring + Preview MVP en transicion a una plataforma multi-rol con autenticacion real. El repositorio incluye:
 
-- Flujo docente completo: sugerencias en formulario, generacion asincrona con LangGraph, progreso en tiempo real via Supabase Realtime (`postgres_changes`) y preview del caso.
+- Flujo docente completo: sugerencias en formulario, generacion asincrona con LangGraph, progreso en tiempo real via Supabase Realtime (`postgres_changes`), preview del caso y revision docente de entregas por estudiante.
 - Shell frontend auth-aware (Issue #5): `AuthProvider`, guards por rol, callback OAuth PKCE, helper `sessionStorage` de activacion con TTL 5 minutos, dashboard docente en `/app/teacher/dashboard`, detalle de curso en `/app/teacher/courses/:courseId` y ruta canonica de authoring en `/app/teacher/case-designer` (con compatibilidad via redirect `/app/teacher` -> `/app/teacher/case-designer`).
 - Auth perimeter backend (Issue #3): verificacion JWT via JWKS, actor resolution por memberships, `GET /api/auth/me`, endpoints de activacion body-only.
 
@@ -73,6 +73,8 @@ El endpoint interno `/api/internal/tasks/authoring_step` se conserva como seam d
 - `frontend/src/app/`: shell del frontend. Aqui viven router, entrypoint, layout base y estilos globales.
 - `frontend/src/features/teacher-authoring/`: flujo docente real. Contiene formulario, submit del job, suscripcion Realtime, timeline y estados del authoring.
 - `frontend/src/features/teacher-course/`: vista de detalle del curso docente, incluyendo tabs de syllabus, estudiantes y configuracion del access link.
+- `frontend/src/features/teacher-case-submissions/`: listado docente de entregas por caso publicado.
+- `frontend/src/features/teacher-case-submission-detail/`: detalle docente read-only de una entrega individual, con snapshot, borrador y solucion esperada.
 - `frontend/src/features/case-preview/`: preview editorial del caso generado, incluyendo renderers y modulos `M1..M6`.
 - `frontend/src/shared/`: piezas transversales del MVP. Aqui viven cliente API, tipos compartidos, header, toast, utilidades y primitives UI.
 
@@ -98,6 +100,8 @@ En este corte no se renombran carpetas del frontend.
 9. `GET /api/teacher/courses/{course_id}` compone la ficha docente del curso y su syllabus vigente.
 10. `GET /api/teacher/courses/{course_id}/students` devuelve el gradebook de solo lectura del curso con estudiantes activos, casos publicados y overlay de `StudentCaseResponse` + `case_grades`.
 11. `GET /api/teacher/courses/{course_id}/access-link` expone la metadata vigente del enlace de acceso para estudiantes.
+12. `GET /api/teacher/cases/{assignment_id}/submissions` devuelve el listado docente de entregas por caso publicado.
+13. `GET /api/teacher/cases/{assignment_id}/submissions/{membership_id}` devuelve el detalle read-only de una entrega con snapshot, borrador y solucion esperada docente.
 
 El frontend usa ese flujo para renderizar el timeline y el `CasePreview` del profesor.
 
@@ -105,6 +109,8 @@ Rutas funcionales actuales del shell docente (frontend):
 
 - `/app/teacher/dashboard`: dashboard principal del docente.
 - `/app/teacher/courses/:courseId`: detalle del curso con tabs de syllabus, estudiantes y configuracion.
+- `/app/teacher/cases/:assignmentId/entregas`: listado de entregas del caso publicado.
+- `/app/teacher/cases/:assignmentId/entregas/:membershipId`: detalle read-only de una entrega individual.
 - `/app/teacher/case-designer`: entrada canonica al Diseñador de Casos.
 - `/app/teacher`: redirect de compatibilidad hacia `/app/teacher/case-designer`.
 

--- a/backend/src/shared/case_sanitization.py
+++ b/backend/src/shared/case_sanitization.py
@@ -37,6 +37,11 @@ _ALLOWED_CONTENT_FIELDS = (
     "m5Content",
 )
 
+_TEACHER_ALLOWED_CONTENT_FIELDS = _ALLOWED_CONTENT_FIELDS + (
+    "m5QuestionsSolutions",
+    "teachingNote",
+)
+
 _QUESTION_FIELD_WHITELIST = (
     "numero",
     "titulo",
@@ -51,6 +56,10 @@ _QUESTION_FIELD_WHITELIST = (
     "task_type",
 )
 
+_TEACHER_QUESTION_FIELD_WHITELIST = _QUESTION_FIELD_WHITELIST + (
+    "solucion_esperada",
+)
+
 _QUESTION_ARRAY_FIELDS = (
     "caseQuestions",
     "edaQuestions",
@@ -60,27 +69,75 @@ _QUESTION_ARRAY_FIELDS = (
 )
 
 
-def _project_question(question: Any) -> dict[str, Any] | None:
+def _project_question(
+    question: Any,
+    *,
+    question_field_whitelist: tuple[str, ...],
+) -> dict[str, Any] | None:
     if not isinstance(question, dict):
         return None
     projected = {
         field: deepcopy(question[field])
-        for field in _QUESTION_FIELD_WHITELIST
+        for field in question_field_whitelist
         if field in question
     }
     return projected or None
 
 
-def _project_question_array(value: Any) -> list[dict[str, Any]]:
+def _project_question_array(
+    value: Any,
+    *,
+    question_field_whitelist: tuple[str, ...],
+) -> list[dict[str, Any]]:
     if not isinstance(value, list):
         return []
 
     projected_items: list[dict[str, Any]] = []
     for item in value:
-        projected = _project_question(item)
+        projected = _project_question(
+            item,
+            question_field_whitelist=question_field_whitelist,
+        )
         if projected is not None:
             projected_items.append(projected)
     return projected_items
+
+
+def _sanitize_canonical_output(
+    canonical_output: dict[str, Any],
+    *,
+    allowed_content_fields: tuple[str, ...],
+    question_field_whitelist: tuple[str, ...],
+) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {
+        field: deepcopy(canonical_output[field])
+        for field in _ALLOWED_ROOT_FIELDS
+        if field in canonical_output
+    }
+
+    content = canonical_output.get("content")
+    sanitized_content: dict[str, Any] = {}
+    if isinstance(content, dict):
+        for field in allowed_content_fields:
+            if field in content:
+                if field != "m5QuestionsSolutions":
+                    sanitized_content[field] = deepcopy(content[field])
+
+        for field in _QUESTION_ARRAY_FIELDS:
+            if field in content:
+                sanitized_content[field] = _project_question_array(
+                    content[field],
+                    question_field_whitelist=question_field_whitelist,
+                )
+
+        if "m5QuestionsSolutions" in allowed_content_fields and "m5QuestionsSolutions" in content:
+            sanitized_content["m5QuestionsSolutions"] = _project_question_array(
+                content["m5QuestionsSolutions"],
+                question_field_whitelist=question_field_whitelist,
+            )
+
+    sanitized["content"] = sanitized_content
+    return sanitized
 
 
 def sanitize_canonical_output_for_student(
@@ -105,22 +162,31 @@ def sanitize_canonical_output_for_student(
       - content.m5QuestionsSolutions
       - content.teachingNote
     """
-    sanitized: dict[str, Any] = {
-        field: deepcopy(canonical_output[field])
-        for field in _ALLOWED_ROOT_FIELDS
-        if field in canonical_output
-    }
+    return _sanitize_canonical_output(
+        canonical_output,
+        allowed_content_fields=_ALLOWED_CONTENT_FIELDS,
+        question_field_whitelist=_QUESTION_FIELD_WHITELIST,
+    )
 
-    content = canonical_output.get("content")
-    sanitized_content: dict[str, Any] = {}
-    if isinstance(content, dict):
-        for field in _ALLOWED_CONTENT_FIELDS:
-            if field in content:
-                sanitized_content[field] = deepcopy(content[field])
 
-        for field in _QUESTION_ARRAY_FIELDS:
-            if field in content:
-                sanitized_content[field] = _project_question_array(content[field])
+def build_teacher_case_review_payload(
+    canonical_output: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Whitelist canonical_output fields safe to expose to a teacher reviewing a submission.
 
-    sanitized["content"] = sanitized_content
-    return sanitized
+    Exposes:
+      - content.{caseQuestions, edaQuestions, m3Questions, m4Questions, m5Questions}
+        with student-visible pedagogical fields plus `solucion_esperada`.
+      - content.m5QuestionsSolutions for teacher review flows.
+      - content.teachingNote.
+
+    Omits:
+      - Raw authoring telemetry, prompts, job ids, validation traces, debug logs,
+        and any other keys outside the explicit whitelist.
+    """
+    return _sanitize_canonical_output(
+        canonical_output,
+        allowed_content_fields=_TEACHER_ALLOWED_CONTENT_FIELDS,
+        question_field_whitelist=_TEACHER_QUESTION_FIELD_WHITELIST,
+    )

--- a/backend/src/shared/teacher_gradebook_schema.py
+++ b/backend/src/shared/teacher_gradebook_schema.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 
 class StrictModel(BaseModel):
@@ -70,3 +71,69 @@ class TeacherCaseSubmissionRow(StrictModel):
 class TeacherCaseSubmissionsResponse(StrictModel):
     case: TeacherCourseGradebookCase
     submissions: list[TeacherCaseSubmissionRow]
+
+
+class TeacherCaseSubmissionDetailQuestion(StrictModel):
+    id: str
+    order: int = Field(ge=1)
+    statement: str
+    context: str | None = None
+    expected_solution: str
+    student_answer: str | None = None
+    student_answer_chars: int = Field(ge=0)
+    is_answer_from_draft: bool
+
+
+class TeacherCaseSubmissionDetailModule(StrictModel):
+    id: Literal["M1", "M2", "M3", "M4", "M5"]
+    title: str
+    questions: list[TeacherCaseSubmissionDetailQuestion]
+
+
+class TeacherCaseSubmissionDetailCase(StrictModel):
+    id: str
+    title: str
+    deadline: datetime | None
+    available_from: datetime | None
+    course_id: str
+    course_code: str
+    course_name: str
+    teaching_note: str | None = None
+
+
+class TeacherCaseSubmissionDetailStudent(StrictModel):
+    membership_id: str
+    full_name: str
+    email: str
+    enrolled_at: datetime
+
+
+class TeacherCaseSubmissionDetailResponseState(StrictModel):
+    status: TeacherCourseGradebookStatus
+    first_opened_at: datetime | None
+    last_autosaved_at: datetime | None
+    submitted_at: datetime | None
+    snapshot_id: str | None = None
+    snapshot_hash: str | None = None
+
+
+class TeacherCaseSubmissionDetailGradeSummary(StrictModel):
+    status: Literal["in_progress", "submitted", "graded"] | None = None
+    score: Decimal | None = None
+    max_score: Decimal = Field(ge=0)
+    graded_at: datetime | None = None
+
+    @field_serializer("score", "max_score", when_used="json")
+    def _serialize_decimals(self, value: Decimal | None) -> float | None:
+        if value is None:
+            return None
+        return float(value)
+
+
+class TeacherCaseSubmissionDetailResponse(StrictModel):
+    payload_version: Literal[1] = 1
+    case: TeacherCaseSubmissionDetailCase
+    student: TeacherCaseSubmissionDetailStudent
+    response_state: TeacherCaseSubmissionDetailResponseState
+    grade_summary: TeacherCaseSubmissionDetailGradeSummary
+    modules: list[TeacherCaseSubmissionDetailModule]

--- a/backend/src/shared/teacher_gradebook_schema.py
+++ b/backend/src/shared/teacher_gradebook_schema.py
@@ -132,6 +132,7 @@ class TeacherCaseSubmissionDetailGradeSummary(StrictModel):
 
 class TeacherCaseSubmissionDetailResponse(StrictModel):
     payload_version: Literal[1] = 1
+    is_truncated: bool = False
     case: TeacherCaseSubmissionDetailCase
     student: TeacherCaseSubmissionDetailStudent
     response_state: TeacherCaseSubmissionDetailResponseState

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
+import json
 import logging
-from typing import Any, Literal, Sequence
+from typing import Any, Literal, Mapping, Sequence
 from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException, status
@@ -14,6 +15,10 @@ from sqlalchemy.engine import RowMapping
 from sqlalchemy.orm import Session, joinedload, load_only
 
 from shared.auth import CurrentActor, ensure_legacy_teacher_bridge, get_supabase_admin_auth_client
+from shared.case_sanitization import (
+    build_teacher_case_review_payload,
+    sanitize_canonical_output_for_student,
+)
 from shared.course_access_schema import TeacherCourseAccessLinkResponse
 from shared.identity_activation import upsert_legacy_user
 from shared.models import (
@@ -27,6 +32,7 @@ from shared.models import (
     Membership,
     Profile,
     StudentCaseResponse,
+    StudentCaseResponseSubmission,
     Syllabus,
     User,
 )
@@ -39,6 +45,13 @@ from shared.syllabus_schema import (
 )
 from shared.teacher_context import TeacherContext
 from shared.teacher_gradebook_schema import (
+    TeacherCaseSubmissionDetailCase,
+    TeacherCaseSubmissionDetailGradeSummary,
+    TeacherCaseSubmissionDetailModule,
+    TeacherCaseSubmissionDetailQuestion,
+    TeacherCaseSubmissionDetailResponse,
+    TeacherCaseSubmissionDetailResponseState,
+    TeacherCaseSubmissionDetailStudent,
     TeacherCaseSubmissionRow,
     TeacherCaseSubmissionsResponse,
     TeacherCourseGradebookCase,
@@ -51,7 +64,17 @@ from shared.teacher_gradebook_schema import (
 
 _BOGOTA_TZ = ZoneInfo("America/Bogota")
 _DEFAULT_CASE_MAX_SCORE = 5.0
+_DEFAULT_CASE_MAX_SCORE_DECIMAL = Decimal("5.00")
 _logger = logging.getLogger(__name__)
+_DETAIL_PAYLOAD_MAX_BYTES = 1_500_000
+_DETAIL_EXPECTED_SOLUTION_TRUNCATION_CHARS = 8_000
+_MODULE_TITLES: Mapping[str, str] = {
+    "M1": "Módulo 1 · Comprensión del caso",
+    "M2": "Módulo 2 · Análisis de datos",
+    "M3": "Módulo 3 · Diagnóstico",
+    "M4": "Módulo 4 · Recomendación",
+    "M5": "Módulo 5 · Reflexión",
+}
 
 
 class TeacherCourseItemResponse(BaseModel):
@@ -95,6 +118,492 @@ def _decimal_to_float(value: Decimal | None) -> float | None:
 def _display_name(*, profile_full_name: str | None, email: str) -> str:
     candidate = profile_full_name.strip() if profile_full_name is not None else ""
     return candidate or email
+
+
+def _stringify_review_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+    return str(value)
+
+
+def _question_context(question: dict[str, Any]) -> str | None:
+    context_parts: list[str] = []
+
+    title = question.get("titulo")
+    if isinstance(title, str) and title.strip():
+        context_parts.append(title.strip())
+
+    bloom_level = question.get("bloom_level")
+    if isinstance(bloom_level, str) and bloom_level.strip():
+        context_parts.append(f"Bloom: {bloom_level.strip()}")
+
+    exhibit_ref = question.get("exhibit_ref")
+    if isinstance(exhibit_ref, str) and exhibit_ref.strip():
+        context_parts.append(f"Exhibito: {exhibit_ref.strip()}")
+
+    chart_ref = question.get("chart_ref")
+    if isinstance(chart_ref, str) and chart_ref.strip():
+        context_parts.append(f"Grafico: {chart_ref.strip()}")
+
+    task_type = question.get("task_type")
+    if isinstance(task_type, str) and task_type.strip():
+        context_parts.append(f"Tipo: {task_type.strip()}")
+
+    modules_integrated = question.get("modules_integrated")
+    if isinstance(modules_integrated, list):
+        normalized_modules = [str(module).strip() for module in modules_integrated if str(module).strip()]
+        if normalized_modules:
+            context_parts.append(f"Integra: {', '.join(normalized_modules)}")
+
+    if not context_parts:
+        return None
+    return "\n".join(context_parts)
+
+
+def _detail_question_id(module_id: str, question: dict[str, Any], order: int) -> str:
+    numero = question.get("numero")
+    if numero is not None:
+        normalized_numero = str(numero).strip()
+        if normalized_numero:
+            return f"{module_id}-Q{normalized_numero}"
+    return f"{module_id}.{order}"
+
+
+def _lookup_student_answer(
+    answers: dict[str, str],
+    *,
+    module_id: str,
+    question: dict[str, Any],
+    order: int,
+) -> str | None:
+    question_id = _detail_question_id(module_id, question, order)
+    answer = answers.get(question_id)
+    if answer is not None:
+        return answer
+
+    numero = question.get("numero")
+    if numero is not None:
+        legacy_answer = answers.get(f"q{str(numero).strip()}")
+        if legacy_answer is not None:
+            return legacy_answer
+
+    return None
+
+
+def _m5_solution_lookup(content: dict[str, Any]) -> dict[str, str]:
+    raw_solutions = content.get("m5QuestionsSolutions")
+    if not isinstance(raw_solutions, list):
+        return {}
+
+    solutions: dict[str, str] = {}
+    for item in raw_solutions:
+        if not isinstance(item, dict):
+            continue
+        numero = item.get("numero")
+        if numero is None:
+            continue
+        normalized_numero = str(numero).strip()
+        if not normalized_numero:
+            continue
+        solutions[normalized_numero] = _stringify_review_value(item.get("solucion_esperada"))
+    return solutions
+
+
+def _truncate_detail_modules_if_needed(
+    modules: list[TeacherCaseSubmissionDetailModule],
+    *,
+    assignment_id: str,
+    membership_id: str,
+) -> list[TeacherCaseSubmissionDetailModule]:
+    serialized_modules = json.dumps(
+        [module.model_dump(mode="json") for module in modules],
+        ensure_ascii=False,
+    )
+    if len(serialized_modules) <= _DETAIL_PAYLOAD_MAX_BYTES:
+        return modules
+
+    for module in modules:
+        for question in module.questions:
+            if len(question.expected_solution) > _DETAIL_EXPECTED_SOLUTION_TRUNCATION_CHARS:
+                question.expected_solution = (
+                    question.expected_solution[:_DETAIL_EXPECTED_SOLUTION_TRUNCATION_CHARS]
+                    + "... [truncado por tamano]"
+                )
+
+    _logger.warning(
+        "teacher_case_submission_detail_payload_truncated",
+        extra={
+            "assignment_id": assignment_id,
+            "membership_id": membership_id,
+            "payload_size": len(serialized_modules),
+        },
+    )
+    return modules
+
+
+def _build_submission_detail_modules(
+    *,
+    canonical_output: dict[str, Any],
+    answers: dict[str, str],
+    is_answer_from_draft: bool,
+    assignment_id: str,
+    membership_id: str,
+) -> list[TeacherCaseSubmissionDetailModule]:
+    from shared.student_reads import QUESTION_FIELD_TO_MODULE
+
+    teacher_payload = build_teacher_case_review_payload(canonical_output)
+    content = teacher_payload.get("content")
+    if not isinstance(content, dict):
+        return []
+
+    m5_solution_lookup = _m5_solution_lookup(content)
+    modules: list[TeacherCaseSubmissionDetailModule] = []
+    for field_name, module_id in QUESTION_FIELD_TO_MODULE.items():
+        raw_questions = content.get(field_name)
+        if not isinstance(raw_questions, list) or not raw_questions:
+            continue
+
+        questions: list[TeacherCaseSubmissionDetailQuestion] = []
+        for order, raw_question in enumerate(raw_questions, start=1):
+            if not isinstance(raw_question, dict):
+                continue
+
+            question_id = _detail_question_id(module_id, raw_question, order)
+            student_answer = _lookup_student_answer(
+                answers,
+                module_id=module_id,
+                question=raw_question,
+                order=order,
+            )
+            expected_solution = _stringify_review_value(raw_question.get("solucion_esperada"))
+            if not expected_solution and module_id == "M5":
+                numero = raw_question.get("numero")
+                if numero is not None:
+                    expected_solution = m5_solution_lookup.get(str(numero).strip(), "")
+
+            questions.append(
+                TeacherCaseSubmissionDetailQuestion(
+                    id=question_id,
+                    order=order,
+                    statement=_stringify_review_value(raw_question.get("enunciado")),
+                    context=_question_context(raw_question),
+                    expected_solution=expected_solution,
+                    student_answer=student_answer,
+                    student_answer_chars=len(student_answer) if student_answer is not None else 0,
+                    is_answer_from_draft=is_answer_from_draft,
+                )
+            )
+
+        if questions:
+            modules.append(
+                TeacherCaseSubmissionDetailModule(
+                    id=module_id,
+                    title=_MODULE_TITLES[module_id],
+                    questions=questions,
+                )
+            )
+
+    return _truncate_detail_modules_if_needed(
+        modules,
+        assignment_id=assignment_id,
+        membership_id=membership_id,
+    )
+
+
+def _load_teacher_submission_assignment(
+    db: Session,
+    context: TeacherContext,
+    *,
+    assignment_id: str,
+) -> Assignment | None:
+    assignment_target_courses = _build_assignment_target_courses_subquery()
+    return (
+        db.execute(
+            select(Assignment)
+            .options(
+                load_only(
+                    Assignment.id,
+                    Assignment.course_id,
+                    Assignment.title,
+                    Assignment.status,
+                    Assignment.available_from,
+                    Assignment.deadline,
+                    Assignment.canonical_output,
+                ),
+                joinedload(Assignment.course).load_only(
+                    Course.id,
+                    Course.code,
+                    Course.title,
+                    Course.university_id,
+                    Course.teacher_membership_id,
+                ),
+                joinedload(Assignment.assignment_courses)
+                .joinedload(AssignmentCourse.course)
+                .load_only(
+                    Course.id,
+                    Course.code,
+                    Course.title,
+                    Course.university_id,
+                    Course.teacher_membership_id,
+                ),
+            )
+            .where(
+                Assignment.id == assignment_id,
+                Assignment.status == "published",
+                exists(
+                    select(1)
+                    .select_from(assignment_target_courses)
+                    .join(
+                        Course,
+                        and_(
+                            assignment_target_courses.c.course_id == Course.id,
+                            Course.university_id == context.university_id,
+                            Course.teacher_membership_id == context.teacher_membership_id,
+                        ),
+                    )
+                    .where(assignment_target_courses.c.assignment_id == Assignment.id)
+                ),
+            )
+        )
+        .unique()
+        .scalar_one_or_none()
+    )
+
+
+def get_teacher_case_submission_detail(
+    db: Session,
+    context: TeacherContext,
+    assignment_id: str,
+    membership_id: str,
+) -> TeacherCaseSubmissionDetailResponse:
+    assignment = _load_teacher_submission_assignment(
+        db,
+        context,
+        assignment_id=assignment_id,
+    )
+    if assignment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="assignment_not_found")
+
+    target_course_ids, _course_codes = _assignment_target_course_metadata(assignment)
+    if not target_course_ids:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="assignment_not_found")
+
+    _ensure_supported_gradebook_topology(
+        db,
+        context,
+        assignments=[assignment],
+        student_membership_ids=[membership_id],
+    )
+
+    detail_row = (
+        db.execute(
+            select(
+                Membership.id.label("membership_id"),
+                Membership.user_id.label("user_id"),
+                CourseMembership.created_at.label("enrolled_at"),
+                Profile.full_name.label("profile_full_name"),
+                User.email.label("email"),
+                Course.id.label("course_id"),
+                Course.code.label("course_code"),
+                Course.title.label("course_name"),
+                StudentCaseResponse.id.label("response_id"),
+                StudentCaseResponse.status.label("student_case_status"),
+                StudentCaseResponse.answers.label("student_answers"),
+                StudentCaseResponse.first_opened_at.label("first_opened_at"),
+                StudentCaseResponse.last_autosaved_at.label("last_autosaved_at"),
+                StudentCaseResponse.submitted_at.label("submitted_at"),
+                CaseGrade.status.label("case_grade_status"),
+                CaseGrade.score.label("score"),
+                CaseGrade.max_score.label("max_score"),
+                CaseGrade.graded_at.label("graded_at"),
+            )
+            .select_from(CourseMembership)
+            .join(
+                Membership,
+                and_(
+                    CourseMembership.membership_id == Membership.id,
+                    Membership.university_id == context.university_id,
+                    Membership.role == "student",
+                    Membership.status == "active",
+                ),
+            )
+            .join(
+                Course,
+                and_(
+                    CourseMembership.course_id == Course.id,
+                    Course.university_id == context.university_id,
+                    Course.teacher_membership_id == context.teacher_membership_id,
+                ),
+            )
+            .outerjoin(User, User.id == Membership.user_id)
+            .outerjoin(Profile, Profile.id == Membership.user_id)
+            .outerjoin(
+                StudentCaseResponse,
+                and_(
+                    StudentCaseResponse.membership_id == Membership.id,
+                    StudentCaseResponse.assignment_id == assignment.id,
+                ),
+            )
+            .outerjoin(
+                CaseGrade,
+                and_(
+                    CaseGrade.membership_id == Membership.id,
+                    CaseGrade.assignment_id == assignment.id,
+                    CaseGrade.course_id == Course.id,
+                ),
+            )
+            .where(
+                Membership.id == membership_id,
+                CourseMembership.course_id.in_(target_course_ids),
+            )
+        )
+        .mappings()
+        .first()
+    )
+    if detail_row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="submission_not_found")
+
+    repaired_row = _repair_gradebook_student_rows(db, context, student_rows=[detail_row])[0]
+
+    response_id = repaired_row["response_id"]
+    latest_submission = None
+    if response_id is not None:
+        latest_submission = db.execute(
+            select(StudentCaseResponseSubmission)
+            .where(StudentCaseResponseSubmission.response_id == response_id)
+            .order_by(
+                StudentCaseResponseSubmission.submitted_at.desc(),
+                StudentCaseResponseSubmission.id.desc(),
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+
+    canonical_output = assignment.canonical_output
+    try:
+        if not isinstance(canonical_output, dict):
+            raise TypeError("assignment canonical_output must be a dict")
+        student_safe_payload = sanitize_canonical_output_for_student(canonical_output)
+        teacher_payload = build_teacher_case_review_payload(canonical_output)
+    except Exception:
+        _logger.exception(
+            "teacher_case_submission_detail_invalid_canonical_output",
+            extra={
+                "assignment_id": assignment.id,
+                "membership_id": membership_id,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="case_canonical_output_invalid",
+        )
+
+    if latest_submission is not None:
+        from shared.student_reads import _canonical_output_hash
+
+        current_hash = _canonical_output_hash(student_safe_payload)
+        if latest_submission.canonical_output_hash != current_hash:
+            _logger.warning(
+                "teacher_case_submission_detail_hash_drift",
+                extra={
+                    "assignment_id": assignment.id,
+                    "membership_id": membership_id,
+                    "snapshot_hash": latest_submission.canonical_output_hash,
+                    "current_hash": current_hash,
+                },
+            )
+
+    derived_status: TeacherCourseGradebookStatus = _derive_grade_cell_status(
+        repaired_row["student_case_status"],
+        repaired_row["case_grade_status"],
+    )
+
+    response_answers = (
+        dict(repaired_row["student_answers"])
+        if isinstance(repaired_row["student_answers"], dict)
+        else {}
+    )
+    if latest_submission is not None:
+        answer_source = dict(latest_submission.answers_snapshot or {})
+        is_answer_from_draft = False
+    elif response_id is not None:
+        answer_source = response_answers
+        is_answer_from_draft = True
+        if derived_status in {"submitted", "graded"}:
+            _logger.warning(
+                "teacher_case_submission_detail_missing_snapshot",
+                extra={
+                    "assignment_id": assignment.id,
+                    "membership_id": membership_id,
+                    "response_id": response_id,
+                    "derived_status": derived_status,
+                },
+            )
+    else:
+        answer_source = {}
+        is_answer_from_draft = False
+
+    modules = _build_submission_detail_modules(
+        canonical_output=canonical_output,
+        answers=answer_source,
+        is_answer_from_draft=is_answer_from_draft,
+        assignment_id=assignment.id,
+        membership_id=membership_id,
+    )
+
+    available_from, deadline = resolve_assignment_schedule_values(assignment)
+    teacher_content = teacher_payload.get("content") if isinstance(teacher_payload, dict) else None
+    teaching_note = None
+    if isinstance(teacher_content, dict) and teacher_content.get("teachingNote") is not None:
+        teaching_note = _stringify_review_value(teacher_content.get("teachingNote")) or None
+
+    return TeacherCaseSubmissionDetailResponse(
+        case=TeacherCaseSubmissionDetailCase(
+            id=assignment.id,
+            title=_resolve_assignment_title(assignment),
+            deadline=deadline,
+            available_from=available_from,
+            course_id=repaired_row["course_id"],
+            course_code=repaired_row["course_code"],
+            course_name=repaired_row["course_name"],
+            teaching_note=teaching_note,
+        ),
+        student=TeacherCaseSubmissionDetailStudent(
+            membership_id=repaired_row["membership_id"],
+            full_name=_display_name(
+                profile_full_name=repaired_row["profile_full_name"],
+                email=repaired_row["email"],
+            ),
+            email=repaired_row["email"],
+            enrolled_at=repaired_row["enrolled_at"],
+        ),
+        response_state=TeacherCaseSubmissionDetailResponseState(
+            status=derived_status,
+            first_opened_at=repaired_row["first_opened_at"],
+            last_autosaved_at=repaired_row["last_autosaved_at"],
+            submitted_at=(
+                latest_submission.submitted_at
+                if latest_submission is not None
+                else repaired_row["submitted_at"]
+            ),
+            snapshot_id=latest_submission.id if latest_submission is not None else None,
+            snapshot_hash=(
+                latest_submission.canonical_output_hash
+                if latest_submission is not None
+                else None
+            ),
+        ),
+        grade_summary=TeacherCaseSubmissionDetailGradeSummary(
+            status=repaired_row["case_grade_status"],
+            score=repaired_row["score"],
+            max_score=repaired_row["max_score"] or _DEFAULT_CASE_MAX_SCORE_DECIMAL,
+            graded_at=repaired_row["graded_at"],
+        ),
+        modules=modules,
+    )
 
 
 def _derive_grade_cell_status(

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -68,6 +68,7 @@ _DEFAULT_CASE_MAX_SCORE_DECIMAL = Decimal("5.00")
 _logger = logging.getLogger(__name__)
 _DETAIL_PAYLOAD_MAX_BYTES = 1_500_000
 _DETAIL_EXPECTED_SOLUTION_TRUNCATION_CHARS = 8_000
+_DETAIL_EXPECTED_SOLUTION_TRUNCATION_PLACEHOLDER = "[truncado por tamano]"
 _MODULE_TITLES: Mapping[str, str] = {
     "M1": "Módulo 1 · Comprensión del caso",
     "M2": "Módulo 2 · Análisis de datos",
@@ -219,30 +220,87 @@ def _truncate_detail_modules_if_needed(
     assignment_id: str,
     membership_id: str,
 ) -> tuple[list[TeacherCaseSubmissionDetailModule], bool]:
-    serialized_modules = json.dumps(
-        [module.model_dump(mode="json") for module in modules],
-        ensure_ascii=False,
-    )
-    if len(serialized_modules) <= _DETAIL_PAYLOAD_MAX_BYTES:
+    serialized_modules = _serialize_detail_modules(modules)
+    serialized_size_bytes = len(serialized_modules.encode("utf-8"))
+    if serialized_size_bytes <= _DETAIL_PAYLOAD_MAX_BYTES:
         return modules, False
 
-    for module in modules:
-        for question in module.questions:
-            if len(question.expected_solution) > _DETAIL_EXPECTED_SOLUTION_TRUNCATION_CHARS:
-                question.expected_solution = (
-                    question.expected_solution[:_DETAIL_EXPECTED_SOLUTION_TRUNCATION_CHARS]
-                    + "... [truncado por tamano]"
-                )
+    truncatable_questions = [
+        question
+        for module in modules
+        for question in module.questions
+        if question.expected_solution
+    ]
+    if not truncatable_questions:
+        raise ValueError("teacher submission detail exceeds size cap without truncatable expected solutions")
+
+    original_expected_solutions = {
+        id(question): question.expected_solution
+        for question in truncatable_questions
+    }
+
+    def apply_expected_solution_cap(max_chars: int) -> int:
+        for question in truncatable_questions:
+            question.expected_solution = _truncate_expected_solution_for_detail(
+                original_expected_solutions[id(question)],
+                max_chars=max_chars,
+            )
+        return len(_serialize_detail_modules(modules).encode("utf-8"))
+
+    minimum_size_bytes = apply_expected_solution_cap(0)
+    if minimum_size_bytes > _DETAIL_PAYLOAD_MAX_BYTES:
+        raise ValueError(
+            "teacher submission detail exceeds size cap even after fully truncating expected solutions"
+        )
+
+    max_original_chars = max(len(value) for value in original_expected_solutions.values())
+    best_cap = 0
+    low = 0
+    high = max_original_chars
+
+    while low <= high:
+        candidate_cap = (low + high) // 2
+        candidate_size_bytes = apply_expected_solution_cap(candidate_cap)
+        if candidate_size_bytes <= _DETAIL_PAYLOAD_MAX_BYTES:
+            best_cap = candidate_cap
+            low = candidate_cap + 1
+        else:
+            high = candidate_cap - 1
+
+    final_char_cap = min(best_cap, _DETAIL_EXPECTED_SOLUTION_TRUNCATION_CHARS)
+    final_size_bytes = apply_expected_solution_cap(final_char_cap)
+    if final_size_bytes > _DETAIL_PAYLOAD_MAX_BYTES:
+        final_size_bytes = apply_expected_solution_cap(best_cap)
+        final_char_cap = best_cap
+    if final_size_bytes > _DETAIL_PAYLOAD_MAX_BYTES:
+        raise ValueError("teacher submission detail still exceeds the size cap after truncation")
 
     _logger.warning(
         "teacher_case_submission_detail_payload_truncated",
         extra={
             "assignment_id": assignment_id,
             "membership_id": membership_id,
-            "payload_size": len(serialized_modules),
+            "payload_size_bytes": serialized_size_bytes,
+            "final_payload_size_bytes": final_size_bytes,
+            "expected_solution_char_cap": final_char_cap,
         },
     )
     return modules, True
+
+
+def _serialize_detail_modules(modules: list[TeacherCaseSubmissionDetailModule]) -> str:
+    return json.dumps(
+        [module.model_dump(mode="json") for module in modules],
+        ensure_ascii=False,
+    )
+
+
+def _truncate_expected_solution_for_detail(value: str, *, max_chars: int) -> str:
+    if len(value) <= max_chars:
+        return value
+    if max_chars <= 0:
+        return _DETAIL_EXPECTED_SOLUTION_TRUNCATION_PLACEHOLDER
+    return f"{value[:max_chars]}... [truncado por tamano]"
 
 
 def _detail_row_with_fallback_email(detail_row: RowMapping) -> dict[str, Any]:
@@ -553,13 +611,26 @@ def get_teacher_case_submission_detail(
         answer_source = {}
         is_answer_from_draft = False
 
-    modules, is_truncated = _build_submission_detail_modules(
-        canonical_output=canonical_output,
-        answers=answer_source,
-        is_answer_from_draft=is_answer_from_draft,
-        assignment_id=assignment.id,
-        membership_id=membership_id,
-    )
+    try:
+        modules, is_truncated = _build_submission_detail_modules(
+            canonical_output=canonical_output,
+            answers=answer_source,
+            is_answer_from_draft=is_answer_from_draft,
+            assignment_id=assignment.id,
+            membership_id=membership_id,
+        )
+    except ValueError:
+        _logger.exception(
+            "teacher_case_submission_detail_oversized_modules",
+            extra={
+                "assignment_id": assignment.id,
+                "membership_id": membership_id,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="case_canonical_output_invalid",
+        )
 
     available_from, deadline = resolve_assignment_schedule_values(assignment)
     teacher_content = teacher_payload.get("content") if isinstance(teacher_payload, dict) else None

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -218,13 +218,13 @@ def _truncate_detail_modules_if_needed(
     *,
     assignment_id: str,
     membership_id: str,
-) -> list[TeacherCaseSubmissionDetailModule]:
+) -> tuple[list[TeacherCaseSubmissionDetailModule], bool]:
     serialized_modules = json.dumps(
         [module.model_dump(mode="json") for module in modules],
         ensure_ascii=False,
     )
     if len(serialized_modules) <= _DETAIL_PAYLOAD_MAX_BYTES:
-        return modules
+        return modules, False
 
     for module in modules:
         for question in module.questions:
@@ -242,7 +242,14 @@ def _truncate_detail_modules_if_needed(
             "payload_size": len(serialized_modules),
         },
     )
-    return modules
+    return modules, True
+
+
+def _detail_row_with_fallback_email(detail_row: RowMapping) -> dict[str, Any]:
+    resolved_row = dict(detail_row)
+    if not resolved_row.get("email"):
+        resolved_row["email"] = _missing_gradebook_email(user_id=resolved_row.get("user_id"))
+    return resolved_row
 
 
 def _build_submission_detail_modules(
@@ -252,13 +259,13 @@ def _build_submission_detail_modules(
     is_answer_from_draft: bool,
     assignment_id: str,
     membership_id: str,
-) -> list[TeacherCaseSubmissionDetailModule]:
+) -> tuple[list[TeacherCaseSubmissionDetailModule], bool]:
     from shared.student_reads import QUESTION_FIELD_TO_MODULE
 
     teacher_payload = build_teacher_case_review_payload(canonical_output)
     content = teacher_payload.get("content")
     if not isinstance(content, dict):
-        return []
+        return [], False
 
     m5_solution_lookup = _m5_solution_lookup(content)
     modules: list[TeacherCaseSubmissionDetailModule] = []
@@ -467,7 +474,7 @@ def get_teacher_case_submission_detail(
     if detail_row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="submission_not_found")
 
-    repaired_row = _repair_gradebook_student_rows(db, context, student_rows=[detail_row])[0]
+    repaired_row = _detail_row_with_fallback_email(detail_row)
 
     response_id = repaired_row["response_id"]
     latest_submission = None
@@ -546,7 +553,7 @@ def get_teacher_case_submission_detail(
         answer_source = {}
         is_answer_from_draft = False
 
-    modules = _build_submission_detail_modules(
+    modules, is_truncated = _build_submission_detail_modules(
         canonical_output=canonical_output,
         answers=answer_source,
         is_answer_from_draft=is_answer_from_draft,
@@ -561,6 +568,7 @@ def get_teacher_case_submission_detail(
         teaching_note = _stringify_review_value(teacher_content.get("teachingNote")) or None
 
     return TeacherCaseSubmissionDetailResponse(
+        is_truncated=is_truncated,
         case=TeacherCaseSubmissionDetailCase(
             id=assignment.id,
             title=_resolve_assignment_title(assignment),

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -5,7 +5,7 @@ import math
 from typing import Annotated, Any
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
@@ -14,7 +14,11 @@ from shared.auth import CurrentActor, require_current_actor_password_ready
 from shared.course_access_schema import CourseAccessLinkRegenerateResponse, TeacherCourseAccessLinkResponse
 from shared.database import get_db
 from shared.models import Assignment, AssignmentCourse, Course
-from shared.teacher_gradebook_schema import TeacherCaseSubmissionsResponse, TeacherCourseGradebookResponse
+from shared.teacher_gradebook_schema import (
+    TeacherCaseSubmissionDetailResponse,
+    TeacherCaseSubmissionsResponse,
+    TeacherCourseGradebookResponse,
+)
 from shared.syllabus_schema import TeacherCourseDetailResponse, TeacherSyllabusSaveRequest
 from shared.teacher_context import TeacherContext, require_teacher_context
 from shared.teacher_reads import (
@@ -24,6 +28,7 @@ from shared.teacher_reads import (
     get_teacher_course_detail,
     get_teacher_course_gradebook,
     get_teacher_case_submissions,
+    get_teacher_case_submission_detail,
     list_teacher_active_cases,
     list_teacher_courses,
     resolve_assignment_schedule_values,
@@ -259,6 +264,26 @@ def get_teacher_case_submissions_view(
 ) -> TeacherCaseSubmissionsResponse:
     assignment = _get_owned_assignment_or_404(db, assignment_id, actor)
     return get_teacher_case_submissions(db, context, assignment)
+
+
+@router.get(
+    "/cases/{assignment_id}/submissions/{membership_id}",
+    response_model=TeacherCaseSubmissionDetailResponse,
+)
+def get_teacher_case_submission_detail_view(
+    assignment_id: str,
+    membership_id: str,
+    response: Response,
+    context: Annotated[TeacherContext, Depends(require_teacher_context)],
+    db: Session = Depends(get_db),
+) -> TeacherCaseSubmissionDetailResponse:
+    """Read-only teacher submission detail view.
+
+    Mutations de calificación (`POST/PUT /api/teacher/cases/.../grade`) se entregarán
+    en una issue posterior. Este endpoint es solo de lectura.
+    """
+    response.headers["Cache-Control"] = "private, max-age=0, must-revalidate"
+    return get_teacher_case_submission_detail(db, context, assignment_id, membership_id)
 
 
 @router.patch("/cases/{assignment_id}/publish", response_model=TeacherCaseDetailResponse)

--- a/backend/tests/test_case_sanitization.py
+++ b/backend/tests/test_case_sanitization.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from shared.case_sanitization import (
+    build_teacher_case_review_payload,
+    sanitize_canonical_output_for_student,
+)
+
+
+def _build_canonical_output() -> dict[str, object]:
+    return {
+        "caseId": "case-213",
+        "title": "Caso 213",
+        "subject": "Analitica",
+        "syllabusModule": "M1",
+        "guidingQuestion": "Que deberia hacer la empresa?",
+        "industry": "Fintech",
+        "academicLevel": "MBA",
+        "caseType": "harvard_with_eda",
+        "generatedAt": "2026-04-27T10:00:00Z",
+        "studentProfile": "business",
+        "outputDepth": "standard",
+        "__internal_token": "secret",
+        "authoring_job_id": "job-123",
+        "content": {
+            "instructions": "Lee y responde.",
+            "narrative": "Narrativa del caso",
+            "caseQuestions": [
+                {
+                    "numero": 1,
+                    "titulo": "Pregunta 1",
+                    "enunciado": "Describe la situacion.",
+                    "solucion_esperada": "Solucion docente M1",
+                    "prompt_trace": "internal",
+                }
+            ],
+            "edaQuestions": [
+                {
+                    "numero": 2,
+                    "titulo": "EDA 2",
+                    "enunciado": "Interpreta el grafico.",
+                    "solucion_esperada": {
+                        "teoria": "Teoria",
+                        "ejemplo": "Ejemplo",
+                    },
+                    "task_type": "text_response",
+                    "debug_logs": ["internal"],
+                }
+            ],
+            "m5Questions": [
+                {
+                    "numero": 5,
+                    "titulo": "M5",
+                    "enunciado": "Redacta memo ejecutivo.",
+                    "solucion_esperada": "Solucion docente M5",
+                }
+            ],
+            "m5QuestionsSolutions": [
+                {"numero": 5, "solucion_esperada": "Solucion separada M5", "hidden": True}
+            ],
+            "teachingNote": "Nota docente M6",
+            "prompt_trace": "internal",
+        },
+    }
+
+
+def test_build_teacher_case_review_payload_keeps_solucion_esperada() -> None:
+    payload = build_teacher_case_review_payload(_build_canonical_output())
+
+    assert payload["content"]["caseQuestions"][0]["solucion_esperada"] == "Solucion docente M1"
+    assert payload["content"]["edaQuestions"][0]["solucion_esperada"] == {
+        "teoria": "Teoria",
+        "ejemplo": "Ejemplo",
+    }
+    assert payload["content"]["m5QuestionsSolutions"] == [
+        {"numero": 5, "solucion_esperada": "Solucion separada M5"}
+    ]
+
+
+def test_build_teacher_case_review_payload_drops_unknown_root_fields() -> None:
+    payload = build_teacher_case_review_payload(_build_canonical_output())
+
+    assert "__internal_token" not in payload
+    assert "authoring_job_id" not in payload
+    assert "prompt_trace" not in payload["content"]
+    assert "prompt_trace" not in payload["content"]["caseQuestions"][0]
+    assert "debug_logs" not in payload["content"]["edaQuestions"][0]
+    assert payload["content"]["teachingNote"] == "Nota docente M6"
+
+
+def test_build_teacher_case_review_payload_handles_missing_content() -> None:
+    payload = build_teacher_case_review_payload({"caseId": "case-213", "title": "Caso 213"})
+
+    assert payload == {
+        "caseId": "case-213",
+        "title": "Caso 213",
+        "content": {},
+    }
+
+
+def test_student_sanitizer_still_removes_teacher_only_fields() -> None:
+    payload = sanitize_canonical_output_for_student(_build_canonical_output())
+
+    serialized = str(payload)
+    assert "solucion_esperada" not in serialized
+    assert "m5QuestionsSolutions" not in payload["content"]
+    assert "teachingNote" not in payload["content"]

--- a/backend/tests/test_teacher_case_submission_detail.py
+++ b/backend/tests/test_teacher_case_submission_detail.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from shared.models import Assignment, AssignmentCourse, CaseGrade, StudentCaseResponse, StudentCaseResponseSubmission
+from shared.models import Assignment, AssignmentCourse, CaseGrade, Profile, StudentCaseResponse, StudentCaseResponseSubmission
 from shared.teacher_context import TeacherContext
 from shared.teacher_reads import get_teacher_case_submission_detail
 
@@ -399,6 +399,112 @@ def test_returns_not_started_payload_when_no_response(
     assert payload["modules"][0]["questions"][0]["is_answer_from_draft"] is False
 
 
+def test_requires_authentication_for_teacher_case_submission_detail(client) -> None:
+    response = client.get(
+        f"/api/teacher/cases/{uuid.uuid4()}/submissions/{uuid.uuid4()}"
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "invalid_token"
+
+
+def test_returns_profile_incomplete_before_detail_lookup(
+    client,
+    auth_headers_factory,
+    seed_identity,
+) -> None:
+    user_id = str(uuid.uuid4())
+    email = "teacher-detail-noprofile@example.edu"
+    seed_identity(
+        user_id=user_id,
+        email=email,
+        role="teacher",
+        create_profile=False,
+        create_legacy_user=True,
+    )
+    headers = auth_headers_factory(sub=user_id, email=email)
+
+    response = client.get(
+        f"/api/teacher/cases/{uuid.uuid4()}/submissions/{uuid.uuid4()}",
+        headers=headers,
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "profile_incomplete"
+
+
+def test_returns_membership_required_before_detail_lookup(
+    client,
+    db,
+    auth_headers_factory,
+) -> None:
+    user_id = str(uuid.uuid4())
+    email = "teacher-detail-nomembership@example.edu"
+    db.add(Profile(id=user_id, full_name="No Membership"))
+    db.commit()
+    headers = auth_headers_factory(sub=user_id, email=email)
+
+    response = client.get(
+        f"/api/teacher/cases/{uuid.uuid4()}/submissions/{uuid.uuid4()}",
+        headers=headers,
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "membership_required"
+
+
+def test_returns_password_rotation_required_before_detail_lookup(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002141"
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-rotate-detail@example.edu",
+        role="teacher",
+        university_id=university_id,
+        must_rotate_password=True,
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-rotate-detail@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso rotate",
+        code="CASE-215A",
+    )
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=_build_canonical_output(),
+        available_from=datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc),
+        deadline=datetime(2026, 6, 8, 15, 0, tzinfo=timezone.utc),
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=teacher["legacy_user"].id,
+            email=teacher["legacy_user"].email,
+        ),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "password_rotation_required"
+
+
 def test_404_when_assignment_does_not_belong_to_teacher(
     client,
     db,
@@ -622,6 +728,63 @@ def test_returns_500_when_canonical_output_is_invalid(
     assert response.json()["detail"] == "case_canonical_output_invalid"
 
 
+def test_detail_read_does_not_attempt_identity_repair_side_effects(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002142"
+    reference_now = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-readonly@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-readonly@example.edu",
+        role="student",
+        university_id=university_id,
+        create_legacy_user=False,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso readonly",
+        code="CASE-223A",
+    )
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=_build_canonical_output(),
+        available_from=reference_now - timedelta(days=1),
+        deadline=reference_now + timedelta(days=9),
+    )
+    db.commit()
+
+    with patch("shared.teacher_reads.get_supabase_admin_auth_client", side_effect=AssertionError("admin client should not be used")), patch(
+        "shared.teacher_reads.upsert_legacy_user",
+        side_effect=AssertionError("identity repair should not be persisted"),
+    ):
+        response = client.get(
+            f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+            headers=_auth_headers(
+                auth_headers_factory,
+                user_id=teacher["legacy_user"].id,
+                email=teacher["legacy_user"].email,
+            ),
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["student"]["email"].startswith("Correo no disponible")
+
+
 def test_warns_on_snapshot_hash_drift(
     db,
     seed_identity,
@@ -667,6 +830,50 @@ def test_warns_on_snapshot_hash_drift(
 
     assert detail.response_state.snapshot_hash == "stale-hash"
     assert any(call.args and call.args[0] == "teacher_case_submission_detail_hash_drift" for call in warning_mock.call_args_list)
+
+
+def test_sets_is_truncated_when_expected_solution_payload_exceeds_cap(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+    monkeypatch,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002143"
+    reference_now = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    teacher = seed_identity(user_id=str(uuid.uuid4()), email="teacher-truncate@example.edu", role="teacher", university_id=university_id)
+    student = seed_identity(user_id=str(uuid.uuid4()), email="student-truncate@example.edu", role="student", university_id=university_id)
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso truncate", code="CASE-223B")
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    canonical_output = _build_canonical_output()
+    canonical_output["content"]["caseQuestions"][0]["solucion_esperada"] = "abcdefghij"
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=canonical_output,
+        available_from=reference_now - timedelta(days=1),
+        deadline=reference_now + timedelta(days=9),
+    )
+    db.commit()
+    monkeypatch.setattr("shared.teacher_reads._DETAIL_PAYLOAD_MAX_BYTES", 1)
+    monkeypatch.setattr("shared.teacher_reads._DETAIL_EXPECTED_SOLUTION_TRUNCATION_CHARS", 5)
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=teacher["legacy_user"].id,
+            email=teacher["legacy_user"].email,
+        ),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["is_truncated"] is True
+    assert payload["modules"][0]["questions"][0]["expected_solution"] == "abcde... [truncado por tamano]"
 
 
 def test_returns_409_for_cross_enrollment_unsupported(

--- a/backend/tests/test_teacher_case_submission_detail.py
+++ b/backend/tests/test_teacher_case_submission_detail.py
@@ -1,0 +1,705 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+import json
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from shared.models import Assignment, AssignmentCourse, CaseGrade, StudentCaseResponse, StudentCaseResponseSubmission
+from shared.teacher_context import TeacherContext
+from shared.teacher_reads import get_teacher_case_submission_detail
+
+
+def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
+    return auth_headers_factory(sub=user_id, email=email)
+
+
+def _seed_case_grade(
+    db,
+    *,
+    membership_id: str,
+    assignment_id: str,
+    course_id: str,
+    status: str,
+    score: Decimal | None = None,
+    max_score: Decimal = Decimal("5.00"),
+    graded_at: datetime | None = None,
+    feedback: str | None = None,
+) -> CaseGrade:
+    grade = CaseGrade(
+        membership_id=membership_id,
+        assignment_id=assignment_id,
+        course_id=course_id,
+        status=status,
+        score=score,
+        max_score=max_score,
+        graded_at=graded_at,
+        feedback=feedback,
+    )
+    db.add(grade)
+    db.flush()
+    return grade
+
+
+def _seed_student_case_response(
+    db,
+    *,
+    membership_id: str,
+    assignment_id: str,
+    status: str,
+    opened_at: datetime,
+    answers: dict[str, str],
+) -> StudentCaseResponse:
+    response = StudentCaseResponse(
+        membership_id=membership_id,
+        assignment_id=assignment_id,
+        status=status,
+        answers=answers,
+        version=1,
+        first_opened_at=opened_at,
+        last_autosaved_at=opened_at,
+        submitted_at=opened_at if status == "submitted" else None,
+    )
+    db.add(response)
+    db.flush()
+    return response
+
+
+def _seed_student_case_response_submission(
+    db,
+    *,
+    response_id: str,
+    submitted_at: datetime,
+    answers_snapshot: dict[str, str],
+    canonical_output_hash: str,
+) -> StudentCaseResponseSubmission:
+    snapshot = StudentCaseResponseSubmission(
+        response_id=response_id,
+        answers_snapshot=answers_snapshot,
+        submitted_at=submitted_at,
+        canonical_output_hash=canonical_output_hash,
+    )
+    db.add(snapshot)
+    db.flush()
+    return snapshot
+
+
+def _build_canonical_output(*, include_m2: bool = True, include_m4: bool = True) -> dict[str, object]:
+    content: dict[str, object] = {
+        "instructions": "Lee y responde.",
+        "narrative": "Narrativa del caso",
+        "caseQuestions": [
+            {
+                "numero": 1,
+                "titulo": "Pregunta 1",
+                "enunciado": "Describe la situacion.",
+                "solucion_esperada": "Solucion docente M1",
+                "prompt_trace": "internal",
+            }
+        ],
+        "m3Content": "Contenido M3",
+        "m3Questions": [
+            {
+                "numero": 3,
+                "titulo": "M3",
+                "enunciado": "Analiza control interno.",
+                "solucion_esperada": "Solucion docente M3",
+            }
+        ],
+        "m5Content": "Contenido M5",
+        "m5Questions": [
+            {
+                "numero": 5,
+                "titulo": "M5",
+                "enunciado": "Redacta memo ejecutivo.",
+                "solucion_esperada": "Solucion docente M5",
+                "modules_integrated": ["M1", "M2", "M3"],
+            }
+        ],
+        "m5QuestionsSolutions": [
+            {"numero": 5, "solucion_esperada": "Solucion separada M5", "hidden": True}
+        ],
+        "teachingNote": "Nota docente M6",
+        "authoring_job_id": "job-123",
+    }
+    if include_m2:
+        content["edaQuestions"] = [
+            {
+                "numero": 2,
+                "titulo": "EDA 2",
+                "enunciado": "Interpreta el grafico.",
+                "solucion_esperada": {
+                    "teoria": "Teoria",
+                    "ejemplo": "Ejemplo",
+                },
+                "task_type": "text_response",
+            }
+        ]
+        content["edaReport"] = "Reporte EDA"
+    if include_m4:
+        content["m4Content"] = "Contenido M4"
+        content["m4Questions"] = [
+            {
+                "numero": 4,
+                "titulo": "M4",
+                "enunciado": "Evalua la recomendacion.",
+                "solucion_esperada": "Solucion docente M4",
+            }
+        ]
+
+    return {
+        "caseId": "case-213",
+        "title": "Caso 213",
+        "subject": "Analitica",
+        "syllabusModule": "M1",
+        "guidingQuestion": "Que deberia hacer la empresa?",
+        "industry": "Fintech",
+        "academicLevel": "MBA",
+        "caseType": "harvard_with_eda",
+        "generatedAt": "2026-04-27T10:00:00Z",
+        "studentProfile": "business",
+        "content": content,
+        "__internal_token": "secret",
+    }
+
+
+def _seed_assignment(
+    db,
+    *,
+    teacher_user_id: str,
+    course_id: str,
+    canonical_output: dict[str, object] | object,
+    available_from: datetime,
+    deadline: datetime,
+) -> Assignment:
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        course_id=course_id,
+        title="Teacher Assignment Title",
+        canonical_output=canonical_output,
+        status="published",
+        available_from=available_from,
+        deadline=deadline,
+    )
+    db.add(assignment)
+    db.flush()
+    return assignment
+
+
+def _teacher_context(*, teacher, university_id: str) -> TeacherContext:
+    return TeacherContext(
+        auth_user_id=teacher["legacy_user"].id,
+        teacher_membership_id=teacher["membership"].id,
+        university_id=university_id,
+    )
+
+
+def test_returns_full_payload_for_submitted_response_with_snapshot(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002130"
+    reference_now = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-detail@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Detail",
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-detail@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Student Detail",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso detalle",
+        code="CASE-213",
+    )
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=_build_canonical_output(),
+        available_from=reference_now - timedelta(days=3),
+        deadline=reference_now + timedelta(days=7),
+    )
+    response = _seed_student_case_response(
+        db,
+        membership_id=student["membership"].id,
+        assignment_id=assignment.id,
+        status="submitted",
+        opened_at=reference_now - timedelta(hours=4),
+        answers={
+            "M1-Q1": "Borrador M1",
+            "M2-Q2": "Borrador M2",
+        },
+    )
+    _seed_student_case_response_submission(
+        db,
+        response_id=response.id,
+        submitted_at=reference_now - timedelta(hours=2),
+        answers_snapshot={
+            "M1-Q1": "Entrega final M1",
+            "M2-Q2": "Entrega final M2",
+            "M3-Q3": "Entrega final M3",
+        },
+        canonical_output_hash="hash-match",
+    )
+    db.commit()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("shared.student_reads._canonical_output_hash", lambda _payload: "hash-match")
+        api_response = client.get(
+            f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+            headers=_auth_headers(
+                auth_headers_factory,
+                user_id=teacher["legacy_user"].id,
+                email=teacher["legacy_user"].email,
+            ),
+        )
+
+    assert api_response.status_code == 200, api_response.text
+    payload = api_response.json()
+    assert payload["payload_version"] == 1
+    assert payload["case"]["course_code"] == "CASE-213"
+    assert payload["case"]["course_name"] == "Curso detalle"
+    assert payload["case"]["teaching_note"] == "Nota docente M6"
+    assert payload["student"]["membership_id"] == student["membership"].id
+    assert payload["response_state"]["status"] == "submitted"
+    assert payload["response_state"]["snapshot_id"] is not None
+    assert payload["response_state"]["snapshot_hash"] == "hash-match"
+    assert payload["grade_summary"]["status"] is None
+    assert [module["id"] for module in payload["modules"]] == ["M1", "M2", "M3", "M4", "M5"]
+    first_question = payload["modules"][0]["questions"][0]
+    assert first_question["id"] == "M1-Q1"
+    assert first_question["student_answer"] == "Entrega final M1"
+    assert first_question["is_answer_from_draft"] is False
+    assert first_question["expected_solution"] == "Solucion docente M1"
+    assert "prompt_trace" not in str(payload)
+    assert "authoring_job_id" not in str(payload)
+
+
+def test_uses_draft_when_no_snapshot_exists_and_marks_is_draft(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002131"
+    reference_now = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher-draft@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="student-draft@example.edu",
+        role="student",
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso draft",
+        code="CASE-214",
+    )
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=_build_canonical_output(),
+        available_from=reference_now - timedelta(days=2),
+        deadline=reference_now + timedelta(days=8),
+    )
+    _seed_student_case_response(
+        db,
+        membership_id=student["membership"].id,
+        assignment_id=assignment.id,
+        status="submitted",
+        opened_at=reference_now - timedelta(hours=3),
+        answers={"M1-Q1": "Respuesta draft"},
+    )
+    db.commit()
+
+    with patch("shared.teacher_reads._logger.warning") as warning_mock:
+        response = client.get(
+            f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+            headers=_auth_headers(
+                auth_headers_factory,
+                user_id=teacher["legacy_user"].id,
+                email=teacher["legacy_user"].email,
+            ),
+        )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["response_state"]["snapshot_id"] is None
+    assert payload["modules"][0]["questions"][0]["student_answer"] == "Respuesta draft"
+    assert payload["modules"][0]["questions"][0]["is_answer_from_draft"] is True
+    assert any(call.args and call.args[0] == "teacher_case_submission_detail_missing_snapshot" for call in warning_mock.call_args_list)
+
+
+def test_returns_not_started_payload_when_no_response(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002132"
+    reference_now = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    teacher = seed_identity(user_id=str(uuid.uuid4()), email="teacher-empty@example.edu", role="teacher", university_id=university_id)
+    student = seed_identity(user_id=str(uuid.uuid4()), email="student-empty@example.edu", role="student", university_id=university_id)
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Curso vacio",
+        code="CASE-215",
+    )
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=_build_canonical_output(),
+        available_from=reference_now - timedelta(days=1),
+        deadline=reference_now + timedelta(days=9),
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher["legacy_user"].id, email=teacher["legacy_user"].email),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["response_state"]["status"] == "not_started"
+    assert payload["grade_summary"]["status"] is None
+    assert payload["modules"][0]["questions"][0]["student_answer"] is None
+    assert payload["modules"][0]["questions"][0]["is_answer_from_draft"] is False
+
+
+def test_404_when_assignment_does_not_belong_to_teacher(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002133"
+    teacher_a = seed_identity(user_id=str(uuid.uuid4()), email="teacher-a@example.edu", role="teacher", university_id=university_id)
+    teacher_b = seed_identity(user_id=str(uuid.uuid4()), email="teacher-b@example.edu", role="teacher", university_id=university_id)
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher_a["membership"].id, title="Curso A", code="CASE-216")
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher_a["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=_build_canonical_output(),
+        available_from=datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc),
+        deadline=datetime(2026, 6, 8, 15, 0, tzinfo=timezone.utc),
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions/{uuid.uuid4()}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher_b["legacy_user"].id, email=teacher_b["legacy_user"].email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "assignment_not_found"
+
+
+def test_404_when_membership_not_in_assignment_target_courses(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002134"
+    teacher = seed_identity(user_id=str(uuid.uuid4()), email="teacher-scope@example.edu", role="teacher", university_id=university_id)
+    student = seed_identity(user_id=str(uuid.uuid4()), email="student-scope@example.edu", role="student", university_id=university_id)
+    target_course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso target", code="CASE-217")
+    other_course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso other", code="CASE-218")
+    seed_course_membership(course_id=other_course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=target_course.id,
+        canonical_output=_build_canonical_output(),
+        available_from=datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc),
+        deadline=datetime(2026, 6, 8, 15, 0, tzinfo=timezone.utc),
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher["legacy_user"].id, email=teacher["legacy_user"].email),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "submission_not_found"
+
+
+def test_status_reflects_case_grade_when_present(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002135"
+    reference_now = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    teacher = seed_identity(user_id=str(uuid.uuid4()), email="teacher-grade@example.edu", role="teacher", university_id=university_id)
+    student = seed_identity(user_id=str(uuid.uuid4()), email="student-grade@example.edu", role="student", university_id=university_id)
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso grade", code="CASE-219")
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=_build_canonical_output(),
+        available_from=reference_now - timedelta(days=2),
+        deadline=reference_now + timedelta(days=8),
+    )
+    _seed_student_case_response(
+        db,
+        membership_id=student["membership"].id,
+        assignment_id=assignment.id,
+        status="submitted",
+        opened_at=reference_now - timedelta(hours=5),
+        answers={"M1-Q1": "Respuesta final"},
+    )
+    _seed_case_grade(
+        db,
+        membership_id=student["membership"].id,
+        assignment_id=assignment.id,
+        course_id=course.id,
+        status="graded",
+        score=Decimal("4.50"),
+        max_score=Decimal("5.00"),
+        graded_at=reference_now - timedelta(hours=1),
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher["legacy_user"].id, email=teacher["legacy_user"].email),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["response_state"]["status"] == "graded"
+    assert payload["grade_summary"]["status"] == "graded"
+    assert payload["grade_summary"]["score"] == 4.5
+
+
+def test_response_payload_omits_case_grade_feedback_field(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002136"
+    reference_now = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    teacher = seed_identity(user_id=str(uuid.uuid4()), email="teacher-feedback@example.edu", role="teacher", university_id=university_id)
+    student = seed_identity(user_id=str(uuid.uuid4()), email="student-feedback@example.edu", role="student", university_id=university_id)
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso feedback", code="CASE-220")
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=_build_canonical_output(),
+        available_from=reference_now - timedelta(days=2),
+        deadline=reference_now + timedelta(days=8),
+    )
+    _seed_case_grade(
+        db,
+        membership_id=student["membership"].id,
+        assignment_id=assignment.id,
+        course_id=course.id,
+        status="graded",
+        score=Decimal("4.20"),
+        graded_at=reference_now - timedelta(hours=1),
+        feedback="Texto privado",
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher["legacy_user"].id, email=teacher["legacy_user"].email),
+    )
+
+    assert response.status_code == 200, response.text
+    serialized = json.dumps(response.json())
+    assert '"feedback"' not in serialized
+
+
+def test_modules_ordered_M1_to_M5_and_skips_missing_modules(
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    caplog,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002137"
+    reference_now = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    teacher = seed_identity(user_id=str(uuid.uuid4()), email="teacher-order@example.edu", role="teacher", university_id=university_id)
+    student = seed_identity(user_id=str(uuid.uuid4()), email="student-order@example.edu", role="student", university_id=university_id)
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso orden", code="CASE-221")
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=_build_canonical_output(include_m2=False, include_m4=False),
+        available_from=reference_now - timedelta(days=1),
+        deadline=reference_now + timedelta(days=9),
+    )
+    context = _teacher_context(teacher=teacher, university_id=university_id)
+    db.commit()
+
+    response = get_teacher_case_submission_detail(db, context, assignment.id, student["membership"].id)
+
+    assert [module.id for module in response.modules] == ["M1", "M3", "M5"]
+    assert not caplog.records
+
+
+def test_returns_500_when_canonical_output_is_invalid(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002138"
+    teacher = seed_identity(user_id=str(uuid.uuid4()), email="teacher-invalid@example.edu", role="teacher", university_id=university_id)
+    student = seed_identity(user_id=str(uuid.uuid4()), email="student-invalid@example.edu", role="student", university_id=university_id)
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso invalido", code="CASE-222")
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output="invalid",
+        available_from=datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc),
+        deadline=datetime(2026, 6, 8, 15, 0, tzinfo=timezone.utc),
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher["legacy_user"].id, email=teacher["legacy_user"].email),
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "case_canonical_output_invalid"
+
+
+def test_warns_on_snapshot_hash_drift(
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    monkeypatch,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002139"
+    reference_now = datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc)
+    teacher = seed_identity(user_id=str(uuid.uuid4()), email="teacher-drift@example.edu", role="teacher", university_id=university_id)
+    student = seed_identity(user_id=str(uuid.uuid4()), email="student-drift@example.edu", role="student", university_id=university_id)
+    course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso drift", code="CASE-223")
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        canonical_output=_build_canonical_output(),
+        available_from=reference_now - timedelta(days=1),
+        deadline=reference_now + timedelta(days=9),
+    )
+    response = _seed_student_case_response(
+        db,
+        membership_id=student["membership"].id,
+        assignment_id=assignment.id,
+        status="submitted",
+        opened_at=reference_now - timedelta(hours=3),
+        answers={"M1-Q1": "Respuesta drift"},
+    )
+    _seed_student_case_response_submission(
+        db,
+        response_id=response.id,
+        submitted_at=reference_now - timedelta(hours=2),
+        answers_snapshot={"M1-Q1": "Respuesta final"},
+        canonical_output_hash="stale-hash",
+    )
+    context = _teacher_context(teacher=teacher, university_id=university_id)
+    db.commit()
+    monkeypatch.setattr("shared.student_reads._canonical_output_hash", lambda _payload: "fresh-hash")
+
+    with patch("shared.teacher_reads._logger.warning") as warning_mock:
+        detail = get_teacher_case_submission_detail(db, context, assignment.id, student["membership"].id)
+
+    assert detail.response_state.snapshot_hash == "stale-hash"
+    assert any(call.args and call.args[0] == "teacher_case_submission_detail_hash_drift" for call in warning_mock.call_args_list)
+
+
+def test_returns_409_for_cross_enrollment_unsupported(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    university_id = "10000000-0000-0000-0000-000000002140"
+    teacher = seed_identity(user_id=str(uuid.uuid4()), email="teacher-cross@example.edu", role="teacher", university_id=university_id)
+    student = seed_identity(user_id=str(uuid.uuid4()), email="student-cross@example.edu", role="student", university_id=university_id)
+    course_a = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso A", code="CASE-224A")
+    course_b = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso B", code="CASE-224B")
+    seed_course_membership(course_id=course_a.id, membership_id=student["membership"].id)
+    seed_course_membership(course_id=course_b.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course_a.id,
+        canonical_output=_build_canonical_output(),
+        available_from=datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc),
+        deadline=datetime(2026, 6, 8, 15, 0, tzinfo=timezone.utc),
+    )
+    db.add(AssignmentCourse(assignment_id=assignment.id, course_id=course_a.id))
+    db.add(AssignmentCourse(assignment_id=assignment.id, course_id=course_b.id))
+    db.commit()
+
+    response = client.get(
+        f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
+        headers=_auth_headers(auth_headers_factory, user_id=teacher["legacy_user"].id, email=teacher["legacy_user"].email),
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "course_gradebook_cross_enrollment_unsupported"

--- a/backend/tests/test_teacher_case_submission_detail.py
+++ b/backend/tests/test_teacher_case_submission_detail.py
@@ -832,7 +832,7 @@ def test_warns_on_snapshot_hash_drift(
     assert any(call.args and call.args[0] == "teacher_case_submission_detail_hash_drift" for call in warning_mock.call_args_list)
 
 
-def test_sets_is_truncated_when_expected_solution_payload_exceeds_cap(
+def test_sets_is_truncated_when_expected_solution_payload_exceeds_utf8_byte_cap(
     client,
     db,
     seed_identity,
@@ -848,7 +848,7 @@ def test_sets_is_truncated_when_expected_solution_payload_exceeds_cap(
     course = seed_course(university_id=university_id, teacher_membership_id=teacher["membership"].id, title="Curso truncate", code="CASE-223B")
     seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
     canonical_output = _build_canonical_output()
-    canonical_output["content"]["caseQuestions"][0]["solucion_esperada"] = "abcdefghij"
+    canonical_output["content"]["caseQuestions"][0]["solucion_esperada"] = "á" * 1_200
     assignment = _seed_assignment(
         db,
         teacher_user_id=teacher["legacy_user"].id,
@@ -858,8 +858,7 @@ def test_sets_is_truncated_when_expected_solution_payload_exceeds_cap(
         deadline=reference_now + timedelta(days=9),
     )
     db.commit()
-    monkeypatch.setattr("shared.teacher_reads._DETAIL_PAYLOAD_MAX_BYTES", 1)
-    monkeypatch.setattr("shared.teacher_reads._DETAIL_EXPECTED_SOLUTION_TRUNCATION_CHARS", 5)
+    monkeypatch.setattr("shared.teacher_reads._DETAIL_PAYLOAD_MAX_BYTES", 1_600)
 
     response = client.get(
         f"/api/teacher/cases/{assignment.id}/submissions/{student['membership'].id}",
@@ -873,7 +872,9 @@ def test_sets_is_truncated_when_expected_solution_payload_exceeds_cap(
     assert response.status_code == 200, response.text
     payload = response.json()
     assert payload["is_truncated"] is True
-    assert payload["modules"][0]["questions"][0]["expected_solution"] == "abcde... [truncado por tamano]"
+    expected_solution = payload["modules"][0]["questions"][0]["expected_solution"]
+    assert expected_solution.endswith("[truncado por tamano]")
+    assert len(json.dumps(payload["modules"], ensure_ascii=False).encode("utf-8")) <= 1_600
 
 
 def test_returns_409_for_cross_enrollment_unsupported(

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -24,6 +24,11 @@ vi.mock("@/features/teacher-case-submissions/TeacherCaseSubmissionsPage", () => 
         <div data-testid="teacher-case-submissions-page">Teacher case submissions page</div>
     ),
 }));
+vi.mock("@/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage", () => ({
+    TeacherCaseSubmissionDetailPage: () => (
+        <div data-testid="teacher-case-submission-detail-page">Teacher case submission detail page</div>
+    ),
+}));
 vi.mock("@/features/admin-dashboard/AdminDashboardPage", () => ({
     AdminDashboardPage: () => <div data-testid="admin-dashboard-page">Dashboard admin</div>,
 }));
@@ -281,7 +286,7 @@ describe("App admin shell layout", () => {
         expect(screen.queryByTestId("site-header")).toBeNull();
     });
 
-    it("resolves the teacher submission detail placeholder route without a SPA 404", async () => {
+    it("resolves the teacher submission detail route without a SPA 404", async () => {
         vi.mocked(useAuth).mockReturnValue({
             ...baseContext,
             session: { access_token: "jwt" } as never,
@@ -292,7 +297,7 @@ describe("App admin shell layout", () => {
             initialEntries: ["/teacher/cases/case-1/entregas/membership-1"],
         });
 
-        expect(await screen.findByRole("heading", { name: /Ver entrega y calificar/i })).toBeTruthy();
+        expect(await screen.findByTestId("teacher-case-submission-detail-page")).toBeTruthy();
         expect(screen.queryByTestId("site-header")).toBeNull();
     });
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -33,6 +33,11 @@ const TeacherCaseSubmissionsPage = lazy(() =>
         (module) => ({ default: module.TeacherCaseSubmissionsPage }),
     ),
 );
+const TeacherCaseSubmissionDetailPage = lazy(() =>
+    import("@/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage").then(
+        (module) => ({ default: module.TeacherCaseSubmissionDetailPage }),
+    ),
+);
 const AuthCallbackPage = lazy(() =>
     import("@/features/auth-callback/AuthCallbackPage").then((module) => ({
         default: module.AuthCallbackPage,
@@ -164,12 +169,7 @@ function App() {
                             path="/teacher/cases/:assignmentId/entregas/:membershipId"
                             element={
                                 <RequireRole role="teacher">
-                                    <div className="flex flex-col items-center justify-center gap-4 px-4 py-24 text-center">
-                                        <h1 className="text-xl font-semibold">Ver entrega y calificar</h1>
-                                        <p className="max-w-xs text-sm text-muted-foreground">
-                                            Esta vista estará disponible en la próxima versión.
-                                        </p>
-                                    </div>
+                                    <TeacherCaseSubmissionDetailPage />
                                 </RequireRole>
                             }
                         />

--- a/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.test.tsx
@@ -33,7 +33,8 @@ function createSubmissionDetailResponse(
     overrides?: Partial<TeacherCaseSubmissionDetailResponse>,
 ): TeacherCaseSubmissionDetailResponse {
     return {
-        payload_version: 1,
+        payload_version: overrides?.payload_version ?? 1,
+        is_truncated: overrides?.is_truncated ?? false,
         case: {
             id: "assignment-1",
             title: "Caso Plataforma",
@@ -144,12 +145,129 @@ describe("TeacherCaseSubmissionDetailPage", () => {
         expect(screen.getByText("Caso Plataforma · A-210 · Analítica Directiva")).toBeTruthy();
         expect(screen.getByText("Describe la situación principal del caso.")).toBeTruthy();
         expect(screen.getByText("Reconoce el cuello de botella operativo.")).toBeTruthy();
-        expect(screen.getByText(/Calificación aún en modo lectura/i)).toBeTruthy();
+        expect(screen.getByTestId("teacher-case-submission-detail-grading-slot")).toBeTruthy();
+        expect(screen.getByText(/La calificación estará disponible en una próxima actualización./i)).toBeTruthy();
 
-        fireEvent.click(screen.getByRole("button", { name: "Abrir módulo M5" }));
+        fireEvent.click(screen.getByRole("tab", { name: /M5/i }));
 
         expect(await screen.findByText("Escribe un memo ejecutivo final.")).toBeTruthy();
         expect(screen.getByText("Borrador vigente")).toBeTruthy();
+    });
+
+    it("selects the requested module from the modulo query param", async () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail).mockResolvedValue(createSubmissionDetailResponse());
+
+        renderPage(["/teacher/cases/assignment-1/entregas/membership-1?modulo=M5"]);
+
+        expect(await screen.findByText("Escribe un memo ejecutivo final.")).toBeTruthy();
+        expect(screen.queryByText("Describe la situación principal del caso.")).toBeNull();
+    });
+
+    it("shows the not-started banner when the student has not opened the case", async () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail).mockResolvedValue(
+            createSubmissionDetailResponse({
+                response_state: {
+                    status: "not_started",
+                    first_opened_at: null,
+                    last_autosaved_at: null,
+                    submitted_at: null,
+                    snapshot_id: null,
+                    snapshot_hash: null,
+                },
+                modules: [
+                    {
+                        id: "M1",
+                        title: "Módulo 1 · Comprensión del caso",
+                        questions: [
+                            {
+                                id: "M1-Q1",
+                                order: 1,
+                                statement: "Describe la situación principal del caso.",
+                                context: "Pregunta 1",
+                                expected_solution: "Reconoce el cuello de botella operativo.",
+                                student_answer: null,
+                                student_answer_chars: 0,
+                                is_answer_from_draft: false,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        renderPage();
+
+        expect(await screen.findByText("Este estudiante todavía no abrió el caso. Las respuestas aparecerán cuando lo entregue.")).toBeTruthy();
+    });
+
+    it("shows the draft fallback banner when a submitted response has no snapshot", async () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail).mockResolvedValue(
+            createSubmissionDetailResponse({
+                response_state: {
+                    status: "submitted",
+                    first_opened_at: "2026-06-02T12:00:00Z",
+                    last_autosaved_at: "2026-06-05T18:15:00Z",
+                    submitted_at: "2026-06-05T19:00:00Z",
+                    snapshot_id: null,
+                    snapshot_hash: null,
+                },
+            }),
+        );
+
+        renderPage();
+
+        expect(await screen.findByText("Mostrando borrador del estudiante; no se encontró snapshot de entrega.")).toBeTruthy();
+    });
+
+    it("renders student answers as plain text without interpreting HTML", async () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail).mockResolvedValue(
+            createSubmissionDetailResponse({
+                modules: [
+                    {
+                        id: "M1",
+                        title: "Módulo 1 · Comprensión del caso",
+                        questions: [
+                            {
+                                id: "M1-Q1",
+                                order: 1,
+                                statement: "Describe la situación principal del caso.",
+                                context: "Pregunta 1",
+                                expected_solution: "Reconoce el cuello de botella operativo.",
+                                student_answer: "<strong>texto</strong>\nsegunda línea",
+                                student_answer_chars: 37,
+                                is_answer_from_draft: false,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        const view = renderPage();
+
+        expect(await screen.findByText(/<strong>texto<\/strong>/)).toBeTruthy();
+        expect(view.container.querySelector("strong")).toBeNull();
+    });
+
+    it("shows the truncation banner when the backend marks the payload as truncated", async () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail).mockResolvedValue(
+            createSubmissionDetailResponse({ is_truncated: true }),
+        );
+
+        renderPage();
+
+        expect(await screen.findByText("Parte de la solución esperada fue truncada para mantener esta vista estable.")).toBeTruthy();
+    });
+
+    it("shows the outdated-app banner when the payload version is unsupported", async () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail).mockResolvedValue({
+            ...createSubmissionDetailResponse(),
+            payload_version: 2,
+        } as unknown as TeacherCaseSubmissionDetailResponse);
+
+        renderPage();
+
+        expect(await screen.findByText("Tu versión de la app está desactualizada. Recarga para continuar.")).toBeTruthy();
     });
 
     it("renders an error state and retries the detail query", async () => {

--- a/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.test.tsx
@@ -154,6 +154,94 @@ describe("TeacherCaseSubmissionDetailPage", () => {
         expect(screen.getByText("Borrador vigente")).toBeTruthy();
     });
 
+    it("supports keyboard navigation across module tabs", async () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail).mockResolvedValue(
+            createSubmissionDetailResponse({
+                modules: [
+                    {
+                        id: "M1",
+                        title: "Módulo 1 · Comprensión del caso",
+                        questions: [
+                            {
+                                id: "M1-Q1",
+                                order: 1,
+                                statement: "Describe la situación principal del caso.",
+                                context: "Pregunta 1",
+                                expected_solution: "Reconoce el cuello de botella operativo.",
+                                student_answer: "La empresa tiene un cuello de botella en onboarding.",
+                                student_answer_chars: 58,
+                                is_answer_from_draft: false,
+                            },
+                        ],
+                    },
+                    {
+                        id: "M3",
+                        title: "Módulo 3 · Diagnóstico",
+                        questions: [
+                            {
+                                id: "M3-Q1",
+                                order: 1,
+                                statement: "Formula el diagnóstico central.",
+                                context: "Relaciona evidencia y causa raíz.",
+                                expected_solution: "Diagnóstico priorizado con evidencia.",
+                                student_answer: "El diagnóstico central es fragmentación de procesos.",
+                                student_answer_chars: 55,
+                                is_answer_from_draft: false,
+                            },
+                        ],
+                    },
+                    {
+                        id: "M5",
+                        title: "Módulo 5 · Reflexión",
+                        questions: [
+                            {
+                                id: "M5-Q5",
+                                order: 1,
+                                statement: "Escribe un memo ejecutivo final.",
+                                context: "Integra: M1, M2, M3",
+                                expected_solution: "Memo estructurado con recomendación y riesgos.",
+                                student_answer: "Borrador del memo ejecutivo.",
+                                student_answer_chars: 27,
+                                is_answer_from_draft: true,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        renderPage();
+
+        const moduleOneTab = await screen.findByRole("tab", { name: /M1/i });
+        moduleOneTab.focus();
+
+        fireEvent.keyDown(moduleOneTab, { key: "End" });
+
+        const moduleFiveTab = screen.getByRole("tab", { name: /M5/i });
+        await waitFor(() => {
+            expect(moduleFiveTab).toHaveFocus();
+            expect(moduleFiveTab).toHaveAttribute("aria-selected", "true");
+        });
+        expect(await screen.findByText("Escribe un memo ejecutivo final.")).toBeTruthy();
+
+        fireEvent.keyDown(moduleFiveTab, { key: "ArrowLeft" });
+
+        const moduleThreeTab = screen.getByRole("tab", { name: /M3/i });
+        await waitFor(() => {
+            expect(moduleThreeTab).toHaveFocus();
+            expect(moduleThreeTab).toHaveAttribute("aria-selected", "true");
+        });
+        expect(await screen.findByText("Formula el diagnóstico central.")).toBeTruthy();
+
+        fireEvent.keyDown(moduleThreeTab, { key: "Home" });
+
+        await waitFor(() => {
+            expect(moduleOneTab).toHaveFocus();
+            expect(moduleOneTab).toHaveAttribute("aria-selected", "true");
+        });
+        expect(await screen.findByText("Describe la situación principal del caso.")).toBeTruthy();
+    });
+
     it("selects the requested module from the modulo query param", async () => {
         vi.mocked(api.teacher.getCaseSubmissionDetail).mockResolvedValue(createSubmissionDetailResponse());
 

--- a/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.test.tsx
@@ -1,0 +1,186 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/shared/test-utils";
+import { api, ApiError } from "@/shared/api";
+import type { TeacherCaseSubmissionDetailResponse } from "@/shared/adam-types";
+
+import { TeacherCaseSubmissionDetailPage } from "./TeacherCaseSubmissionDetailPage";
+
+vi.mock("@/features/teacher-layout/TeacherLayout", () => ({
+    TeacherLayout: ({ children, testId }: { children: React.ReactNode; testId?: string }) => (
+        <div data-testid={testId ?? "teacher-layout"}>{children}</div>
+    ),
+}));
+
+vi.mock("@/shared/api", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/api")>("@/shared/api");
+
+    return {
+        ...actual,
+        api: {
+            ...actual.api,
+            teacher: {
+                ...actual.api.teacher,
+                getCaseSubmissionDetail: vi.fn(),
+            },
+        },
+    };
+});
+
+function createSubmissionDetailResponse(
+    overrides?: Partial<TeacherCaseSubmissionDetailResponse>,
+): TeacherCaseSubmissionDetailResponse {
+    return {
+        payload_version: 1,
+        case: {
+            id: "assignment-1",
+            title: "Caso Plataforma",
+            deadline: "2026-06-08T15:00:00Z",
+            available_from: "2026-06-01T15:00:00Z",
+            course_id: "course-1",
+            course_code: "A-210",
+            course_name: "Analítica Directiva",
+            teaching_note: "Prioriza la coherencia entre diagnóstico y recomendación.",
+            ...overrides?.case,
+        },
+        student: {
+            membership_id: "membership-1",
+            full_name: "Ana Student",
+            email: "ana.student@example.edu",
+            enrolled_at: "2026-05-20T15:00:00Z",
+            ...overrides?.student,
+        },
+        response_state: {
+            status: "submitted",
+            first_opened_at: "2026-06-02T12:00:00Z",
+            last_autosaved_at: "2026-06-05T18:15:00Z",
+            submitted_at: "2026-06-05T19:00:00Z",
+            snapshot_id: "snapshot-1",
+            snapshot_hash: "hash-123",
+            ...overrides?.response_state,
+        },
+        grade_summary: {
+            status: null,
+            score: null,
+            max_score: 5,
+            graded_at: null,
+            ...overrides?.grade_summary,
+        },
+        modules: overrides?.modules ?? [
+            {
+                id: "M1",
+                title: "Módulo 1 · Comprensión del caso",
+                questions: [
+                    {
+                        id: "M1-Q1",
+                        order: 1,
+                        statement: "Describe la situación principal del caso.",
+                        context: "Pregunta 1",
+                        expected_solution: "Reconoce el cuello de botella operativo.",
+                        student_answer: "La empresa tiene un cuello de botella en onboarding.",
+                        student_answer_chars: 58,
+                        is_answer_from_draft: false,
+                    },
+                ],
+            },
+            {
+                id: "M5",
+                title: "Módulo 5 · Reflexión",
+                questions: [
+                    {
+                        id: "M5-Q5",
+                        order: 1,
+                        statement: "Escribe un memo ejecutivo final.",
+                        context: "Integra: M1, M2, M3",
+                        expected_solution: "Memo estructurado con recomendación y riesgos.",
+                        student_answer: "Borrador del memo ejecutivo.",
+                        student_answer_chars: 27,
+                        is_answer_from_draft: true,
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+function renderPage(initialEntries = ["/teacher/cases/assignment-1/entregas/membership-1"]) {
+    return renderWithProviders(
+        <Routes>
+            <Route path="/teacher/cases/:assignmentId/entregas" element={<div data-testid="submissions-list">Listado</div>} />
+            <Route
+                path="/teacher/cases/:assignmentId/entregas/:membershipId"
+                element={<TeacherCaseSubmissionDetailPage />}
+            />
+        </Routes>,
+        { initialEntries },
+    );
+}
+
+describe("TeacherCaseSubmissionDetailPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("renders a loading state while the detail query is pending", () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail).mockReturnValue(new Promise(() => undefined));
+
+        renderPage();
+
+        expect(screen.getByText("Cargando detalle de la entrega")).toBeTruthy();
+    });
+
+    it("renders the detail payload and switches between modules", async () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail).mockResolvedValue(createSubmissionDetailResponse());
+
+        renderPage();
+
+        expect(await screen.findByText("Entrega de Ana Student")).toBeTruthy();
+        expect(screen.getByText("Caso Plataforma · A-210 · Analítica Directiva")).toBeTruthy();
+        expect(screen.getByText("Describe la situación principal del caso.")).toBeTruthy();
+        expect(screen.getByText("Reconoce el cuello de botella operativo.")).toBeTruthy();
+        expect(screen.getByText(/Calificación aún en modo lectura/i)).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: "Abrir módulo M5" }));
+
+        expect(await screen.findByText("Escribe un memo ejecutivo final.")).toBeTruthy();
+        expect(screen.getByText("Borrador vigente")).toBeTruthy();
+    });
+
+    it("renders an error state and retries the detail query", async () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail)
+            .mockRejectedValueOnce(new ApiError(404, "Not found", "submission_not_found"))
+            .mockResolvedValueOnce(createSubmissionDetailResponse());
+
+        renderPage();
+
+        expect(await screen.findByText("No encontramos esta entrega o no tienes acceso.")).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: /Reintentar/i }));
+
+        expect(await screen.findByText("Entrega de Ana Student")).toBeTruthy();
+        expect(api.teacher.getCaseSubmissionDetail).toHaveBeenCalledTimes(2);
+    });
+
+    it("refetches the detail payload when the refresh button is pressed", async () => {
+        vi.mocked(api.teacher.getCaseSubmissionDetail)
+            .mockResolvedValueOnce(createSubmissionDetailResponse())
+            .mockResolvedValueOnce(createSubmissionDetailResponse());
+
+        renderPage();
+
+        expect(await screen.findByText("Entrega de Ana Student")).toBeTruthy();
+        expect(api.teacher.getCaseSubmissionDetail).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole("button", { name: /Actualizar entrega/i }));
+
+        await waitFor(() => {
+            expect(api.teacher.getCaseSubmissionDetail).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
     AlertCircle,
@@ -84,6 +84,8 @@ export function TeacherCaseSubmissionDetailPage() {
     const [searchParams, setSearchParams] = useSearchParams();
     const detailQuery = useTeacherCaseSubmissionDetail(assignmentId, membershipId);
     const activeModuleHeadingRef = useRef<HTMLHeadingElement | null>(null);
+    const moduleTabRefs = useRef<Partial<Record<TeacherCaseSubmissionDetailModule["id"], HTMLButtonElement | null>>>({});
+    const moduleFocusTargetRef = useRef<"heading" | "tab">("heading");
 
     const detail = detailQuery.data;
     const modules = detail?.modules ?? [];
@@ -132,14 +134,67 @@ export function TeacherCaseSubmissionDetailPage() {
 
     useEffect(() => {
         if (activeModuleId && !detailQuery.isLoading) {
+            if (moduleFocusTargetRef.current === "tab") {
+                moduleTabRefs.current[activeModuleId]?.focus();
+                moduleFocusTargetRef.current = "heading";
+                return;
+            }
+
             activeModuleHeadingRef.current?.focus();
         }
     }, [activeModuleId, detailQuery.isLoading]);
 
-    function handleModuleSelect(moduleId: TeacherCaseSubmissionDetailModule["id"]) {
+    function handleModuleSelect(
+        moduleId: TeacherCaseSubmissionDetailModule["id"],
+        focusTarget: "heading" | "tab" = "heading",
+    ) {
+        moduleFocusTargetRef.current = focusTarget;
         const nextParams = new URLSearchParams(searchParams);
         nextParams.set("modulo", moduleId);
         setSearchParams(nextParams, { replace: true });
+    }
+
+    function handleModuleTabKeyDown(
+        event: ReactKeyboardEvent<HTMLButtonElement>,
+        moduleId: TeacherCaseSubmissionDetailModule["id"],
+    ) {
+        if (modules.length <= 1) {
+            return;
+        }
+
+        const currentIndex = modules.findIndex((module) => module.id === moduleId);
+        if (currentIndex < 0) {
+            return;
+        }
+
+        let targetIndex: number | null = null;
+        switch (event.key) {
+            case "ArrowDown":
+            case "ArrowRight":
+                targetIndex = (currentIndex + 1) % modules.length;
+                break;
+            case "ArrowUp":
+            case "ArrowLeft":
+                targetIndex = (currentIndex - 1 + modules.length) % modules.length;
+                break;
+            case "Home":
+                targetIndex = 0;
+                break;
+            case "End":
+                targetIndex = modules.length - 1;
+                break;
+            default:
+                return;
+        }
+
+        event.preventDefault();
+
+        const targetModuleId = modules[targetIndex]?.id;
+        if (!targetModuleId || targetModuleId === moduleId) {
+            return;
+        }
+
+        handleModuleSelect(targetModuleId, "tab");
     }
 
     return (
@@ -388,16 +443,21 @@ export function TeacherCaseSubmissionDetailPage() {
                                 <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">
                                     Módulos del caso
                                 </h2>
-                                <div className="mt-4 space-y-3" role="tablist" aria-label="Módulos del caso">
+                                <div className="mt-4 space-y-3" role="tablist" aria-label="Módulos del caso" aria-orientation="vertical">
                                     {modules.map((module) => (
                                         <button
                                             key={module.id}
                                             type="button"
                                             role="tab"
+                                            ref={(button) => {
+                                                moduleTabRefs.current[module.id] = button;
+                                            }}
                                             aria-selected={module.id === activeModule?.id}
                                             aria-controls={`teacher-case-submission-module-panel-${module.id}`}
                                             id={`teacher-case-submission-module-tab-${module.id}`}
+                                            tabIndex={module.id === activeModule?.id ? 0 : -1}
                                             onClick={() => handleModuleSelect(module.id)}
+                                            onKeyDown={(event) => handleModuleTabKeyDown(event, module.id)}
                                             className={module.id === activeModule?.id
                                                 ? "rounded-[18px] border border-blue-200 bg-blue-50 px-4 py-4 text-left shadow-sm"
                                                 : "rounded-[18px] border border-slate-200 bg-white px-4 py-4 text-left transition hover:border-slate-300 hover:bg-slate-50"

--- a/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.tsx
@@ -1,0 +1,463 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+    AlertCircle,
+    ArrowLeft,
+    BookOpen,
+    FileText,
+    GraduationCap,
+    LoaderCircle,
+    RefreshCcw,
+    UserRound,
+} from "lucide-react";
+
+import "@/features/teacher-course/teacherCoursePage.css";
+
+import { TeacherLayout } from "@/features/teacher-layout/TeacherLayout";
+import {
+    formatTeacherCourseTimestamp,
+    formatTeacherGradebookCellStatus,
+    formatTeacherGradebookScore,
+} from "@/features/teacher-course/teacherCourseModel";
+
+import {
+    countAnsweredQuestions,
+    countAnsweredSubmissionQuestions,
+    countDraftQuestions,
+    countSubmissionQuestions,
+    getDefaultTeacherCaseSubmissionModuleId,
+} from "./teacherCaseSubmissionDetailModel";
+import {
+    getTeacherCaseSubmissionDetailErrorMessage,
+    useTeacherCaseSubmissionDetail,
+} from "./useTeacherCaseSubmissionDetail";
+
+import type { TeacherCaseSubmissionDetailModule } from "@/shared/adam-types";
+
+interface MetricCardProps {
+    icon: React.ReactNode;
+    label: string;
+    value: string;
+}
+
+function MetricCard({ icon, label, value }: MetricCardProps) {
+    return (
+        <div className="teacher-gradebook-metric-card">
+            <span className="teacher-gradebook-metric-icon" aria-hidden="true">{icon}</span>
+            <div>
+                <p className="teacher-gradebook-metric-label">{label}</p>
+                <p className="teacher-gradebook-metric-value">{value}</p>
+            </div>
+        </div>
+    );
+}
+
+function renderStatusChip(status: string) {
+    return (
+        <div className={`teacher-gradebook-chip teacher-gradebook-chip--${status}`}>
+            <span className="teacher-gradebook-chip-label">{formatTeacherGradebookCellStatus(status)}</span>
+        </div>
+    );
+}
+
+function formatDetailTimestamp(value: string | null, fallback: string): string {
+    return value ? formatTeacherCourseTimestamp(value) : fallback;
+}
+
+function getSnapshotSummaryLabel(snapshotId: string | null, status: string): string {
+    if (snapshotId) {
+        return "Versión entregada";
+    }
+    if (status === "not_started") {
+        return "Sin actividad";
+    }
+    return "Borrador vigente";
+}
+
+function ModuleButton({
+    module,
+    isActive,
+    onClick,
+}: {
+    module: TeacherCaseSubmissionDetailModule;
+    isActive: boolean;
+    onClick: () => void;
+}) {
+    const answeredCount = countAnsweredQuestions(module);
+    const draftCount = countDraftQuestions(module);
+
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            aria-label={`Abrir módulo ${module.id}`}
+            className={isActive
+                ? "rounded-[18px] border border-blue-200 bg-blue-50 px-4 py-4 text-left shadow-sm"
+                : "rounded-[18px] border border-slate-200 bg-white px-4 py-4 text-left transition hover:border-slate-300 hover:bg-slate-50"
+            }
+        >
+            <div className="flex items-start justify-between gap-3">
+                <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{module.id}</p>
+                    <p className="mt-1 text-sm font-semibold text-slate-900">{module.title}</p>
+                </div>
+                <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">
+                    {answeredCount}/{module.questions.length}
+                </span>
+            </div>
+            <p className="mt-2 text-xs text-slate-500">
+                {draftCount > 0 ? `${draftCount} respuesta(s) en borrador` : "Sin respuestas en borrador"}
+            </p>
+        </button>
+    );
+}
+
+export function TeacherCaseSubmissionDetailPage() {
+    const navigate = useNavigate();
+    const { assignmentId = "", membershipId = "" } = useParams<{
+        assignmentId: string;
+        membershipId: string;
+    }>();
+    const detailQuery = useTeacherCaseSubmissionDetail(assignmentId, membershipId);
+    const [activeModuleId, setActiveModuleId] = useState<TeacherCaseSubmissionDetailModule["id"] | null>(null);
+
+    useEffect(() => {
+        setActiveModuleId((currentModuleId) => {
+            const modules = detailQuery.data?.modules ?? [];
+            if (modules.length === 0) {
+                return null;
+            }
+            if (currentModuleId && modules.some((module) => module.id === currentModuleId)) {
+                return currentModuleId;
+            }
+            return getDefaultTeacherCaseSubmissionModuleId(detailQuery.data);
+        });
+    }, [detailQuery.data]);
+
+    const detail = detailQuery.data;
+    const modules = detail?.modules ?? [];
+    const activeModule = modules.find((module) => module.id === activeModuleId) ?? modules[0] ?? null;
+    const answeredQuestions = countAnsweredSubmissionQuestions(detail);
+    const totalQuestions = countSubmissionQuestions(detail);
+    const refreshLabel = detailQuery.isFetching && !detailQuery.isLoading
+        ? "Actualizando entrega"
+        : "Actualizar entrega";
+    const errorMessage = detailQuery.error
+        ? getTeacherCaseSubmissionDetailErrorMessage(
+            detailQuery.error,
+            "No se pudo cargar esta entrega. Intenta nuevamente.",
+        )
+        : null;
+    const scoreSummary = detail?.grade_summary.score !== null && detail?.grade_summary.score !== undefined
+        ? `${formatTeacherGradebookScore(detail.grade_summary.score)} / ${formatTeacherGradebookScore(detail.grade_summary.max_score)}`
+        : "Pendiente";
+
+    return (
+        <TeacherLayout contentClassName="teacher-course-page mx-auto w-full max-w-7xl px-6 py-9" testId="teacher-case-submission-detail-page">
+            <div className="space-y-6">
+                <section className="rounded-[24px] border border-slate-200 bg-white p-6 shadow-sm md:p-8">
+                    <div className="teacher-gradebook-header">
+                        <div className="teacher-gradebook-header-row">
+                            <div className="min-w-0">
+                                <button
+                                    type="button"
+                                    onClick={() => navigate(`/teacher/cases/${assignmentId}/entregas`)}
+                                    className="mb-4 inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                                >
+                                    <ArrowLeft className="h-4 w-4" />
+                                    Volver al listado
+                                </button>
+                                <div className="flex flex-wrap items-center gap-3">
+                                    <h1 className="text-2xl font-bold tracking-tight text-slate-900 md:text-[32px]">
+                                        {detail ? `Entrega de ${detail.student.full_name}` : "Detalle de entrega"}
+                                    </h1>
+                                    {detail ? renderStatusChip(detail.response_state.status) : null}
+                                </div>
+                                <p className="mt-2 max-w-3xl text-sm text-slate-500 md:text-base">
+                                    {detail
+                                        ? `${detail.case.title} · ${detail.case.course_code} · ${detail.case.course_name}`
+                                        : "Revisa el contenido entregado por el estudiante y valida el contexto del caso."}
+                                </p>
+                                {detail ? (
+                                    <div className="mt-4 flex flex-wrap items-center gap-3 text-sm text-slate-500">
+                                        <span className="rounded-full bg-slate-100 px-3 py-1 font-semibold text-slate-700">
+                                            Disponible: {formatDetailTimestamp(detail.case.available_from, "Sin fecha")}
+                                        </span>
+                                        <span className="rounded-full bg-blue-50 px-3 py-1 font-semibold text-blue-700">
+                                            Fecha límite: {formatDetailTimestamp(detail.case.deadline, "Sin fecha")}
+                                        </span>
+                                        <span className="rounded-full bg-emerald-50 px-3 py-1 font-semibold text-emerald-700">
+                                            Snapshot: {getSnapshotSummaryLabel(
+                                                detail.response_state.snapshot_id,
+                                                detail.response_state.status,
+                                            )}
+                                        </span>
+                                    </div>
+                                ) : null}
+                            </div>
+                            <div className="teacher-gradebook-refresh-group">
+                                <button
+                                    type="button"
+                                    onClick={() => void detailQuery.refetch()}
+                                    disabled={detailQuery.isFetching}
+                                    className="teacher-gradebook-refresh-button"
+                                    aria-label={refreshLabel}
+                                >
+                                    <RefreshCcw className={`h-4 w-4${detailQuery.isFetching ? " animate-spin" : ""}`} />
+                                    {refreshLabel}
+                                </button>
+                                {detailQuery.isFetching && !detailQuery.isLoading ? (
+                                    <p className="teacher-gradebook-refresh-status" aria-live="polite">
+                                        Sincronizando el detalle más reciente de la entrega.
+                                    </p>
+                                ) : null}
+                            </div>
+                        </div>
+                        {detail ? (
+                            <div className="teacher-gradebook-metrics">
+                                <MetricCard
+                                    icon={<UserRound className="h-4 w-4" />}
+                                    label="Estudiante"
+                                    value={detail.student.full_name}
+                                />
+                                <MetricCard
+                                    icon={<BookOpen className="h-4 w-4" />}
+                                    label="Preguntas respondidas"
+                                    value={`${answeredQuestions}/${totalQuestions}`}
+                                />
+                                <MetricCard
+                                    icon={<GraduationCap className="h-4 w-4" />}
+                                    label="Calificación actual"
+                                    value={scoreSummary}
+                                />
+                                <MetricCard
+                                    icon={<FileText className="h-4 w-4" />}
+                                    label="Fuente visible"
+                                    value={getSnapshotSummaryLabel(
+                                        detail.response_state.snapshot_id,
+                                        detail.response_state.status,
+                                    )}
+                                />
+                            </div>
+                        ) : null}
+                    </div>
+                </section>
+
+                {errorMessage ? (
+                    <div className="alert-strip alert-warn" role="alert">
+                        <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+                        <div className="flex min-w-0 flex-1 flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                            <span>{errorMessage}</span>
+                            <button
+                                type="button"
+                                onClick={() => void detailQuery.refetch()}
+                                className="inline-flex items-center gap-2 self-start rounded-xl border border-amber-300 bg-white px-4 py-2 text-sm font-semibold text-amber-900 transition hover:bg-amber-50"
+                            >
+                                <RefreshCcw className="h-4 w-4" />
+                                Reintentar
+                            </button>
+                        </div>
+                    </div>
+                ) : null}
+
+                {detailQuery.isLoading && !detail ? (
+                    <section className="teacher-gradebook-empty-state" aria-live="polite">
+                        <LoaderCircle className="h-6 w-6 animate-spin text-[#0144a0]" />
+                        <div>
+                            <p className="teacher-gradebook-empty-title">Cargando detalle de la entrega</p>
+                            <p className="teacher-gradebook-empty-copy">
+                                ADAM está reconstruyendo la versión docente del caso y las respuestas del estudiante.
+                            </p>
+                        </div>
+                    </section>
+                ) : null}
+
+                {!detailQuery.isLoading && !errorMessage && detail ? (
+                    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.6fr)_minmax(280px,0.85fr)]">
+                        <section className="space-y-6">
+                            {activeModule ? (
+                                <article className="rounded-[24px] border border-slate-200 bg-white p-6 shadow-sm md:p-8">
+                                    <div className="flex flex-wrap items-start justify-between gap-4 border-b border-slate-100 pb-5">
+                                        <div>
+                                            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                {activeModule.id}
+                                            </p>
+                                            <h2 className="mt-2 text-xl font-semibold text-slate-900">
+                                                {activeModule.title}
+                                            </h2>
+                                            <p className="mt-2 text-sm text-slate-500">
+                                                {countAnsweredQuestions(activeModule)} de {activeModule.questions.length} preguntas con respuesta visible.
+                                            </p>
+                                        </div>
+                                        {countDraftQuestions(activeModule) > 0 ? (
+                                            <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+                                                {countDraftQuestions(activeModule)} en borrador
+                                            </span>
+                                        ) : null}
+                                    </div>
+
+                                    <div className="mt-6 space-y-5">
+                                        {activeModule.questions.map((question) => (
+                                            <article
+                                                key={question.id}
+                                                className="rounded-[22px] border border-slate-200 bg-slate-50/70 p-5"
+                                            >
+                                                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                                    <span>{question.id}</span>
+                                                    <span className="h-1 w-1 rounded-full bg-slate-300" aria-hidden="true" />
+                                                    <span>{question.student_answer_chars} caracteres</span>
+                                                    {question.is_answer_from_draft ? (
+                                                        <span className="rounded-full bg-amber-100 px-2.5 py-1 text-[11px] tracking-[0.08em] text-amber-800">
+                                                            Borrador vigente
+                                                        </span>
+                                                    ) : null}
+                                                </div>
+                                                <h3 className="mt-3 text-lg font-semibold text-slate-900">
+                                                    {question.statement}
+                                                </h3>
+                                                {question.context ? (
+                                                    <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-500">
+                                                        {question.context}
+                                                    </p>
+                                                ) : null}
+
+                                                <div className="mt-5 grid gap-4 xl:grid-cols-2">
+                                                    <section className="rounded-[18px] border border-blue-100 bg-blue-50/70 p-4">
+                                                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-blue-700">
+                                                            Solución esperada
+                                                        </p>
+                                                        <pre className="mt-3 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+                                                            {question.expected_solution || "Sin solución esperada documentada."}
+                                                        </pre>
+                                                    </section>
+
+                                                    <section className="rounded-[18px] border border-slate-200 bg-white p-4">
+                                                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                                            Respuesta del estudiante
+                                                        </p>
+                                                        {question.student_answer ? (
+                                                            <pre className="mt-3 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+                                                                {question.student_answer}
+                                                            </pre>
+                                                        ) : (
+                                                            <p className="mt-3 text-sm leading-6 text-slate-500">
+                                                                Aún no hay respuesta visible para esta pregunta.
+                                                            </p>
+                                                        )}
+                                                    </section>
+                                                </div>
+                                            </article>
+                                        ))}
+                                    </div>
+                                </article>
+                            ) : (
+                                <section className="teacher-gradebook-empty-state" data-testid="teacher-case-submission-detail-empty">
+                                    <AlertCircle className="h-6 w-6 text-slate-400" />
+                                    <div>
+                                        <p className="teacher-gradebook-empty-title">No hay módulos visibles para esta entrega</p>
+                                        <p className="teacher-gradebook-empty-copy">
+                                            El caso publicado no expone contenido pedagógico suficiente para una revisión docente.
+                                        </p>
+                                    </div>
+                                </section>
+                            )}
+                        </section>
+
+                        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
+                            <section className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-sm">
+                                <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">
+                                    Módulos del caso
+                                </h2>
+                                <div className="mt-4 space-y-3">
+                                    {modules.map((module) => (
+                                        <ModuleButton
+                                            key={module.id}
+                                            module={module}
+                                            isActive={module.id === activeModule?.id}
+                                            onClick={() => setActiveModuleId(module.id)}
+                                        />
+                                    ))}
+                                </div>
+                            </section>
+
+                            {detail ? (
+                                <section className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-sm">
+                                    <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">
+                                        Estado de la entrega
+                                    </h2>
+                                    <dl className="mt-4 space-y-3 text-sm text-slate-600">
+                                        <div className="flex items-start justify-between gap-4">
+                                            <dt className="font-medium text-slate-500">Correo</dt>
+                                            <dd className="text-right text-slate-900">{detail.student.email}</dd>
+                                        </div>
+                                        <div className="flex items-start justify-between gap-4">
+                                            <dt className="font-medium text-slate-500">Inscripción</dt>
+                                            <dd className="text-right text-slate-900">
+                                                {formatDetailTimestamp(detail.student.enrolled_at, "Sin registro")}
+                                            </dd>
+                                        </div>
+                                        <div className="flex items-start justify-between gap-4">
+                                            <dt className="font-medium text-slate-500">Primer acceso</dt>
+                                            <dd className="text-right text-slate-900">
+                                                {formatDetailTimestamp(detail.response_state.first_opened_at, "Sin abrir")}
+                                            </dd>
+                                        </div>
+                                        <div className="flex items-start justify-between gap-4">
+                                            <dt className="font-medium text-slate-500">Último guardado</dt>
+                                            <dd className="text-right text-slate-900">
+                                                {formatDetailTimestamp(detail.response_state.last_autosaved_at, "Sin borrador")}
+                                            </dd>
+                                        </div>
+                                        <div className="flex items-start justify-between gap-4">
+                                            <dt className="font-medium text-slate-500">Entrega visible</dt>
+                                            <dd className="text-right text-slate-900">
+                                                {formatDetailTimestamp(detail.response_state.submitted_at, "Sin entrega")}
+                                            </dd>
+                                        </div>
+                                        <div className="flex items-start justify-between gap-4">
+                                            <dt className="font-medium text-slate-500">Snapshot hash</dt>
+                                            <dd className="max-w-[180px] break-all text-right text-slate-900" title={detail.response_state.snapshot_hash ?? undefined}>
+                                                {detail.response_state.snapshot_hash ?? "No disponible"}
+                                            </dd>
+                                        </div>
+                                        <div className="flex items-start justify-between gap-4">
+                                            <dt className="font-medium text-slate-500">Nota</dt>
+                                            <dd className="text-right text-slate-900">{scoreSummary}</dd>
+                                        </div>
+                                        <div className="flex items-start justify-between gap-4">
+                                            <dt className="font-medium text-slate-500">Calificado</dt>
+                                            <dd className="text-right text-slate-900">
+                                                {formatDetailTimestamp(detail.grade_summary.graded_at, "Pendiente")}
+                                            </dd>
+                                        </div>
+                                    </dl>
+                                </section>
+                            ) : null}
+
+                            {detail?.case.teaching_note ? (
+                                <section className="rounded-[24px] border border-emerald-100 bg-emerald-50/80 p-5 shadow-sm">
+                                    <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-emerald-800">
+                                        Nota docente
+                                    </h2>
+                                    <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-emerald-950/85">
+                                        {detail.case.teaching_note}
+                                    </p>
+                                </section>
+                            ) : null}
+
+                            <section className="rounded-[24px] bg-slate-900 p-5 text-white shadow-[0_18px_50px_-28px_rgba(15,23,42,0.9)]">
+                                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-300">
+                                    Próxima entrega
+                                </p>
+                                <h2 className="mt-2 text-lg font-semibold">Calificación aún en modo lectura</h2>
+                                <p className="mt-3 text-sm leading-6 text-slate-300">
+                                    Esta pantalla ya consolida snapshot, borrador y solución esperada. La edición y publicación de calificaciones llegará en una siguiente issue sin cambiar este contrato de lectura.
+                                </p>
+                            </section>
+                        </aside>
+                    </div>
+                ) : null}
+            </div>
+        </TeacherLayout>
+    );
+}

--- a/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useRef } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
     AlertCircle,
     ArrowLeft,
@@ -31,6 +31,7 @@ import {
     getTeacherCaseSubmissionDetailErrorMessage,
     useTeacherCaseSubmissionDetail,
 } from "./useTeacherCaseSubmissionDetail";
+import { GradingPlaceholderPanel } from "./components/GradingPlaceholderPanel";
 
 import type { TeacherCaseSubmissionDetailModule } from "@/shared/adam-types";
 
@@ -74,68 +75,23 @@ function getSnapshotSummaryLabel(snapshotId: string | null, status: string): str
     return "Borrador vigente";
 }
 
-function ModuleButton({
-    module,
-    isActive,
-    onClick,
-}: {
-    module: TeacherCaseSubmissionDetailModule;
-    isActive: boolean;
-    onClick: () => void;
-}) {
-    const answeredCount = countAnsweredQuestions(module);
-    const draftCount = countDraftQuestions(module);
-
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            aria-label={`Abrir módulo ${module.id}`}
-            className={isActive
-                ? "rounded-[18px] border border-blue-200 bg-blue-50 px-4 py-4 text-left shadow-sm"
-                : "rounded-[18px] border border-slate-200 bg-white px-4 py-4 text-left transition hover:border-slate-300 hover:bg-slate-50"
-            }
-        >
-            <div className="flex items-start justify-between gap-3">
-                <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{module.id}</p>
-                    <p className="mt-1 text-sm font-semibold text-slate-900">{module.title}</p>
-                </div>
-                <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">
-                    {answeredCount}/{module.questions.length}
-                </span>
-            </div>
-            <p className="mt-2 text-xs text-slate-500">
-                {draftCount > 0 ? `${draftCount} respuesta(s) en borrador` : "Sin respuestas en borrador"}
-            </p>
-        </button>
-    );
-}
-
 export function TeacherCaseSubmissionDetailPage() {
     const navigate = useNavigate();
     const { assignmentId = "", membershipId = "" } = useParams<{
         assignmentId: string;
         membershipId: string;
     }>();
+    const [searchParams, setSearchParams] = useSearchParams();
     const detailQuery = useTeacherCaseSubmissionDetail(assignmentId, membershipId);
-    const [activeModuleId, setActiveModuleId] = useState<TeacherCaseSubmissionDetailModule["id"] | null>(null);
-
-    useEffect(() => {
-        setActiveModuleId((currentModuleId) => {
-            const modules = detailQuery.data?.modules ?? [];
-            if (modules.length === 0) {
-                return null;
-            }
-            if (currentModuleId && modules.some((module) => module.id === currentModuleId)) {
-                return currentModuleId;
-            }
-            return getDefaultTeacherCaseSubmissionModuleId(detailQuery.data);
-        });
-    }, [detailQuery.data]);
+    const activeModuleHeadingRef = useRef<HTMLHeadingElement | null>(null);
 
     const detail = detailQuery.data;
     const modules = detail?.modules ?? [];
+    const requestedModuleId = searchParams.get("modulo");
+    const defaultModuleId = detail ? getDefaultTeacherCaseSubmissionModuleId(detail) : null;
+    const activeModuleId = modules.some((module) => module.id === requestedModuleId)
+        ? requestedModuleId as TeacherCaseSubmissionDetailModule["id"]
+        : defaultModuleId;
     const activeModule = modules.find((module) => module.id === activeModuleId) ?? modules[0] ?? null;
     const answeredQuestions = countAnsweredSubmissionQuestions(detail);
     const totalQuestions = countSubmissionQuestions(detail);
@@ -148,9 +104,43 @@ export function TeacherCaseSubmissionDetailPage() {
             "No se pudo cargar esta entrega. Intenta nuevamente.",
         )
         : null;
-    const scoreSummary = detail?.grade_summary.score !== null && detail?.grade_summary.score !== undefined
+    const scoreSummary = detail?.grade_summary.status === "graded"
+        && detail.grade_summary.score !== null
+        && detail.grade_summary.score !== undefined
         ? `${formatTeacherGradebookScore(detail.grade_summary.score)} / ${formatTeacherGradebookScore(detail.grade_summary.max_score)}`
         : "Pendiente";
+    const hasDraftFallbackAnswers = detail
+        ? detail.modules.some((module) => module.questions.some((question) => question.is_answer_from_draft))
+        : false;
+    const showNotStartedBanner = detail?.response_state.status === "not_started";
+    const showSubmittedDraftFallbackBanner = Boolean(
+        detail
+        && detail.response_state.snapshot_id === null
+        && (detail.response_state.status === "submitted" || detail.response_state.status === "graded")
+        && hasDraftFallbackAnswers,
+    );
+
+    useEffect(() => {
+        if (!activeModuleId || requestedModuleId === activeModuleId) {
+            return;
+        }
+
+        const nextParams = new URLSearchParams(searchParams);
+        nextParams.set("modulo", activeModuleId);
+        setSearchParams(nextParams, { replace: true });
+    }, [activeModuleId, requestedModuleId, searchParams, setSearchParams]);
+
+    useEffect(() => {
+        if (activeModuleId && !detailQuery.isLoading) {
+            activeModuleHeadingRef.current?.focus();
+        }
+    }, [activeModuleId, detailQuery.isLoading]);
+
+    function handleModuleSelect(moduleId: TeacherCaseSubmissionDetailModule["id"]) {
+        const nextParams = new URLSearchParams(searchParams);
+        nextParams.set("modulo", moduleId);
+        setSearchParams(nextParams, { replace: true });
+    }
 
     return (
         <TeacherLayout contentClassName="teacher-course-page mx-auto w-full max-w-7xl px-6 py-9" testId="teacher-case-submission-detail-page">
@@ -260,6 +250,27 @@ export function TeacherCaseSubmissionDetailPage() {
                     </div>
                 ) : null}
 
+                {showNotStartedBanner ? (
+                    <div className="alert-strip alert-info" role="status">
+                        <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+                        <span>Este estudiante todavía no abrió el caso. Las respuestas aparecerán cuando lo entregue.</span>
+                    </div>
+                ) : null}
+
+                {showSubmittedDraftFallbackBanner ? (
+                    <div className="alert-strip alert-warn" role="status">
+                        <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+                        <span>Mostrando borrador del estudiante; no se encontró snapshot de entrega.</span>
+                    </div>
+                ) : null}
+
+                {detail?.is_truncated ? (
+                    <div className="alert-strip alert-info" role="status">
+                        <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+                        <span>Parte de la solución esperada fue truncada para mantener esta vista estable.</span>
+                    </div>
+                ) : null}
+
                 {detailQuery.isLoading && !detail ? (
                     <section className="teacher-gradebook-empty-state" aria-live="polite">
                         <LoaderCircle className="h-6 w-6 animate-spin text-[#0144a0]" />
@@ -276,13 +287,22 @@ export function TeacherCaseSubmissionDetailPage() {
                     <div className="grid gap-6 lg:grid-cols-[minmax(0,1.6fr)_minmax(280px,0.85fr)]">
                         <section className="space-y-6">
                             {activeModule ? (
-                                <article className="rounded-[24px] border border-slate-200 bg-white p-6 shadow-sm md:p-8">
+                                <article
+                                    id={`teacher-case-submission-module-panel-${activeModule.id}`}
+                                    role="tabpanel"
+                                    aria-labelledby={`teacher-case-submission-module-tab-${activeModule.id}`}
+                                    className="rounded-[24px] border border-slate-200 bg-white p-6 shadow-sm md:p-8"
+                                >
                                     <div className="flex flex-wrap items-start justify-between gap-4 border-b border-slate-100 pb-5">
                                         <div>
                                             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
                                                 {activeModule.id}
                                             </p>
-                                            <h2 className="mt-2 text-xl font-semibold text-slate-900">
+                                            <h2
+                                                ref={activeModuleHeadingRef}
+                                                tabIndex={-1}
+                                                className="mt-2 text-xl font-semibold text-slate-900"
+                                            >
                                                 {activeModule.title}
                                             </h2>
                                             <p className="mt-2 text-sm text-slate-500">
@@ -368,14 +388,34 @@ export function TeacherCaseSubmissionDetailPage() {
                                 <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">
                                     Módulos del caso
                                 </h2>
-                                <div className="mt-4 space-y-3">
+                                <div className="mt-4 space-y-3" role="tablist" aria-label="Módulos del caso">
                                     {modules.map((module) => (
-                                        <ModuleButton
+                                        <button
                                             key={module.id}
-                                            module={module}
-                                            isActive={module.id === activeModule?.id}
-                                            onClick={() => setActiveModuleId(module.id)}
-                                        />
+                                            type="button"
+                                            role="tab"
+                                            aria-selected={module.id === activeModule?.id}
+                                            aria-controls={`teacher-case-submission-module-panel-${module.id}`}
+                                            id={`teacher-case-submission-module-tab-${module.id}`}
+                                            onClick={() => handleModuleSelect(module.id)}
+                                            className={module.id === activeModule?.id
+                                                ? "rounded-[18px] border border-blue-200 bg-blue-50 px-4 py-4 text-left shadow-sm"
+                                                : "rounded-[18px] border border-slate-200 bg-white px-4 py-4 text-left transition hover:border-slate-300 hover:bg-slate-50"
+                                            }
+                                        >
+                                            <div className="flex items-start justify-between gap-3">
+                                                <div>
+                                                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{module.id}</p>
+                                                    <p className="mt-1 text-sm font-semibold text-slate-900">{module.title}</p>
+                                                </div>
+                                                <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">
+                                                    {countAnsweredQuestions(module)}/{module.questions.length}
+                                                </span>
+                                            </div>
+                                            <p className="mt-2 text-xs text-slate-500">
+                                                {countDraftQuestions(module) > 0 ? `${countDraftQuestions(module)} respuesta(s) en borrador` : "Sin respuestas en borrador"}
+                                            </p>
+                                        </button>
                                     ))}
                                 </div>
                             </section>
@@ -445,15 +485,7 @@ export function TeacherCaseSubmissionDetailPage() {
                                 </section>
                             ) : null}
 
-                            <section className="rounded-[24px] bg-slate-900 p-5 text-white shadow-[0_18px_50px_-28px_rgba(15,23,42,0.9)]">
-                                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-300">
-                                    Próxima entrega
-                                </p>
-                                <h2 className="mt-2 text-lg font-semibold">Calificación aún en modo lectura</h2>
-                                <p className="mt-3 text-sm leading-6 text-slate-300">
-                                    Esta pantalla ya consolida snapshot, borrador y solución esperada. La edición y publicación de calificaciones llegará en una siguiente issue sin cambiar este contrato de lectura.
-                                </p>
-                            </section>
+                            <GradingPlaceholderPanel />
                         </aside>
                     </div>
                 ) : null}

--- a/frontend/src/features/teacher-case-submission-detail/components/GradingPlaceholderPanel.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/GradingPlaceholderPanel.tsx
@@ -1,0 +1,16 @@
+export function GradingPlaceholderPanel() {
+    return (
+        <section
+            className="rounded-[24px] bg-slate-900 p-5 text-white shadow-[0_18px_50px_-28px_rgba(15,23,42,0.9)]"
+            data-testid="teacher-case-submission-detail-grading-slot"
+        >
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-300">
+                Próxima iteración
+            </p>
+            <h2 className="mt-2 text-lg font-semibold">Calificación</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+                La calificación estará disponible en una próxima actualización.
+            </p>
+        </section>
+    );
+}

--- a/frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionDetailApi.ts
+++ b/frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionDetailApi.ts
@@ -1,0 +1,35 @@
+import { api } from "@/shared/api";
+import type { TeacherCaseSubmissionDetailResponse } from "@/shared/adam-types";
+
+export const TEACHER_CASE_SUBMISSION_DETAIL_QUERY_GC_TIME = 5 * 60_000;
+export const SUPPORTED_TEACHER_CASE_SUBMISSION_DETAIL_PAYLOAD_VERSION = 1;
+
+type TeacherCaseSubmissionDetailRuntimeResponse = Omit<TeacherCaseSubmissionDetailResponse, "payload_version"> & {
+    payload_version: number;
+};
+
+export class UnsupportedTeacherCaseSubmissionDetailPayloadVersionError extends Error {
+    payloadVersion: number;
+
+    constructor(payloadVersion: number) {
+        super("Tu versión de la app está desactualizada. Recarga para continuar.");
+        this.name = "UnsupportedTeacherCaseSubmissionDetailPayloadVersionError";
+        this.payloadVersion = payloadVersion;
+    }
+}
+
+export async function fetchTeacherCaseSubmissionDetail(
+    assignmentId: string,
+    membershipId: string,
+): Promise<TeacherCaseSubmissionDetailResponse> {
+    const response = await api.teacher.getCaseSubmissionDetail(
+        assignmentId,
+        membershipId,
+    ) as TeacherCaseSubmissionDetailRuntimeResponse;
+
+    if (response.payload_version !== SUPPORTED_TEACHER_CASE_SUBMISSION_DETAIL_PAYLOAD_VERSION) {
+        throw new UnsupportedTeacherCaseSubmissionDetailPayloadVersionError(response.payload_version);
+    }
+
+    return response as TeacherCaseSubmissionDetailResponse;
+}

--- a/frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionDetailModel.ts
+++ b/frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionDetailModel.ts
@@ -1,0 +1,36 @@
+import type {
+    TeacherCaseSubmissionDetailModule,
+    TeacherCaseSubmissionDetailResponse,
+} from "@/shared/adam-types";
+
+function hasAnswer(value: string | null): boolean {
+    return Boolean(value && value.trim());
+}
+
+export function getDefaultTeacherCaseSubmissionModuleId(
+    detail: TeacherCaseSubmissionDetailResponse | null | undefined,
+): TeacherCaseSubmissionDetailModule["id"] | null {
+    return detail?.modules[0]?.id ?? null;
+}
+
+export function countAnsweredQuestions(module: TeacherCaseSubmissionDetailModule): number {
+    return module.questions.filter((question) => hasAnswer(question.student_answer)).length;
+}
+
+export function countDraftQuestions(module: TeacherCaseSubmissionDetailModule): number {
+    return module.questions.filter(
+        (question) => question.is_answer_from_draft && hasAnswer(question.student_answer),
+    ).length;
+}
+
+export function countSubmissionQuestions(
+    detail: TeacherCaseSubmissionDetailResponse | null | undefined,
+): number {
+    return detail?.modules.reduce((total, module) => total + module.questions.length, 0) ?? 0;
+}
+
+export function countAnsweredSubmissionQuestions(
+    detail: TeacherCaseSubmissionDetailResponse | null | undefined,
+): number {
+    return detail?.modules.reduce((total, module) => total + countAnsweredQuestions(module), 0) ?? 0;
+}

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.test.ts
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/shared/api";
+import { queryKeys } from "@/shared/queryKeys";
+
+import { useTeacherCaseSubmissionDetail } from "./useTeacherCaseSubmissionDetail";
+
+vi.mock("@tanstack/react-query", () => ({
+    useQuery: vi.fn(),
+}));
+
+vi.mock("@/shared/api", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/api")>("@/shared/api");
+
+    return {
+        ...actual,
+        api: {
+            ...actual.api,
+            teacher: {
+                ...actual.api.teacher,
+                getCaseSubmissionDetail: vi.fn(),
+            },
+        },
+    };
+});
+
+describe("useTeacherCaseSubmissionDetail", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("configures the detail query with the expected cache policy", async () => {
+        vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+
+        useTeacherCaseSubmissionDetail("assignment-1", "membership-1");
+
+        expect(useQuery).toHaveBeenCalledWith({
+            queryKey: queryKeys.teacher.caseSubmissionDetail("assignment-1", "membership-1"),
+            queryFn: expect.any(Function),
+            enabled: true,
+            staleTime: 30_000,
+            refetchOnMount: true,
+            refetchOnWindowFocus: true,
+        });
+
+        const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as {
+            queryFn: () => Promise<unknown>;
+        };
+        await options.queryFn();
+        expect(api.teacher.getCaseSubmissionDetail).toHaveBeenCalledWith("assignment-1", "membership-1");
+    });
+
+    it("disables the detail query when either route parameter is empty", () => {
+        vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+
+        useTeacherCaseSubmissionDetail("assignment-1", "");
+
+        const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+        expect(options.enabled).toBe(false);
+    });
+});

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.test.ts
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.test.ts
@@ -1,10 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useQuery } from "@tanstack/react-query";
 
-import { api } from "@/shared/api";
+import { ApiError, api } from "@/shared/api";
 import { queryKeys } from "@/shared/queryKeys";
+import type { TeacherCaseSubmissionDetailResponse } from "@/shared/adam-types";
 
-import { useTeacherCaseSubmissionDetail } from "./useTeacherCaseSubmissionDetail";
+import {
+    getTeacherCaseSubmissionDetailErrorMessage,
+    useTeacherCaseSubmissionDetail,
+} from "./useTeacherCaseSubmissionDetail";
+import {
+    TEACHER_CASE_SUBMISSION_DETAIL_QUERY_GC_TIME,
+    UnsupportedTeacherCaseSubmissionDetailPayloadVersionError,
+} from "./teacherCaseSubmissionDetailApi";
 
 vi.mock("@tanstack/react-query", () => ({
     useQuery: vi.fn(),
@@ -32,6 +40,41 @@ describe("useTeacherCaseSubmissionDetail", () => {
 
     it("configures the detail query with the expected cache policy", async () => {
         vi.mocked(useQuery).mockReturnValue({ data: undefined } as never);
+        vi.mocked(api.teacher.getCaseSubmissionDetail).mockResolvedValue({
+            payload_version: 1,
+            is_truncated: false,
+            case: {
+                id: "assignment-1",
+                title: "Caso Plataforma",
+                deadline: null,
+                available_from: null,
+                course_id: "course-1",
+                course_code: "A-210",
+                course_name: "Analítica Directiva",
+                teaching_note: null,
+            },
+            student: {
+                membership_id: "membership-1",
+                full_name: "Ana Student",
+                email: "ana.student@example.edu",
+                enrolled_at: "2026-05-20T15:00:00Z",
+            },
+            response_state: {
+                status: "submitted",
+                first_opened_at: null,
+                last_autosaved_at: null,
+                submitted_at: null,
+                snapshot_id: null,
+                snapshot_hash: null,
+            },
+            grade_summary: {
+                status: null,
+                score: null,
+                max_score: 5,
+                graded_at: null,
+            },
+            modules: [],
+        } satisfies TeacherCaseSubmissionDetailResponse);
 
         useTeacherCaseSubmissionDetail("assignment-1", "membership-1");
 
@@ -40,6 +83,7 @@ describe("useTeacherCaseSubmissionDetail", () => {
             queryFn: expect.any(Function),
             enabled: true,
             staleTime: 30_000,
+            gcTime: TEACHER_CASE_SUBMISSION_DETAIL_QUERY_GC_TIME,
             refetchOnMount: true,
             refetchOnWindowFocus: true,
         });
@@ -58,5 +102,37 @@ describe("useTeacherCaseSubmissionDetail", () => {
 
         const options = vi.mocked(useQuery).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
         expect(options.enabled).toBe(false);
+    });
+
+    it("maps localized auth and lookup errors for the detail view", () => {
+        expect(
+            getTeacherCaseSubmissionDetailErrorMessage(
+                new ApiError(404, "Not found", "submission_not_found"),
+                "fallback",
+            ),
+        ).toBe("No encontramos esta entrega o no tienes acceso.");
+
+        expect(
+            getTeacherCaseSubmissionDetailErrorMessage(
+                new ApiError(403, "Forbidden", "profile_incomplete"),
+                "fallback",
+            ),
+        ).toBe("Tu perfil docente todavía no está listo para usar esta vista.");
+
+        expect(
+            getTeacherCaseSubmissionDetailErrorMessage(
+                new ApiError(403, "Forbidden", "membership_required"),
+                "fallback",
+            ),
+        ).toBe("Tu cuenta no tiene una membresía docente activa para este caso.");
+    });
+
+    it("maps unsupported payload versions to the outdated-app copy", () => {
+        expect(
+            getTeacherCaseSubmissionDetailErrorMessage(
+                new UnsupportedTeacherCaseSubmissionDetailPayloadVersionError(2),
+                "fallback",
+            ),
+        ).toBe("Tu versión de la app está desactualizada. Recarga para continuar.");
     });
 });

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.ts
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.ts
@@ -1,13 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { api, ApiError } from "@/shared/api";
+import { ApiError } from "@/shared/api";
 import type { TeacherCaseSubmissionDetailResponse } from "@/shared/adam-types";
 import { queryKeys } from "@/shared/queryKeys";
+
+import {
+    fetchTeacherCaseSubmissionDetail,
+    TEACHER_CASE_SUBMISSION_DETAIL_QUERY_GC_TIME,
+    UnsupportedTeacherCaseSubmissionDetailPayloadVersionError,
+} from "./teacherCaseSubmissionDetailApi";
 
 export function getTeacherCaseSubmissionDetailErrorMessage(
     error: unknown,
     fallback: string,
 ): string {
+    if (error instanceof UnsupportedTeacherCaseSubmissionDetailPayloadVersionError) {
+        return error.message;
+    }
+
     if (!(error instanceof ApiError)) {
         return error instanceof Error ? error.message : fallback;
     }
@@ -40,9 +50,10 @@ export function getTeacherCaseSubmissionDetailErrorMessage(
 export function useTeacherCaseSubmissionDetail(assignmentId: string, membershipId: string) {
     return useQuery<TeacherCaseSubmissionDetailResponse>({
         queryKey: queryKeys.teacher.caseSubmissionDetail(assignmentId, membershipId),
-        queryFn: () => api.teacher.getCaseSubmissionDetail(assignmentId, membershipId),
+        queryFn: () => fetchTeacherCaseSubmissionDetail(assignmentId, membershipId),
         enabled: Boolean(assignmentId) && Boolean(membershipId),
         staleTime: 30_000,
+        gcTime: TEACHER_CASE_SUBMISSION_DETAIL_QUERY_GC_TIME,
         refetchOnMount: true,
         refetchOnWindowFocus: true,
     });

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.ts
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.ts
@@ -1,0 +1,49 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api, ApiError } from "@/shared/api";
+import type { TeacherCaseSubmissionDetailResponse } from "@/shared/adam-types";
+import { queryKeys } from "@/shared/queryKeys";
+
+export function getTeacherCaseSubmissionDetailErrorMessage(
+    error: unknown,
+    fallback: string,
+): string {
+    if (!(error instanceof ApiError)) {
+        return error instanceof Error ? error.message : fallback;
+    }
+
+    if (error.status === 404) {
+        return "No encontramos esta entrega o no tienes acceso.";
+    }
+
+    switch (error.detail) {
+        case "course_gradebook_cross_enrollment_unsupported":
+            return "Este caso está publicado en varios cursos con estudiantes superpuestos. Corrige esa configuración antes de abrir la entrega.";
+        case "course_gradebook_inconsistent_max_score":
+        case "course_gradebook_invalid_max_score":
+            return "Este caso tiene calificaciones inválidas o inconsistentes. Corrige esos registros antes de abrir la entrega.";
+        case "student_identity_unavailable":
+            return "No se pudo recuperar la identidad del estudiante para esta entrega.";
+        case "case_canonical_output_invalid":
+            return "El caso publicado tiene un payload inválido y no puede reconstruirse para revisión docente.";
+        case "invalid_token":
+            return "Tu sesión expiró. Vuelve a iniciar sesión para continuar.";
+        case "profile_incomplete":
+            return "Tu perfil docente todavía no está listo para usar esta vista.";
+        case "membership_required":
+            return "Tu cuenta no tiene una membresía docente activa para este caso.";
+        default:
+            return error.message || fallback;
+    }
+}
+
+export function useTeacherCaseSubmissionDetail(assignmentId: string, membershipId: string) {
+    return useQuery<TeacherCaseSubmissionDetailResponse>({
+        queryKey: queryKeys.teacher.caseSubmissionDetail(assignmentId, membershipId),
+        queryFn: () => api.teacher.getCaseSubmissionDetail(assignmentId, membershipId),
+        enabled: Boolean(assignmentId) && Boolean(membershipId),
+        staleTime: 30_000,
+        refetchOnMount: true,
+        refetchOnWindowFocus: true,
+    });
+}

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -844,6 +844,66 @@ export interface TeacherCaseSubmissionsResponse {
     submissions: TeacherCaseSubmissionRow[];
 }
 
+export interface TeacherCaseSubmissionDetailQuestion {
+    id: string;
+    order: number;
+    statement: string;
+    context: string | null;
+    expected_solution: string;
+    student_answer: string | null;
+    student_answer_chars: number;
+    is_answer_from_draft: boolean;
+}
+
+export interface TeacherCaseSubmissionDetailModule {
+    id: "M1" | "M2" | "M3" | "M4" | "M5";
+    title: string;
+    questions: TeacherCaseSubmissionDetailQuestion[];
+}
+
+export interface TeacherCaseSubmissionDetailCase {
+    id: string;
+    title: string;
+    deadline: string | null;
+    available_from: string | null;
+    course_id: string;
+    course_code: string;
+    course_name: string;
+    teaching_note: string | null;
+}
+
+export interface TeacherCaseSubmissionDetailStudent {
+    membership_id: string;
+    full_name: string;
+    email: string;
+    enrolled_at: string;
+}
+
+export interface TeacherCaseSubmissionDetailResponseState {
+    status: TeacherCourseGradebookStatus;
+    first_opened_at: string | null;
+    last_autosaved_at: string | null;
+    submitted_at: string | null;
+    snapshot_id: string | null;
+    snapshot_hash: string | null;
+}
+
+export interface TeacherCaseSubmissionDetailGradeSummary {
+    status: "in_progress" | "submitted" | "graded" | null;
+    score: number | null;
+    max_score: number;
+    graded_at: string | null;
+}
+
+export interface TeacherCaseSubmissionDetailResponse {
+    payload_version: 1;
+    case: TeacherCaseSubmissionDetailCase;
+    student: TeacherCaseSubmissionDetailStudent;
+    response_state: TeacherCaseSubmissionDetailResponseState;
+    grade_summary: TeacherCaseSubmissionDetailGradeSummary;
+    modules: TeacherCaseSubmissionDetailModule[];
+}
+
 export interface DeadlineUpdateRequest {
     available_from?: string | null;
     deadline?: string | null;

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -897,6 +897,7 @@ export interface TeacherCaseSubmissionDetailGradeSummary {
 
 export interface TeacherCaseSubmissionDetailResponse {
     payload_version: 1;
+    is_truncated: boolean;
     case: TeacherCaseSubmissionDetailCase;
     student: TeacherCaseSubmissionDetailStudent;
     response_state: TeacherCaseSubmissionDetailResponseState;

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -46,6 +46,7 @@ import type {
     SuggestRequest,
     SuggestResponse,
     TeacherCaseDetailResponse,
+    TeacherCaseSubmissionDetailResponse,
     TeacherCaseSubmissionsResponse,
     TeacherCourseAccessLinkRegenerateResponse,
     TeacherCourseAccessLinkResponse,
@@ -79,13 +80,19 @@ type ApiErrorCode =
     | "db_timeout"
     | "assignment_forbidden"
     | "assignment_not_found"
+    | "submission_not_found"
     | "version_conflict"
     | "already_submitted"
     | "deadline_passed"
     | "payload_too_large"
     | "invalid_question_id"
     | "invalid_answer_value"
-    | "too_many_answers";
+    | "too_many_answers"
+    | "course_gradebook_cross_enrollment_unsupported"
+    | "course_gradebook_inconsistent_max_score"
+    | "course_gradebook_invalid_max_score"
+    | "student_identity_unavailable"
+    | "case_canonical_output_invalid";
 
 export interface ProgressEvent {
     event: string;
@@ -1191,6 +1198,14 @@ export const api = {
         async getCaseSubmissions(assignmentId: string): Promise<TeacherCaseSubmissionsResponse> {
             return parseJsonResponse<TeacherCaseSubmissionsResponse>(
                 `/teacher/cases/${assignmentId}/submissions`,
+            );
+        },
+        async getCaseSubmissionDetail(
+            assignmentId: string,
+            membershipId: string,
+        ): Promise<TeacherCaseSubmissionDetailResponse> {
+            return parseJsonResponse<TeacherCaseSubmissionDetailResponse>(
+                `/teacher/cases/${assignmentId}/submissions/${membershipId}`,
             );
         },
         async publishCase(assignmentId: string): Promise<TeacherCaseDetailResponse> {

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -90,5 +90,8 @@ export const queryKeys = {
         case: (id: string) => ["teacher", "case", id] as const,
         /** ["teacher", "case-submissions", id] — entregas por caso del docente */
         caseSubmissions: (id: string) => ["teacher", "case-submissions", id] as const,
+        /** ["teacher", "case-submission-detail", assignmentId, membershipId] — detalle de una entrega docente */
+        caseSubmissionDetail: (assignmentId: string, membershipId: string) =>
+            ["teacher", "case-submission-detail", assignmentId, membershipId] as const,
     },
 } as const;


### PR DESCRIPTION
## Summary
- keeps `GET /api/teacher/cases/:assignmentId/submissions/:membershipId` read-only by removing identity-repair side effects from the detail path and using fallback email rendering instead
- adds `is_truncated` to the teacher submission detail contract and surfaces truncation state in the review UI
- adds feature-local runtime guarding for `payload_version`, `?modulo=` deep-linking, `not_started` and submitted-with-draft banners, and the reserved grading slot component
- expands backend and frontend coverage for auth precedence, read-only regressions, truncation, module deep links, plain-text rendering, and outdated-client handling

## Spec + Reuse Map
- Canonical spec: `docs/planPlataforma/issue-teacher-case-submission-detail.md`
- Reused backend surfaces: `QUESTION_FIELD_TO_MODULE`, `TeacherContext`, `_build_assignment_target_courses_subquery`, `_assignment_target_course_metadata`, `_derive_grade_cell_status`
- Reused frontend surfaces: `TeacherLayout`, `formatTeacherCourseTimestamp`, `formatTeacherGradebookScore`, `formatTeacherGradebookCellStatus`, and the existing route `/teacher/cases/:assignmentId/entregas/:membershipId`

## Review Fixes
1. The detail GET path is now side-effect free: no identity repair, no admin auth client lookup, and no DB commit from the read path.
2. The backend payload now returns `is_truncated`; the frontend shows a dedicated truncation notice when that contract is exercised.
3. The detail page now persists the active module in `?modulo=...`, shows the `not_started` banner, shows the submitted-with-draft fallback banner, and renders `GradingPlaceholderPanel` with `data-testid=teacher-case-submission-detail-grading-slot`.
4. The query hook now uses `gcTime: 5 * 60_000` and a feature-local payload-version guard with localized outdated-app copy.
5. The test matrix now covers auth precedence, the read-only regression, truncation, URL module selection, plain-text answer rendering, localized error mapping, and unsupported payload versions.

## Out Of Scope
- grading mutations or rubric forms
- feedback capture or any exposure of `CaseGrade.feedback`
- changing the parent submissions list beyond the existing navigation entrypoint

## Main Files Changed
- `backend/src/shared/teacher_gradebook_schema.py`
- `backend/src/shared/teacher_reads.py`
- `backend/tests/test_teacher_case_submission_detail.py`
- `frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.tsx`
- `frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.test.tsx`
- `frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.ts`
- `frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.test.ts`
- `frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionDetailApi.ts`
- `frontend/src/features/teacher-case-submission-detail/components/GradingPlaceholderPanel.tsx`
- `frontend/src/shared/adam-types.ts`

## Validation Evidence
- [x] `uv run --directory backend pytest -q` (`395 passed, 12 skipped`)
- [x] `uv run --directory backend mypy src`
- [x] `npm --prefix frontend run lint`
- [x] `npm --prefix frontend run test` (`54 passed`, `395 passed`)
- [x] `npm --prefix frontend run build`
- [x] `npm --prefix frontend run test -- src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.test.tsx src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.test.ts` (`2 files`, `14 tests`)

## Screenshots / GIFs
- Not attached from this CLI-only session.
- Added explicit UI coverage for the shipped states in Vitest: default render, `?modulo=` deep-link, `not_started`, submitted-with-draft fallback, truncation banner, and outdated-client banner.

## References
- Closes #213
- Spec: `docs/planPlataforma/issue-teacher-case-submission-detail.md`