### PR TITLE
feat: add teacher manual grading workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ This repository does not currently include a student runtime, full authenticatio
 
 - `backend/src/case_generator/` owns authoring business logic, prompts, schemas, and graph execution.
 - `backend/src/shared/` owns FastAPI app composition, DB, ORM, shared contracts, and progress snapshot endpoints.
+- Teacher manual grading runtime lives in `backend/src/shared/case_grade_service.py`, `backend/src/shared/teacher_grading_schema.py`, and the `case_grade_*_entries` tables; do not move that workflow into `case_generator` or hide it in routers.
 - `frontend/src/` follows the stable top-level split `app / features / shared`.
 - `shared/` must not become a catch-all for new product logic.
 - Use absolute imports by domain. Do not reintroduce `sys.path` hacks or deep relative import chains.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Use the repo-driven gstack runtime materialized from the pinned lock in `scripts
 
 - `backend/src/case_generator/`: authoring business logic, LangGraph orchestration, prompts, schemas, and downstream generation services.
 - `backend/src/shared/`: FastAPI composition root, database access, ORM models, shared contracts, sanitization, and progress snapshot endpoints.
+- Teacher manual grading runtime stays in `backend/src/shared/case_grade_service.py`, `backend/src/shared/teacher_grading_schema.py`, and the `case_grade_*_entries` tables; do not push that workflow into `case_generator` or bury it inside routers.
 - `frontend/src/app/`: application shell, router, entrypoint, and global styles.
 - `frontend/src/features/teacher-authoring/`: teacher-facing authoring workflow.
 - `frontend/src/features/case-preview/`: generated case preview and `M1..M6` rendering surface.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,19 @@ npm --prefix frontend run build
 npm --prefix frontend run test
 ```
 
+Cuando el cambio toque imports pesados, renderer compartido, Plotly o fronteras de bundle
+del frontend, corre ademas desde la raiz:
+
+```powershell
+npm --prefix frontend run assert:bundle-isolation
+```
+
+Si trabajas en un entorno con `make`, el repo tambien expone el atajo:
+
+```powershell
+make validate-frontend-bundle
+```
+
 La suite backend actual debe correr en serie. No uses `pytest-xdist` ni `pytest -n ...`
 mientras el harness siga compartiendo una sola base de datos local.
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Optional local development shortcuts. In Windows, prefer the documented direct commands.
-.PHONY: help dev-frontend dev-backend dev-langgraph dev
+.PHONY: help dev-frontend dev-backend dev-langgraph dev validate-frontend-bundle
 
 help:
 	@echo "Available commands:"
@@ -19,6 +19,10 @@ dev-backend:
 dev-langgraph:
 	@echo "Starting LangGraph development server..."
 	@cd backend && uv run langgraph dev
+
+validate-frontend-bundle:
+	@echo "Validating frontend bundle isolation..."
+	@cd frontend && npm run assert:bundle-isolation
 
 # Run frontend and backend concurrently
 dev:

--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ Eso significa:
   `npm --prefix frontend run build`
 - Frontend tests:
   `npm --prefix frontend run test`
+- Frontend bundle isolation:
+  `npm --prefix frontend run assert:bundle-isolation`
+  Opcional en entornos con `make`: `make validate-frontend-bundle`
 - Live LLM:
   `RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm -q`
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -49,6 +49,8 @@ ENVIRONMENT=development
 # Optional override used by the runtime launcher.
 # If set, APP_ENV takes precedence over ENVIRONMENT.
 APP_ENV=
+# Optional rollback switch for manual teacher grading.
+TEACHER_MANUAL_GRADING_ENABLED=true
 
 # -- Runtime launcher profile (shared.app) ------------------------
 # Launcher command: uv run python -m shared.app

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -50,7 +50,7 @@ ENVIRONMENT=development
 # If set, APP_ENV takes precedence over ENVIRONMENT.
 APP_ENV=
 # Optional rollback switch for manual teacher grading.
-TEACHER_MANUAL_GRADING_ENABLED=true
+TEACHER_MANUAL_GRADING_ENABLED=false  # set true to enable teacher manual grading (Issue #219)
 
 # -- Runtime launcher profile (shared.app) ------------------------
 # Launcher command: uv run python -m shared.app

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -52,6 +52,7 @@ uv run pytest -m live_llm -q
 
 - `src/case_generator/` owns teacher authoring business logic.
 - `src/shared/` owns app composition, DB, ORM, sanitization, progress snapshot endpoints, and shared contracts.
+- Teacher manual grading runtime stays in `src/shared/case_grade_service.py`, `src/shared/teacher_grading_schema.py`, and the `case_grade_*_entries` tables.
 - `shared/` must not absorb new product domains.
 - Use absolute imports. Do not add `sys.path` mutations.
 - Keep application schema changes in Alembic migrations under `alembic/versions/`.

--- a/backend/alembic/versions/c7e9d12a4b6f_issue219_teacher_manual_grading.py
+++ b/backend/alembic/versions/c7e9d12a4b6f_issue219_teacher_manual_grading.py
@@ -1,0 +1,189 @@
+"""issue219_teacher_manual_grading
+
+Revision ID: c7e9d12a4b6f
+Revises: 9ee3b0659e9a
+Create Date: 2026-04-27 23:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "c7e9d12a4b6f"
+down_revision: Union[str, Sequence[str], None] = "9ee3b0659e9a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "assignments",
+        sa.Column("weight_per_module", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+    op.add_column(
+        "case_grades",
+        sa.Column("graded_by", sa.String(length=16), server_default=sa.text("'human'"), nullable=False),
+    )
+    op.add_column("case_grades", sa.Column("ai_model_version", sa.String(length=64), nullable=True))
+    op.add_column("case_grades", sa.Column("ai_suggested_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("case_grades", sa.Column("human_reviewed_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "case_grades",
+        sa.Column("version", sa.Integer(), server_default=sa.text("1"), nullable=False),
+    )
+    op.add_column("case_grades", sa.Column("published_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("case_grades", sa.Column("draft_feedback_global", sa.Text(), nullable=True))
+    op.add_column(
+        "case_grades",
+        sa.Column(
+            "last_modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+    )
+    op.create_check_constraint(
+        "ck_case_grades_graded_by",
+        "case_grades",
+        "graded_by IN ('human', 'ai', 'hybrid')",
+    )
+    op.create_check_constraint(
+        "ck_case_grades_version_positive",
+        "case_grades",
+        "version >= 1",
+    )
+
+    op.create_table(
+        "case_grade_module_entries",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("case_grade_id", sa.String(length=36), nullable=False),
+        sa.Column("module_id", sa.String(length=2), nullable=False),
+        sa.Column("weight", sa.Numeric(precision=4, scale=3), server_default=sa.text("0.200"), nullable=False),
+        sa.Column("feedback_module", sa.Text(), nullable=True),
+        sa.Column("state", sa.String(length=16), server_default=sa.text("'draft'"), nullable=False),
+        sa.Column("source", sa.String(length=24), server_default=sa.text("'human'"), nullable=False),
+        sa.Column("ai_confidence", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("module_id IN ('M1', 'M2', 'M3', 'M4', 'M5')", name="ck_case_grade_module_entries_module_id"),
+        sa.CheckConstraint("weight >= 0 AND weight <= 1", name="ck_case_grade_module_entries_weight_range"),
+        sa.CheckConstraint("state IN ('draft', 'published')", name="ck_case_grade_module_entries_state"),
+        sa.CheckConstraint(
+            "source IN ('human', 'ai_suggested', 'ai_edited_by_human')",
+            name="ck_case_grade_module_entries_source",
+        ),
+        sa.CheckConstraint(
+            "ai_confidence IS NULL OR (ai_confidence >= 0 AND ai_confidence <= 1)",
+            name="ck_case_grade_module_entries_ai_confidence_range",
+        ),
+        sa.ForeignKeyConstraint(["case_grade_id"], ["case_grades.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "case_grade_id",
+            "module_id",
+            "state",
+            name="uix_case_grade_module_entries_case_grade_module_state",
+        ),
+    )
+    op.create_index(
+        "ix_case_grade_module_entries_case_grade_id",
+        "case_grade_module_entries",
+        ["case_grade_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "case_grade_question_entries",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("case_grade_id", sa.String(length=36), nullable=False),
+        sa.Column("question_id", sa.String(length=64), nullable=False),
+        sa.Column("module_id", sa.String(length=2), nullable=False),
+        sa.Column("rubric_level", sa.String(length=16), nullable=True),
+        sa.Column("score_normalized", sa.Float(), nullable=True),
+        sa.Column("feedback_question", sa.Text(), nullable=True),
+        sa.Column("state", sa.String(length=16), server_default=sa.text("'draft'"), nullable=False),
+        sa.Column("source", sa.String(length=24), server_default=sa.text("'human'"), nullable=False),
+        sa.Column("ai_confidence", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("module_id IN ('M1', 'M2', 'M3', 'M4', 'M5')", name="ck_case_grade_question_entries_module_id"),
+        sa.CheckConstraint(
+            "rubric_level IS NULL OR rubric_level IN ('excelente', 'bien', 'aceptable', 'insuficiente', 'no_responde')",
+            name="ck_case_grade_question_entries_rubric_level",
+        ),
+        sa.CheckConstraint(
+            "score_normalized IS NULL OR (score_normalized >= 0 AND score_normalized <= 1)",
+            name="ck_case_grade_question_entries_score_normalized_range",
+        ),
+        sa.CheckConstraint("state IN ('draft', 'published')", name="ck_case_grade_question_entries_state"),
+        sa.CheckConstraint(
+            "source IN ('human', 'ai_suggested', 'ai_edited_by_human')",
+            name="ck_case_grade_question_entries_source",
+        ),
+        sa.CheckConstraint(
+            "ai_confidence IS NULL OR (ai_confidence >= 0 AND ai_confidence <= 1)",
+            name="ck_case_grade_question_entries_ai_confidence_range",
+        ),
+        sa.ForeignKeyConstraint(["case_grade_id"], ["case_grades.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "case_grade_id",
+            "question_id",
+            "state",
+            name="uix_case_grade_question_entries_case_grade_question_state",
+        ),
+    )
+    op.create_index(
+        "ix_case_grade_question_entries_case_grade_module",
+        "case_grade_question_entries",
+        ["case_grade_id", "module_id"],
+        unique=False,
+    )
+
+    op.execute("ALTER TABLE case_grade_module_entries ENABLE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS case_grade_module_entries_deny_all ON case_grade_module_entries")
+    op.execute(
+        """
+        CREATE POLICY case_grade_module_entries_deny_all ON case_grade_module_entries
+          FOR ALL
+          USING (false)
+          WITH CHECK (false)
+        """
+    )
+
+    op.execute("ALTER TABLE case_grade_question_entries ENABLE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS case_grade_question_entries_deny_all ON case_grade_question_entries")
+    op.execute(
+        """
+        CREATE POLICY case_grade_question_entries_deny_all ON case_grade_question_entries
+          FOR ALL
+          USING (false)
+          WITH CHECK (false)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS case_grade_question_entries_deny_all ON case_grade_question_entries")
+    op.execute("DROP POLICY IF EXISTS case_grade_module_entries_deny_all ON case_grade_module_entries")
+    op.drop_index("ix_case_grade_question_entries_case_grade_module", table_name="case_grade_question_entries")
+    op.drop_table("case_grade_question_entries")
+    op.drop_index("ix_case_grade_module_entries_case_grade_id", table_name="case_grade_module_entries")
+    op.drop_table("case_grade_module_entries")
+
+    op.drop_constraint("ck_case_grades_version_positive", "case_grades", type_="check")
+    op.drop_constraint("ck_case_grades_graded_by", "case_grades", type_="check")
+    op.drop_column("case_grades", "last_modified_at")
+    op.drop_column("case_grades", "published_at")
+    op.drop_column("case_grades", "version")
+    op.drop_column("case_grades", "human_reviewed_at")
+    op.drop_column("case_grades", "ai_suggested_at")
+    op.drop_column("case_grades", "ai_model_version")
+    op.drop_column("case_grades", "draft_feedback_global")
+    op.drop_column("case_grades", "graded_by")
+
+    op.drop_column("assignments", "weight_per_module")

--- a/backend/scripts/seed_manual_grading_fixture.py
+++ b/backend/scripts/seed_manual_grading_fixture.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import secrets
+import string
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from sqlalchemy import select
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+from shared.auth import ensure_course_membership, ensure_membership, ensure_profile, get_supabase_admin_client
+from shared.database import SessionLocal, settings
+from shared.identity_activation import upsert_legacy_user
+from shared.models import Assignment, CaseGrade, Course, StudentCaseResponse, StudentCaseResponseSubmission, Tenant
+
+FIXTURE_TENANT_ID = "10000000-0000-0000-0000-000000002219"
+FIXTURE_COURSE_ID = "20000000-0000-0000-0000-000000002219"
+FIXTURE_ASSIGNMENT_ID = "30000000-0000-0000-0000-000000002219"
+FIXTURE_RESPONSE_ID = "40000000-0000-0000-0000-000000002219"
+FIXTURE_SUBMISSION_ID = "50000000-0000-0000-0000-000000002219"
+FIXTURE_CANONICAL_HASH = "hash-manual-grading-fixture"
+
+
+@dataclass(slots=True)
+class SeededAuthUser:
+    user_id: str
+    email: str
+    password_to_report: str | None
+    password_status: str
+
+
+def _generate_password(length: int = 20) -> str:
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def _build_answers() -> dict[str, str]:
+    return {
+        "M1-Q1": "La operación se frena por cuellos de botella en onboarding y soporte.",
+        "M2-Q2": "La evidencia apunta a tiempos de activación inconsistentes por segmento.",
+        "M3-Q3": "La causa raíz combina handoffs manuales y métricas de éxito mal alineadas.",
+        "M4-Q4": "La recomendación es rediseñar el onboarding con ownership único y metas por cohorte.",
+        "M5-Q5": "La implementación debe empezar por el flujo enterprise y luego escalar al resto.",
+    }
+
+
+def _build_canonical_output() -> dict[str, object]:
+    return {
+        "caseId": FIXTURE_ASSIGNMENT_ID,
+        "title": "Caso Manual Grading Fixture",
+        "subject": "Analítica Directiva",
+        "syllabusModule": "Decisiones con datos",
+        "guidingQuestion": "¿Qué cambio operativo desbloquea crecimiento sin degradar la experiencia?",
+        "industry": "Tecnología",
+        "academicLevel": "MBA",
+        "caseType": "harvard_only",
+        "studentProfile": "business",
+        "generatedAt": "2026-06-01T15:00:00Z",
+        "outputDepth": "standard",
+        "content": {
+            "instructions": "Lee el caso, revisa la evidencia y responde cada módulo.",
+            "narrative": "Una empresa SaaS regional necesita estabilizar su onboarding antes de expandirse.",
+            "caseQuestions": [
+                {
+                    "numero": 1,
+                    "titulo": "Diagnóstico inicial",
+                    "enunciado": "Describe el principal bloqueo operativo.",
+                    "solucion_esperada": "Reconoce el cuello de botella entre ventas, onboarding y soporte.",
+                }
+            ],
+            "edaQuestions": [
+                {
+                    "numero": 2,
+                    "titulo": "Lectura de evidencia",
+                    "enunciado": "Interpreta la señal más crítica de los datos disponibles.",
+                    "solucion_esperada": "Identifica la variabilidad del tiempo a valor por segmento.",
+                }
+            ],
+            "m3Questions": [
+                {
+                    "numero": 3,
+                    "titulo": "Causa raíz",
+                    "enunciado": "Explica la causa raíz del problema.",
+                    "solucion_esperada": "Atribuye el problema a handoffs manuales y ownership difuso.",
+                }
+            ],
+            "m4Questions": [
+                {
+                    "numero": 4,
+                    "titulo": "Recomendación",
+                    "enunciado": "Propón una recomendación priorizada.",
+                    "solucion_esperada": "Plantea un rediseño del onboarding con KPIs de activación.",
+                }
+            ],
+            "m5Questions": [
+                {
+                    "numero": 5,
+                    "titulo": "Memo ejecutivo",
+                    "enunciado": "Redacta un memo ejecutivo final.",
+                    "solucion_esperada": "Sintetiza recomendación, riesgos y secuencia de ejecución.",
+                }
+            ],
+            "m4Content": "Evalúa impactos de negocio y riesgos de ejecución.",
+            "m5Content": "Cierra con una recomendación ejecutiva clara.",
+            "teachingNote": "La revisión docente debe enfatizar coherencia entre diagnóstico, evidencia y recomendación.",
+        },
+    }
+
+
+def _seed_auth_user(*, email: str, password: str | None) -> SeededAuthUser:
+    admin_client = get_supabase_admin_client()
+    password_to_apply = password or _generate_password()
+    result = admin_client.get_or_create_user_by_email(email, password_to_apply)
+
+    if result.created:
+        return SeededAuthUser(
+            user_id=result.user.id,
+            email=email,
+            password_to_report=password_to_apply,
+            password_status="created",
+        )
+
+    if password is not None:
+        admin_client.update_user_password(result.user.id, password)
+        return SeededAuthUser(
+            user_id=result.user.id,
+            email=email,
+            password_to_report=password,
+            password_status="updated",
+        )
+
+    return SeededAuthUser(
+        user_id=result.user.id,
+        email=email,
+        password_to_report=None,
+        password_status="reused",
+    )
+
+
+def _upsert_tenant(db, *, name: str) -> Tenant:
+    tenant = db.get(Tenant, FIXTURE_TENANT_ID)
+    if tenant is None:
+        tenant = Tenant(id=FIXTURE_TENANT_ID, name=name)
+        db.add(tenant)
+        db.flush()
+        return tenant
+
+    tenant.name = name
+    db.flush()
+    return tenant
+
+
+def _upsert_course(db, *, title: str, code: str, teacher_membership_id: str) -> Course:
+    course = db.get(Course, FIXTURE_COURSE_ID)
+    if course is None:
+        course = Course(
+            id=FIXTURE_COURSE_ID,
+            university_id=FIXTURE_TENANT_ID,
+            teacher_membership_id=teacher_membership_id,
+            pending_teacher_invite_id=None,
+            title=title,
+            code=code,
+            semester="2026-I",
+            academic_level="MBA",
+            max_students=30,
+            status="active",
+        )
+        db.add(course)
+        db.flush()
+        return course
+
+    course.university_id = FIXTURE_TENANT_ID
+    course.teacher_membership_id = teacher_membership_id
+    course.pending_teacher_invite_id = None
+    course.title = title
+    course.code = code
+    course.semester = "2026-I"
+    course.academic_level = "MBA"
+    course.max_students = 30
+    course.status = "active"
+    db.flush()
+    return course
+
+
+def _upsert_assignment(db, *, teacher_user_id: str, course_id: str, title: str) -> Assignment:
+    now = datetime.now(timezone.utc)
+    assignment = db.get(Assignment, FIXTURE_ASSIGNMENT_ID)
+    if assignment is None:
+        assignment = Assignment(
+            id=FIXTURE_ASSIGNMENT_ID,
+            teacher_id=teacher_user_id,
+            course_id=course_id,
+            title=title,
+            canonical_output=_build_canonical_output(),
+            status="published",
+            available_from=now - timedelta(days=2),
+            deadline=now + timedelta(days=6),
+            weight_per_module={"M1": 0.2, "M2": 0.2, "M3": 0.2, "M4": 0.2, "M5": 0.2},
+        )
+        db.add(assignment)
+        db.flush()
+        return assignment
+
+    assignment.teacher_id = teacher_user_id
+    assignment.course_id = course_id
+    assignment.title = title
+    assignment.canonical_output = _build_canonical_output()
+    assignment.status = "published"
+    assignment.available_from = now - timedelta(days=2)
+    assignment.deadline = now + timedelta(days=6)
+    assignment.weight_per_module = {"M1": 0.2, "M2": 0.2, "M3": 0.2, "M4": 0.2, "M5": 0.2}
+    db.flush()
+    return assignment
+
+
+def _upsert_response(db, *, membership_id: str, assignment_id: str) -> StudentCaseResponse:
+    now = datetime.now(timezone.utc)
+    response = db.get(StudentCaseResponse, FIXTURE_RESPONSE_ID)
+    answers = _build_answers()
+    if response is None:
+        response = StudentCaseResponse(
+            id=FIXTURE_RESPONSE_ID,
+            membership_id=membership_id,
+            assignment_id=assignment_id,
+            answers=answers,
+            status="submitted",
+            version=1,
+            first_opened_at=now - timedelta(hours=4),
+            last_autosaved_at=now - timedelta(hours=3),
+            submitted_at=now - timedelta(hours=2),
+        )
+        db.add(response)
+        db.flush()
+        return response
+
+    response.membership_id = membership_id
+    response.assignment_id = assignment_id
+    response.answers = answers
+    response.status = "submitted"
+    response.version = 1
+    response.first_opened_at = now - timedelta(hours=4)
+    response.last_autosaved_at = now - timedelta(hours=3)
+    response.submitted_at = now - timedelta(hours=2)
+    db.flush()
+    return response
+
+
+def _upsert_submission_snapshot(db, *, response_id: str, submitted_at: datetime) -> StudentCaseResponseSubmission:
+    snapshot = db.get(StudentCaseResponseSubmission, FIXTURE_SUBMISSION_ID)
+    answers = _build_answers()
+    if snapshot is None:
+        snapshot = StudentCaseResponseSubmission(
+            id=FIXTURE_SUBMISSION_ID,
+            response_id=response_id,
+            answers_snapshot=answers,
+            submitted_at=submitted_at,
+            canonical_output_hash=FIXTURE_CANONICAL_HASH,
+        )
+        db.add(snapshot)
+        db.flush()
+        return snapshot
+
+    snapshot.response_id = response_id
+    snapshot.answers_snapshot = answers
+    snapshot.submitted_at = submitted_at
+    snapshot.canonical_output_hash = FIXTURE_CANONICAL_HASH
+    db.flush()
+    return snapshot
+
+
+def _reset_existing_grade(db, *, membership_id: str, assignment_id: str) -> None:
+    existing_grade = db.scalar(
+        select(CaseGrade).where(
+            CaseGrade.membership_id == membership_id,
+            CaseGrade.assignment_id == assignment_id,
+        )
+    )
+    if existing_grade is not None:
+        db.delete(existing_grade)
+        db.flush()
+
+
+def seed_manual_grading_fixture(args: argparse.Namespace) -> None:
+    db = SessionLocal()
+    try:
+        tenant = _upsert_tenant(db, name=args.university_name)
+
+        teacher_auth = _seed_auth_user(email=args.teacher_email, password=args.teacher_password)
+        student_auth = _seed_auth_user(email=args.student_email, password=args.student_password)
+
+        ensure_profile(db, user_id=teacher_auth.user_id, full_name=args.teacher_full_name)
+        teacher_membership = ensure_membership(
+            db,
+            user_id=teacher_auth.user_id,
+            university_id=tenant.id,
+            role="teacher",
+            must_rotate_password=False,
+        )
+        upsert_legacy_user(
+            db,
+            auth_user_id=teacher_auth.user_id,
+            university_id=tenant.id,
+            email=teacher_auth.email,
+            role="teacher",
+        )
+
+        ensure_profile(db, user_id=student_auth.user_id, full_name=args.student_full_name)
+        student_membership = ensure_membership(
+            db,
+            user_id=student_auth.user_id,
+            university_id=tenant.id,
+            role="student",
+            must_rotate_password=False,
+        )
+        upsert_legacy_user(
+            db,
+            auth_user_id=student_auth.user_id,
+            university_id=tenant.id,
+            email=student_auth.email,
+            role="student",
+        )
+
+        course = _upsert_course(
+            db,
+            title=args.course_title,
+            code=args.course_code,
+            teacher_membership_id=teacher_membership.id,
+        )
+        ensure_course_membership(db, course_id=course.id, membership_id=student_membership.id)
+
+        assignment = _upsert_assignment(
+            db,
+            teacher_user_id=teacher_auth.user_id,
+            course_id=course.id,
+            title=args.assignment_title,
+        )
+        response = _upsert_response(
+            db,
+            membership_id=student_membership.id,
+            assignment_id=assignment.id,
+        )
+        _upsert_submission_snapshot(
+            db,
+            response_id=response.id,
+            submitted_at=response.submitted_at or datetime.now(timezone.utc),
+        )
+        _reset_existing_grade(
+            db,
+            membership_id=student_membership.id,
+            assignment_id=assignment.id,
+        )
+
+        db.commit()
+
+        print("Manual grading fixture ready.")
+        print(f"  University: {tenant.name} ({tenant.id})")
+        print(f"  Course: {course.title} [{course.code}] ({course.id})")
+        print(f"  Assignment: {assignment.title} ({assignment.id})")
+        print(f"  Student membership: {student_membership.id}")
+        print(f"  Teacher login: http://localhost:5173/app/teacher/login")
+        print(f"  Teacher submissions list: http://localhost:5173/app/teacher/cases/{assignment.id}/entregas")
+        print(f"  Teacher submission detail: http://localhost:5173/app/teacher/cases/{assignment.id}/entregas/{student_membership.id}")
+        print(f"  Student email: {student_auth.email}")
+        if student_auth.password_to_report:
+            print(f"  Student password ({student_auth.password_status}): {student_auth.password_to_report}")
+        else:
+            print("  Student password: unchanged (account reused without --student-password)")
+        print(f"  Teacher email: {teacher_auth.email}")
+        if teacher_auth.password_to_report:
+            print(f"  Teacher password ({teacher_auth.password_status}): {teacher_auth.password_to_report}")
+        else:
+            print("  Teacher password: unchanged (account reused without --teacher-password)")
+        if not settings.teacher_manual_grading_enabled:
+            print("  WARNING: TEACHER_MANUAL_GRADING_ENABLED is false in backend/.env; enable it before opening the grading UI.")
+    except Exception as exc:
+        db.rollback()
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        db.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed a reproducible local manual grading fixture.")
+    parser.add_argument("--teacher-email", default="teacher.manual-grading@example.edu")
+    parser.add_argument("--teacher-full-name", default="Teacher Manual Grading")
+    parser.add_argument("--teacher-password")
+    parser.add_argument("--student-email", default="student.manual-grading@example.edu")
+    parser.add_argument("--student-full-name", default="Student Manual Grading")
+    parser.add_argument("--student-password")
+    parser.add_argument("--university-name", default="Universidad Manual Grading Local")
+    parser.add_argument("--course-title", default="Curso Fixture Manual Grading")
+    parser.add_argument("--course-code", default="MG-219")
+    parser.add_argument("--assignment-title", default="Caso Fixture Manual Grading")
+    return parser
+
+
+def main() -> None:
+    seed_manual_grading_fixture(build_parser().parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/sql/rls_policies.sql
+++ b/backend/sql/rls_policies.sql
@@ -63,6 +63,8 @@ CREATE POLICY deny_all ON university_sso_configs
 ALTER TABLE assignments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE authoring_jobs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE case_grades ENABLE ROW LEVEL SECURITY;
+ALTER TABLE case_grade_module_entries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE case_grade_question_entries ENABLE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS assignments_teacher_owner_select ON assignments;
 CREATE POLICY assignments_teacher_owner_select ON assignments
@@ -85,6 +87,18 @@ DROP POLICY IF EXISTS case_grades_teacher_select ON case_grades;
 DROP POLICY IF EXISTS case_grades_student_self_select ON case_grades;
 DROP POLICY IF EXISTS case_grades_deny_all ON case_grades;
 CREATE POLICY case_grades_deny_all ON case_grades
+  FOR ALL
+  USING (false)
+  WITH CHECK (false);
+
+DROP POLICY IF EXISTS case_grade_module_entries_deny_all ON case_grade_module_entries;
+CREATE POLICY case_grade_module_entries_deny_all ON case_grade_module_entries
+  FOR ALL
+  USING (false)
+  WITH CHECK (false);
+
+DROP POLICY IF EXISTS case_grade_question_entries_deny_all ON case_grade_question_entries;
+CREATE POLICY case_grade_question_entries_deny_all ON case_grade_question_entries
   FOR ALL
   USING (false)
   WITH CHECK (false);

--- a/backend/src/shared/case_grade_service.py
+++ b/backend/src/shared/case_grade_service.py
@@ -48,7 +48,7 @@ class SnapshotConflictError(Exception):
 
 @dataclass(slots=True)
 class IncompleteGradeError(Exception):
-    missing_count: int
+    missing_question_ids: list[str]
 
 
 @dataclass(slots=True)
@@ -109,9 +109,9 @@ def save_teacher_case_grade(
     if payload.snapshot_hash != current_snapshot_hash:
         raise SnapshotConflictError(current_snapshot_hash=current_snapshot_hash)
 
-    missing_count = _count_ungraded_questions(payload.modules)
-    if payload.intent == "publish" and missing_count > 0:
-        raise IncompleteGradeError(missing_count=missing_count)
+    missing_question_ids = _list_ungraded_question_ids(payload.modules)
+    if payload.intent == "publish" and missing_question_ids:
+        raise IncompleteGradeError(missing_question_ids=missing_question_ids)
 
     now = utc_now()
     sanitized_global_feedback = _sanitize_optional_text(payload.feedback_global, _GLOBAL_FEEDBACK_MAX_CHARS)
@@ -461,13 +461,13 @@ def _validate_payload_structure(
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_question_id")
 
 
-def _count_ungraded_questions(modules: list[TeacherGradeModulePayload]) -> int:
-    missing_count = 0
+def _list_ungraded_question_ids(modules: list[TeacherGradeModulePayload]) -> list[str]:
+    missing_question_ids: list[str] = []
     for module in modules:
         for question in module.questions:
             if question.rubric_level is None:
-                missing_count += 1
-    return missing_count
+                missing_question_ids.append(question.question_id)
+    return missing_question_ids
 
 
 def _replace_grade_state_entries(

--- a/backend/src/shared/case_grade_service.py
+++ b/backend/src/shared/case_grade_service.py
@@ -1,0 +1,646 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Literal, Sequence
+from uuid import uuid4
+
+from fastapi import HTTPException, status
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from shared.models import Assignment, CaseGrade, CaseGradeModuleEntry, CaseGradeQuestionEntry
+from shared.sanitization import sanitize_untrusted_text
+from shared.teacher_context import TeacherContext
+from shared.teacher_gradebook_schema import TeacherCaseSubmissionDetailResponse
+from shared.teacher_grading_schema import (
+    RUBRIC_TO_SCORE,
+    PublicationState,
+    TeacherGradeModulePayload,
+    TeacherGradeModuleResponse,
+    TeacherGradeQuestionPayload,
+    TeacherGradeQuestionResponse,
+    TeacherGradeRequestBody,
+    TeacherGradeResponse,
+)
+from shared.teacher_reads import (
+    _assignment_target_course_metadata,
+    _load_teacher_submission_assignment,
+    get_teacher_case_submission_detail,
+)
+from shared.teacher_writes import utc_now
+
+_DEFAULT_MAX_SCORE = Decimal("5.0")
+_DISPLAY_SCORE_QUANTUM = Decimal("0.1")
+_NORMALIZED_SCORE_QUANTUM = Decimal("0.0001")
+_WEIGHT_QUANTUM = Decimal("0.001")
+_MODULE_FEEDBACK_MAX_CHARS = 2000
+_QUESTION_FEEDBACK_MAX_CHARS = 2000
+_GLOBAL_FEEDBACK_MAX_CHARS = 4000
+
+
+@dataclass(slots=True)
+class SnapshotConflictError(Exception):
+    current_snapshot_hash: str
+
+
+@dataclass(slots=True)
+class IncompleteGradeError(Exception):
+    missing_count: int
+
+
+@dataclass(slots=True)
+class ResolvedTeacherGradeContext:
+    assignment: Assignment
+    detail: TeacherCaseSubmissionDetailResponse
+
+
+def get_teacher_case_grade(
+    db: Session,
+    context: TeacherContext,
+    course_id: str,
+    assignment_id: str,
+    membership_id: str,
+) -> TeacherGradeResponse:
+    grade_context = _resolve_grade_context(
+        db=db,
+        context=context,
+        course_id=course_id,
+        assignment_id=assignment_id,
+        membership_id=membership_id,
+    )
+    case_grade = _load_case_grade(
+        db=db,
+        assignment_id=assignment_id,
+        membership_id=membership_id,
+    )
+    return _build_grade_response(
+        assignment=grade_context.assignment,
+        detail=grade_context.detail,
+        case_grade=case_grade,
+        module_entries=_load_module_entries(db, case_grade.id) if case_grade is not None else [],
+        question_entries=_load_question_entries(db, case_grade.id) if case_grade is not None else [],
+    )
+
+
+def save_teacher_case_grade(
+    db: Session,
+    context: TeacherContext,
+    course_id: str,
+    assignment_id: str,
+    membership_id: str,
+    payload: TeacherGradeRequestBody,
+) -> TeacherGradeResponse:
+    _validate_human_only_payload(payload)
+    grade_context = _resolve_grade_context(
+        db=db,
+        context=context,
+        course_id=course_id,
+        assignment_id=assignment_id,
+        membership_id=membership_id,
+    )
+    _validate_payload_structure(payload, grade_context.detail)
+
+    current_snapshot_hash = grade_context.detail.response_state.snapshot_hash
+    if current_snapshot_hash is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="submission_not_found")
+    if payload.snapshot_hash != current_snapshot_hash:
+        raise SnapshotConflictError(current_snapshot_hash=current_snapshot_hash)
+
+    missing_count = _count_ungraded_questions(payload.modules)
+    if payload.intent == "publish" and missing_count > 0:
+        raise IncompleteGradeError(missing_count=missing_count)
+
+    now = utc_now()
+    sanitized_global_feedback = _sanitize_optional_text(payload.feedback_global, _GLOBAL_FEEDBACK_MAX_CHARS)
+
+    try:
+        case_grade = _load_case_grade_for_update(
+            db=db,
+            assignment_id=assignment_id,
+            membership_id=membership_id,
+        )
+        if case_grade is None:
+            case_grade = CaseGrade(
+                id=str(uuid4()),
+                membership_id=membership_id,
+                assignment_id=assignment_id,
+                course_id=course_id,
+                score=None,
+                max_score=_DEFAULT_MAX_SCORE,
+                status="submitted",
+                graded_at=None,
+                graded_by_membership_id=None,
+                feedback=None,
+                graded_by="human",
+                ai_model_version=None,
+                ai_suggested_at=None,
+                human_reviewed_at=None,
+                version=1,
+                published_at=None,
+                draft_feedback_global=None,
+                last_modified_at=now,
+            )
+            db.add(case_grade)
+            db.flush()
+
+        if case_grade.course_id != course_id:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="submission_course_mismatch")
+
+        publication_state: PublicationState
+        score_normalized: float | None
+        score_display: Decimal | None
+        response_modules: list[TeacherGradeModuleResponse]
+
+        if payload.intent == "save_draft":
+            _replace_grade_state_entries(
+                db=db,
+                case_grade_id=case_grade.id,
+                state="draft",
+                modules=payload.modules,
+                created_at=now,
+            )
+            case_grade.last_modified_at = now
+            case_grade.graded_by = "human"
+            case_grade.draft_feedback_global = sanitized_global_feedback
+            if case_grade.status != "graded":
+                case_grade.status = "submitted"
+                case_grade.score = None
+                case_grade.graded_at = None
+                case_grade.graded_by_membership_id = None
+                case_grade.feedback = None
+                case_grade.published_at = None
+
+            publication_state = "draft"
+            response_modules = _build_response_modules_from_payload(payload.modules)
+            score_normalized, score_display = _calculate_score(
+                modules=response_modules,
+                publish=False,
+                max_score=case_grade.max_score,
+            )
+        else:
+            response_modules = _build_response_modules_from_payload(payload.modules)
+            score_normalized, score_display = _calculate_score(
+                modules=response_modules,
+                publish=True,
+                max_score=case_grade.max_score,
+            )
+
+            _replace_grade_state_entries(
+                db=db,
+                case_grade_id=case_grade.id,
+                state="published",
+                modules=payload.modules,
+                created_at=now,
+            )
+            _clear_grade_state_entries(db, case_grade.id, "draft")
+
+            previous_publication_exists = bool(case_grade.published_at is not None or case_grade.status == "graded")
+            case_grade.status = "graded"
+            case_grade.score = score_display
+            case_grade.graded_at = now
+            case_grade.graded_by_membership_id = context.teacher_membership_id
+            case_grade.feedback = sanitized_global_feedback
+            case_grade.graded_by = "human"
+            case_grade.human_reviewed_at = now
+            case_grade.published_at = now
+            case_grade.draft_feedback_global = None
+            case_grade.last_modified_at = now
+            if previous_publication_exists:
+                case_grade.version += 1
+
+            publication_state = "published"
+
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="manual_grading_state_invalid",
+        ) from exc
+
+    return TeacherGradeResponse(
+        payload_version=1,
+        snapshot_hash=current_snapshot_hash,
+        publication_state=publication_state,
+        version=case_grade.version,
+        score_normalized=score_normalized,
+        score_display=score_display,
+        max_score_display=case_grade.max_score,
+        modules=response_modules,
+        feedback_global=(
+            sanitized_global_feedback
+            if publication_state == "draft"
+            else case_grade.feedback
+        ),
+        graded_at=case_grade.graded_at,
+        published_at=case_grade.published_at,
+        last_modified_at=case_grade.last_modified_at,
+        graded_by="human",
+    )
+
+
+def _resolve_grade_context(
+    *,
+    db: Session,
+    context: TeacherContext,
+    course_id: str,
+    assignment_id: str,
+    membership_id: str,
+) -> ResolvedTeacherGradeContext:
+    assignment = _load_teacher_submission_assignment(db, context, assignment_id=assignment_id)
+    if assignment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="assignment_not_found")
+
+    target_course_ids, _ = _assignment_target_course_metadata(assignment)
+    if course_id not in target_course_ids:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="assignment_not_found")
+
+    detail = get_teacher_case_submission_detail(db, context, assignment_id, membership_id)
+    if detail.case.course_id != course_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="submission_not_found")
+    if detail.response_state.snapshot_hash is None or detail.response_state.status not in {"submitted", "graded"}:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="submission_not_found")
+
+    return ResolvedTeacherGradeContext(assignment=assignment, detail=detail)
+
+
+def _load_case_grade(
+    db: Session,
+    *,
+    assignment_id: str,
+    membership_id: str,
+) -> CaseGrade | None:
+    return db.scalar(
+        select(CaseGrade).where(
+            CaseGrade.assignment_id == assignment_id,
+            CaseGrade.membership_id == membership_id,
+        )
+    )
+
+
+def _load_case_grade_for_update(
+    db: Session,
+    *,
+    assignment_id: str,
+    membership_id: str,
+) -> CaseGrade | None:
+    return db.scalar(
+        select(CaseGrade)
+        .where(
+            CaseGrade.assignment_id == assignment_id,
+            CaseGrade.membership_id == membership_id,
+        )
+        .with_for_update()
+    )
+
+
+def _load_module_entries(db: Session, case_grade_id: str) -> list[CaseGradeModuleEntry]:
+    return list(
+        db.scalars(
+            select(CaseGradeModuleEntry)
+            .where(CaseGradeModuleEntry.case_grade_id == case_grade_id)
+            .order_by(CaseGradeModuleEntry.module_id.asc())
+        )
+    )
+
+
+def _load_question_entries(db: Session, case_grade_id: str) -> list[CaseGradeQuestionEntry]:
+    return list(
+        db.scalars(
+            select(CaseGradeQuestionEntry)
+            .where(CaseGradeQuestionEntry.case_grade_id == case_grade_id)
+            .order_by(CaseGradeQuestionEntry.module_id.asc(), CaseGradeQuestionEntry.question_id.asc())
+        )
+    )
+
+
+def _build_grade_response(
+    *,
+    assignment: Assignment,
+    detail: TeacherCaseSubmissionDetailResponse,
+    case_grade: CaseGrade | None,
+    module_entries: list[CaseGradeModuleEntry],
+    question_entries: list[CaseGradeQuestionEntry],
+) -> TeacherGradeResponse:
+    default_weights = _resolve_default_weights(assignment, detail)
+    active_state: PublicationState = "draft"
+    draft_module_entries = [entry for entry in module_entries if entry.state == "draft"]
+    draft_question_entries = [entry for entry in question_entries if entry.state == "draft"]
+    published_module_entries = [entry for entry in module_entries if entry.state == "published"]
+    published_question_entries = [entry for entry in question_entries if entry.state == "published"]
+
+    if draft_module_entries or draft_question_entries or (case_grade is not None and case_grade.draft_feedback_global is not None):
+        active_state = "draft"
+        active_module_entries = draft_module_entries
+        active_question_entries = draft_question_entries
+    elif case_grade is not None and case_grade.status == "graded":
+        active_state = "published"
+        active_module_entries = published_module_entries
+        active_question_entries = published_question_entries
+    else:
+        active_module_entries = []
+        active_question_entries = []
+
+    response_modules = _build_response_modules_from_entries(
+        detail=detail,
+        module_entries=active_module_entries,
+        question_entries=active_question_entries,
+        default_weights=default_weights,
+    )
+
+    max_score_display = case_grade.max_score if case_grade is not None else _DEFAULT_MAX_SCORE
+    score_normalized: float | None
+    score_display: Decimal | None
+    if active_state == "published" and not active_question_entries and case_grade is not None and case_grade.score is not None:
+        score_display = case_grade.score
+        score_normalized = float(
+            (case_grade.score / max_score_display).quantize(_NORMALIZED_SCORE_QUANTUM, rounding=ROUND_HALF_UP)
+        )
+    else:
+        score_normalized, score_display = _calculate_score(
+            modules=response_modules,
+            publish=active_state == "published",
+            max_score=max_score_display,
+        )
+
+    return TeacherGradeResponse(
+        payload_version=1,
+        snapshot_hash=detail.response_state.snapshot_hash or "",
+        publication_state=active_state,
+        version=case_grade.version if case_grade is not None else 1,
+        score_normalized=score_normalized,
+        score_display=score_display,
+        max_score_display=max_score_display,
+        modules=response_modules,
+        feedback_global=(
+            case_grade.draft_feedback_global
+            if case_grade is not None and active_state == "draft"
+            else case_grade.feedback if case_grade is not None else None
+        ),
+        graded_at=case_grade.graded_at if case_grade is not None else None,
+        published_at=case_grade.published_at if case_grade is not None else None,
+        last_modified_at=case_grade.last_modified_at if case_grade is not None else detail.response_state.submitted_at or utc_now(),
+        graded_by=case_grade.graded_by if case_grade is not None else "human",
+    )
+
+
+def _resolve_default_weights(
+    assignment: Assignment,
+    detail: TeacherCaseSubmissionDetailResponse,
+) -> dict[str, Decimal]:
+    module_ids = [module.id for module in detail.modules]
+    configured_weights = assignment.weight_per_module if isinstance(assignment.weight_per_module, dict) else None
+    if configured_weights is not None:
+        parsed: dict[str, Decimal] = {}
+        try:
+            for module_id in module_ids:
+                raw_value = configured_weights[module_id]
+                parsed[module_id] = Decimal(str(raw_value)).quantize(_WEIGHT_QUANTUM, rounding=ROUND_HALF_UP)
+        except (ArithmeticError, KeyError, TypeError, ValueError):
+            parsed = {}
+        if parsed:
+            total = sum(parsed.values())
+            if abs(total - Decimal("1.0")) <= _WEIGHT_QUANTUM:
+                return parsed
+    return _build_equal_weights(module_ids)
+
+
+def _build_equal_weights(module_ids: Sequence[str]) -> dict[str, Decimal]:
+    if not module_ids:
+        return {}
+    if len(module_ids) == 1:
+        return {module_ids[0]: Decimal("1.000")}
+
+    base_weight = (Decimal("1.0") / Decimal(len(module_ids))).quantize(_WEIGHT_QUANTUM, rounding=ROUND_HALF_UP)
+    weights = {module_id: base_weight for module_id in module_ids}
+    first_module_id = module_ids[0]
+    weights[first_module_id] = Decimal("1.0") - sum(
+        weight for module_id, weight in weights.items() if module_id != first_module_id
+    )
+    return weights
+
+
+def _validate_human_only_payload(payload: TeacherGradeRequestBody) -> None:
+    if payload.graded_by != "human":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="graded_by_not_supported",
+        )
+
+    for module in payload.modules:
+        if module.source != "human":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="feedback_source_not_supported",
+            )
+        for question in module.questions:
+            if question.source != "human":
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="feedback_source_not_supported",
+                )
+
+
+def _validate_payload_structure(
+    payload: TeacherGradeRequestBody,
+    detail: TeacherCaseSubmissionDetailResponse,
+) -> None:
+    expected_modules = {module.id: [question.id for question in module.questions] for module in detail.modules}
+    payload_module_ids = {module.module_id for module in payload.modules}
+    if payload_module_ids != set(expected_modules):
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_question_id")
+
+    for module in payload.modules:
+        question_ids = [question.question_id for question in module.questions]
+        if len(set(question_ids)) != len(question_ids):
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_question_id")
+        if set(question_ids) != set(expected_modules[module.module_id]):
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="invalid_question_id")
+
+
+def _count_ungraded_questions(modules: list[TeacherGradeModulePayload]) -> int:
+    missing_count = 0
+    for module in modules:
+        for question in module.questions:
+            if question.rubric_level is None:
+                missing_count += 1
+    return missing_count
+
+
+def _replace_grade_state_entries(
+    *,
+    db: Session,
+    case_grade_id: str,
+    state: Literal["draft", "published"],
+    modules: list[TeacherGradeModulePayload],
+    created_at: datetime,
+) -> None:
+    _clear_grade_state_entries(db, case_grade_id, state)
+
+    module_rows: list[CaseGradeModuleEntry] = []
+    question_rows: list[CaseGradeQuestionEntry] = []
+    for module in modules:
+        module_rows.append(
+            CaseGradeModuleEntry(
+                id=str(uuid4()),
+                case_grade_id=case_grade_id,
+                module_id=module.module_id,
+                weight=module.weight,
+                feedback_module=_sanitize_optional_text(module.feedback_module, _MODULE_FEEDBACK_MAX_CHARS),
+                state=state,
+                source=module.source,
+                ai_confidence=None,
+                created_at=created_at,
+                updated_at=created_at,
+            )
+        )
+        for question in module.questions:
+            score_normalized = (
+                float(RUBRIC_TO_SCORE[question.rubric_level])
+                if question.rubric_level is not None
+                else None
+            )
+            question_rows.append(
+                CaseGradeQuestionEntry(
+                    id=str(uuid4()),
+                    case_grade_id=case_grade_id,
+                    question_id=question.question_id,
+                    module_id=module.module_id,
+                    rubric_level=question.rubric_level,
+                    score_normalized=score_normalized,
+                    feedback_question=_sanitize_optional_text(question.feedback_question, _QUESTION_FEEDBACK_MAX_CHARS),
+                    state=state,
+                    source=question.source,
+                    ai_confidence=None,
+                    created_at=created_at,
+                    updated_at=created_at,
+                )
+            )
+
+    db.add_all(module_rows)
+    db.add_all(question_rows)
+    db.flush()
+
+
+def _clear_grade_state_entries(
+    db: Session,
+    case_grade_id: str,
+    state: Literal["draft", "published"],
+) -> None:
+    db.execute(
+        delete(CaseGradeQuestionEntry).where(
+            CaseGradeQuestionEntry.case_grade_id == case_grade_id,
+            CaseGradeQuestionEntry.state == state,
+        )
+    )
+    db.execute(
+        delete(CaseGradeModuleEntry).where(
+            CaseGradeModuleEntry.case_grade_id == case_grade_id,
+            CaseGradeModuleEntry.state == state,
+        )
+    )
+
+
+def _build_response_modules_from_payload(
+    modules: list[TeacherGradeModulePayload],
+) -> list[TeacherGradeModuleResponse]:
+    return [
+        TeacherGradeModuleResponse(
+            module_id=module.module_id,
+            weight=module.weight,
+            feedback_module=_sanitize_optional_text(module.feedback_module, _MODULE_FEEDBACK_MAX_CHARS),
+            questions=[
+                TeacherGradeQuestionResponse(
+                    question_id=question.question_id,
+                    rubric_level=question.rubric_level,
+                    feedback_question=_sanitize_optional_text(question.feedback_question, _QUESTION_FEEDBACK_MAX_CHARS),
+                )
+                for question in module.questions
+            ],
+        )
+        for module in modules
+    ]
+
+
+def _build_response_modules_from_entries(
+    *,
+    detail: TeacherCaseSubmissionDetailResponse,
+    module_entries: list[CaseGradeModuleEntry],
+    question_entries: list[CaseGradeQuestionEntry],
+    default_weights: dict[str, Decimal],
+) -> list[TeacherGradeModuleResponse]:
+    module_entry_map = {entry.module_id: entry for entry in module_entries}
+    question_entry_map = {entry.question_id: entry for entry in question_entries}
+
+    response_modules: list[TeacherGradeModuleResponse] = []
+    for module in detail.modules:
+        module_entry = module_entry_map.get(module.id)
+        response_modules.append(
+            TeacherGradeModuleResponse(
+                module_id=module.id,
+                weight=module_entry.weight if module_entry is not None else default_weights[module.id],
+                feedback_module=module_entry.feedback_module if module_entry is not None else None,
+                questions=[
+                    TeacherGradeQuestionResponse(
+                        question_id=question.id,
+                        rubric_level=question_entry_map[question.id].rubric_level if question.id in question_entry_map else None,
+                        feedback_question=question_entry_map[question.id].feedback_question if question.id in question_entry_map else None,
+                    )
+                    for question in module.questions
+                ],
+            )
+        )
+    return response_modules
+
+
+def _calculate_score(
+    *,
+    modules: list[TeacherGradeModuleResponse],
+    publish: bool,
+    max_score: Decimal,
+) -> tuple[float | None, Decimal | None]:
+    if not modules:
+        return None, None
+
+    weighted_total = Decimal("0")
+    included_weight_total = Decimal("0")
+
+    for module in modules:
+        question_scores = [
+            Decimal(str(RUBRIC_TO_SCORE[question.rubric_level]))
+            for question in module.questions
+            if question.rubric_level is not None
+        ]
+        if publish:
+            denominator = len(module.questions)
+            if denominator == 0:
+                continue
+            module_average = sum(question_scores, Decimal("0")) / Decimal(denominator)
+            weighted_total += module_average * module.weight
+            included_weight_total += module.weight
+            continue
+
+        if not question_scores:
+            continue
+        module_average = sum(question_scores, Decimal("0")) / Decimal(len(question_scores))
+        weighted_total += module_average * module.weight
+        included_weight_total += module.weight
+
+    if publish:
+        normalized_score = weighted_total
+    else:
+        if included_weight_total == 0:
+            return None, None
+        normalized_score = weighted_total / included_weight_total
+
+    normalized_score = normalized_score.quantize(_NORMALIZED_SCORE_QUANTUM, rounding=ROUND_HALF_UP)
+    score_display = (normalized_score * max_score).quantize(_DISPLAY_SCORE_QUANTUM, rounding=ROUND_HALF_UP)
+    return float(normalized_score), score_display
+
+
+def _sanitize_optional_text(value: str | None, max_chars: int) -> str | None:
+    sanitized = sanitize_untrusted_text(value, max_chars)
+    return sanitized or None

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
     db_retry_after_seconds: int = 3
     db_critical_endpoint_budget: int = 64
     authoring_bootstrap_timeout_seconds: int | None = None
-    teacher_manual_grading_enabled: bool = True
+    teacher_manual_grading_enabled: bool = False
 
     model_config = SettingsConfigDict(env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -46,6 +46,7 @@ class Settings(BaseSettings):
     db_retry_after_seconds: int = 3
     db_critical_endpoint_budget: int = 64
     authoring_bootstrap_timeout_seconds: int | None = None
+    teacher_manual_grading_enabled: bool = True
 
     model_config = SettingsConfigDict(env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/src/shared/models.py
+++ b/backend/src/shared/models.py
@@ -336,6 +336,9 @@ class Assignment(Base):
     # Canonical teacher preview output stored separately from the internal blueprint.
     canonical_output: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
 
+    # Optional manual grading weights by module, e.g. {"M1": 0.2, "M2": 0.2, ...}.
+    weight_per_module: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+
     status: Mapped[str] = mapped_column(String(50), default="draft")
     deadline: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     available_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -408,6 +411,14 @@ class CaseGrade(Base):
             name="ck_case_grades_score_range",
         ),
         CheckConstraint(
+            "graded_by IN ('human', 'ai', 'hybrid')",
+            name="ck_case_grades_graded_by",
+        ),
+        CheckConstraint(
+            "version >= 1",
+            name="ck_case_grades_version_positive",
+        ),
+        CheckConstraint(
             "((status = 'graded' AND score IS NOT NULL AND graded_at IS NOT NULL) OR "
             "(status IN ('in_progress', 'submitted') AND score IS NULL AND graded_at IS NULL))",
             name="ck_case_grades_state_consistency",
@@ -440,11 +451,34 @@ class CaseGrade(Base):
         server_default=sql_text("5.00"),
     )
     status: Mapped[str] = mapped_column(String(32), nullable=False)
+    graded_by: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default="human",
+        server_default=sql_text("'human'"),
+    )
     graded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     graded_by_membership_id: Mapped[str | None] = mapped_column(
         Text,
         ForeignKey("memberships.id", ondelete="SET NULL"),
         nullable=True,
+    )
+    ai_model_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    ai_suggested_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    human_reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    version: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=1,
+        server_default=sql_text("1"),
+    )
+    published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    draft_feedback_global: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_modified_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=sql_text("CURRENT_TIMESTAMP"),
     )
     feedback: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
@@ -463,6 +497,169 @@ class CaseGrade(Base):
     graded_by_membership: Mapped["Membership | None"] = relationship(
         foreign_keys=[graded_by_membership_id],
     )
+    module_entries: Mapped[list["CaseGradeModuleEntry"]] = relationship(
+        back_populates="case_grade",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+    question_entries: Mapped[list["CaseGradeQuestionEntry"]] = relationship(
+        back_populates="case_grade",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class CaseGradeModuleEntry(Base):
+    """Per-module grading draft/published entry attached to a case grade."""
+
+    __tablename__ = "case_grade_module_entries"
+    __table_args__ = (
+        UniqueConstraint(
+            "case_grade_id",
+            "module_id",
+            "state",
+            name="uix_case_grade_module_entries_case_grade_module_state",
+        ),
+        CheckConstraint(
+            "module_id IN ('M1', 'M2', 'M3', 'M4', 'M5')",
+            name="ck_case_grade_module_entries_module_id",
+        ),
+        CheckConstraint(
+            "weight >= 0 AND weight <= 1",
+            name="ck_case_grade_module_entries_weight_range",
+        ),
+        CheckConstraint(
+            "state IN ('draft', 'published')",
+            name="ck_case_grade_module_entries_state",
+        ),
+        CheckConstraint(
+            "source IN ('human', 'ai_suggested', 'ai_edited_by_human')",
+            name="ck_case_grade_module_entries_source",
+        ),
+        CheckConstraint(
+            "ai_confidence IS NULL OR (ai_confidence >= 0 AND ai_confidence <= 1)",
+            name="ck_case_grade_module_entries_ai_confidence_range",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
+    case_grade_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("case_grades.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    module_id: Mapped[str] = mapped_column(String(2), nullable=False)
+    weight: Mapped[Decimal] = mapped_column(
+        Numeric(4, 3),
+        nullable=False,
+        default=Decimal("0.200"),
+        server_default=sql_text("0.200"),
+    )
+    feedback_module: Mapped[str | None] = mapped_column(Text, nullable=True)
+    state: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default="draft",
+        server_default=sql_text("'draft'"),
+    )
+    source: Mapped[str] = mapped_column(
+        String(24),
+        nullable=False,
+        default="human",
+        server_default=sql_text("'human'"),
+    )
+    ai_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    case_grade: Mapped["CaseGrade"] = relationship(back_populates="module_entries")
+
+
+class CaseGradeQuestionEntry(Base):
+    """Per-question grading draft/published entry attached to a case grade."""
+
+    __tablename__ = "case_grade_question_entries"
+    __table_args__ = (
+        UniqueConstraint(
+            "case_grade_id",
+            "question_id",
+            "state",
+            name="uix_case_grade_question_entries_case_grade_question_state",
+        ),
+        CheckConstraint(
+            "module_id IN ('M1', 'M2', 'M3', 'M4', 'M5')",
+            name="ck_case_grade_question_entries_module_id",
+        ),
+        CheckConstraint(
+            "rubric_level IS NULL OR rubric_level IN ('excelente', 'bien', 'aceptable', 'insuficiente', 'no_responde')",
+            name="ck_case_grade_question_entries_rubric_level",
+        ),
+        CheckConstraint(
+            "score_normalized IS NULL OR (score_normalized >= 0 AND score_normalized <= 1)",
+            name="ck_case_grade_question_entries_score_normalized_range",
+        ),
+        CheckConstraint(
+            "state IN ('draft', 'published')",
+            name="ck_case_grade_question_entries_state",
+        ),
+        CheckConstraint(
+            "source IN ('human', 'ai_suggested', 'ai_edited_by_human')",
+            name="ck_case_grade_question_entries_source",
+        ),
+        CheckConstraint(
+            "ai_confidence IS NULL OR (ai_confidence >= 0 AND ai_confidence <= 1)",
+            name="ck_case_grade_question_entries_ai_confidence_range",
+        ),
+        Index(
+            "ix_case_grade_question_entries_case_grade_module",
+            "case_grade_id",
+            "module_id",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
+    case_grade_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("case_grades.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    question_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    module_id: Mapped[str] = mapped_column(String(2), nullable=False)
+    rubric_level: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    score_normalized: Mapped[float | None] = mapped_column(Float, nullable=True)
+    feedback_question: Mapped[str | None] = mapped_column(Text, nullable=True)
+    state: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default="draft",
+        server_default=sql_text("'draft'"),
+    )
+    source: Mapped[str] = mapped_column(
+        String(24),
+        nullable=False,
+        default="human",
+        server_default=sql_text("'human'"),
+    )
+    ai_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    case_grade: Mapped["CaseGrade"] = relationship(back_populates="question_entries")
 
 
 class StudentCaseResponse(Base):

--- a/backend/src/shared/teacher_grading_schema.py
+++ b/backend/src/shared/teacher_grading_schema.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Final, Literal
+
+from pydantic import Field, field_serializer, model_validator
+
+from shared.teacher_gradebook_schema import StrictModel
+
+RubricLevel = Literal["excelente", "bien", "aceptable", "insuficiente", "no_responde"]
+GradedBy = Literal["human", "ai", "hybrid"]
+FeedbackSource = Literal["human", "ai_suggested", "ai_edited_by_human"]
+PublicationState = Literal["draft", "published"]
+Intent = Literal["save_draft", "publish"]
+GradeModuleId = Literal["M1", "M2", "M3", "M4", "M5"]
+
+RUBRIC_TO_SCORE: Final[dict[RubricLevel, float]] = {
+    "excelente": 1.0,
+    "bien": 0.8,
+    "aceptable": 0.6,
+    "insuficiente": 0.3,
+    "no_responde": 0.0,
+}
+
+
+class TeacherGradeQuestionPayload(StrictModel):
+    question_id: str
+    rubric_level: RubricLevel | None = None
+    feedback_question: str | None = Field(default=None, max_length=2000)
+    source: FeedbackSource = "human"
+
+
+class TeacherGradeModulePayload(StrictModel):
+    module_id: GradeModuleId
+    weight: Decimal = Field(ge=0, le=1)
+    feedback_module: str | None = Field(default=None, max_length=2000)
+    source: FeedbackSource = "human"
+    questions: list[TeacherGradeQuestionPayload]
+
+    @field_serializer("weight", when_used="json")
+    def _serialize_weight(self, value: Decimal) -> float:
+        return float(value)
+
+
+class TeacherGradeRequestBody(StrictModel):
+    payload_version: Literal[1] = 1
+    snapshot_hash: str
+    intent: Intent
+    modules: list[TeacherGradeModulePayload]
+    feedback_global: str | None = Field(default=None, max_length=4000)
+    graded_by: GradedBy = "human"
+
+    @model_validator(mode="after")
+    def _validate_weight_sum(self) -> "TeacherGradeRequestBody":
+        if not self.modules:
+            return self
+
+        total_weight = sum(module.weight for module in self.modules)
+        if abs(total_weight - Decimal("1.0")) > Decimal("0.001"):
+            raise ValueError("module weights must sum to 1.0")
+
+        module_ids = [module.module_id for module in self.modules]
+        if len(set(module_ids)) != len(module_ids):
+            raise ValueError("module_ids must be unique")
+
+        return self
+
+
+class TeacherGradeQuestionResponse(StrictModel):
+    question_id: str
+    rubric_level: RubricLevel | None = None
+    feedback_question: str | None = Field(default=None, max_length=2000)
+
+
+class TeacherGradeModuleResponse(StrictModel):
+    module_id: GradeModuleId
+    weight: Decimal = Field(ge=0, le=1)
+    feedback_module: str | None = Field(default=None, max_length=2000)
+    questions: list[TeacherGradeQuestionResponse]
+
+    @field_serializer("weight", when_used="json")
+    def _serialize_weight(self, value: Decimal) -> float:
+        return float(value)
+
+
+class TeacherGradeResponse(StrictModel):
+    payload_version: Literal[1] = 1
+    snapshot_hash: str
+    publication_state: PublicationState
+    version: int = Field(ge=1)
+    score_normalized: float | None = Field(default=None, ge=0, le=1)
+    score_display: Decimal | None = Field(default=None, ge=0)
+    max_score_display: Decimal = Field(default=Decimal("5.0"), ge=0)
+    modules: list[TeacherGradeModuleResponse]
+    feedback_global: str | None = Field(default=None, max_length=4000)
+    graded_at: datetime | None = None
+    published_at: datetime | None = None
+    last_modified_at: datetime
+    graded_by: GradedBy = "human"
+
+    @field_serializer("score_display", "max_score_display", when_used="json")
+    def _serialize_decimals(self, value: Decimal | None) -> float | None:
+        if value is None:
+            return None
+        return float(value)

--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -631,6 +631,7 @@ def _load_teacher_submission_assignment(
                     Assignment.available_from,
                     Assignment.deadline,
                     Assignment.canonical_output,
+                    Assignment.weight_per_module,
                 ),
                 joinedload(Assignment.course).load_only(
                     Course.id,

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -396,11 +396,12 @@ async def put_teacher_case_grade_view(
         ) from exc
     except IncompleteGradeError as exc:
         raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail={
+                "payload_version": 1,
                 "code": "incomplete_grade",
                 "message": "All questions must be graded before publishing.",
-                "missing_count": exc.missing_count,
+                "missing_question_ids": exc.missing_question_ids,
             },
             headers=_private_revalidate_headers(),
         ) from exc

--- a/backend/src/shared/teacher_router.py
+++ b/backend/src/shared/teacher_router.py
@@ -2,23 +2,30 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import math
-from typing import Annotated, Any
+from typing import Annotated, Any, Never
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
 from shared.auth import CurrentActor, require_current_actor_password_ready
+from shared.case_grade_service import (
+    IncompleteGradeError,
+    SnapshotConflictError,
+    get_teacher_case_grade,
+    save_teacher_case_grade,
+)
 from shared.course_access_schema import CourseAccessLinkRegenerateResponse, TeacherCourseAccessLinkResponse
-from shared.database import get_db
+from shared.database import get_db, settings
 from shared.models import Assignment, AssignmentCourse, Course
 from shared.teacher_gradebook_schema import (
     TeacherCaseSubmissionDetailResponse,
     TeacherCaseSubmissionsResponse,
     TeacherCourseGradebookResponse,
 )
+from shared.teacher_grading_schema import TeacherGradeRequestBody, TeacherGradeResponse
 from shared.syllabus_schema import TeacherCourseDetailResponse, TeacherSyllabusSaveRequest
 from shared.teacher_context import TeacherContext, require_teacher_context
 from shared.teacher_reads import (
@@ -37,6 +44,8 @@ from shared.teacher_writes import regenerate_teacher_course_access_link, save_te
 
 router = APIRouter(prefix="/api/teacher", tags=["teacher"])
 _BOGOTA_TZ = ZoneInfo("America/Bogota")
+_PRIVATE_REVALIDATE_CACHE_CONTROL = "private, max-age=0, must-revalidate"
+_TEACHER_GRADE_MAX_BODY_BYTES = 1_500_000
 
 
 class TeacherCaseItemResponse(BaseModel):
@@ -85,6 +94,29 @@ def _days_remaining(deadline: datetime | None, now: datetime) -> int | None:
     if remaining_days <= 0:
         return 0
     return remaining_days
+
+
+def _private_revalidate_headers() -> dict[str, str]:
+    return {"Cache-Control": _PRIVATE_REVALIDATE_CACHE_CONTROL}
+
+
+def _raise_with_private_cache(exc: HTTPException) -> Never:
+    headers = dict(exc.headers or {})
+    headers.update(_private_revalidate_headers())
+    raise HTTPException(status_code=exc.status_code, detail=exc.detail, headers=headers) from exc
+
+
+def _ensure_teacher_manual_grading_enabled() -> None:
+    if settings.teacher_manual_grading_enabled:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "code": "feature_disabled",
+            "message": "Teacher manual grading is disabled.",
+        },
+        headers=_private_revalidate_headers(),
+    )
 
 
 @router.get("/courses", response_model=TeacherCoursesResponse)
@@ -277,13 +309,103 @@ def get_teacher_case_submission_detail_view(
     context: Annotated[TeacherContext, Depends(require_teacher_context)],
     db: Session = Depends(get_db),
 ) -> TeacherCaseSubmissionDetailResponse:
-    """Read-only teacher submission detail view.
-
-    Mutations de calificación (`POST/PUT /api/teacher/cases/.../grade`) se entregarán
-    en una issue posterior. Este endpoint es solo de lectura.
-    """
-    response.headers["Cache-Control"] = "private, max-age=0, must-revalidate"
+    response.headers["Cache-Control"] = _PRIVATE_REVALIDATE_CACHE_CONTROL
     return get_teacher_case_submission_detail(db, context, assignment_id, membership_id)
+
+
+@router.get(
+    "/courses/{course_id}/cases/{assignment_id}/submissions/{membership_id}/grade",
+    response_model=TeacherGradeResponse,
+)
+def get_teacher_case_grade_view(
+    course_id: str,
+    assignment_id: str,
+    membership_id: str,
+    response: Response,
+    context: Annotated[TeacherContext, Depends(require_teacher_context)],
+    db: Session = Depends(get_db),
+) -> TeacherGradeResponse:
+    response.headers["Cache-Control"] = _PRIVATE_REVALIDATE_CACHE_CONTROL
+    _ensure_teacher_manual_grading_enabled()
+    try:
+        return get_teacher_case_grade(
+            db=db,
+            context=context,
+            course_id=course_id,
+            assignment_id=assignment_id,
+            membership_id=membership_id,
+        )
+    except HTTPException as exc:
+        _raise_with_private_cache(exc)
+
+
+@router.put(
+    "/courses/{course_id}/cases/{assignment_id}/submissions/{membership_id}/grade",
+    response_model=TeacherGradeResponse,
+)
+async def put_teacher_case_grade_view(
+    course_id: str,
+    assignment_id: str,
+    membership_id: str,
+    request: Request,
+    response: Response,
+    context: Annotated[TeacherContext, Depends(require_teacher_context)],
+    db: Session = Depends(get_db),
+) -> TeacherGradeResponse:
+    response.headers["Cache-Control"] = _PRIVATE_REVALIDATE_CACHE_CONTROL
+    _ensure_teacher_manual_grading_enabled()
+
+    raw_body = await request.body()
+    if len(raw_body) > _TEACHER_GRADE_MAX_BODY_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail={
+                "code": "payload_too_large",
+                "message": "Teacher manual grading payload exceeds the 1.5 MB limit.",
+            },
+            headers=_private_revalidate_headers(),
+        )
+
+    try:
+        payload = TeacherGradeRequestBody.model_validate_json(raw_body or b"{}")
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=exc.errors(),
+            headers=_private_revalidate_headers(),
+        ) from exc
+
+    try:
+        return save_teacher_case_grade(
+            db=db,
+            context=context,
+            course_id=course_id,
+            assignment_id=assignment_id,
+            membership_id=membership_id,
+            payload=payload,
+        )
+    except SnapshotConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "snapshot_changed",
+                "message": "The submission snapshot changed. Reload the latest submission before saving.",
+                "current_snapshot_hash": exc.current_snapshot_hash,
+            },
+            headers=_private_revalidate_headers(),
+        ) from exc
+    except IncompleteGradeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "incomplete_grade",
+                "message": "All questions must be graded before publishing.",
+                "missing_count": exc.missing_count,
+            },
+            headers=_private_revalidate_headers(),
+        ) from exc
+    except HTTPException as exc:
+        _raise_with_private_cache(exc)
 
 
 @router.patch("/cases/{assignment_id}/publish", response_model=TeacherCaseDetailResponse)

--- a/backend/tests/test_teacher_manual_grading.py
+++ b/backend/tests/test_teacher_manual_grading.py
@@ -1,0 +1,694 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+import uuid
+
+from sqlalchemy import select
+
+from shared.database import settings
+from shared.models import (
+    Assignment,
+    CaseGrade,
+    CaseGradeModuleEntry,
+    CaseGradeQuestionEntry,
+    StudentCaseResponse,
+    StudentCaseResponseSubmission,
+)
+
+
+def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
+    return auth_headers_factory(sub=user_id, email=email)
+
+
+def _build_canonical_output() -> dict[str, object]:
+    return {
+        "caseId": "case-219",
+        "title": "Caso 219",
+        "content": {
+            "instructions": "Lee y responde.",
+            "caseQuestions": [
+                {
+                    "numero": 1,
+                    "titulo": "Pregunta 1",
+                    "enunciado": "Describe la situacion.",
+                    "solucion_esperada": "Solucion docente M1",
+                }
+            ],
+            "edaQuestions": [
+                {
+                    "numero": 2,
+                    "titulo": "Pregunta 2",
+                    "enunciado": "Interpreta el grafico.",
+                    "solucion_esperada": "Solucion docente M2",
+                }
+            ],
+            "m3Content": "Modulo 3",
+            "m3Questions": [
+                {
+                    "numero": 3,
+                    "titulo": "Pregunta 3",
+                    "enunciado": "Analiza control interno.",
+                    "solucion_esperada": "Solucion docente M3",
+                }
+            ],
+            "m4Content": "Modulo 4",
+            "m4Questions": [
+                {
+                    "numero": 4,
+                    "titulo": "Pregunta 4",
+                    "enunciado": "Evalua la recomendacion.",
+                    "solucion_esperada": "Solucion docente M4",
+                }
+            ],
+            "m5Content": "Modulo 5",
+            "m5Questions": [
+                {
+                    "numero": 5,
+                    "titulo": "Pregunta 5",
+                    "enunciado": "Redacta memo ejecutivo.",
+                    "solucion_esperada": "Solucion docente M5",
+                    "modules_integrated": ["M1", "M2", "M3"],
+                }
+            ],
+        },
+    }
+
+
+def _seed_assignment(
+    db,
+    *,
+    teacher_user_id: str,
+    course_id: str,
+    available_from: datetime,
+    deadline: datetime,
+) -> Assignment:
+    assignment = Assignment(
+        teacher_id=teacher_user_id,
+        course_id=course_id,
+        title="Teacher Assignment Title",
+        canonical_output=_build_canonical_output(),
+        status="published",
+        available_from=available_from,
+        deadline=deadline,
+    )
+    db.add(assignment)
+    db.flush()
+    return assignment
+
+
+def _seed_student_case_response(
+    db,
+    *,
+    membership_id: str,
+    assignment_id: str,
+    opened_at: datetime,
+) -> StudentCaseResponse:
+    response = StudentCaseResponse(
+        membership_id=membership_id,
+        assignment_id=assignment_id,
+        status="submitted",
+        answers={
+            "M1-Q1": "Respuesta final M1",
+            "M2-Q2": "Respuesta final M2",
+            "M3-Q3": "Respuesta final M3",
+            "M4-Q4": "Respuesta final M4",
+            "M5-Q5": "Respuesta final M5",
+        },
+        version=1,
+        first_opened_at=opened_at,
+        last_autosaved_at=opened_at,
+        submitted_at=opened_at,
+    )
+    db.add(response)
+    db.flush()
+    return response
+
+
+def _seed_student_case_response_submission(
+    db,
+    *,
+    response_id: str,
+    submitted_at: datetime,
+    canonical_output_hash: str,
+) -> StudentCaseResponseSubmission:
+    snapshot = StudentCaseResponseSubmission(
+        response_id=response_id,
+        answers_snapshot={
+            "M1-Q1": "Respuesta final M1",
+            "M2-Q2": "Respuesta final M2",
+            "M3-Q3": "Respuesta final M3",
+            "M4-Q4": "Respuesta final M4",
+            "M5-Q5": "Respuesta final M5",
+        },
+        submitted_at=submitted_at,
+        canonical_output_hash=canonical_output_hash,
+    )
+    db.add(snapshot)
+    db.flush()
+    return snapshot
+
+
+def _seed_manual_grading_context(
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    *,
+    email_suffix: str,
+) -> dict[str, object]:
+    university_id = f"10000000-0000-0000-0000-{uuid.uuid4().hex[:12]}"
+    reference_now = datetime(2026, 6, 2, 15, 0, tzinfo=timezone.utc)
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email=f"teacher-{email_suffix}@example.edu",
+        role="teacher",
+        university_id=university_id,
+        full_name="Teacher Manual Grading",
+    )
+    student = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email=f"student-{email_suffix}@example.edu",
+        role="student",
+        university_id=university_id,
+        full_name="Student Manual Grading",
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title=f"Curso {email_suffix}",
+        code=f"CASE-{email_suffix[:6].upper()}",
+    )
+    seed_course_membership(course_id=course.id, membership_id=student["membership"].id)
+    assignment = _seed_assignment(
+        db,
+        teacher_user_id=teacher["legacy_user"].id,
+        course_id=course.id,
+        available_from=reference_now - timedelta(days=2),
+        deadline=reference_now + timedelta(days=6),
+    )
+    response = _seed_student_case_response(
+        db,
+        membership_id=student["membership"].id,
+        assignment_id=assignment.id,
+        opened_at=reference_now - timedelta(hours=4),
+    )
+    _seed_student_case_response_submission(
+        db,
+        response_id=response.id,
+        submitted_at=reference_now - timedelta(hours=2),
+        canonical_output_hash="hash-match",
+    )
+    db.commit()
+    return {
+        "teacher": teacher,
+        "student": student,
+        "course": course,
+        "assignment": assignment,
+    }
+
+
+def _build_grade_payload(
+    *,
+    snapshot_hash: str,
+    intent: str,
+    rubric_levels: dict[str, str | None],
+    feedback_global: str | None,
+    graded_by: str = "human",
+) -> dict[str, object]:
+    modules = [
+        ("M1", "M1-Q1"),
+        ("M2", "M2-Q2"),
+        ("M3", "M3-Q3"),
+        ("M4", "M4-Q4"),
+        ("M5", "M5-Q5"),
+    ]
+    return {
+        "payload_version": 1,
+        "snapshot_hash": snapshot_hash,
+        "intent": intent,
+        "graded_by": graded_by,
+        "feedback_global": feedback_global,
+        "modules": [
+            {
+                "module_id": module_id,
+                "weight": 0.2,
+                "feedback_module": f"Feedback {module_id}",
+                "source": "human",
+                "questions": [
+                    {
+                        "question_id": question_id,
+                        "rubric_level": rubric_levels[question_id],
+                        "feedback_question": f"Feedback {question_id}",
+                        "source": "human",
+                    }
+                ],
+            }
+            for module_id, question_id in modules
+        ],
+    }
+
+
+def _grade_route(context: dict[str, object]) -> str:
+    course = context["course"]
+    assignment = context["assignment"]
+    student = context["student"]
+    return f"/api/teacher/courses/{course.id}/cases/{assignment.id}/submissions/{student['membership'].id}/grade"
+
+
+def test_get_teacher_case_grade_returns_empty_draft_for_submitted_submission(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    context = _seed_manual_grading_context(
+        db,
+        seed_identity,
+        seed_course,
+        seed_course_membership,
+        email_suffix="get-draft",
+    )
+
+    response = client.get(
+        _grade_route(context),
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert response.headers["Cache-Control"] == "private, max-age=0, must-revalidate"
+    assert payload["payload_version"] == 1
+    assert payload["snapshot_hash"] == "hash-match"
+    assert payload["publication_state"] == "draft"
+    assert payload["version"] == 1
+    assert payload["score_display"] is None
+    assert payload["feedback_global"] is None
+    assert [module["weight"] for module in payload["modules"]] == [0.2, 0.2, 0.2, 0.2, 0.2]
+    assert all(question["rubric_level"] is None for module in payload["modules"] for question in module["questions"])
+
+
+def test_put_teacher_case_grade_saves_draft_without_publishing(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    context = _seed_manual_grading_context(
+        db,
+        seed_identity,
+        seed_course,
+        seed_course_membership,
+        email_suffix="save-draft",
+    )
+    payload = _build_grade_payload(
+        snapshot_hash="hash-match",
+        intent="save_draft",
+        rubric_levels={
+            "M1-Q1": "excelente",
+            "M2-Q2": "bien",
+            "M3-Q3": "aceptable",
+            "M4-Q4": "insuficiente",
+            "M5-Q5": "no_responde",
+        },
+        feedback_global="  Feedback global borrador  ",
+    )
+
+    response = client.put(
+        _grade_route(context),
+        json=payload,
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["payload_version"] == 1
+    assert body["publication_state"] == "draft"
+    assert body["feedback_global"] == "Feedback global borrador"
+    assert body["score_display"] == 2.7
+    case_grade = db.scalar(
+        select(CaseGrade).where(CaseGrade.assignment_id == context["assignment"].id)
+    )
+    assert case_grade is not None
+    assert case_grade.status == "submitted"
+    assert case_grade.score is None
+    assert case_grade.feedback is None
+    assert case_grade.draft_feedback_global == "Feedback global borrador"
+    assert case_grade.published_at is None
+    draft_modules = list(
+        db.scalars(
+            select(CaseGradeModuleEntry).where(
+                CaseGradeModuleEntry.case_grade_id == case_grade.id,
+                CaseGradeModuleEntry.state == "draft",
+            )
+        )
+    )
+    draft_questions = list(
+        db.scalars(
+            select(CaseGradeQuestionEntry).where(
+                CaseGradeQuestionEntry.case_grade_id == case_grade.id,
+                CaseGradeQuestionEntry.state == "draft",
+            )
+        )
+    )
+    assert len(draft_modules) == 5
+    assert len(draft_questions) == 5
+
+
+def test_put_teacher_case_grade_publishes_grade_and_persists_entries(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    context = _seed_manual_grading_context(
+        db,
+        seed_identity,
+        seed_course,
+        seed_course_membership,
+        email_suffix="publish-grade",
+    )
+    payload = _build_grade_payload(
+        snapshot_hash="hash-match",
+        intent="publish",
+        rubric_levels={question_id: "excelente" for question_id in ["M1-Q1", "M2-Q2", "M3-Q3", "M4-Q4", "M5-Q5"]},
+        feedback_global="Feedback publicado",
+    )
+
+    response = client.put(
+        _grade_route(context),
+        json=payload,
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["publication_state"] == "published"
+    assert body["version"] == 1
+    assert body["score_display"] == 5.0
+    assert body["graded_at"] is not None
+    assert body["published_at"] is not None
+    case_grade = db.scalar(
+        select(CaseGrade).where(CaseGrade.assignment_id == context["assignment"].id)
+    )
+    assert case_grade is not None
+    assert case_grade.status == "graded"
+    assert case_grade.score == Decimal("5.0")
+    assert case_grade.feedback == "Feedback publicado"
+    assert case_grade.draft_feedback_global is None
+    published_modules = list(
+        db.scalars(
+            select(CaseGradeModuleEntry).where(
+                CaseGradeModuleEntry.case_grade_id == case_grade.id,
+                CaseGradeModuleEntry.state == "published",
+            )
+        )
+    )
+    published_questions = list(
+        db.scalars(
+            select(CaseGradeQuestionEntry).where(
+                CaseGradeQuestionEntry.case_grade_id == case_grade.id,
+                CaseGradeQuestionEntry.state == "published",
+            )
+        )
+    )
+    assert len(published_modules) == 5
+    assert len(published_questions) == 5
+
+
+def test_put_teacher_case_grade_supports_republish_without_overwriting_visible_grade_until_publish(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    context = _seed_manual_grading_context(
+        db,
+        seed_identity,
+        seed_course,
+        seed_course_membership,
+        email_suffix="republish",
+    )
+    initial_publish = _build_grade_payload(
+        snapshot_hash="hash-match",
+        intent="publish",
+        rubric_levels={question_id: "excelente" for question_id in ["M1-Q1", "M2-Q2", "M3-Q3", "M4-Q4", "M5-Q5"]},
+        feedback_global="Feedback publicado inicial",
+    )
+    draft_regrade = _build_grade_payload(
+        snapshot_hash="hash-match",
+        intent="save_draft",
+        rubric_levels={
+            "M1-Q1": "insuficiente",
+            "M2-Q2": "bien",
+            "M3-Q3": "aceptable",
+            "M4-Q4": "aceptable",
+            "M5-Q5": "bien",
+        },
+        feedback_global="Feedback republicacion",
+    )
+
+    publish_response = client.put(
+        _grade_route(context),
+        json=initial_publish,
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+    assert publish_response.status_code == 200, publish_response.text
+    original_published_at = publish_response.json()["published_at"]
+
+    draft_response = client.put(
+        _grade_route(context),
+        json=draft_regrade,
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+    assert draft_response.status_code == 200, draft_response.text
+    draft_body = draft_response.json()
+    assert draft_body["publication_state"] == "draft"
+    assert draft_body["published_at"] == original_published_at
+    assert draft_body["feedback_global"] == "Feedback republicacion"
+
+    case_grade = db.scalar(
+        select(CaseGrade).where(CaseGrade.assignment_id == context["assignment"].id)
+    )
+    assert case_grade is not None
+    assert case_grade.status == "graded"
+    assert case_grade.score == Decimal("5.0")
+    assert case_grade.feedback == "Feedback publicado inicial"
+    assert case_grade.version == 1
+    assert case_grade.draft_feedback_global == "Feedback republicacion"
+
+    get_draft_response = client.get(
+        _grade_route(context),
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+    assert get_draft_response.status_code == 200, get_draft_response.text
+    assert get_draft_response.json()["publication_state"] == "draft"
+
+    republish_payload = dict(draft_regrade)
+    republish_payload["intent"] = "publish"
+    republish_response = client.put(
+        _grade_route(context),
+        json=republish_payload,
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+    assert republish_response.status_code == 200, republish_response.text
+    republish_body = republish_response.json()
+    assert republish_body["publication_state"] == "published"
+    assert republish_body["version"] == 2
+    assert republish_body["score_display"] == 3.1
+    db.expire_all()
+    case_grade = db.scalar(
+        select(CaseGrade).where(CaseGrade.assignment_id == context["assignment"].id)
+    )
+    assert case_grade is not None
+    assert case_grade.feedback == "Feedback republicacion"
+    assert case_grade.draft_feedback_global is None
+    assert case_grade.version == 2
+    assert case_grade.score == Decimal("3.1")
+
+
+def test_put_teacher_case_grade_rejects_snapshot_conflicts(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    context = _seed_manual_grading_context(
+        db,
+        seed_identity,
+        seed_course,
+        seed_course_membership,
+        email_suffix="snapshot",
+    )
+    payload = _build_grade_payload(
+        snapshot_hash="stale-hash",
+        intent="save_draft",
+        rubric_levels={question_id: "excelente" for question_id in ["M1-Q1", "M2-Q2", "M3-Q3", "M4-Q4", "M5-Q5"]},
+        feedback_global="Feedback con snapshot viejo",
+    )
+
+    response = client.put(
+        _grade_route(context),
+        json=payload,
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+
+    assert response.status_code == 409, response.text
+    payload = response.json()["detail"]
+    assert payload["code"] == "snapshot_changed"
+    assert payload["current_snapshot_hash"] == "hash-match"
+
+
+def test_put_teacher_case_grade_rejects_incomplete_publish(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    context = _seed_manual_grading_context(
+        db,
+        seed_identity,
+        seed_course,
+        seed_course_membership,
+        email_suffix="incomplete",
+    )
+    payload = _build_grade_payload(
+        snapshot_hash="hash-match",
+        intent="publish",
+        rubric_levels={
+            "M1-Q1": "excelente",
+            "M2-Q2": "excelente",
+            "M3-Q3": "excelente",
+            "M4-Q4": "excelente",
+            "M5-Q5": None,
+        },
+        feedback_global="Feedback incompleto",
+    )
+
+    response = client.put(
+        _grade_route(context),
+        json=payload,
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+
+    assert response.status_code == 409, response.text
+    detail = response.json()["detail"]
+    assert detail["code"] == "incomplete_grade"
+    assert detail["missing_count"] == 1
+
+
+def test_put_teacher_case_grade_rejects_non_human_payloads(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+) -> None:
+    context = _seed_manual_grading_context(
+        db,
+        seed_identity,
+        seed_course,
+        seed_course_membership,
+        email_suffix="non-human",
+    )
+    payload = _build_grade_payload(
+        snapshot_hash="hash-match",
+        intent="save_draft",
+        rubric_levels={question_id: "excelente" for question_id in ["M1-Q1", "M2-Q2", "M3-Q3", "M4-Q4", "M5-Q5"]},
+        feedback_global="Feedback AI",
+        graded_by="ai",
+    )
+
+    response = client.put(
+        _grade_route(context),
+        json=payload,
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "graded_by_not_supported"
+
+
+def test_teacher_manual_grading_feature_flag_returns_not_found(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_membership,
+    auth_headers_factory,
+    monkeypatch,
+) -> None:
+    context = _seed_manual_grading_context(
+        db,
+        seed_identity,
+        seed_course,
+        seed_course_membership,
+        email_suffix="feature-flag",
+    )
+    monkeypatch.setattr(settings, "teacher_manual_grading_enabled", False)
+
+    response = client.get(
+        _grade_route(context),
+        headers=_auth_headers(
+            auth_headers_factory,
+            user_id=context["teacher"]["legacy_user"].id,
+            email=context["teacher"]["legacy_user"].email,
+        ),
+    )
+
+    assert response.status_code == 404, response.text
+    assert response.headers["Cache-Control"] == "private, max-age=0, must-revalidate"
+    assert response.json()["detail"]["code"] == "feature_disabled"

--- a/backend/tests/test_teacher_manual_grading.py
+++ b/backend/tests/test_teacher_manual_grading.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 import uuid
 
+import pytest
 from sqlalchemy import select
 
 from shared.database import settings
@@ -15,6 +16,11 @@ from shared.models import (
     StudentCaseResponse,
     StudentCaseResponseSubmission,
 )
+
+
+@pytest.fixture(autouse=True)
+def _enable_teacher_manual_grading(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "teacher_manual_grading_enabled", True)
 
 
 def _auth_headers(auth_headers_factory, *, user_id: str, email: str) -> dict[str, str]:
@@ -619,10 +625,11 @@ def test_put_teacher_case_grade_rejects_incomplete_publish(
         ),
     )
 
-    assert response.status_code == 409, response.text
+    assert response.status_code == 422, response.text
     detail = response.json()["detail"]
+    assert detail["payload_version"] == 1
     assert detail["code"] == "incomplete_grade"
-    assert detail["missing_count"] == 1
+    assert detail["missing_question_ids"] == ["M5-Q5"]
 
 
 def test_put_teacher_case_grade_rejects_non_human_payloads(

--- a/docs/runbooks/local-dev-auth.md
+++ b/docs/runbooks/local-dev-auth.md
@@ -121,6 +121,10 @@ Frontend:
 
 Nunca lleves `SUPABASE_SERVICE_ROLE_KEY` al browser ni a ejemplos frontend.
 
+Si vas a probar la calificacion manual docente localmente, habilita ademas en `backend/.env`:
+
+- `TEACHER_MANUAL_GRADING_ENABLED=true`
+
 ## Smoke minimo
 
 - `GET /health` responde `200`
@@ -130,6 +134,26 @@ Nunca lleves `SUPABASE_SERVICE_ROLE_KEY` al browser ni a ejemplos frontend.
 - `http://localhost:5173/app/teacher/dashboard` sin sesion redirige a `http://localhost:5173/app/teacher/login`
 - `http://localhost:5173/app/teacher/case-designer` sin sesion redirige a `http://localhost:5173/app/teacher/login`
 - `http://localhost:5173/app/auth/callback` muestra spinner de "Completando inicio de sesion"
+
+## Fixture reproducible para calificacion manual
+
+Para levantar una entrega lista para revisar desde la UI docente, usa el seed local idempotente:
+
+```powershell
+uv run --directory backend python scripts/seed_manual_grading_fixture.py `
+  --teacher-password "<elige-un-password-local-docente>" `
+  --student-password "<elige-un-password-local-estudiante>"
+```
+
+Que hace este script:
+
+- crea o reutiliza un docente y un estudiante en Supabase Auth local
+- actualiza las passwords si las pasas por CLI
+- upserta `profile`, `membership`, bridge `users`, curso, assignment publicado y una `student_case_response` en estado `submitted`
+- elimina cualquier `case_grade` existente para esa misma entrega y deja el borrador docente limpio
+- imprime la URL exacta de `submissions` y la de `submission detail` para abrir el caso ya seedado
+
+Si no pasas `--teacher-password` o `--student-password` y la cuenta ya existia, el script reutiliza la cuenta sin cambiar la password actual.
 
 ## Prerequisito manual para produccion
 

--- a/frontend/src/app/auth/AuthContext.tsx
+++ b/frontend/src/app/auth/AuthContext.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { queryKeys } from "@/shared/queryKeys";
 import { getSupabaseClient } from "@/shared/supabaseClient";
-import { apiFetch } from "@/shared/api";
+import { ApiError, apiFetch } from "@/shared/api";
 
 import type { AuthMeActor, Session } from "./auth-types";
 import { AuthContext } from "./auth-context";
@@ -19,8 +19,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const [actorQueryEnabled, setActorQueryEnabled] = useState(false);
 
     const fetchActorOrThrow = useCallback(async (): Promise<AuthMeActor> => {
-        const res = await apiFetch("/auth/me");
-        return (await res.json()) as AuthMeActor;
+        try {
+            const res = await apiFetch("/auth/me");
+            return (await res.json()) as AuthMeActor;
+        } catch (error) {
+            if (error instanceof ApiError && error.status === 401) {
+                setSession(null);
+                setBootstrapError(null);
+                setActorQueryEnabled(false);
+
+                const supabase = getSupabaseClient();
+                if (supabase) {
+                    void supabase.auth.signOut();
+                }
+            }
+
+            throw error;
+        }
     }, []);
 
     const actorQuery = useQuery({

--- a/frontend/src/app/auth/AuthProvider.test.tsx
+++ b/frontend/src/app/auth/AuthProvider.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createTestQueryClient, createWrapper } from "@/shared/test-utils";
@@ -12,6 +13,7 @@ const {
     mockSignOut,
     mockOnAuthStateChange,
     mockApiFetch,
+    MockApiError,
 } = vi.hoisted(() => ({
     mockGetSession: vi.fn(),
     mockSignOut: vi.fn(),
@@ -19,6 +21,15 @@ const {
         data: { subscription: { unsubscribe: vi.fn() } },
     })),
     mockApiFetch: vi.fn(),
+    MockApiError: class MockApiError extends Error {
+        status: number;
+
+        constructor(status: number, message = "api error") {
+            super(message);
+            this.name = "ApiError";
+            this.status = status;
+        }
+    },
 }));
 
 vi.mock("@/shared/supabaseClient", () => ({
@@ -33,6 +44,7 @@ vi.mock("@/shared/supabaseClient", () => ({
 
 vi.mock("@/shared/api", () => ({
     apiFetch: mockApiFetch,
+    ApiError: MockApiError,
 }));
 
 const mockActor: AuthMeActor = {
@@ -73,6 +85,7 @@ describe("AuthProvider", () => {
         vi.useRealTimers();
         vi.clearAllMocks();
         mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
+        mockSignOut.mockResolvedValue(undefined);
         mockOnAuthStateChange.mockReturnValue({
             data: { subscription: { unsubscribe: vi.fn() } },
         });
@@ -145,6 +158,80 @@ describe("AuthProvider", () => {
         expect(screen.getByTestId("error").textContent).toBe(
             "No se pudo cargar tu perfil. Intenta iniciar sesión de nuevo.",
         );
+    });
+
+    it("clears the local session when /api/auth/me returns 401", async () => {
+        const fakeSession = { access_token: "jwt-abc" };
+        mockGetSession.mockResolvedValue({
+            data: { session: fakeSession },
+            error: null,
+        });
+        mockApiFetch.mockRejectedValue(new MockApiError(401, "unauthorized"));
+
+        renderWithAuthProvider();
+
+        await waitFor(() =>
+            expect(screen.getByTestId("loading").textContent).toBe("false"),
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId("session").textContent).toBe("no"),
+        );
+        expect(screen.getByTestId("actor").textContent).toBe("none");
+        expect(screen.getByTestId("error").textContent).toBe("none");
+        expect(mockSignOut).toHaveBeenCalledTimes(1);
+    });
+
+    it("breaks the production-style 401 clear loop for /api/auth/me", async () => {
+        const fakeSession = { access_token: "jwt-abc" };
+        mockGetSession.mockResolvedValue({
+            data: { session: fakeSession },
+            error: null,
+        });
+        mockApiFetch.mockRejectedValue(new MockApiError(401, "unauthorized"));
+
+        let loopQueryClient!: QueryClient;
+        loopQueryClient = new QueryClient({
+            queryCache: new QueryCache({
+                onError: (error) => {
+                    if (error instanceof MockApiError && error.status === 401) {
+                        loopQueryClient.cancelQueries();
+                        loopQueryClient.clear();
+                    }
+                },
+            }),
+            defaultOptions: {
+                queries: {
+                    retry: false,
+                    gcTime: 0,
+                    staleTime: 0,
+                },
+                mutations: {
+                    retry: false,
+                },
+            },
+        });
+
+        render(
+            <AuthProvider>
+                <Probe />
+            </AuthProvider>,
+            {
+                wrapper: createWrapper({ queryClient: loopQueryClient }),
+            },
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId("session").textContent).toBe("no"),
+        );
+
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(mockApiFetch).toHaveBeenCalledTimes(1);
+        expect(mockSignOut).toHaveBeenCalledTimes(1);
     });
 
     it("clears actor on SIGNED_OUT event", async () => {

--- a/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherCaseSubmissionDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { AlertCircle, LoaderCircle, RefreshCcw } from "lucide-react";
 import { useParams } from "react-router-dom";
 
@@ -16,6 +17,9 @@ export function TeacherCaseSubmissionDetailPage() {
     }>();
     const detailQuery = useTeacherCaseSubmissionDetail(assignmentId, membershipId);
     const detail = detailQuery.data;
+    const refreshDetail = useCallback(async () => {
+        await detailQuery.refetch({ throwOnError: true });
+    }, [detailQuery]);
     const errorMessage = detailQuery.error
         ? getTeacherCaseSubmissionDetailErrorMessage(
             detailQuery.error,
@@ -33,7 +37,9 @@ export function TeacherCaseSubmissionDetailPage() {
                             <span>{errorMessage}</span>
                             <button
                                 type="button"
-                                onClick={() => void detailQuery.refetch()}
+                                onClick={() => {
+                                    void refreshDetail().catch(() => undefined);
+                                }}
                                 className="inline-flex items-center gap-2 self-start rounded-full border border-amber-300 bg-white px-4 py-2 text-sm font-semibold text-amber-900 transition hover:bg-amber-100"
                             >
                                 <RefreshCcw className="h-4 w-4" />
@@ -63,9 +69,7 @@ export function TeacherCaseSubmissionDetailPage() {
                     assignmentId={assignmentId}
                     detail={detail}
                     isRefreshing={detailQuery.isFetching && !detailQuery.isLoading}
-                    onRefresh={() => {
-                        void detailQuery.refetch();
-                    }}
+                    onRefresh={refreshDetail}
                 />
             ) : null}
         </TeacherLayout>

--- a/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { ArrowLeft, RefreshCcw } from "lucide-react";
+import { ArrowLeft, ClipboardCheck, RefreshCcw } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 import {
@@ -7,7 +7,9 @@ import {
     countSubmissionQuestions,
 } from "./teacherCaseSubmissionDetailModel";
 import { toCanonicalCaseOutput } from "./toCanonicalCaseOutput";
-import { GradingPlaceholderSlot } from "./components/GradingPlaceholderPanel";
+import { TeacherGradingPanel } from "./components/TeacherGradingPanel";
+import { TeacherQuestionGradingSupplement } from "./components/TeacherQuestionGradingSupplement";
+import { useTeacherManualGrading } from "./useTeacherManualGrading";
 
 import {
     formatTeacherCourseTimestamp,
@@ -31,6 +33,10 @@ interface TeacherSubmissionPreviewProps {
     detail: TeacherCaseSubmissionDetailResponse;
     isRefreshing: boolean;
     onRefresh: () => void;
+}
+
+function toTeacherGradeModuleId(moduleId: ModuleId): "M1" | "M2" | "M3" | "M4" | "M5" {
+    return moduleId.toUpperCase() as "M1" | "M2" | "M3" | "M4" | "M5";
 }
 
 function buildAnswersMap(detail: TeacherCaseSubmissionDetailResponse): Record<string, string> {
@@ -59,7 +65,14 @@ function getSnapshotLabel(detail: TeacherCaseSubmissionDetailResponse): string {
         : "Enviado";
 }
 
-function getGradeSummary(detail: TeacherCaseSubmissionDetailResponse): string {
+function getGradeSummary(
+    detail: TeacherCaseSubmissionDetailResponse,
+    currentGrade: { score_display: number | null; max_score_display: number } | null,
+): string {
+    if (currentGrade && currentGrade.score_display !== null) {
+        return `${formatTeacherGradebookScore(currentGrade.score_display)} / ${formatTeacherGradebookScore(currentGrade.max_score_display)}`;
+    }
+
     if (
         detail.grade_summary.status !== "graded"
         || detail.grade_summary.score === null
@@ -96,12 +109,88 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
     const answers = useMemo(() => buildAnswersMap(detail), [detail]);
     const visibleModules = useMemo(() => getVisibleModules(detail), [detail]);
     const [activeModule, setActiveModule] = useState<ModuleId>(visibleModules[0] ?? "m1");
+    const [isGradingMode, setIsGradingMode] = useState(false);
     const answeredQuestions = countAnsweredSubmissionQuestions(detail);
     const totalQuestions = countSubmissionQuestions(detail);
     const refreshLabel = isRefreshing ? "Actualizando entrega" : "Actualizar entrega";
     const snapshotLabel = getSnapshotLabel(detail);
     const statusLabel = formatTeacherGradebookCellStatus(detail.response_state.status).toUpperCase();
     const statusBadgeClasses = getStatusBadgeClasses(detail.response_state.status);
+    const grading = useTeacherManualGrading(
+        detail.case.course_id,
+        assignmentId,
+        detail.student.membership_id,
+        detail,
+    );
+    const activeGradingModuleId = toTeacherGradeModuleId(activeModule);
+    const gradingModeLabel = isGradingMode
+        ? "Vista previa"
+        : grading.hasPublishedVersion
+            ? "Editar y republicar"
+            : "Modo calificar";
+    const currentGradeSummary = grading.grade
+        ? {
+            score_display: grading.grade.score_display,
+            max_score_display: grading.grade.max_score_display,
+        }
+        : null;
+
+    const questionSupplement = useMemo(() => {
+        const currentGrade = grading.grade;
+        if (grading.mode !== "ready" || !currentGrade || !isGradingMode) {
+            return undefined;
+        }
+
+        return (questionId: string) => {
+            for (const module of currentGrade.modules) {
+                const question = module.questions.find((currentQuestion) => currentQuestion.question_id === questionId);
+                if (!question) {
+                    continue;
+                }
+
+                return (
+                    <TeacherQuestionGradingSupplement
+                        questionId={questionId}
+                        rubricLevel={question.rubric_level}
+                        feedbackQuestion={question.feedback_question}
+                        onRubricChange={(value) => grading.setQuestionRubric(questionId, value)}
+                        onFeedbackChange={(value) => grading.setQuestionFeedback(questionId, value)}
+                    />
+                );
+            }
+
+            return null;
+        };
+    }, [grading.grade, grading.mode, grading.setQuestionFeedback, grading.setQuestionRubric, isGradingMode]);
+
+    const gradingPanel = (
+        <TeacherGradingPanel
+            mode={grading.mode}
+            grade={grading.grade}
+            loadErrorMessage={grading.loadErrorMessage}
+            activeModuleId={activeGradingModuleId}
+            autosaveState={grading.autosaveState}
+            banner={grading.banner}
+            isDirty={grading.isDirty}
+            isGradingMode={isGradingMode}
+            isPublishing={grading.isPublishing}
+            missingQuestionCount={grading.missingQuestionCount}
+            hasPublishedVersion={grading.hasPublishedVersion}
+            requiresRefresh={grading.requiresRefresh}
+            onGlobalFeedbackChange={grading.setGlobalFeedback}
+            onModuleFeedbackChange={grading.setModuleFeedback}
+            onPublish={() => {
+                void grading.publish();
+            }}
+            onRefresh={() => {
+                onRefresh();
+                void grading.refresh();
+            }}
+            onToggleMode={() => {
+                setIsGradingMode((currentValue) => !currentValue);
+            }}
+        />
+    );
 
     useEffect(() => {
         if (visibleModules.length === 0) {
@@ -121,6 +210,12 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
             document.body.style.overflow = previousOverflow;
         };
     }, []);
+
+    useEffect(() => {
+        if (grading.mode !== "ready") {
+            setIsGradingMode(false);
+        }
+    }, [grading.mode]);
 
     return (
         <>
@@ -163,7 +258,7 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                             <dd className="text-right text-[11px]">{answeredQuestions}/{totalQuestions}</dd>
 
                             <dt className="text-[10px] uppercase tracking-wider text-slate-500">Calificación</dt>
-                            <dd className="text-right text-[11px]">{getGradeSummary(detail)}</dd>
+                            <dd className="text-right text-[11px]">{getGradeSummary(detail, currentGradeSummary)}</dd>
 
                             <dt className="text-[10px] uppercase tracking-wider text-slate-500">Entrega</dt>
                             <dd className="truncate text-right text-[11px]" title={formatTimestamp(detail.response_state.submitted_at, "Sin entrega")}>
@@ -198,12 +293,26 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                         </div>
 
                         <div className="flex items-center gap-3">
+                            {grading.mode === "ready" ? (
+                                <button
+                                    type="button"
+                                    onClick={() => setIsGradingMode((currentValue) => !currentValue)}
+                                    className="hidden items-center gap-2 rounded-full border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 lg:inline-flex"
+                                    data-testid="teacher-grading-header-toggle"
+                                >
+                                    <ClipboardCheck className="h-4 w-4" />
+                                    {gradingModeLabel}
+                                </button>
+                            ) : null}
                             <span className={`hidden rounded-full px-3 py-1 text-xs font-semibold lg:inline-flex ${statusBadgeClasses}`}>
                                 {statusLabel}
                             </span>
                             <button
                                 type="button"
-                                onClick={onRefresh}
+                                onClick={() => {
+                                    onRefresh();
+                                    void grading.refresh();
+                                }}
                                 disabled={isRefreshing}
                                 className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-70"
                                 aria-label={refreshLabel}
@@ -241,10 +350,12 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                         onAnswersChange={() => undefined}
                         readOnly={true}
                         showExpectedSolutions={true}
+                        questionSupplement={questionSupplement}
+                        supplementalRightPanelSlot={gradingPanel}
                     />
 
                     <div className="shrink-0 border-t border-slate-200 bg-white px-4 py-3 md:hidden">
-                        <GradingPlaceholderSlot />
+                        {gradingPanel}
                     </div>
                 </div>
             </div>

--- a/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
@@ -34,7 +34,7 @@ interface TeacherSubmissionPreviewProps {
     assignmentId: string;
     detail: TeacherCaseSubmissionDetailResponse;
     isRefreshing: boolean;
-    onRefresh: () => void;
+    onRefresh: () => Promise<void>;
 }
 
 function toTeacherGradeModuleId(moduleId: ModuleId): "M1" | "M2" | "M3" | "M4" | "M5" {
@@ -139,12 +139,24 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
         : null;
     const gradingMode = grading.mode;
     const gradingGrade = grading.grade;
-    const gradingRequiresRefresh = grading.requiresRefresh;
+    const gradingIsLocked = grading.isLocked;
     const setQuestionFeedback = grading.setQuestionFeedback;
     const setQuestionRubric = grading.setQuestionRubric;
     const handleRefresh = useCallback(async () => {
-        onRefresh();
-        await grading.refresh();
+        try {
+            await Promise.all([onRefresh(), grading.refresh()]);
+        } catch {
+            // The page-level error surface already renders the failure state.
+        }
+    }, [grading, onRefresh]);
+    const handleSnapshotConflictRefresh = useCallback(async () => {
+        grading.setRefreshError(null);
+        try {
+            await Promise.all([onRefresh(), grading.refresh()]);
+            grading.clearSnapshotConflict();
+        } catch (error) {
+            grading.setRefreshError(error);
+        }
     }, [grading, onRefresh]);
     const handlePublishConfirm = useCallback(async () => {
         const published = await grading.publish();
@@ -170,7 +182,7 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                         questionId={questionId}
                         rubricLevel={question.rubric_level}
                         feedbackQuestion={question.feedback_question}
-                        disabled={gradingRequiresRefresh}
+                        disabled={gradingIsLocked}
                         onRubricChange={(value) => setQuestionRubric(questionId, value)}
                         onFeedbackChange={(value) => setQuestionFeedback(questionId, value)}
                     />
@@ -182,7 +194,7 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
     }, [
         gradingGrade,
         gradingMode,
-        gradingRequiresRefresh,
+        gradingIsLocked,
         setQuestionFeedback,
         setQuestionRubric,
         isGradingMode,
@@ -200,6 +212,7 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                 banner={grading.banner}
                 isDirty={grading.isDirty}
                 isGradingMode={isGradingMode}
+                isLocked={grading.isLocked}
                 isPublishing={grading.isPublishing}
                 missingQuestionCount={grading.missingQuestionCount}
                 hasPublishedVersion={grading.hasPublishedVersion}
@@ -342,8 +355,7 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                             <button
                                 type="button"
                                 onClick={() => {
-                                    onRefresh();
-                                    void grading.refresh();
+                                    void handleRefresh();
                                 }}
                                 disabled={isRefreshing}
                                 className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-70"
@@ -419,7 +431,8 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
             <TeacherSnapshotConflictModal
                 isOpen={grading.isSnapshotConflictOpen}
                 isReloading={isRefreshing || grading.isRefreshing}
-                onReload={() => handleRefresh()}
+                refreshError={grading.refreshError}
+                onReload={() => handleSnapshotConflictRefresh()}
             />
         </>
     );

--- a/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ArrowLeft, ClipboardCheck, RefreshCcw } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
@@ -8,7 +8,9 @@ import {
 } from "./teacherCaseSubmissionDetailModel";
 import { toCanonicalCaseOutput } from "./toCanonicalCaseOutput";
 import { TeacherGradingPanel } from "./components/TeacherGradingPanel";
+import { TeacherPublishConfirmModal } from "./components/TeacherPublishConfirmModal";
 import { TeacherQuestionGradingSupplement } from "./components/TeacherQuestionGradingSupplement";
+import { TeacherSnapshotConflictModal } from "./components/TeacherSnapshotConflictModal";
 import { useTeacherManualGrading } from "./useTeacherManualGrading";
 
 import {
@@ -110,6 +112,7 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
     const visibleModules = useMemo(() => getVisibleModules(detail), [detail]);
     const [activeModule, setActiveModule] = useState<ModuleId>(visibleModules[0] ?? "m1");
     const [isGradingMode, setIsGradingMode] = useState(false);
+    const [isPublishConfirmOpen, setIsPublishConfirmOpen] = useState(false);
     const answeredQuestions = countAnsweredSubmissionQuestions(detail);
     const totalQuestions = countSubmissionQuestions(detail);
     const refreshLabel = isRefreshing ? "Actualizando entrega" : "Actualizar entrega";
@@ -134,15 +137,29 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
             max_score_display: grading.grade.max_score_display,
         }
         : null;
+    const gradingMode = grading.mode;
+    const gradingGrade = grading.grade;
+    const gradingRequiresRefresh = grading.requiresRefresh;
+    const setQuestionFeedback = grading.setQuestionFeedback;
+    const setQuestionRubric = grading.setQuestionRubric;
+    const handleRefresh = useCallback(async () => {
+        onRefresh();
+        await grading.refresh();
+    }, [grading, onRefresh]);
+    const handlePublishConfirm = useCallback(async () => {
+        const published = await grading.publish();
+        if (published) {
+            setIsPublishConfirmOpen(false);
+        }
+    }, [grading]);
 
     const questionSupplement = useMemo(() => {
-        const currentGrade = grading.grade;
-        if (grading.mode !== "ready" || !currentGrade || !isGradingMode) {
+        if (gradingMode !== "ready" || !gradingGrade || !isGradingMode) {
             return undefined;
         }
 
         return (questionId: string) => {
-            for (const module of currentGrade.modules) {
+            for (const module of gradingGrade.modules) {
                 const question = module.questions.find((currentQuestion) => currentQuestion.question_id === questionId);
                 if (!question) {
                     continue;
@@ -153,44 +170,53 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                         questionId={questionId}
                         rubricLevel={question.rubric_level}
                         feedbackQuestion={question.feedback_question}
-                        onRubricChange={(value) => grading.setQuestionRubric(questionId, value)}
-                        onFeedbackChange={(value) => grading.setQuestionFeedback(questionId, value)}
+                        disabled={gradingRequiresRefresh}
+                        onRubricChange={(value) => setQuestionRubric(questionId, value)}
+                        onFeedbackChange={(value) => setQuestionFeedback(questionId, value)}
                     />
                 );
             }
 
             return null;
         };
-    }, [grading.grade, grading.mode, grading.setQuestionFeedback, grading.setQuestionRubric, isGradingMode]);
+    }, [
+        gradingGrade,
+        gradingMode,
+        gradingRequiresRefresh,
+        setQuestionFeedback,
+        setQuestionRubric,
+        isGradingMode,
+    ]);
 
-    const gradingPanel = (
-        <TeacherGradingPanel
-            mode={grading.mode}
-            grade={grading.grade}
-            loadErrorMessage={grading.loadErrorMessage}
-            activeModuleId={activeGradingModuleId}
-            autosaveState={grading.autosaveState}
-            banner={grading.banner}
-            isDirty={grading.isDirty}
-            isGradingMode={isGradingMode}
-            isPublishing={grading.isPublishing}
-            missingQuestionCount={grading.missingQuestionCount}
-            hasPublishedVersion={grading.hasPublishedVersion}
-            requiresRefresh={grading.requiresRefresh}
-            onGlobalFeedbackChange={grading.setGlobalFeedback}
-            onModuleFeedbackChange={grading.setModuleFeedback}
-            onPublish={() => {
-                void grading.publish();
-            }}
-            onRefresh={() => {
-                onRefresh();
-                void grading.refresh();
-            }}
-            onToggleMode={() => {
-                setIsGradingMode((currentValue) => !currentValue);
-            }}
-        />
-    );
+    const gradingPanel = grading.mode === "disabled"
+        ? null
+        : (
+            <TeacherGradingPanel
+                mode={grading.mode}
+                grade={grading.grade}
+                loadErrorMessage={grading.loadErrorMessage}
+                activeModuleId={activeGradingModuleId}
+                autosaveState={grading.autosaveState}
+                banner={grading.banner}
+                isDirty={grading.isDirty}
+                isGradingMode={isGradingMode}
+                isPublishing={grading.isPublishing}
+                missingQuestionCount={grading.missingQuestionCount}
+                hasPublishedVersion={grading.hasPublishedVersion}
+                requiresRefresh={grading.requiresRefresh}
+                onGlobalFeedbackChange={grading.setGlobalFeedback}
+                onModuleFeedbackChange={grading.setModuleFeedback}
+                onPublishRequest={() => {
+                    setIsPublishConfirmOpen(true);
+                }}
+                onRefresh={() => {
+                    void handleRefresh();
+                }}
+                onToggleMode={() => {
+                    setIsGradingMode((currentValue) => !currentValue);
+                }}
+            />
+        );
 
     useEffect(() => {
         if (visibleModules.length === 0) {
@@ -216,6 +242,12 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
             setIsGradingMode(false);
         }
     }, [grading.mode]);
+
+    useEffect(() => {
+        if (grading.mode !== "ready" || !isGradingMode || grading.requiresRefresh) {
+            setIsPublishConfirmOpen(false);
+        }
+    }, [grading.mode, grading.requiresRefresh, isGradingMode]);
 
     return (
         <>
@@ -341,24 +373,54 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                         </div>
                     </div>
 
-                    <CaseContentRenderer
-                        result={canonicalOutput}
-                        visibleModules={visibleModules}
-                        activeModule={activeModule}
-                        onActiveModuleChange={setActiveModule}
-                        answers={answers}
-                        onAnswersChange={() => undefined}
-                        readOnly={true}
-                        showExpectedSolutions={true}
-                        questionSupplement={questionSupplement}
-                        supplementalRightPanelSlot={gradingPanel}
-                    />
+                    <div className="flex min-h-0 flex-1 overflow-hidden">
+                        <div className="min-w-0 flex-1 overflow-hidden">
+                            <CaseContentRenderer
+                                result={canonicalOutput}
+                                visibleModules={visibleModules}
+                                activeModule={activeModule}
+                                onActiveModuleChange={setActiveModule}
+                                answers={answers}
+                                onAnswersChange={() => undefined}
+                                readOnly={true}
+                                showExpectedSolutions={true}
+                                questionSupplement={questionSupplement}
+                            />
+                        </div>
 
-                    <div className="shrink-0 border-t border-slate-200 bg-white px-4 py-3 md:hidden">
-                        {gradingPanel}
+                        {gradingPanel ? (
+                            <aside className="hidden w-80 shrink-0 border-l border-slate-200 bg-white xl:flex xl:flex-col">
+                                <div className="min-h-0 flex-1 overflow-y-auto px-4 py-6">
+                                    {gradingPanel}
+                                </div>
+                            </aside>
+                        ) : null}
                     </div>
+
+                    {gradingPanel ? (
+                        <div className="shrink-0 border-t border-slate-200 bg-white px-4 py-3 md:hidden">
+                            {gradingPanel}
+                        </div>
+                    ) : null}
                 </div>
             </div>
+
+            <TeacherPublishConfirmModal
+                isOpen={isPublishConfirmOpen}
+                hasPublishedVersion={grading.hasPublishedVersion}
+                isSubmitting={grading.isPublishing}
+                scoreLabel={getGradeSummary(detail, currentGradeSummary)}
+                onClose={() => setIsPublishConfirmOpen(false)}
+                onConfirm={() => {
+                    void handlePublishConfirm();
+                }}
+            />
+
+            <TeacherSnapshotConflictModal
+                isOpen={grading.isSnapshotConflictOpen}
+                isReloading={isRefreshing || grading.isRefreshing}
+                onReload={() => handleRefresh()}
+            />
         </>
     );
 }

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.integration.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.integration.test.tsx
@@ -1,9 +1,12 @@
+import { useCallback, useState } from "react";
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { TeacherCaseSubmissionGradeRequest } from "@/shared/adam-types";
+import type { TeacherCaseSubmissionGradeRequest, TeacherCaseSubmissionGradeResponse } from "@/shared/adam-types";
+import { queryKeys } from "@/shared/queryKeys";
 import { server } from "@/shared/testing/msw/server";
 import { renderWithProviders } from "@/shared/test-utils";
 
@@ -43,10 +46,12 @@ vi.mock("@/shared/case-viewer", async () => {
         CaseContentRenderer: (props: unknown) => {
             const rendererProps = props as {
                 questionSupplement?: (questionId: string) => React.ReactNode;
+                answers?: Record<string, string>;
             };
 
             return (
                 <div data-testid="case-content-renderer">
+                    <div data-testid="student-answer-M1-Q1">{rendererProps.answers?.["M1-Q1"] ?? ""}</div>
                     {rendererProps.questionSupplement?.("M1-Q1") ?? null}
                 </div>
             );
@@ -54,12 +59,24 @@ vi.mock("@/shared/case-viewer", async () => {
     };
 });
 
+function createDeferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+
+    const promise = new Promise<T>((innerResolve, innerReject) => {
+        resolve = innerResolve;
+        reject = innerReject;
+    });
+
+    return { promise, resolve, reject };
+}
+
 function renderPreview(options?: {
     detail?: ReturnType<typeof createSubmissionDetailResponse>;
-    onRefresh?: () => void;
+    onRefresh?: () => Promise<void>;
 }) {
     const detail = options?.detail ?? createSubmissionDetailResponse();
-    const onRefresh = options?.onRefresh ?? vi.fn();
+    const onRefresh = options?.onRefresh ?? vi.fn().mockResolvedValue(undefined);
 
     return renderWithProviders(
         <Routes>
@@ -80,6 +97,55 @@ function renderPreview(options?: {
             initialEntries: ["/teacher/cases/assignment-1/entregas/membership-1"],
         },
     );
+}
+
+function renderStatefulPreview(options: {
+    initialDetail?: ReturnType<typeof createSubmissionDetailResponse>;
+    refreshedDetail?: ReturnType<typeof createSubmissionDetailResponse>;
+    refreshDetail?: () => Promise<void>;
+}) {
+    const initialDetail = options.initialDetail ?? createSubmissionDetailResponse();
+    const refreshedDetail = options.refreshedDetail ?? createSubmissionDetailResponse();
+    const refreshDetail = options.refreshDetail ?? vi.fn().mockResolvedValue(undefined);
+
+    function PreviewHarness() {
+        const [detail, setDetail] = useState(initialDetail);
+        const [isRefreshing, setIsRefreshing] = useState(false);
+
+        const handleRefresh = useCallback(async () => {
+            setIsRefreshing(true);
+            try {
+                await refreshDetail();
+                setDetail(refreshedDetail);
+            } finally {
+                setIsRefreshing(false);
+            }
+        }, []);
+
+        return (
+            <Routes>
+                <Route path="/teacher/cases/:assignmentId/entregas" element={<div data-testid="submissions-list">Listado</div>} />
+                <Route
+                    path="/teacher/cases/:assignmentId/entregas/:membershipId"
+                    element={(
+                        <TeacherSubmissionPreview
+                            assignmentId="assignment-1"
+                            detail={detail}
+                            isRefreshing={isRefreshing}
+                            onRefresh={handleRefresh}
+                        />
+                    )}
+                />
+            </Routes>
+        );
+    }
+
+    return {
+        ...renderWithProviders(<PreviewHarness />, {
+            initialEntries: ["/teacher/cases/assignment-1/entregas/membership-1"],
+        }),
+        refreshDetail,
+    };
 }
 
 function buildGradedResponse() {
@@ -248,5 +314,337 @@ describe("TeacherSubmissionPreview integration", () => {
 
         expect(await screen.findByTestId("teacher-snapshot-conflict-modal")).toBeTruthy();
         expect(screen.getByText(/El estudiante modificó su entrega/i)).toBeTruthy();
+    });
+
+    it("waits for both detail and grade refetches before closing the snapshot modal", async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTimeAsync });
+        const detailRefresh = createDeferred<void>();
+        const refreshDetail = vi.fn(() => detailRefresh.promise);
+        let gradeFetchCount = 0;
+
+        server.use(
+            http.get("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => {
+                gradeFetchCount += 1;
+
+                return HttpResponse.json(
+                    gradeFetchCount === 1
+                        ? buildGradedResponse()
+                        : createSubmissionGradeResponse({
+                            ...buildGradedResponse(),
+                            snapshot_hash: "hash-456",
+                            last_modified_at: "2026-06-05T19:11:00Z",
+                        }),
+                );
+            }),
+            http.put("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json({
+                    detail: {
+                        code: "snapshot_changed",
+                        message: "El estudiante modificó su entrega. Recarga para ver cambios.",
+                    },
+                }, { status: 409 })
+            )),
+        );
+
+        renderStatefulPreview({
+            initialDetail: createSubmissionDetailResponse({
+                modules: [
+                    {
+                        id: "M1",
+                        title: "Módulo 1 · Comprensión del caso",
+                        questions: [
+                            {
+                                id: "M1-Q1",
+                                order: 1,
+                                statement: "Describe la situación principal del caso.",
+                                context: "Pregunta 1",
+                                expected_solution: "Reconoce el cuello de botella operativo.",
+                                student_answer: "Respuesta antigua del estudiante.",
+                                student_answer_chars: 31,
+                                is_answer_from_draft: false,
+                            },
+                        ],
+                    },
+                    createSubmissionDetailResponse().modules[1],
+                ],
+            }),
+            refreshedDetail: createSubmissionDetailResponse({
+                response_state: {
+                    ...createSubmissionDetailResponse().response_state,
+                    snapshot_hash: "hash-456",
+                },
+                modules: [
+                    {
+                        id: "M1",
+                        title: "Módulo 1 · Comprensión del caso",
+                        questions: [
+                            {
+                                id: "M1-Q1",
+                                order: 1,
+                                statement: "Describe la situación principal del caso.",
+                                context: "Pregunta 1",
+                                expected_solution: "Reconoce el cuello de botella operativo.",
+                                student_answer: "Respuesta nueva del estudiante.",
+                                student_answer_chars: 29,
+                                is_answer_from_draft: false,
+                            },
+                        ],
+                    },
+                    createSubmissionDetailResponse().modules[1],
+                ],
+            }),
+            refreshDetail,
+        });
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+        fireEvent.click((await screen.findAllByTestId("teacher-grading-publish-button"))[0]);
+        fireEvent.click(await screen.findByRole("button", { name: /Confirmar publicación/i }));
+
+        expect(await screen.findByTestId("teacher-snapshot-conflict-modal")).toBeTruthy();
+        expect(screen.getByTestId("student-answer-M1-Q1")).toHaveTextContent("Respuesta antigua del estudiante.");
+
+        await user.click(screen.getByRole("button", { name: /Recargar entrega/i }));
+
+        await waitFor(() => {
+            expect(refreshDetail).toHaveBeenCalledTimes(1);
+        });
+        expect(screen.getByTestId("teacher-snapshot-conflict-modal")).toBeTruthy();
+        expect(screen.getByTestId("student-answer-M1-Q1")).toHaveTextContent("Respuesta antigua del estudiante.");
+
+        await act(async () => {
+            detailRefresh.resolve();
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByTestId("teacher-snapshot-conflict-modal")).toBeNull();
+        });
+        expect(screen.getByTestId("student-answer-M1-Q1")).toHaveTextContent("Respuesta nueva del estudiante.");
+    });
+
+    it("keeps the snapshot modal open and shows a retry error when the detail refresh fails", async () => {
+        const refreshDetail = vi.fn().mockRejectedValue(new Error("No se pudo recargar la entrega."));
+        let gradeFetchCount = 0;
+
+        server.use(
+            http.get("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => {
+                gradeFetchCount += 1;
+
+                return HttpResponse.json(
+                    gradeFetchCount === 1
+                        ? buildGradedResponse()
+                        : createSubmissionGradeResponse({
+                            ...buildGradedResponse(),
+                            snapshot_hash: "hash-456",
+                        }),
+                );
+            }),
+            http.put("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json({
+                    detail: {
+                        code: "snapshot_changed",
+                        message: "El estudiante modificó su entrega. Recarga para ver cambios.",
+                    },
+                }, { status: 409 })
+            )),
+        );
+
+        renderStatefulPreview({ refreshDetail });
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+        fireEvent.click((await screen.findAllByTestId("teacher-grading-publish-button"))[0]);
+        fireEvent.click(await screen.findByRole("button", { name: /Confirmar publicación/i }));
+
+        expect(await screen.findByTestId("teacher-snapshot-conflict-modal")).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: /Recargar entrega/i }));
+
+        expect(await screen.findByText("No se pudo recargar la entrega.")).toBeTruthy();
+        expect(screen.getByTestId("teacher-snapshot-conflict-modal")).toBeTruthy();
+        expect(screen.getByRole("radiogroup", { name: "Nivel de rúbrica" })).toHaveAttribute("aria-disabled", "true");
+        expect(screen.getByPlaceholderText(/Explica qué sostuvo o debilitó/i)).toBeDisabled();
+    });
+
+    it("releases the lock and rehydrates the grade cache after a successful snapshot refresh", async () => {
+        const refreshedGrade = createSubmissionGradeResponse({
+            ...buildGradedResponse(),
+            snapshot_hash: "hash-456",
+            last_modified_at: "2026-06-05T19:11:00Z",
+        });
+        let gradeFetchCount = 0;
+
+        server.use(
+            http.get("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => {
+                gradeFetchCount += 1;
+                return HttpResponse.json(gradeFetchCount === 1 ? buildGradedResponse() : refreshedGrade);
+            }),
+            http.put("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json({
+                    detail: {
+                        code: "snapshot_changed",
+                        message: "El estudiante modificó su entrega. Recarga para ver cambios.",
+                    },
+                }, { status: 409 })
+            )),
+        );
+
+        const { queryClient } = renderStatefulPreview({
+            refreshedDetail: createSubmissionDetailResponse({
+                response_state: {
+                    ...createSubmissionDetailResponse().response_state,
+                    snapshot_hash: "hash-456",
+                },
+                modules: [
+                    {
+                        id: "M1",
+                        title: "Módulo 1 · Comprensión del caso",
+                        questions: [
+                            {
+                                id: "M1-Q1",
+                                order: 1,
+                                statement: "Describe la situación principal del caso.",
+                                context: "Pregunta 1",
+                                expected_solution: "Reconoce el cuello de botella operativo.",
+                                student_answer: "Respuesta rehidratada del estudiante.",
+                                student_answer_chars: 36,
+                                is_answer_from_draft: false,
+                            },
+                        ],
+                    },
+                    createSubmissionDetailResponse().modules[1],
+                ],
+            }),
+        });
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+        fireEvent.click((await screen.findAllByTestId("teacher-grading-publish-button"))[0]);
+        fireEvent.click(await screen.findByRole("button", { name: /Confirmar publicación/i }));
+
+        expect(await screen.findByTestId("teacher-snapshot-conflict-modal")).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: /Recargar entrega/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId("teacher-snapshot-conflict-modal")).toBeNull();
+        });
+        expect(screen.getByRole("radiogroup", { name: "Nivel de rúbrica" })).toHaveAttribute("aria-disabled", "false");
+        expect(screen.getByPlaceholderText(/Explica qué sostuvo o debilitó/i)).not.toBeDisabled();
+
+        const cachedGrade = queryClient.getQueryData<TeacherCaseSubmissionGradeResponse>(
+            queryKeys.teacher.caseSubmissionGrade("course-1", "assignment-1", "membership-1"),
+        );
+        expect(cachedGrade?.snapshot_hash).toBe("hash-456");
+    });
+
+    it("disables per-question grading controls while publish is in flight and ignores edits", async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTimeAsync });
+        const publishDeferred = createDeferred<void>();
+
+        server.use(
+            http.get("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json(buildGradedResponse())
+            )),
+            http.put("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", async () => {
+                await publishDeferred.promise;
+
+                return HttpResponse.json(createSubmissionGradeResponse({
+                    ...buildGradedResponse(),
+                    publication_state: "published",
+                    version: 2,
+                    published_at: "2026-06-05T19:10:00Z",
+                    graded_at: "2026-06-05T19:10:00Z",
+                }));
+            }),
+        );
+
+        renderPreview();
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+        fireEvent.click((await screen.findAllByTestId("teacher-grading-publish-button"))[0]);
+        fireEvent.click(await screen.findByRole("button", { name: /Confirmar publicación/i }));
+
+        const radiogroup = await screen.findByRole("radiogroup", { name: "Nivel de rúbrica" });
+        const excellentOption = screen.getByRole("radio", { name: "Excelente" });
+        const goodOption = screen.getByRole("radio", { name: "Bien" });
+        const feedbackTextarea = screen.getByPlaceholderText(/Explica qué sostuvo o debilitó/i);
+
+        await waitFor(() => {
+            expect(radiogroup).toHaveAttribute("aria-disabled", "true");
+        });
+        expect(feedbackTextarea).toBeDisabled();
+
+        await user.click(goodOption);
+        await user.type(feedbackTextarea, "Cambio bloqueado");
+
+        expect(excellentOption).toHaveAttribute("aria-checked", "true");
+        expect(goodOption).toHaveAttribute("aria-checked", "false");
+        expect(feedbackTextarea).toHaveValue("");
+
+        publishDeferred.resolve();
+
+        await waitFor(() => {
+            expect(screen.queryByTestId("teacher-publish-confirm-modal")).toBeNull();
+        });
+    });
+
+    it("re-enables per-question grading controls after a successful publish", async () => {
+        const publishDeferred = createDeferred<void>();
+
+        server.use(
+            http.get("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json(buildGradedResponse())
+            )),
+            http.put("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", async () => {
+                await publishDeferred.promise;
+
+                return HttpResponse.json(createSubmissionGradeResponse({
+                    ...buildGradedResponse(),
+                    publication_state: "published",
+                    version: 2,
+                    published_at: "2026-06-05T19:10:00Z",
+                    graded_at: "2026-06-05T19:10:00Z",
+                }));
+            }),
+        );
+
+        renderPreview();
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+        fireEvent.click((await screen.findAllByTestId("teacher-grading-publish-button"))[0]);
+        fireEvent.click(await screen.findByRole("button", { name: /Confirmar publicación/i }));
+
+        expect(await screen.findByRole("radiogroup", { name: "Nivel de rúbrica" })).toHaveAttribute("aria-disabled", "true");
+
+        publishDeferred.resolve();
+
+        await waitFor(() => {
+            expect(screen.getByRole("radiogroup", { name: "Nivel de rúbrica" })).toHaveAttribute("aria-disabled", "false");
+        });
+        expect(screen.getByPlaceholderText(/Explica qué sostuvo o debilitó/i)).not.toBeDisabled();
+    });
+
+    it("keeps per-question grading controls disabled after a 409 publish conflict", async () => {
+        server.use(
+            http.get("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json(buildGradedResponse())
+            )),
+            http.put("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json({
+                    detail: {
+                        code: "snapshot_changed",
+                        message: "El estudiante modificó su entrega. Recarga para ver cambios.",
+                    },
+                }, { status: 409 })
+            )),
+        );
+
+        renderPreview();
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+        fireEvent.click((await screen.findAllByTestId("teacher-grading-publish-button"))[0]);
+        fireEvent.click(await screen.findByRole("button", { name: /Confirmar publicación/i }));
+
+        expect(await screen.findByTestId("teacher-snapshot-conflict-modal")).toBeTruthy();
+        expect(screen.getByRole("radiogroup", { name: "Nivel de rúbrica" })).toHaveAttribute("aria-disabled", "true");
+        expect(screen.getByPlaceholderText(/Explica qué sostuvo o debilitó/i)).toBeDisabled();
     });
 });

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.integration.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.integration.test.tsx
@@ -1,0 +1,252 @@
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TeacherCaseSubmissionGradeRequest } from "@/shared/adam-types";
+import { server } from "@/shared/testing/msw/server";
+import { renderWithProviders } from "@/shared/test-utils";
+
+import { TeacherSubmissionPreview } from "../TeacherSubmissionPreview";
+import { TEACHER_MANUAL_GRADING_AUTOSAVE_DELAY_MS } from "../teacherManualGradingModel";
+
+import { createSubmissionDetailResponse, createSubmissionGradeResponse } from "./testData";
+
+vi.mock("@/shared/case-viewer", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/case-viewer")>("@/shared/case-viewer");
+
+    return {
+        ...actual,
+        CASE_VIEWER_STYLES: ".case-preview {}",
+        ModulesSidebar: ({
+            visibleModules,
+            activeModule,
+            onActiveModuleChange,
+        }: {
+            visibleModules: string[];
+            activeModule: string;
+            onActiveModuleChange: (id: never) => void;
+        }) => (
+            <nav data-testid="mock-modules-sidebar">
+                {visibleModules.map((moduleId) => (
+                    <button
+                        key={moduleId}
+                        type="button"
+                        data-active={String(moduleId === activeModule)}
+                        onClick={() => onActiveModuleChange(moduleId as never)}
+                    >
+                        {moduleId}
+                    </button>
+                ))}
+            </nav>
+        ),
+        CaseContentRenderer: (props: unknown) => {
+            const rendererProps = props as {
+                questionSupplement?: (questionId: string) => React.ReactNode;
+            };
+
+            return (
+                <div data-testid="case-content-renderer">
+                    {rendererProps.questionSupplement?.("M1-Q1") ?? null}
+                </div>
+            );
+        },
+    };
+});
+
+function renderPreview(options?: {
+    detail?: ReturnType<typeof createSubmissionDetailResponse>;
+    onRefresh?: () => void;
+}) {
+    const detail = options?.detail ?? createSubmissionDetailResponse();
+    const onRefresh = options?.onRefresh ?? vi.fn();
+
+    return renderWithProviders(
+        <Routes>
+            <Route path="/teacher/cases/:assignmentId/entregas" element={<div data-testid="submissions-list">Listado</div>} />
+            <Route
+                path="/teacher/cases/:assignmentId/entregas/:membershipId"
+                element={(
+                    <TeacherSubmissionPreview
+                        assignmentId="assignment-1"
+                        detail={detail}
+                        isRefreshing={false}
+                        onRefresh={onRefresh}
+                    />
+                )}
+            />
+        </Routes>,
+        {
+            initialEntries: ["/teacher/cases/assignment-1/entregas/membership-1"],
+        },
+    );
+}
+
+function buildGradedResponse() {
+    return createSubmissionGradeResponse({
+        score_normalized: 0.9,
+        score_display: 4.5,
+        feedback_global: "Buen trabajo general.",
+        modules: [
+            {
+                module_id: "M1",
+                weight: 0.5,
+                feedback_module: null,
+                questions: [
+                    {
+                        question_id: "M1-Q1",
+                        rubric_level: "excelente",
+                        feedback_question: null,
+                    },
+                ],
+            },
+            {
+                module_id: "M5",
+                weight: 0.5,
+                feedback_module: null,
+                questions: [
+                    {
+                        question_id: "M5-Q1",
+                        rubric_level: "bien",
+                        feedback_question: null,
+                    },
+                ],
+            },
+        ],
+    });
+}
+
+describe("TeacherSubmissionPreview integration", () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("autosaves rubric changes through the real hook", async () => {
+        const requests: TeacherCaseSubmissionGradeRequest[] = [];
+
+        server.use(
+            http.get("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json(createSubmissionGradeResponse())
+            )),
+            http.put("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", async ({ request }) => {
+                requests.push(await request.json() as TeacherCaseSubmissionGradeRequest);
+
+                return HttpResponse.json(createSubmissionGradeResponse({
+                    modules: [
+                        {
+                            module_id: "M1",
+                            weight: 0.5,
+                            feedback_module: null,
+                            questions: [
+                                {
+                                    question_id: "M1-Q1",
+                                    rubric_level: "excelente",
+                                    feedback_question: null,
+                                },
+                            ],
+                        },
+                        {
+                            module_id: "M5",
+                            weight: 0.5,
+                            feedback_module: null,
+                            questions: [
+                                {
+                                    question_id: "M5-Q1",
+                                    rubric_level: null,
+                                    feedback_question: null,
+                                },
+                            ],
+                        },
+                    ],
+                    score_normalized: 1,
+                    score_display: 5,
+                    last_modified_at: "2026-06-05T19:05:00Z",
+                }));
+            }),
+        );
+
+        renderPreview();
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+        fireEvent.click(await screen.findByRole("radio", { name: "Excelente" }));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(TEACHER_MANUAL_GRADING_AUTOSAVE_DELAY_MS);
+        });
+
+        await waitFor(() => {
+            expect(requests).toHaveLength(1);
+        });
+        expect(requests[0].intent).toBe("save_draft");
+        expect(requests[0].modules[0].questions[0].rubric_level).toBe("excelente");
+    });
+
+    it("publishes only after explicit confirmation with the real hook", async () => {
+        const requests: TeacherCaseSubmissionGradeRequest[] = [];
+
+        server.use(
+            http.get("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json(buildGradedResponse())
+            )),
+            http.put("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", async ({ request }) => {
+                requests.push(await request.json() as TeacherCaseSubmissionGradeRequest);
+
+                return HttpResponse.json(createSubmissionGradeResponse({
+                    ...buildGradedResponse(),
+                    publication_state: "published",
+                    version: 2,
+                    published_at: "2026-06-05T19:10:00Z",
+                    graded_at: "2026-06-05T19:10:00Z",
+                    last_modified_at: "2026-06-05T19:10:00Z",
+                }));
+            }),
+        );
+
+        renderPreview();
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+        const [publishButton] = await screen.findAllByTestId("teacher-grading-publish-button");
+        fireEvent.click(publishButton);
+
+        expect(requests).toHaveLength(0);
+        expect(await screen.findByTestId("teacher-publish-confirm-modal")).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: /Confirmar publicación/i }));
+
+        await waitFor(() => {
+            expect(requests).toHaveLength(1);
+        });
+        expect(requests[0].intent).toBe("publish");
+        expect((await screen.findAllByText(/Versión 2 publicada correctamente/i)).length).toBeGreaterThan(0);
+    });
+
+    it("shows the blocking snapshot modal when publish hits a 409 conflict", async () => {
+        server.use(
+            http.get("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json(buildGradedResponse())
+            )),
+            http.put("/api/teacher/courses/:courseId/cases/:assignmentId/submissions/:membershipId/grade", () => (
+                HttpResponse.json({
+                    detail: {
+                        code: "snapshot_changed",
+                        message: "El estudiante modificó su entrega. Recarga para ver cambios.",
+                    },
+                }, { status: 409 })
+            )),
+        );
+
+        renderPreview();
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+        const [publishButton] = await screen.findAllByTestId("teacher-grading-publish-button");
+        fireEvent.click(publishButton);
+        fireEvent.click(await screen.findByRole("button", { name: /Confirmar publicación/i }));
+
+        expect(await screen.findByTestId("teacher-snapshot-conflict-modal")).toBeTruthy();
+        expect(screen.getByText(/El estudiante modificó su entrega/i)).toBeTruthy();
+    });
+});

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
@@ -6,10 +6,15 @@ import { formatTeacherGradebookScore } from "@/features/teacher-course/teacherCo
 import { renderWithProviders } from "@/shared/test-utils";
 
 import { TeacherSubmissionPreview } from "../TeacherSubmissionPreview";
+import { useTeacherManualGrading } from "../useTeacherManualGrading";
 
-import { createSubmissionDetailResponse } from "./testData";
+import { createSubmissionDetailResponse, createSubmissionGradeResponse } from "./testData";
 
 const caseContentRendererSpy = vi.fn();
+
+vi.mock("../useTeacherManualGrading", () => ({
+    useTeacherManualGrading: vi.fn(),
+}));
 
 vi.mock("@/shared/case-viewer", async () => {
     const actual = await vi.importActual<typeof import("@/shared/case-viewer")>("@/shared/case-viewer");
@@ -48,7 +53,9 @@ vi.mock("@/shared/case-viewer", async () => {
                 showExpectedSolutions: boolean;
                 answers: Record<string, string>;
                 result: { studentProfile?: string | null };
+                questionSupplement?: (questionId: string) => React.ReactNode;
             };
+            const supplement = rendererProps.questionSupplement?.("M1-Q1") ?? null;
 
             return (
                 <div
@@ -59,7 +66,9 @@ vi.mock("@/shared/case-viewer", async () => {
                     data-show-expected-solutions={String(rendererProps.showExpectedSolutions)}
                     data-answer-keys={Object.keys(rendererProps.answers).sort().join(",")}
                     data-student-profile={rendererProps.result.studentProfile ?? "null"}
-                />
+                >
+                    {supplement}
+                </div>
             );
         },
     };
@@ -99,9 +108,34 @@ function renderPreview(options?: {
     return { ...view, detail, onRefresh };
 }
 
+function buildManualGradingHookState(
+    overrides: Partial<ReturnType<typeof useTeacherManualGrading>> = {},
+): ReturnType<typeof useTeacherManualGrading> {
+    return {
+        mode: "ready",
+        grade: createSubmissionGradeResponse(),
+        loadErrorMessage: null,
+        autosaveState: "saved",
+        banner: null,
+        isDirty: false,
+        isPublishing: false,
+        missingQuestionCount: 0,
+        hasPublishedVersion: false,
+        requiresRefresh: false,
+        refresh: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockResolvedValue(true),
+        setGlobalFeedback: vi.fn(),
+        setModuleFeedback: vi.fn(),
+        setQuestionFeedback: vi.fn(),
+        setQuestionRubric: vi.fn(),
+        ...overrides,
+    };
+}
+
 describe("TeacherSubmissionPreview", () => {
     beforeEach(() => {
         caseContentRendererSpy.mockReset();
+        vi.mocked(useTeacherManualGrading).mockReturnValue(buildManualGradingHookState());
     });
 
     it("renders header and sidebar summary metadata", async () => {
@@ -120,7 +154,7 @@ describe("TeacherSubmissionPreview", () => {
         expect(within(summary).getByText("2/2")).toBeTruthy();
         expect(within(summary).getByText("Pendiente")).toBeTruthy();
         expect(within(header).getByText("Caso Plataforma")).toBeTruthy();
-        expect(screen.getAllByTestId("teacher-case-submission-detail-grading-slot").length).toBeGreaterThan(0);
+        expect(screen.getAllByTestId("teacher-grading-panel").length).toBeGreaterThan(0);
     });
 
     it("passes canonical output, answers and read-only flags to the renderer", async () => {
@@ -190,11 +224,24 @@ describe("TeacherSubmissionPreview", () => {
 
     it("forwards the refresh action", async () => {
         const onRefresh = vi.fn();
+        const gradingRefresh = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(useTeacherManualGrading).mockReturnValue(buildManualGradingHookState({ refresh: gradingRefresh }));
         renderPreview({ onRefresh });
 
         fireEvent.click(await screen.findByRole("button", { name: /Actualizar entrega/i }));
 
         expect(onRefresh).toHaveBeenCalledTimes(1);
+        expect(gradingRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it("toggles grading mode and renders the per-question grading supplement", async () => {
+        renderPreview();
+
+        expect(screen.queryByTestId("teacher-question-grading-M1-Q1")).toBeNull();
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+
+        expect(await screen.findByTestId("teacher-question-grading-M1-Q1")).toBeTruthy();
     });
 
     it("locks and restores body overflow while mounted", async () => {

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
@@ -78,10 +78,10 @@ function renderPreview(options?: {
     initialEntries?: string[];
     isRefreshing?: boolean;
     detail?: ReturnType<typeof createSubmissionDetailResponse>;
-    onRefresh?: () => void;
+    onRefresh?: () => Promise<void> | void;
 }) {
     const detail = options?.detail ?? createSubmissionDetailResponse();
-    const onRefresh = options?.onRefresh ?? vi.fn();
+    const onRefresh = options?.onRefresh ?? vi.fn().mockResolvedValue(undefined);
 
     const view = renderWithProviders(
         <Routes>
@@ -93,8 +93,8 @@ function renderPreview(options?: {
                         assignmentId="assignment-1"
                         detail={detail}
                         isRefreshing={options?.isRefreshing ?? false}
-                        onRefresh={() => {
-                            onRefresh();
+                        onRefresh={async () => {
+                            await onRefresh();
                         }}
                     />
                 )}
@@ -118,6 +118,8 @@ function buildManualGradingHookState(
         autosaveState: "saved",
         banner: null,
         isDirty: false,
+        refreshError: null,
+        isLocked: false,
         isPublishing: false,
         isRefreshing: false,
         isSnapshotConflictOpen: false,
@@ -125,6 +127,8 @@ function buildManualGradingHookState(
         hasPublishedVersion: false,
         requiresRefresh: false,
         refresh: vi.fn().mockResolvedValue(undefined),
+        clearSnapshotConflict: vi.fn(),
+        setRefreshError: vi.fn(),
         publish: vi.fn().mockResolvedValue(true),
         setGlobalFeedback: vi.fn(),
         setModuleFeedback: vi.fn(),
@@ -225,7 +229,7 @@ describe("TeacherSubmissionPreview", () => {
     });
 
     it("forwards the refresh action", async () => {
-        const onRefresh = vi.fn();
+        const onRefresh = vi.fn().mockResolvedValue(undefined);
         const gradingRefresh = vi.fn().mockResolvedValue(undefined);
         vi.mocked(useTeacherManualGrading).mockReturnValue(buildManualGradingHookState({ refresh: gradingRefresh }));
         renderPreview({ onRefresh });

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
@@ -119,6 +119,8 @@ function buildManualGradingHookState(
         banner: null,
         isDirty: false,
         isPublishing: false,
+        isRefreshing: false,
+        isSnapshotConflictOpen: false,
         missingQuestionCount: 0,
         hasPublishedVersion: false,
         requiresRefresh: false,
@@ -242,6 +244,46 @@ describe("TeacherSubmissionPreview", () => {
         fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
 
         expect(await screen.findByTestId("teacher-question-grading-M1-Q1")).toBeTruthy();
+    });
+
+    it("requires an explicit confirmation before publishing", async () => {
+        const publish = vi.fn().mockResolvedValue(true);
+        vi.mocked(useTeacherManualGrading).mockReturnValue(buildManualGradingHookState({ publish }));
+
+        renderPreview();
+
+        fireEvent.click(await screen.findByTestId("teacher-grading-header-toggle"));
+        const [publishButton] = await screen.findAllByTestId("teacher-grading-publish-button");
+        fireEvent.click(publishButton);
+
+        expect(publish).not.toHaveBeenCalled();
+        expect(await screen.findByTestId("teacher-publish-confirm-modal")).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: /Confirmar publicación/i }));
+
+        await waitFor(() => {
+            expect(publish).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it("shows a blocking snapshot conflict modal when the hook requests it", async () => {
+        vi.mocked(useTeacherManualGrading).mockReturnValue(buildManualGradingHookState({
+            isSnapshotConflictOpen: true,
+        }));
+
+        renderPreview();
+
+        expect(await screen.findByTestId("teacher-snapshot-conflict-modal")).toBeTruthy();
+        expect(screen.getByText(/El estudiante modificó su entrega/i)).toBeTruthy();
+    });
+
+    it("does not render the grading panel when the feature is disabled", async () => {
+        vi.mocked(useTeacherManualGrading).mockReturnValue(buildManualGradingHookState({ mode: "disabled" }));
+
+        renderPreview();
+
+        expect(await screen.findByTestId("teacher-submission-preview")).toBeTruthy();
+        expect(screen.queryByTestId("teacher-grading-panel")).toBeNull();
     });
 
     it("locks and restores body overflow while mounted", async () => {

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/testData.ts
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/testData.ts
@@ -1,6 +1,7 @@
 import type {
     CaseContent,
     CanonicalCaseOutput,
+    TeacherCaseSubmissionGradeResponse,
     TeacherCaseSubmissionDetailResponse,
 } from "@/shared/adam-types";
 
@@ -139,5 +140,51 @@ export function createSubmissionDetailResponse(
                 ],
             },
         ],
+    };
+}
+
+export function createSubmissionGradeResponse(
+    overrides: Partial<TeacherCaseSubmissionGradeResponse> = {},
+): TeacherCaseSubmissionGradeResponse {
+    return {
+        payload_version: 1,
+        snapshot_hash: "hash-123",
+        publication_state: "draft",
+        version: 1,
+        score_normalized: null,
+        score_display: null,
+        max_score_display: 5,
+        modules: [
+            {
+                module_id: "M1",
+                weight: 0.5,
+                feedback_module: null,
+                questions: [
+                    {
+                        question_id: "M1-Q1",
+                        rubric_level: null,
+                        feedback_question: null,
+                    },
+                ],
+            },
+            {
+                module_id: "M5",
+                weight: 0.5,
+                feedback_module: null,
+                questions: [
+                    {
+                        question_id: "M5-Q1",
+                        rubric_level: null,
+                        feedback_question: null,
+                    },
+                ],
+            },
+        ],
+        feedback_global: null,
+        graded_at: null,
+        published_at: null,
+        last_modified_at: "2026-06-05T19:00:00Z",
+        graded_by: "human",
+        ...overrides,
     };
 }

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherGradingPanel.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherGradingPanel.tsx
@@ -1,0 +1,314 @@
+import { AlertCircle, CheckCircle2, LoaderCircle, PencilLine, RefreshCcw, SendHorizonal } from "lucide-react";
+
+import type { TeacherCaseSubmissionGradeResponse } from "@/shared/adam-types";
+import {
+    formatTeacherCourseTimestamp,
+    formatTeacherGradebookScore,
+} from "@/features/teacher-course/teacherCourseModel";
+
+import {
+    getTeacherGradePublicationLabel,
+    type TeacherManualGradingAutosaveState,
+    type TeacherManualGradingBannerState,
+} from "../teacherManualGradingModel";
+
+type TeacherGradingPanelMode = "disabled" | "error" | "loading" | "ready" | "unavailable";
+
+interface TeacherGradingPanelProps {
+    mode: TeacherGradingPanelMode;
+    grade: TeacherCaseSubmissionGradeResponse | null;
+    loadErrorMessage: string | null;
+    activeModuleId: string | null;
+    autosaveState: TeacherManualGradingAutosaveState;
+    banner: TeacherManualGradingBannerState | null;
+    isDirty: boolean;
+    isGradingMode: boolean;
+    isPublishing: boolean;
+    missingQuestionCount: number;
+    hasPublishedVersion: boolean;
+    requiresRefresh: boolean;
+    onGlobalFeedbackChange: (value: string) => void;
+    onModuleFeedbackChange: (moduleId: string, value: string) => void;
+    onPublish: () => void;
+    onRefresh: () => void;
+    onToggleMode: () => void;
+}
+
+function buildAutosaveLabel(
+    autosaveState: TeacherManualGradingAutosaveState,
+    grade: TeacherCaseSubmissionGradeResponse | null,
+    requiresRefresh: boolean,
+): string {
+    if (requiresRefresh) {
+        return "Recarga requerida";
+    }
+
+    if (grade?.publication_state === "published" && !autosaveState.startsWith("s")) {
+        return `Publicado ${formatTeacherCourseTimestamp(grade.published_at)}`;
+    }
+
+    switch (autosaveState) {
+        case "dirty":
+            return "Cambios sin guardar";
+        case "saving":
+            return "Guardando borrador...";
+        case "saved":
+            return grade ? `Borrador guardado ${formatTeacherCourseTimestamp(grade.last_modified_at)}` : "Borrador guardado";
+        case "error":
+            return "No se pudo guardar el borrador";
+        default:
+            return grade ? `Actualizado ${formatTeacherCourseTimestamp(grade.last_modified_at)}` : "Sin cambios";
+    }
+}
+
+function AutosaveIcon({
+    autosaveState,
+    isPublishing,
+    requiresRefresh,
+}: {
+    autosaveState: TeacherManualGradingAutosaveState;
+    isPublishing: boolean;
+    requiresRefresh: boolean;
+}) {
+    if (isPublishing) {
+        return <SendHorizonal className="h-3.5 w-3.5" />;
+    }
+    if (requiresRefresh) {
+        return <AlertCircle className="h-3.5 w-3.5" />;
+    }
+
+    switch (autosaveState) {
+        case "saving":
+            return <LoaderCircle className="h-3.5 w-3.5 animate-spin" />;
+        case "saved":
+            return <CheckCircle2 className="h-3.5 w-3.5" />;
+        case "error":
+            return <AlertCircle className="h-3.5 w-3.5" />;
+        default:
+            return <PencilLine className="h-3.5 w-3.5" />;
+    }
+}
+
+function Banner({ banner }: { banner: TeacherManualGradingBannerState }) {
+    const toneClassName = banner.tone === "emerald"
+        ? "border-emerald-200 bg-emerald-50 text-emerald-900"
+        : banner.tone === "amber"
+            ? "border-amber-200 bg-amber-50 text-amber-950"
+            : "border-rose-200 bg-rose-50 text-rose-950";
+
+    return (
+        <div className={`rounded-[18px] border px-4 py-3 ${toneClassName}`} role="status">
+            <p className="text-sm font-semibold">{banner.title}</p>
+            <p className="mt-1 text-xs leading-5">{banner.message}</p>
+        </div>
+    );
+}
+
+function FallbackPanel({
+    title,
+    message,
+    actionLabel,
+    onAction,
+    loading,
+}: {
+    title: string;
+    message: string;
+    actionLabel?: string;
+    onAction?: () => void;
+    loading?: boolean;
+}) {
+    return (
+        <section className="rounded-[24px] border border-slate-200 bg-white p-5 text-slate-900 shadow-sm" data-testid="teacher-grading-panel">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Calificación</p>
+            <div className="mt-3 flex items-start gap-3">
+                {loading ? <LoaderCircle className="mt-0.5 h-5 w-5 animate-spin text-[#0144a0]" /> : <AlertCircle className="mt-0.5 h-5 w-5 text-slate-500" />}
+                <div>
+                    <p className="text-sm font-semibold text-slate-900">{title}</p>
+                    <p className="mt-1 text-sm leading-6 text-slate-600">{message}</p>
+                </div>
+            </div>
+            {actionLabel && onAction ? (
+                <button
+                    type="button"
+                    onClick={onAction}
+                    className="mt-4 inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                >
+                    <RefreshCcw className="h-4 w-4" />
+                    {actionLabel}
+                </button>
+            ) : null}
+        </section>
+    );
+}
+
+export function TeacherGradingPanel({
+    mode,
+    grade,
+    loadErrorMessage,
+    activeModuleId,
+    autosaveState,
+    banner,
+    isDirty,
+    isGradingMode,
+    isPublishing,
+    missingQuestionCount,
+    hasPublishedVersion,
+    requiresRefresh,
+    onGlobalFeedbackChange,
+    onModuleFeedbackChange,
+    onPublish,
+    onRefresh,
+    onToggleMode,
+}: TeacherGradingPanelProps) {
+    if (mode === "loading") {
+        return (
+            <FallbackPanel
+                title="Preparando la calificación manual"
+                message="ADAM está cargando el borrador docente y la versión publicada de esta entrega."
+                loading={true}
+            />
+        );
+    }
+
+    if (mode === "disabled") {
+        return (
+            <FallbackPanel
+                title="Calificación manual deshabilitada"
+                message="Esta capacidad está apagada en el entorno actual. La vista de revisión se mantiene disponible sin perder compatibilidad."
+            />
+        );
+    }
+
+    if (mode === "unavailable") {
+        return (
+            <FallbackPanel
+                title="Calificación pendiente de entrega"
+                message="Esta bandeja se habilita cuando el estudiante ya tiene una entrega enviada o calificada."
+            />
+        );
+    }
+
+    if (mode === "error") {
+        return (
+            <FallbackPanel
+                title="No se pudo cargar la calificación"
+                message={loadErrorMessage ?? "Intenta recargar esta entrega para reconstruir el borrador docente."}
+                actionLabel="Recargar"
+                onAction={onRefresh}
+            />
+        );
+    }
+
+    if (!grade) {
+        return null;
+    }
+
+    const activeModule = activeModuleId
+        ? grade.modules.find((module) => module.module_id === activeModuleId) ?? null
+        : null;
+    const publishDisabled = isPublishing || autosaveState === "saving" || missingQuestionCount > 0 || requiresRefresh;
+    const publicationLabel = getTeacherGradePublicationLabel(grade);
+    const scoreLabel = grade.score_display === null
+        ? "Pendiente"
+        : `${formatTeacherGradebookScore(grade.score_display)} / ${formatTeacherGradebookScore(grade.max_score_display)}`;
+
+    return (
+        <section className="rounded-[24px] border border-slate-200 bg-white p-5 text-slate-900 shadow-sm" data-testid="teacher-grading-panel">
+            <div className="flex items-start justify-between gap-3">
+                <div>
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Calificación</p>
+                    <p className="mt-2 text-base font-semibold text-slate-950">{publicationLabel}</p>
+                    <p className="mt-1 text-sm text-slate-500">{scoreLabel}</p>
+                </div>
+                <button
+                    type="button"
+                    onClick={onToggleMode}
+                    className="inline-flex items-center rounded-full border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                    data-testid="teacher-grading-mode-toggle"
+                >
+                    {isGradingMode ? "Vista previa" : hasPublishedVersion ? "Editar y republicar" : "Modo calificar"}
+                </button>
+            </div>
+
+            <div className="mt-4 flex items-center gap-2 text-xs font-medium text-slate-600">
+                <AutosaveIcon autosaveState={autosaveState} isPublishing={isPublishing} requiresRefresh={requiresRefresh} />
+                <span>{buildAutosaveLabel(autosaveState, grade, requiresRefresh)}</span>
+            </div>
+
+            {banner ? <div className="mt-4"><Banner banner={banner} /></div> : null}
+
+            {!isGradingMode ? (
+                <div className="mt-4 rounded-[18px] border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-600">
+                    Revisa la entrega completa y entra a modo calificar cuando quieras dejar feedback por módulo, por pregunta y publicar una versión nueva.
+                </div>
+            ) : (
+                <div className="mt-4 space-y-4">
+                    {activeModule ? (
+                        <label className="block text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                            Feedback del módulo {activeModule.module_id}
+                            <textarea
+                                value={activeModule.feedback_module ?? ""}
+                                onChange={(event) => onModuleFeedbackChange(activeModule.module_id, event.target.value)}
+                                placeholder={`Resume cómo se sostuvo el desempeño del estudiante en ${activeModule.module_id}.`}
+                                className="mt-2 min-h-[96px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10"
+                                data-testid="teacher-grading-module-feedback"
+                            />
+                        </label>
+                    ) : null}
+
+                    <label className="block text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                        Feedback global
+                        <textarea
+                            value={grade.feedback_global ?? ""}
+                            onChange={(event) => onGlobalFeedbackChange(event.target.value)}
+                            placeholder="Sintetiza qué debe sostener o corregir el estudiante para su siguiente iteración."
+                            className="mt-2 min-h-[120px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10"
+                            data-testid="teacher-grading-global-feedback"
+                        />
+                    </label>
+
+                    {!grade.feedback_global?.trim() ? (
+                        <p className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs leading-5 text-amber-900">
+                            Recomendado: agrega feedback global antes de publicar para que el estudiante entienda la lógica completa de la revisión.
+                        </p>
+                    ) : null}
+
+                    {missingQuestionCount > 0 ? (
+                        <p className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs leading-5 text-slate-600">
+                            Faltan {missingQuestionCount} preguntas por calificar antes de publicar.
+                        </p>
+                    ) : null}
+
+                    {requiresRefresh ? (
+                        <button
+                            type="button"
+                            onClick={onRefresh}
+                            className="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900 transition hover:bg-amber-100"
+                        >
+                            <RefreshCcw className="h-4 w-4" />
+                            Recargar entrega
+                        </button>
+                    ) : null}
+
+                    <button
+                        type="button"
+                        onClick={onPublish}
+                        disabled={publishDisabled}
+                        className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-slate-950 px-4 py-3 text-sm font-semibold text-white transition hover:bg-slate-900 disabled:cursor-not-allowed disabled:bg-slate-300"
+                        data-testid="teacher-grading-publish-button"
+                    >
+                        {isPublishing ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <SendHorizonal className="h-4 w-4" />}
+                        {hasPublishedVersion ? "Republicar calificación" : "Publicar calificación"}
+                    </button>
+                </div>
+            )}
+
+            {grade.published_at ? (
+                <p className="mt-4 text-[11px] text-slate-500">
+                    Última publicación: {formatTeacherCourseTimestamp(grade.published_at)}
+                    {isDirty ? " · hay cambios locales pendientes" : ""}
+                </p>
+            ) : null}
+        </section>
+    );
+}

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherGradingPanel.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherGradingPanel.tsx
@@ -29,7 +29,7 @@ interface TeacherGradingPanelProps {
     requiresRefresh: boolean;
     onGlobalFeedbackChange: (value: string) => void;
     onModuleFeedbackChange: (moduleId: string, value: string) => void;
-    onPublish: () => void;
+    onPublishRequest: () => void;
     onRefresh: () => void;
     onToggleMode: () => void;
 }
@@ -156,25 +156,20 @@ export function TeacherGradingPanel({
     requiresRefresh,
     onGlobalFeedbackChange,
     onModuleFeedbackChange,
-    onPublish,
+    onPublishRequest,
     onRefresh,
     onToggleMode,
 }: TeacherGradingPanelProps) {
+    if (mode === "disabled") {
+        return null;
+    }
+
     if (mode === "loading") {
         return (
             <FallbackPanel
                 title="Preparando la calificación manual"
                 message="ADAM está cargando el borrador docente y la versión publicada de esta entrega."
                 loading={true}
-            />
-        );
-    }
-
-    if (mode === "disabled") {
-        return (
-            <FallbackPanel
-                title="Calificación manual deshabilitada"
-                message="Esta capacidad está apagada en el entorno actual. La vista de revisión se mantiene disponible sin perder compatibilidad."
             />
         );
     }
@@ -206,6 +201,7 @@ export function TeacherGradingPanel({
     const activeModule = activeModuleId
         ? grade.modules.find((module) => module.module_id === activeModuleId) ?? null
         : null;
+    const editingDisabled = requiresRefresh || isPublishing;
     const publishDisabled = isPublishing || autosaveState === "saving" || missingQuestionCount > 0 || requiresRefresh;
     const publicationLabel = getTeacherGradePublicationLabel(grade);
     const scoreLabel = grade.score_display === null
@@ -223,6 +219,7 @@ export function TeacherGradingPanel({
                 <button
                     type="button"
                     onClick={onToggleMode}
+                    disabled={requiresRefresh}
                     className="inline-flex items-center rounded-full border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
                     data-testid="teacher-grading-mode-toggle"
                 >
@@ -249,6 +246,7 @@ export function TeacherGradingPanel({
                             <textarea
                                 value={activeModule.feedback_module ?? ""}
                                 onChange={(event) => onModuleFeedbackChange(activeModule.module_id, event.target.value)}
+                                disabled={editingDisabled}
                                 placeholder={`Resume cómo se sostuvo el desempeño del estudiante en ${activeModule.module_id}.`}
                                 className="mt-2 min-h-[96px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10"
                                 data-testid="teacher-grading-module-feedback"
@@ -261,6 +259,7 @@ export function TeacherGradingPanel({
                         <textarea
                             value={grade.feedback_global ?? ""}
                             onChange={(event) => onGlobalFeedbackChange(event.target.value)}
+                            disabled={editingDisabled}
                             placeholder="Sintetiza qué debe sostener o corregir el estudiante para su siguiente iteración."
                             className="mt-2 min-h-[120px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10"
                             data-testid="teacher-grading-global-feedback"
@@ -279,20 +278,9 @@ export function TeacherGradingPanel({
                         </p>
                     ) : null}
 
-                    {requiresRefresh ? (
-                        <button
-                            type="button"
-                            onClick={onRefresh}
-                            className="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900 transition hover:bg-amber-100"
-                        >
-                            <RefreshCcw className="h-4 w-4" />
-                            Recargar entrega
-                        </button>
-                    ) : null}
-
                     <button
                         type="button"
-                        onClick={onPublish}
+                        onClick={onPublishRequest}
                         disabled={publishDisabled}
                         className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-slate-950 px-4 py-3 text-sm font-semibold text-white transition hover:bg-slate-900 disabled:cursor-not-allowed disabled:bg-slate-300"
                         data-testid="teacher-grading-publish-button"

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherGradingPanel.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherGradingPanel.tsx
@@ -23,6 +23,7 @@ interface TeacherGradingPanelProps {
     banner: TeacherManualGradingBannerState | null;
     isDirty: boolean;
     isGradingMode: boolean;
+    isLocked: boolean;
     isPublishing: boolean;
     missingQuestionCount: number;
     hasPublishedVersion: boolean;
@@ -37,8 +38,13 @@ interface TeacherGradingPanelProps {
 function buildAutosaveLabel(
     autosaveState: TeacherManualGradingAutosaveState,
     grade: TeacherCaseSubmissionGradeResponse | null,
+    isPublishing: boolean,
     requiresRefresh: boolean,
 ): string {
+    if (isPublishing) {
+        return "Publicando calificación...";
+    }
+
     if (requiresRefresh) {
         return "Recarga requerida";
     }
@@ -150,6 +156,7 @@ export function TeacherGradingPanel({
     banner,
     isDirty,
     isGradingMode,
+    isLocked,
     isPublishing,
     missingQuestionCount,
     hasPublishedVersion,
@@ -201,15 +208,15 @@ export function TeacherGradingPanel({
     const activeModule = activeModuleId
         ? grade.modules.find((module) => module.module_id === activeModuleId) ?? null
         : null;
-    const editingDisabled = requiresRefresh || isPublishing;
-    const publishDisabled = isPublishing || autosaveState === "saving" || missingQuestionCount > 0 || requiresRefresh;
+    const editingDisabled = isLocked;
+    const publishDisabled = isLocked || autosaveState === "saving" || missingQuestionCount > 0;
     const publicationLabel = getTeacherGradePublicationLabel(grade);
     const scoreLabel = grade.score_display === null
         ? "Pendiente"
         : `${formatTeacherGradebookScore(grade.score_display)} / ${formatTeacherGradebookScore(grade.max_score_display)}`;
 
     return (
-        <section className="rounded-[24px] border border-slate-200 bg-white p-5 text-slate-900 shadow-sm" data-testid="teacher-grading-panel">
+        <section className="rounded-[24px] border border-slate-200 bg-white p-5 text-slate-900 shadow-sm" data-testid="teacher-grading-panel" aria-busy={isPublishing}>
             <div className="flex items-start justify-between gap-3">
                 <div>
                     <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Calificación</p>
@@ -219,7 +226,7 @@ export function TeacherGradingPanel({
                 <button
                     type="button"
                     onClick={onToggleMode}
-                    disabled={requiresRefresh}
+                    disabled={isLocked}
                     className="inline-flex items-center rounded-full border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
                     data-testid="teacher-grading-mode-toggle"
                 >
@@ -229,8 +236,14 @@ export function TeacherGradingPanel({
 
             <div className="mt-4 flex items-center gap-2 text-xs font-medium text-slate-600">
                 <AutosaveIcon autosaveState={autosaveState} isPublishing={isPublishing} requiresRefresh={requiresRefresh} />
-                <span>{buildAutosaveLabel(autosaveState, grade, requiresRefresh)}</span>
+                <span>{buildAutosaveLabel(autosaveState, grade, isPublishing, requiresRefresh)}</span>
             </div>
+
+            {isPublishing ? (
+                <p className="mt-2 text-xs text-slate-500" aria-live="polite">
+                    Publicando calificación, edición temporalmente deshabilitada.
+                </p>
+            ) : null}
 
             {banner ? <div className="mt-4"><Banner banner={banner} /></div> : null}
 
@@ -239,7 +252,7 @@ export function TeacherGradingPanel({
                     Revisa la entrega completa y entra a modo calificar cuando quieras dejar feedback por módulo, por pregunta y publicar una versión nueva.
                 </div>
             ) : (
-                <div className="mt-4 space-y-4">
+                <div className={`mt-4 space-y-4 ${isLocked ? "opacity-80" : ""}`}>
                     {activeModule ? (
                         <label className="block text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
                             Feedback del módulo {activeModule.module_id}
@@ -248,7 +261,7 @@ export function TeacherGradingPanel({
                                 onChange={(event) => onModuleFeedbackChange(activeModule.module_id, event.target.value)}
                                 disabled={editingDisabled}
                                 placeholder={`Resume cómo se sostuvo el desempeño del estudiante en ${activeModule.module_id}.`}
-                                className="mt-2 min-h-[96px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10"
+                                className="mt-2 min-h-[96px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10 disabled:cursor-not-allowed disabled:opacity-70"
                                 data-testid="teacher-grading-module-feedback"
                             />
                         </label>
@@ -261,7 +274,7 @@ export function TeacherGradingPanel({
                             onChange={(event) => onGlobalFeedbackChange(event.target.value)}
                             disabled={editingDisabled}
                             placeholder="Sintetiza qué debe sostener o corregir el estudiante para su siguiente iteración."
-                            className="mt-2 min-h-[120px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10"
+                            className="mt-2 min-h-[120px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10 disabled:cursor-not-allowed disabled:opacity-70"
                             data-testid="teacher-grading-global-feedback"
                         />
                     </label>

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherPublishConfirmModal.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherPublishConfirmModal.tsx
@@ -1,0 +1,70 @@
+import { LoaderCircle, SendHorizonal } from "lucide-react";
+
+interface TeacherPublishConfirmModalProps {
+    isOpen: boolean;
+    hasPublishedVersion: boolean;
+    isSubmitting: boolean;
+    scoreLabel: string;
+    onClose: () => void;
+    onConfirm: () => void;
+}
+
+export function TeacherPublishConfirmModal({
+    isOpen,
+    hasPublishedVersion,
+    isSubmitting,
+    scoreLabel,
+    onClose,
+    onConfirm,
+}: TeacherPublishConfirmModalProps) {
+    if (!isOpen) {
+        return null;
+    }
+
+    const title = hasPublishedVersion ? "Confirmar republicación" : "Confirmar publicación";
+    const confirmLabel = hasPublishedVersion ? "Confirmar republicación" : "Confirmar publicación";
+
+    return (
+        <div className="fixed inset-0 z-[90] flex items-center justify-center bg-slate-950/60 px-4 py-6 backdrop-blur-sm">
+            <div
+                className="w-full max-w-md overflow-hidden rounded-[20px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.22)]"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="teacher-publish-confirm-title"
+                data-testid="teacher-publish-confirm-modal"
+            >
+                <div className="px-6 py-5">
+                    <h2 id="teacher-publish-confirm-title" className="text-xl font-bold tracking-tight text-slate-900">
+                        {title}
+                    </h2>
+                    <p className="mt-3 text-sm leading-6 text-slate-600">
+                        El estudiante verá esta calificación apenas confirmes la publicación.
+                    </p>
+                    <div className="mt-4 rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">Puntaje final</p>
+                        <p className="mt-1 text-lg font-semibold text-slate-950">{scoreLabel}</p>
+                    </div>
+                </div>
+                <div className="flex items-center justify-end gap-3 border-t border-slate-200 px-6 py-4">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        disabled={isSubmitting}
+                        className="inline-flex items-center justify-center rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        Cancelar
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onConfirm}
+                        disabled={isSubmitting}
+                        className="inline-flex items-center justify-center gap-2 rounded-xl bg-slate-950 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-900 disabled:cursor-not-allowed disabled:bg-slate-300"
+                    >
+                        {isSubmitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <SendHorizonal className="h-4 w-4" />}
+                        {confirmLabel}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherQuestionGradingSupplement.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherQuestionGradingSupplement.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/shared/test-utils";
+
+import { TeacherQuestionGradingSupplement } from "./TeacherQuestionGradingSupplement";
+
+describe("TeacherQuestionGradingSupplement", () => {
+    it("renders an accessible radiogroup and changes selection with arrow keys", () => {
+        const onRubricChange = vi.fn();
+
+        renderWithProviders(
+            <TeacherQuestionGradingSupplement
+                questionId="M1-Q1"
+                rubricLevel="excelente"
+                feedbackQuestion={null}
+                onFeedbackChange={vi.fn()}
+                onRubricChange={onRubricChange}
+            />,
+        );
+
+        const excellentOption = screen.getByRole("radio", { name: "Excelente" });
+        const goodOption = screen.getByRole("radio", { name: "Bien" });
+
+        expect(screen.getByRole("radiogroup", { name: "Nivel de rúbrica" })).toBeTruthy();
+        expect(excellentOption).toHaveAttribute("aria-checked", "true");
+        expect(excellentOption).toHaveAttribute("tabindex", "0");
+
+        excellentOption.focus();
+        fireEvent.keyDown(excellentOption, { key: "ArrowRight" });
+
+        expect(onRubricChange).toHaveBeenCalledWith("bien");
+        expect(goodOption).toHaveFocus();
+        expect(goodOption).toHaveAttribute("tabindex", "0");
+    });
+});

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherQuestionGradingSupplement.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherQuestionGradingSupplement.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { renderWithProviders } from "@/shared/test-utils";
@@ -32,5 +33,36 @@ describe("TeacherQuestionGradingSupplement", () => {
         expect(onRubricChange).toHaveBeenCalledWith("bien");
         expect(goodOption).toHaveFocus();
         expect(goodOption).toHaveAttribute("tabindex", "0");
+    });
+
+    it("exposes aria-disabled and blocks interactions when disabled", async () => {
+        const onRubricChange = vi.fn();
+        const onFeedbackChange = vi.fn();
+        const user = userEvent.setup();
+
+        renderWithProviders(
+            <TeacherQuestionGradingSupplement
+                questionId="M1-Q1"
+                rubricLevel="excelente"
+                feedbackQuestion={null}
+                disabled={true}
+                onFeedbackChange={onFeedbackChange}
+                onRubricChange={onRubricChange}
+            />,
+        );
+
+        const radiogroup = screen.getByRole("radiogroup", { name: "Nivel de rúbrica" });
+        const excellentOption = screen.getByRole("radio", { name: "Excelente" });
+        const feedbackTextarea = screen.getByPlaceholderText(/Explica qué sostuvo o debilitó/i);
+
+        expect(radiogroup).toHaveAttribute("aria-disabled", "true");
+        expect(excellentOption).toHaveAttribute("aria-disabled", "true");
+        expect(feedbackTextarea).toHaveAttribute("aria-disabled", "true");
+
+        await user.click(excellentOption);
+        await user.type(feedbackTextarea, "Nuevo feedback");
+
+        expect(onRubricChange).not.toHaveBeenCalled();
+        expect(onFeedbackChange).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherQuestionGradingSupplement.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherQuestionGradingSupplement.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react";
+
 import type { TeacherGradeRubricLevel } from "@/shared/adam-types";
 
 import { TEACHER_GRADE_RUBRIC_OPTIONS } from "../teacherManualGradingModel";
@@ -6,6 +8,7 @@ interface TeacherQuestionGradingSupplementProps {
     questionId: string;
     rubricLevel: TeacherGradeRubricLevel | null;
     feedbackQuestion: string | null;
+    disabled?: boolean;
     onFeedbackChange: (value: string) => void;
     onRubricChange: (value: TeacherGradeRubricLevel | null) => void;
 }
@@ -14,9 +17,28 @@ export function TeacherQuestionGradingSupplement({
     questionId,
     rubricLevel,
     feedbackQuestion,
+    disabled = false,
     onFeedbackChange,
     onRubricChange,
 }: TeacherQuestionGradingSupplementProps) {
+    const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+    const selectedIndex = TEACHER_GRADE_RUBRIC_OPTIONS.findIndex((option) => option.value === rubricLevel);
+    const [focusedIndex, setFocusedIndex] = useState(selectedIndex >= 0 ? selectedIndex : 0);
+
+    useEffect(() => {
+        setFocusedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    }, [selectedIndex]);
+
+    function focusOption(nextIndex: number) {
+        setFocusedIndex(nextIndex);
+        optionRefs.current[nextIndex]?.focus();
+    }
+
+    function selectOption(nextIndex: number) {
+        onRubricChange(TEACHER_GRADE_RUBRIC_OPTIONS[nextIndex].value);
+        focusOption(nextIndex);
+    }
+
     return (
         <section
             className="rounded-[18px] border border-slate-200 bg-slate-50/90 p-4 shadow-sm"
@@ -34,21 +56,62 @@ export function TeacherQuestionGradingSupplement({
                 <button
                     type="button"
                     onClick={() => onRubricChange(null)}
+                    disabled={disabled}
                     className="rounded-full border border-slate-200 px-3 py-1.5 text-[11px] font-semibold text-slate-500 transition hover:bg-white"
                 >
                     Limpiar
                 </button>
             </div>
 
-            <div className="mt-4 flex flex-wrap gap-2">
+            <div className="mt-4 flex flex-wrap gap-2" role="radiogroup" aria-label="Nivel de rúbrica">
                 {TEACHER_GRADE_RUBRIC_OPTIONS.map((option) => {
+                    const optionIndex = TEACHER_GRADE_RUBRIC_OPTIONS.findIndex((currentOption) => currentOption.value === option.value);
                     const isActive = rubricLevel === option.value;
                     return (
                         <button
                             key={option.value}
+                            ref={(element) => {
+                                optionRefs.current[optionIndex] = element;
+                            }}
                             type="button"
-                            aria-pressed={isActive}
-                            onClick={() => onRubricChange(isActive ? null : option.value)}
+                            role="radio"
+                            aria-checked={isActive}
+                            disabled={disabled}
+                            tabIndex={disabled ? -1 : focusedIndex === optionIndex ? 0 : -1}
+                            onClick={() => selectOption(optionIndex)}
+                            onKeyDown={(event) => {
+                                if (disabled) {
+                                    return;
+                                }
+
+                                switch (event.key) {
+                                    case "ArrowRight":
+                                    case "ArrowDown":
+                                        event.preventDefault();
+                                        selectOption((optionIndex + 1) % TEACHER_GRADE_RUBRIC_OPTIONS.length);
+                                        break;
+                                    case "ArrowLeft":
+                                    case "ArrowUp":
+                                        event.preventDefault();
+                                        selectOption((optionIndex + TEACHER_GRADE_RUBRIC_OPTIONS.length - 1) % TEACHER_GRADE_RUBRIC_OPTIONS.length);
+                                        break;
+                                    case "Home":
+                                        event.preventDefault();
+                                        selectOption(0);
+                                        break;
+                                    case "End":
+                                        event.preventDefault();
+                                        selectOption(TEACHER_GRADE_RUBRIC_OPTIONS.length - 1);
+                                        break;
+                                    case " ":
+                                    case "Enter":
+                                        event.preventDefault();
+                                        selectOption(optionIndex);
+                                        break;
+                                    default:
+                                        break;
+                                }
+                            }}
                             className={isActive
                                 ? `rounded-full border px-3 py-2 text-[11px] font-semibold shadow-sm ${option.tone}`
                                 : "rounded-full border border-slate-200 bg-white px-3 py-2 text-[11px] font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
@@ -65,6 +128,7 @@ export function TeacherQuestionGradingSupplement({
                 <textarea
                     value={feedbackQuestion ?? ""}
                     onChange={(event) => onFeedbackChange(event.target.value)}
+                    disabled={disabled}
                     placeholder="Explica qué sostuvo o debilitó la respuesta del estudiante."
                     className="mt-2 min-h-[104px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10"
                 />

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherQuestionGradingSupplement.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherQuestionGradingSupplement.tsx
@@ -1,0 +1,74 @@
+import type { TeacherGradeRubricLevel } from "@/shared/adam-types";
+
+import { TEACHER_GRADE_RUBRIC_OPTIONS } from "../teacherManualGradingModel";
+
+interface TeacherQuestionGradingSupplementProps {
+    questionId: string;
+    rubricLevel: TeacherGradeRubricLevel | null;
+    feedbackQuestion: string | null;
+    onFeedbackChange: (value: string) => void;
+    onRubricChange: (value: TeacherGradeRubricLevel | null) => void;
+}
+
+export function TeacherQuestionGradingSupplement({
+    questionId,
+    rubricLevel,
+    feedbackQuestion,
+    onFeedbackChange,
+    onRubricChange,
+}: TeacherQuestionGradingSupplementProps) {
+    return (
+        <section
+            className="rounded-[18px] border border-slate-200 bg-slate-50/90 p-4 shadow-sm"
+            data-testid={`teacher-question-grading-${questionId}`}
+        >
+            <div className="flex items-center justify-between gap-3">
+                <div>
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                        Calificación por criterio
+                    </p>
+                    <p className="mt-1 text-xs text-slate-600">
+                        Selecciona el nivel de rúbrica y deja feedback puntual para esta respuesta.
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={() => onRubricChange(null)}
+                    className="rounded-full border border-slate-200 px-3 py-1.5 text-[11px] font-semibold text-slate-500 transition hover:bg-white"
+                >
+                    Limpiar
+                </button>
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+                {TEACHER_GRADE_RUBRIC_OPTIONS.map((option) => {
+                    const isActive = rubricLevel === option.value;
+                    return (
+                        <button
+                            key={option.value}
+                            type="button"
+                            aria-pressed={isActive}
+                            onClick={() => onRubricChange(isActive ? null : option.value)}
+                            className={isActive
+                                ? `rounded-full border px-3 py-2 text-[11px] font-semibold shadow-sm ${option.tone}`
+                                : "rounded-full border border-slate-200 bg-white px-3 py-2 text-[11px] font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+                            }
+                        >
+                            {option.label}
+                        </button>
+                    );
+                })}
+            </div>
+
+            <label className="mt-4 block text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                Feedback por pregunta
+                <textarea
+                    value={feedbackQuestion ?? ""}
+                    onChange={(event) => onFeedbackChange(event.target.value)}
+                    placeholder="Explica qué sostuvo o debilitó la respuesta del estudiante."
+                    className="mt-2 min-h-[104px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10"
+                />
+            </label>
+        </section>
+    );
+}

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherQuestionGradingSupplement.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherQuestionGradingSupplement.tsx
@@ -35,13 +35,17 @@ export function TeacherQuestionGradingSupplement({
     }
 
     function selectOption(nextIndex: number) {
+        if (disabled) {
+            return;
+        }
+
         onRubricChange(TEACHER_GRADE_RUBRIC_OPTIONS[nextIndex].value);
         focusOption(nextIndex);
     }
 
     return (
         <section
-            className="rounded-[18px] border border-slate-200 bg-slate-50/90 p-4 shadow-sm"
+            className={`rounded-[18px] border border-slate-200 bg-slate-50/90 p-4 shadow-sm ${disabled ? "opacity-80" : ""}`}
             data-testid={`teacher-question-grading-${questionId}`}
         >
             <div className="flex items-center justify-between gap-3">
@@ -57,13 +61,13 @@ export function TeacherQuestionGradingSupplement({
                     type="button"
                     onClick={() => onRubricChange(null)}
                     disabled={disabled}
-                    className="rounded-full border border-slate-200 px-3 py-1.5 text-[11px] font-semibold text-slate-500 transition hover:bg-white"
+                    className="rounded-full border border-slate-200 px-3 py-1.5 text-[11px] font-semibold text-slate-500 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
                 >
                     Limpiar
                 </button>
             </div>
 
-            <div className="mt-4 flex flex-wrap gap-2" role="radiogroup" aria-label="Nivel de rúbrica">
+            <div className="mt-4 flex flex-wrap gap-2" role="radiogroup" aria-label="Nivel de rúbrica" aria-disabled={disabled}>
                 {TEACHER_GRADE_RUBRIC_OPTIONS.map((option) => {
                     const optionIndex = TEACHER_GRADE_RUBRIC_OPTIONS.findIndex((currentOption) => currentOption.value === option.value);
                     const isActive = rubricLevel === option.value;
@@ -76,6 +80,7 @@ export function TeacherQuestionGradingSupplement({
                             type="button"
                             role="radio"
                             aria-checked={isActive}
+                            aria-disabled={disabled}
                             disabled={disabled}
                             tabIndex={disabled ? -1 : focusedIndex === optionIndex ? 0 : -1}
                             onClick={() => selectOption(optionIndex)}
@@ -113,8 +118,8 @@ export function TeacherQuestionGradingSupplement({
                                 }
                             }}
                             className={isActive
-                                ? `rounded-full border px-3 py-2 text-[11px] font-semibold shadow-sm ${option.tone}`
-                                : "rounded-full border border-slate-200 bg-white px-3 py-2 text-[11px] font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+                                ? `rounded-full border px-3 py-2 text-[11px] font-semibold shadow-sm disabled:cursor-not-allowed disabled:opacity-60 ${option.tone}`
+                                : "rounded-full border border-slate-200 bg-white px-3 py-2 text-[11px] font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
                             }
                         >
                             {option.label}
@@ -129,8 +134,9 @@ export function TeacherQuestionGradingSupplement({
                     value={feedbackQuestion ?? ""}
                     onChange={(event) => onFeedbackChange(event.target.value)}
                     disabled={disabled}
+                    aria-disabled={disabled}
                     placeholder="Explica qué sostuvo o debilitó la respuesta del estudiante."
-                    className="mt-2 min-h-[104px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10"
+                    className="mt-2 min-h-[104px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm outline-none transition focus:border-[#0144a0] focus:ring-2 focus:ring-[#0144a0]/10 disabled:cursor-not-allowed disabled:opacity-70"
                 />
             </label>
         </section>

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherSnapshotConflictModal.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherSnapshotConflictModal.tsx
@@ -1,0 +1,49 @@
+import { LoaderCircle, RefreshCw } from "lucide-react";
+
+interface TeacherSnapshotConflictModalProps {
+    isOpen: boolean;
+    isReloading: boolean;
+    onReload: () => Promise<void> | void;
+}
+
+export function TeacherSnapshotConflictModal({
+    isOpen,
+    isReloading,
+    onReload,
+}: TeacherSnapshotConflictModalProps) {
+    if (!isOpen) {
+        return null;
+    }
+
+    return (
+        <div className="fixed inset-0 z-[95] flex items-center justify-center bg-slate-950/60 px-4 py-6 backdrop-blur-sm">
+            <div
+                className="w-full max-w-md overflow-hidden rounded-[20px] bg-white shadow-[0_24px_64px_rgba(0,0,0,0.22)]"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="teacher-snapshot-conflict-title"
+                data-testid="teacher-snapshot-conflict-modal"
+            >
+                <div className="px-6 py-5">
+                    <h2 id="teacher-snapshot-conflict-title" className="text-xl font-bold tracking-tight text-slate-900">
+                        El estudiante modificó su entrega
+                    </h2>
+                    <p className="mt-3 text-sm leading-6 text-slate-600">
+                        Esta calificación ya no corresponde al snapshot actual. Recarga para ver los cambios antes de seguir calificando.
+                    </p>
+                </div>
+                <div className="flex items-center justify-end border-t border-slate-200 px-6 py-4">
+                    <button
+                        type="button"
+                        onClick={() => void onReload()}
+                        disabled={isReloading}
+                        className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#0144a0] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#00337a] disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        {isReloading ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                        Recargar entrega
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/teacher-case-submission-detail/components/TeacherSnapshotConflictModal.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/components/TeacherSnapshotConflictModal.tsx
@@ -3,12 +3,14 @@ import { LoaderCircle, RefreshCw } from "lucide-react";
 interface TeacherSnapshotConflictModalProps {
     isOpen: boolean;
     isReloading: boolean;
+    refreshError?: string | null;
     onReload: () => Promise<void> | void;
 }
 
 export function TeacherSnapshotConflictModal({
     isOpen,
     isReloading,
+    refreshError = null,
     onReload,
 }: TeacherSnapshotConflictModalProps) {
     if (!isOpen) {
@@ -31,12 +33,18 @@ export function TeacherSnapshotConflictModal({
                     <p className="mt-3 text-sm leading-6 text-slate-600">
                         Esta calificación ya no corresponde al snapshot actual. Recarga para ver los cambios antes de seguir calificando.
                     </p>
+                    {refreshError ? (
+                        <div className="mt-4 rounded-[16px] border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-900" role="alert">
+                            {refreshError}
+                        </div>
+                    ) : null}
                 </div>
                 <div className="flex items-center justify-end border-t border-slate-200 px-6 py-4">
                     <button
                         type="button"
                         onClick={() => void onReload()}
                         disabled={isReloading}
+                        data-testid="teacher-snapshot-conflict-reload-button"
                         className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#0144a0] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#00337a] disabled:cursor-not-allowed disabled:opacity-50"
                     >
                         {isReloading ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}

--- a/frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionGradeApi.test.ts
+++ b/frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionGradeApi.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/api", async () => {
+    const actual = await vi.importActual<typeof import("@/shared/api")>("@/shared/api");
+
+    return {
+        ...actual,
+        api: {
+            ...actual.api,
+            teacher: {
+                ...actual.api.teacher,
+                getCaseSubmissionGrade: vi.fn(),
+                saveCaseSubmissionGrade: vi.fn(),
+            },
+        },
+    };
+});
+
+import { ApiError, api } from "@/shared/api";
+
+import { IncompleteGradeError, saveTeacherCaseSubmissionGrade } from "./teacherCaseSubmissionGradeApi";
+
+describe("teacherCaseSubmissionGradeApi", () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("maps incomplete_grade responses to a typed error with missing question ids", async () => {
+        vi.mocked(api.teacher.saveCaseSubmissionGrade).mockRejectedValueOnce(
+            new ApiError(422, "Incomplete", {
+                code: "incomplete_grade",
+                message: "All questions must be graded before publishing.",
+                missing_question_ids: ["M5-Q5"],
+            }),
+        );
+
+        await expect(
+            saveTeacherCaseSubmissionGrade("course-1", "assignment-1", "membership-1", {
+                payload_version: 1,
+                snapshot_hash: "hash-123",
+                intent: "publish",
+                modules: [],
+                feedback_global: null,
+                graded_by: "human",
+            }),
+        ).rejects.toEqual(expect.objectContaining<Partial<IncompleteGradeError>>({
+            name: "IncompleteGradeError",
+            missingQuestionIds: ["M5-Q5"],
+        }));
+    });
+});

--- a/frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionGradeApi.ts
+++ b/frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionGradeApi.ts
@@ -1,0 +1,62 @@
+import { api } from "@/shared/api";
+import type {
+    TeacherCaseSubmissionGradeRequest,
+    TeacherCaseSubmissionGradeResponse,
+} from "@/shared/adam-types";
+
+export const TEACHER_CASE_SUBMISSION_GRADE_QUERY_GC_TIME = 5 * 60_000;
+export const SUPPORTED_TEACHER_CASE_SUBMISSION_GRADE_PAYLOAD_VERSION = 1;
+
+type TeacherCaseSubmissionGradeRuntimeResponse = Omit<TeacherCaseSubmissionGradeResponse, "payload_version"> & {
+    payload_version: number;
+};
+
+export class UnsupportedTeacherCaseSubmissionGradePayloadVersionError extends Error {
+    payloadVersion: number;
+
+    constructor(payloadVersion: number) {
+        super("Tu versión de la app está desactualizada. Recarga para continuar.");
+        this.name = "UnsupportedTeacherCaseSubmissionGradePayloadVersionError";
+        this.payloadVersion = payloadVersion;
+    }
+}
+
+function assertSupportedPayloadVersion(
+    response: TeacherCaseSubmissionGradeRuntimeResponse,
+): TeacherCaseSubmissionGradeResponse {
+    if (response.payload_version !== SUPPORTED_TEACHER_CASE_SUBMISSION_GRADE_PAYLOAD_VERSION) {
+        throw new UnsupportedTeacherCaseSubmissionGradePayloadVersionError(response.payload_version);
+    }
+
+    return response as TeacherCaseSubmissionGradeResponse;
+}
+
+export async function fetchTeacherCaseSubmissionGrade(
+    courseId: string,
+    assignmentId: string,
+    membershipId: string,
+): Promise<TeacherCaseSubmissionGradeResponse> {
+    const response = await api.teacher.getCaseSubmissionGrade(
+        courseId,
+        assignmentId,
+        membershipId,
+    ) as TeacherCaseSubmissionGradeRuntimeResponse;
+
+    return assertSupportedPayloadVersion(response);
+}
+
+export async function saveTeacherCaseSubmissionGrade(
+    courseId: string,
+    assignmentId: string,
+    membershipId: string,
+    request: TeacherCaseSubmissionGradeRequest,
+): Promise<TeacherCaseSubmissionGradeResponse> {
+    const response = await api.teacher.saveCaseSubmissionGrade(
+        courseId,
+        assignmentId,
+        membershipId,
+        request,
+    ) as TeacherCaseSubmissionGradeRuntimeResponse;
+
+    return assertSupportedPayloadVersion(response);
+}

--- a/frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionGradeApi.ts
+++ b/frontend/src/features/teacher-case-submission-detail/teacherCaseSubmissionGradeApi.ts
@@ -1,4 +1,4 @@
-import { api } from "@/shared/api";
+import { ApiError, api, getApiErrorCode } from "@/shared/api";
 import type {
     TeacherCaseSubmissionGradeRequest,
     TeacherCaseSubmissionGradeResponse,
@@ -18,6 +18,16 @@ export class UnsupportedTeacherCaseSubmissionGradePayloadVersionError extends Er
         super("Tu versión de la app está desactualizada. Recarga para continuar.");
         this.name = "UnsupportedTeacherCaseSubmissionGradePayloadVersionError";
         this.payloadVersion = payloadVersion;
+    }
+}
+
+export class IncompleteGradeError extends Error {
+    missingQuestionIds: string[];
+
+    constructor(missingQuestionIds: string[]) {
+        super("Debes calificar todas las preguntas antes de publicar.");
+        this.name = "IncompleteGradeError";
+        this.missingQuestionIds = missingQuestionIds;
     }
 }
 
@@ -51,12 +61,32 @@ export async function saveTeacherCaseSubmissionGrade(
     membershipId: string,
     request: TeacherCaseSubmissionGradeRequest,
 ): Promise<TeacherCaseSubmissionGradeResponse> {
-    const response = await api.teacher.saveCaseSubmissionGrade(
-        courseId,
-        assignmentId,
-        membershipId,
-        request,
-    ) as TeacherCaseSubmissionGradeRuntimeResponse;
+    try {
+        const response = await api.teacher.saveCaseSubmissionGrade(
+            courseId,
+            assignmentId,
+            membershipId,
+            request,
+        ) as TeacherCaseSubmissionGradeRuntimeResponse;
 
-    return assertSupportedPayloadVersion(response);
+        return assertSupportedPayloadVersion(response);
+    } catch (error) {
+        if (
+            error instanceof ApiError
+            && error.status === 422
+            && getApiErrorCode(error) === "incomplete_grade"
+            && error.detail
+            && typeof error.detail === "object"
+            && !Array.isArray(error.detail)
+            && Array.isArray(error.detail.missing_question_ids)
+        ) {
+            throw new IncompleteGradeError(
+                error.detail.missing_question_ids.filter(
+                    (questionId): questionId is string => typeof questionId === "string" && questionId.length > 0,
+                ),
+            );
+        }
+
+        throw error;
+    }
 }

--- a/frontend/src/features/teacher-case-submission-detail/teacherManualGradingModel.ts
+++ b/frontend/src/features/teacher-case-submission-detail/teacherManualGradingModel.ts
@@ -1,0 +1,167 @@
+import type {
+    TeacherCaseSubmissionDetailResponse,
+    TeacherCaseSubmissionGradeRequest,
+    TeacherCaseSubmissionGradeResponse,
+    TeacherGradeRubricLevel,
+} from "@/shared/adam-types";
+
+export const TEACHER_MANUAL_GRADING_AUTOSAVE_DELAY_MS = 1_500;
+
+export type TeacherManualGradingAutosaveState = "idle" | "dirty" | "saving" | "saved" | "error";
+
+export interface TeacherManualGradingBannerState {
+    tone: "amber" | "emerald" | "red";
+    title: string;
+    message: string;
+}
+
+export const TEACHER_GRADE_RUBRIC_OPTIONS: Array<{
+    value: TeacherGradeRubricLevel;
+    label: string;
+    tone: string;
+}> = [
+    { value: "excelente", label: "Excelente", tone: "border-emerald-200 bg-emerald-50 text-emerald-700" },
+    { value: "bien", label: "Bien", tone: "border-sky-200 bg-sky-50 text-sky-700" },
+    { value: "aceptable", label: "Aceptable", tone: "border-amber-200 bg-amber-50 text-amber-700" },
+    { value: "insuficiente", label: "Insuficiente", tone: "border-rose-200 bg-rose-50 text-rose-700" },
+    { value: "no_responde", label: "No responde", tone: "border-slate-200 bg-slate-100 text-slate-700" },
+];
+
+const RUBRIC_TO_SCORE: Record<TeacherGradeRubricLevel, number> = {
+    excelente: 1,
+    bien: 0.8,
+    aceptable: 0.6,
+    insuficiente: 0.3,
+    no_responde: 0,
+};
+
+function roundTo(value: number, digits: number): number {
+    const factor = 10 ** digits;
+    return Math.round(value * factor) / factor;
+}
+
+function normalizeFeedback(value: string | null): string | null {
+    if (value === null) {
+        return null;
+    }
+
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+}
+
+export function cloneTeacherCaseSubmissionGrade(
+    grade: TeacherCaseSubmissionGradeResponse,
+): TeacherCaseSubmissionGradeResponse {
+    return JSON.parse(JSON.stringify(grade)) as TeacherCaseSubmissionGradeResponse;
+}
+
+export function canLoadTeacherManualGrading(detail: TeacherCaseSubmissionDetailResponse): boolean {
+    if (!detail.case.course_id || !detail.response_state.snapshot_hash) {
+        return false;
+    }
+
+    return detail.response_state.status === "submitted" || detail.response_state.status === "graded";
+}
+
+export function countUngradedTeacherQuestions(grade: TeacherCaseSubmissionGradeResponse): number {
+    let missingCount = 0;
+
+    for (const module of grade.modules) {
+        for (const question of module.questions) {
+            if (question.rubric_level === null) {
+                missingCount += 1;
+            }
+        }
+    }
+
+    return missingCount;
+}
+
+export function calculateTeacherGradeMetrics(
+    grade: TeacherCaseSubmissionGradeResponse,
+): Pick<TeacherCaseSubmissionGradeResponse, "score_display" | "score_normalized"> {
+    let weightedTotal = 0;
+    let includedWeightTotal = 0;
+    const publish = grade.publication_state === "published";
+
+    for (const module of grade.modules) {
+        const scoredQuestions = module.questions
+            .filter((question) => question.rubric_level !== null)
+            .map((question) => RUBRIC_TO_SCORE[question.rubric_level as TeacherGradeRubricLevel]);
+
+        if (publish) {
+            if (module.questions.length === 0) {
+                continue;
+            }
+
+            const moduleAverage = scoredQuestions.reduce((sum, value) => sum + value, 0) / module.questions.length;
+            weightedTotal += moduleAverage * module.weight;
+            includedWeightTotal += module.weight;
+            continue;
+        }
+
+        if (scoredQuestions.length === 0) {
+            continue;
+        }
+
+        const moduleAverage = scoredQuestions.reduce((sum, value) => sum + value, 0) / scoredQuestions.length;
+        weightedTotal += moduleAverage * module.weight;
+        includedWeightTotal += module.weight;
+    }
+
+    if (!publish && includedWeightTotal === 0) {
+        return { score_display: null, score_normalized: null };
+    }
+
+    const scoreNormalized = publish
+        ? weightedTotal
+        : weightedTotal / includedWeightTotal;
+
+    return {
+        score_normalized: roundTo(scoreNormalized, 4),
+        score_display: roundTo(scoreNormalized * grade.max_score_display, 1),
+    };
+}
+
+export function buildTeacherCaseSubmissionGradeRequest(
+    grade: TeacherCaseSubmissionGradeResponse,
+    intent: "save_draft" | "publish",
+): TeacherCaseSubmissionGradeRequest {
+    return {
+        payload_version: 1,
+        snapshot_hash: grade.snapshot_hash,
+        intent,
+        graded_by: "human",
+        feedback_global: normalizeFeedback(grade.feedback_global),
+        modules: grade.modules.map((module) => ({
+            module_id: module.module_id,
+            weight: module.weight,
+            feedback_module: normalizeFeedback(module.feedback_module),
+            source: "human",
+            questions: module.questions.map((question) => ({
+                question_id: question.question_id,
+                rubric_level: question.rubric_level,
+                feedback_question: normalizeFeedback(question.feedback_question),
+                source: "human",
+            })),
+        })),
+    };
+}
+
+export function hasPublishedTeacherGrade(grade: TeacherCaseSubmissionGradeResponse | null): boolean {
+    return Boolean(grade?.published_at);
+}
+
+export function getTeacherGradePublicationLabel(
+    grade: TeacherCaseSubmissionGradeResponse,
+): string {
+    if (grade.publication_state === "published") {
+        return `Publicado · v${grade.version}`;
+    }
+
+    if (grade.published_at) {
+        return `Borrador · v${grade.version} publicada`;
+    }
+
+    return "Borrador no publicado";
+}

--- a/frontend/src/features/teacher-case-submission-detail/teacherManualGradingModel.ts
+++ b/frontend/src/features/teacher-case-submission-detail/teacherManualGradingModel.ts
@@ -149,7 +149,7 @@ export function buildTeacherCaseSubmissionGradeRequest(
 }
 
 export function hasPublishedTeacherGrade(grade: TeacherCaseSubmissionGradeResponse | null): boolean {
-    return Boolean(grade?.published_at);
+    return grade?.publication_state === "published" || Boolean(grade?.published_at);
 }
 
 export function getTeacherGradePublicationLabel(

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.test.tsx
@@ -1,0 +1,126 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./teacherCaseSubmissionGradeApi", () => ({
+    TEACHER_CASE_SUBMISSION_GRADE_QUERY_GC_TIME: 5 * 60_000,
+    UnsupportedTeacherCaseSubmissionGradePayloadVersionError: class UnsupportedTeacherCaseSubmissionGradePayloadVersionError extends Error {},
+    fetchTeacherCaseSubmissionGrade: vi.fn(),
+    saveTeacherCaseSubmissionGrade: vi.fn(),
+}));
+
+import { ApiError } from "@/shared/api";
+import { createWrapper, createTestQueryClient } from "@/shared/test-utils";
+
+import { createSubmissionDetailResponse, createSubmissionGradeResponse } from "./__tests__/testData";
+import { TEACHER_MANUAL_GRADING_AUTOSAVE_DELAY_MS } from "./teacherManualGradingModel";
+import {
+    fetchTeacherCaseSubmissionGrade,
+    saveTeacherCaseSubmissionGrade,
+} from "./teacherCaseSubmissionGradeApi";
+import { useTeacherManualGrading } from "./useTeacherManualGrading";
+
+function renderTeacherManualGradingHook() {
+    const detail = createSubmissionDetailResponse();
+    const queryClient = createTestQueryClient();
+
+    return {
+        detail,
+        queryClient,
+        ...renderHook(
+            () => useTeacherManualGrading(detail.case.course_id, detail.case.id, detail.student.membership_id, detail),
+            { wrapper: createWrapper({ queryClient }) },
+        ),
+    };
+}
+
+describe("useTeacherManualGrading", () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.clearAllMocks();
+        vi.mocked(fetchTeacherCaseSubmissionGrade).mockResolvedValue(createSubmissionGradeResponse());
+        vi.mocked(saveTeacherCaseSubmissionGrade).mockResolvedValue(createSubmissionGradeResponse({
+            score_normalized: 1,
+            score_display: 5,
+            modules: [
+                {
+                    module_id: "M1",
+                    weight: 0.5,
+                    feedback_module: null,
+                    questions: [
+                        {
+                            question_id: "M1-Q1",
+                            rubric_level: "excelente",
+                            feedback_question: null,
+                        },
+                    ],
+                },
+                {
+                    module_id: "M5",
+                    weight: 0.5,
+                    feedback_module: null,
+                    questions: [
+                        {
+                            question_id: "M5-Q1",
+                            rubric_level: null,
+                            feedback_question: null,
+                        },
+                    ],
+                },
+            ],
+            last_modified_at: "2026-06-05T19:05:00Z",
+        }));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("debounces draft autosave after rubric changes", async () => {
+        const { result } = renderTeacherManualGradingHook();
+
+        await waitFor(() => expect(result.current.mode).toBe("ready"));
+
+        act(() => {
+            result.current.setQuestionRubric("M1-Q1", "excelente");
+        });
+
+        expect(result.current.autosaveState).toBe("dirty");
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(TEACHER_MANUAL_GRADING_AUTOSAVE_DELAY_MS - 1);
+        });
+        expect(saveTeacherCaseSubmissionGrade).not.toHaveBeenCalled();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1);
+        });
+
+        await waitFor(() => {
+            expect(saveTeacherCaseSubmissionGrade).toHaveBeenCalledWith(
+                "course-1",
+                "assignment-1",
+                "membership-1",
+                expect.objectContaining({
+                    intent: "save_draft",
+                    snapshot_hash: "hash-123",
+                }),
+            );
+        });
+        await waitFor(() => expect(result.current.autosaveState).toBe("saved"));
+        expect(result.current.grade?.modules[0].questions[0].rubric_level).toBe("excelente");
+    });
+
+    it("surfaces feature disablement as a disabled UI mode", async () => {
+        vi.mocked(fetchTeacherCaseSubmissionGrade).mockRejectedValueOnce(
+            new ApiError(404, "Disabled", {
+                code: "feature_disabled",
+                message: "Teacher manual grading is disabled.",
+            }),
+        );
+
+        const { result } = renderTeacherManualGradingHook();
+
+        await waitFor(() => expect(result.current.mode).toBe("disabled"));
+        expect(result.current.loadErrorMessage).toBe("La calificación manual todavía no está habilitada en este entorno.");
+    });
+});

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.test.tsx
@@ -84,6 +84,23 @@ describe("useTeacherManualGrading", () => {
         vi.useRealTimers();
     });
 
+    it("keeps hydration idle and still detects published grades without published_at", async () => {
+        vi.mocked(fetchTeacherCaseSubmissionGrade).mockResolvedValueOnce(createSubmissionGradeResponse({
+            publication_state: "published",
+            published_at: null,
+            score_normalized: 0.9,
+            score_display: 4.5,
+            graded_at: "2026-06-05T19:10:00Z",
+        }));
+
+        const { result } = renderTeacherManualGradingHook();
+
+        await waitFor(() => expect(result.current.mode).toBe("ready"));
+
+        expect(result.current.autosaveState).toBe("idle");
+        expect(result.current.hasPublishedVersion).toBe(true);
+    });
+
     it("debounces draft autosave after rubric changes", async () => {
         const { result } = renderTeacherManualGradingHook();
 
@@ -164,5 +181,6 @@ describe("useTeacherManualGrading", () => {
         await waitFor(() => expect(result.current.isSnapshotConflictOpen).toBe(false));
         expect(result.current.requiresRefresh).toBe(false);
         expect(result.current.grade?.snapshot_hash).toBe("hash-456");
+        expect(result.current.autosaveState).toBe("idle");
     });
 });

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.test.tsx
@@ -3,6 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./teacherCaseSubmissionGradeApi", () => ({
     TEACHER_CASE_SUBMISSION_GRADE_QUERY_GC_TIME: 5 * 60_000,
+    IncompleteGradeError: class IncompleteGradeError extends Error {
+        missingQuestionIds: string[];
+
+        constructor(missingQuestionIds: string[]) {
+            super("Debes calificar todas las preguntas antes de publicar.");
+            this.name = "IncompleteGradeError";
+            this.missingQuestionIds = missingQuestionIds;
+        }
+    },
     UnsupportedTeacherCaseSubmissionGradePayloadVersionError: class UnsupportedTeacherCaseSubmissionGradePayloadVersionError extends Error {},
     fetchTeacherCaseSubmissionGrade: vi.fn(),
     saveTeacherCaseSubmissionGrade: vi.fn(),
@@ -122,5 +131,38 @@ describe("useTeacherManualGrading", () => {
 
         await waitFor(() => expect(result.current.mode).toBe("disabled"));
         expect(result.current.loadErrorMessage).toBe("La calificación manual todavía no está habilitada en este entorno.");
+    });
+
+    it("opens a blocking snapshot conflict state and clears it after refresh", async () => {
+        vi.mocked(saveTeacherCaseSubmissionGrade).mockRejectedValueOnce(
+            new ApiError(409, "Conflict", {
+                code: "snapshot_changed",
+                message: "El estudiante modificó su entrega. Recarga para ver cambios.",
+            }),
+        );
+
+        const { result } = renderTeacherManualGradingHook();
+
+        await waitFor(() => expect(result.current.mode).toBe("ready"));
+
+        await act(async () => {
+            await result.current.publish();
+        });
+
+        expect(result.current.isSnapshotConflictOpen).toBe(true);
+        expect(result.current.requiresRefresh).toBe(true);
+        expect(result.current.banner).toBeNull();
+
+        vi.mocked(fetchTeacherCaseSubmissionGrade).mockResolvedValueOnce(createSubmissionGradeResponse({
+            snapshot_hash: "hash-456",
+        }));
+
+        await act(async () => {
+            await result.current.refresh();
+        });
+
+        await waitFor(() => expect(result.current.isSnapshotConflictOpen).toBe(false));
+        expect(result.current.requiresRefresh).toBe(false);
+        expect(result.current.grade?.snapshot_hash).toBe("hash-456");
     });
 });

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.test.tsx
@@ -28,6 +28,18 @@ import {
 } from "./teacherCaseSubmissionGradeApi";
 import { useTeacherManualGrading } from "./useTeacherManualGrading";
 
+function createDeferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+
+    const promise = new Promise<T>((innerResolve, innerReject) => {
+        resolve = innerResolve;
+        reject = innerReject;
+    });
+
+    return { promise, resolve, reject };
+}
+
 function renderTeacherManualGradingHook() {
     const detail = createSubmissionDetailResponse();
     const queryClient = createTestQueryClient();
@@ -150,7 +162,7 @@ describe("useTeacherManualGrading", () => {
         expect(result.current.loadErrorMessage).toBe("La calificación manual todavía no está habilitada en este entorno.");
     });
 
-    it("opens a blocking snapshot conflict state and clears it after refresh", async () => {
+    it("keeps snapshot conflict open after a grade refetch until it is cleared explicitly", async () => {
         vi.mocked(saveTeacherCaseSubmissionGrade).mockRejectedValueOnce(
             new ApiError(409, "Conflict", {
                 code: "snapshot_changed",
@@ -178,9 +190,124 @@ describe("useTeacherManualGrading", () => {
             await result.current.refresh();
         });
 
-        await waitFor(() => expect(result.current.isSnapshotConflictOpen).toBe(false));
-        expect(result.current.requiresRefresh).toBe(false);
+        await waitFor(() => expect(result.current.grade?.snapshot_hash).toBe("hash-456"));
+        expect(result.current.isSnapshotConflictOpen).toBe(true);
+        expect(result.current.requiresRefresh).toBe(true);
         expect(result.current.grade?.snapshot_hash).toBe("hash-456");
         expect(result.current.autosaveState).toBe("idle");
+
+        act(() => {
+            result.current.clearSnapshotConflict();
+        });
+
+        expect(result.current.isSnapshotConflictOpen).toBe(false);
+        expect(result.current.requiresRefresh).toBe(false);
+        expect(result.current.isLocked).toBe(false);
     });
+
+    it("ignores local updates while publish is in flight", async () => {
+        const deferredSave = createDeferred<ReturnType<typeof createSubmissionGradeResponse>>();
+        vi.mocked(saveTeacherCaseSubmissionGrade).mockReturnValueOnce(deferredSave.promise);
+
+        const { result } = renderTeacherManualGradingHook();
+
+        await waitFor(() => expect(result.current.mode).toBe("ready"));
+
+        const initialRubric = result.current.grade?.modules[0].questions[0].rubric_level ?? null;
+        let publishPromise!: Promise<boolean>;
+
+        act(() => {
+            publishPromise = result.current.publish();
+        });
+
+        await waitFor(() => expect(result.current.isPublishing).toBe(true));
+        expect(result.current.isLocked).toBe(true);
+
+        act(() => {
+            result.current.setQuestionRubric("M1-Q1", "excelente");
+        });
+
+        expect(result.current.grade?.modules[0].questions[0].rubric_level ?? null).toBe(initialRubric);
+        expect(result.current.autosaveState).toBe("idle");
+
+        deferredSave.resolve(createSubmissionGradeResponse({
+            publication_state: "published",
+            published_at: "2026-06-05T19:10:00Z",
+            graded_at: "2026-06-05T19:10:00Z",
+        }));
+
+        await act(async () => {
+            await publishPromise;
+        });
+    });
+
+    it("ignores local updates while snapshot conflict is open", async () => {
+        vi.mocked(saveTeacherCaseSubmissionGrade).mockRejectedValueOnce(
+            new ApiError(409, "Conflict", {
+                code: "snapshot_changed",
+                message: "El estudiante modificó su entrega. Recarga para ver cambios.",
+            }),
+        );
+
+        const { result } = renderTeacherManualGradingHook();
+
+        await waitFor(() => expect(result.current.mode).toBe("ready"));
+
+        await act(async () => {
+            await result.current.publish();
+        });
+
+        await waitFor(() => expect(result.current.isLocked).toBe(true));
+        const initialFeedback = result.current.grade?.modules[0].questions[0].feedback_question ?? null;
+
+        act(() => {
+            result.current.setQuestionFeedback("M1-Q1", "Nuevo feedback bloqueado");
+        });
+
+        expect(result.current.grade?.modules[0].questions[0].feedback_question ?? null).toBe(initialFeedback);
+        expect(result.current.autosaveState).toBe("error");
+    });
+
+    it("derives isLocked from publishing and snapshot conflict states", async () => {
+        const deferredSave = createDeferred<ReturnType<typeof createSubmissionGradeResponse>>();
+        vi.mocked(saveTeacherCaseSubmissionGrade).mockReturnValueOnce(deferredSave.promise);
+
+        const { result } = renderTeacherManualGradingHook();
+
+        await waitFor(() => expect(result.current.mode).toBe("ready"));
+        expect(result.current.isLocked).toBe(false);
+
+        let publishPromise!: Promise<boolean>;
+        act(() => {
+            publishPromise = result.current.publish();
+        });
+
+        await waitFor(() => expect(result.current.isLocked).toBe(true));
+
+        deferredSave.resolve(createSubmissionGradeResponse({
+            publication_state: "published",
+            published_at: "2026-06-05T19:10:00Z",
+            graded_at: "2026-06-05T19:10:00Z",
+        }));
+
+        await act(async () => {
+            await publishPromise;
+        });
+
+        await waitFor(() => expect(result.current.isLocked).toBe(false));
+
+        vi.mocked(saveTeacherCaseSubmissionGrade).mockRejectedValueOnce(
+            new ApiError(409, "Conflict", {
+                code: "snapshot_changed",
+                message: "El estudiante modificó su entrega. Recarga para ver cambios.",
+            }),
+        );
+
+        await act(async () => {
+            await result.current.publish();
+        });
+
+        expect(result.current.isLocked).toBe(true);
+    });
+
 });

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.ts
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.ts
@@ -1,0 +1,383 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type {
+    TeacherCaseSubmissionDetailResponse,
+    TeacherCaseSubmissionGradeResponse,
+    TeacherGradeRubricLevel,
+} from "@/shared/adam-types";
+import { ApiError, getApiErrorCode, getApiErrorMessage } from "@/shared/api";
+import { queryKeys } from "@/shared/queryKeys";
+
+import {
+    fetchTeacherCaseSubmissionGrade,
+    saveTeacherCaseSubmissionGrade,
+    TEACHER_CASE_SUBMISSION_GRADE_QUERY_GC_TIME,
+    UnsupportedTeacherCaseSubmissionGradePayloadVersionError,
+} from "./teacherCaseSubmissionGradeApi";
+import {
+    buildTeacherCaseSubmissionGradeRequest,
+    calculateTeacherGradeMetrics,
+    canLoadTeacherManualGrading,
+    cloneTeacherCaseSubmissionGrade,
+    countUngradedTeacherQuestions,
+    hasPublishedTeacherGrade,
+    TEACHER_MANUAL_GRADING_AUTOSAVE_DELAY_MS,
+    type TeacherManualGradingAutosaveState,
+    type TeacherManualGradingBannerState,
+} from "./teacherManualGradingModel";
+
+type TeacherManualGradingMode = "disabled" | "error" | "loading" | "ready" | "unavailable";
+
+interface UseTeacherManualGradingResult {
+    mode: TeacherManualGradingMode;
+    grade: TeacherCaseSubmissionGradeResponse | null;
+    loadErrorMessage: string | null;
+    autosaveState: TeacherManualGradingAutosaveState;
+    banner: TeacherManualGradingBannerState | null;
+    isDirty: boolean;
+    isPublishing: boolean;
+    missingQuestionCount: number;
+    hasPublishedVersion: boolean;
+    requiresRefresh: boolean;
+    refresh: () => Promise<void>;
+    publish: () => Promise<boolean>;
+    setGlobalFeedback: (value: string) => void;
+    setModuleFeedback: (moduleId: string, value: string) => void;
+    setQuestionFeedback: (questionId: string, value: string) => void;
+    setQuestionRubric: (questionId: string, value: TeacherGradeRubricLevel | null) => void;
+}
+
+function isFeatureDisabledError(error: unknown): boolean {
+    return error instanceof ApiError && error.status === 404 && getApiErrorCode(error) === "feature_disabled";
+}
+
+function buildBanner(error: unknown, intent: "draft" | "publish"): TeacherManualGradingBannerState {
+    const code = getApiErrorCode(error);
+
+    if (code === "snapshot_changed") {
+        return {
+            tone: "amber",
+            title: "La entrega cambió",
+            message: getApiErrorMessage(error),
+        };
+    }
+
+    return {
+        tone: "red",
+        title: intent === "publish" ? "No se pudo publicar la calificación" : "No se pudo guardar el borrador",
+        message: getApiErrorMessage(error),
+    };
+}
+
+export function getTeacherManualGradingErrorMessage(error: unknown, fallback: string): string {
+    if (error instanceof UnsupportedTeacherCaseSubmissionGradePayloadVersionError) {
+        return error.message;
+    }
+
+    if (isFeatureDisabledError(error)) {
+        return "La calificación manual todavía no está habilitada en este entorno.";
+    }
+
+    if (!(error instanceof ApiError)) {
+        return error instanceof Error ? error.message : fallback;
+    }
+
+    switch (getApiErrorCode(error)) {
+        case "snapshot_changed":
+            return "La entrega cambió mientras calificabas. Recarga para continuar.";
+        case "incomplete_grade":
+            return "Debes calificar todas las preguntas visibles antes de publicar.";
+        default:
+            return error.message || fallback;
+    }
+}
+
+export function useTeacherManualGrading(
+    courseId: string,
+    assignmentId: string,
+    membershipId: string,
+    detail: TeacherCaseSubmissionDetailResponse,
+): UseTeacherManualGradingResult {
+    const queryClient = useQueryClient();
+    const canLoad = Boolean(courseId) && Boolean(assignmentId) && Boolean(membershipId) && canLoadTeacherManualGrading(detail);
+    const [grade, setGrade] = useState<TeacherCaseSubmissionGradeResponse | null>(null);
+    const [autosaveState, setAutosaveState] = useState<TeacherManualGradingAutosaveState>("idle");
+    const [banner, setBanner] = useState<TeacherManualGradingBannerState | null>(null);
+    const [isDirty, setIsDirty] = useState(false);
+    const [isPublishing, setIsPublishing] = useState(false);
+    const [requiresRefresh, setRequiresRefresh] = useState(false);
+
+    const gradeRef = useRef<TeacherCaseSubmissionGradeResponse | null>(grade);
+    const dirtyRef = useRef(isDirty);
+    const saveInFlightRef = useRef(false);
+    const queuedSaveRef = useRef(false);
+    const autosaveTimerRef = useRef<number | null>(null);
+    const unmountedRef = useRef(false);
+
+    gradeRef.current = grade;
+    dirtyRef.current = isDirty;
+
+    const gradeQuery = useQuery({
+        queryKey: queryKeys.teacher.caseSubmissionGrade(courseId, assignmentId, membershipId),
+        queryFn: () => fetchTeacherCaseSubmissionGrade(courseId, assignmentId, membershipId),
+        enabled: canLoad,
+        staleTime: 30_000,
+        gcTime: TEACHER_CASE_SUBMISSION_GRADE_QUERY_GC_TIME,
+        refetchOnWindowFocus: false,
+        retry: (failureCount, error) => !isFeatureDisabledError(error) && failureCount < 2,
+    });
+
+    const saveMutation = useMutation({
+        mutationFn: ({ nextGrade, intent }: { nextGrade: TeacherCaseSubmissionGradeResponse; intent: "save_draft" | "publish" }) => (
+            saveTeacherCaseSubmissionGrade(
+                courseId,
+                assignmentId,
+                membershipId,
+                buildTeacherCaseSubmissionGradeRequest(nextGrade, intent),
+            )
+        ),
+    });
+
+    const clearAutosaveTimer = useCallback(() => {
+        if (autosaveTimerRef.current !== null) {
+            window.clearTimeout(autosaveTimerRef.current);
+            autosaveTimerRef.current = null;
+        }
+    }, []);
+
+    const syncFromServer = useCallback((nextGrade: TeacherCaseSubmissionGradeResponse) => {
+        const cloned = cloneTeacherCaseSubmissionGrade(nextGrade);
+        setGrade(cloned);
+        gradeRef.current = cloned;
+        setIsDirty(false);
+        dirtyRef.current = false;
+        setRequiresRefresh(false);
+        setAutosaveState("saved");
+    }, []);
+
+    const handleMutationError = useCallback((error: unknown, intent: "draft" | "publish") => {
+        setAutosaveState("error");
+        setBanner(buildBanner(error, intent));
+        setRequiresRefresh(getApiErrorCode(error) === "snapshot_changed");
+    }, []);
+
+    const flushDraft = useCallback(async () => {
+        if (!canLoad || !gradeRef.current || !dirtyRef.current || requiresRefresh || isPublishing) {
+            return;
+        }
+
+        if (saveInFlightRef.current) {
+            queuedSaveRef.current = true;
+            return;
+        }
+
+        saveInFlightRef.current = true;
+        setAutosaveState("saving");
+        try {
+            const response = await saveMutation.mutateAsync({
+                nextGrade: gradeRef.current,
+                intent: "save_draft",
+            });
+            if (unmountedRef.current) {
+                return;
+            }
+
+            queryClient.setQueryData(
+                queryKeys.teacher.caseSubmissionGrade(courseId, assignmentId, membershipId),
+                response,
+            );
+            syncFromServer(response);
+            setBanner(null);
+        } catch (error) {
+            if (!unmountedRef.current) {
+                handleMutationError(error, "draft");
+            }
+        } finally {
+            saveInFlightRef.current = false;
+            if (queuedSaveRef.current) {
+                queuedSaveRef.current = false;
+                void flushDraft();
+            }
+        }
+    }, [assignmentId, canLoad, courseId, handleMutationError, isPublishing, membershipId, queryClient, requiresRefresh, saveMutation, syncFromServer]);
+
+    useEffect(() => {
+        if (!gradeQuery.data) {
+            return;
+        }
+
+        syncFromServer(gradeQuery.data);
+    }, [gradeQuery.data, syncFromServer]);
+
+    useEffect(() => {
+        if (!canLoad || !grade || !isDirty || requiresRefresh || isPublishing) {
+            return;
+        }
+
+        clearAutosaveTimer();
+        autosaveTimerRef.current = window.setTimeout(() => {
+            void flushDraft();
+        }, TEACHER_MANUAL_GRADING_AUTOSAVE_DELAY_MS);
+
+        return () => {
+            clearAutosaveTimer();
+        };
+    }, [canLoad, clearAutosaveTimer, flushDraft, grade, isDirty, isPublishing, requiresRefresh]);
+
+    useEffect(() => {
+        return () => {
+            unmountedRef.current = true;
+            clearAutosaveTimer();
+        };
+    }, [clearAutosaveTimer]);
+
+    const applyLocalUpdate = useCallback((recipe: (nextGrade: TeacherCaseSubmissionGradeResponse) => void) => {
+        setGrade((currentGrade) => {
+            if (!currentGrade) {
+                return currentGrade;
+            }
+
+            const nextGrade = cloneTeacherCaseSubmissionGrade(currentGrade);
+            recipe(nextGrade);
+            nextGrade.publication_state = "draft";
+            nextGrade.last_modified_at = new Date().toISOString();
+            const metrics = calculateTeacherGradeMetrics(nextGrade);
+            nextGrade.score_display = metrics.score_display;
+            nextGrade.score_normalized = metrics.score_normalized;
+            gradeRef.current = nextGrade;
+            return nextGrade;
+        });
+        setBanner(null);
+        setRequiresRefresh(false);
+        setIsDirty(true);
+        dirtyRef.current = true;
+        setAutosaveState("dirty");
+    }, []);
+
+    const publish = useCallback(async () => {
+        if (!gradeRef.current || saveInFlightRef.current || requiresRefresh) {
+            return false;
+        }
+
+        clearAutosaveTimer();
+        setIsPublishing(true);
+        try {
+            const response = await saveMutation.mutateAsync({
+                nextGrade: gradeRef.current,
+                intent: "publish",
+            });
+            if (unmountedRef.current) {
+                return false;
+            }
+
+            queryClient.setQueryData(
+                queryKeys.teacher.caseSubmissionGrade(courseId, assignmentId, membershipId),
+                response,
+            );
+            syncFromServer(response);
+            setBanner({
+                tone: "emerald",
+                title: "Calificación publicada",
+                message: `Versión ${response.version} publicada correctamente.`,
+            });
+            void queryClient.invalidateQueries({
+                queryKey: queryKeys.teacher.caseSubmissionDetail(assignmentId, membershipId),
+            });
+            void queryClient.invalidateQueries({
+                queryKey: queryKeys.teacher.caseSubmissions(assignmentId),
+            });
+            void queryClient.invalidateQueries({
+                queryKey: queryKeys.teacher.courseStudents(courseId),
+            });
+            return true;
+        } catch (error) {
+            if (!unmountedRef.current) {
+                handleMutationError(error, "publish");
+            }
+            return false;
+        } finally {
+            if (!unmountedRef.current) {
+                setIsPublishing(false);
+            }
+        }
+    }, [assignmentId, clearAutosaveTimer, courseId, handleMutationError, membershipId, queryClient, requiresRefresh, saveMutation, syncFromServer]);
+
+    const refresh = useCallback(async () => {
+        clearAutosaveTimer();
+        setBanner(null);
+        setRequiresRefresh(false);
+        await gradeQuery.refetch();
+    }, [clearAutosaveTimer, gradeQuery]);
+
+    const mode: TeacherManualGradingMode = (() => {
+        if (!canLoad) {
+            return "unavailable";
+        }
+        if (isFeatureDisabledError(gradeQuery.error)) {
+            return "disabled";
+        }
+        if (gradeQuery.isLoading && !grade) {
+            return "loading";
+        }
+        if (gradeQuery.error && !grade) {
+            return "error";
+        }
+        return grade ? "ready" : "loading";
+    })();
+
+    return {
+        mode,
+        grade,
+        loadErrorMessage: gradeQuery.error
+            ? getTeacherManualGradingErrorMessage(
+                gradeQuery.error,
+                "No se pudo cargar la calificación manual.",
+            )
+            : null,
+        autosaveState,
+        banner,
+        isDirty,
+        isPublishing,
+        missingQuestionCount: grade ? countUngradedTeacherQuestions(grade) : 0,
+        hasPublishedVersion: hasPublishedTeacherGrade(grade),
+        requiresRefresh,
+        refresh,
+        publish,
+        setGlobalFeedback: (value: string) => {
+            applyLocalUpdate((nextGrade) => {
+                nextGrade.feedback_global = value;
+            });
+        },
+        setModuleFeedback: (moduleId: string, value: string) => {
+            applyLocalUpdate((nextGrade) => {
+                const module = nextGrade.modules.find((currentModule) => currentModule.module_id === moduleId);
+                if (module) {
+                    module.feedback_module = value;
+                }
+            });
+        },
+        setQuestionFeedback: (questionId: string, value: string) => {
+            applyLocalUpdate((nextGrade) => {
+                for (const module of nextGrade.modules) {
+                    const question = module.questions.find((currentQuestion) => currentQuestion.question_id === questionId);
+                    if (question) {
+                        question.feedback_question = value;
+                        return;
+                    }
+                }
+            });
+        },
+        setQuestionRubric: (questionId: string, value: TeacherGradeRubricLevel | null) => {
+            applyLocalUpdate((nextGrade) => {
+                for (const module of nextGrade.modules) {
+                    const question = module.questions.find((currentQuestion) => currentQuestion.question_id === questionId);
+                    if (question) {
+                        question.rubric_level = value;
+                        return;
+                    }
+                }
+            });
+        },
+    };
+}

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.ts
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.ts
@@ -11,6 +11,7 @@ import { queryKeys } from "@/shared/queryKeys";
 
 import {
     fetchTeacherCaseSubmissionGrade,
+    IncompleteGradeError,
     saveTeacherCaseSubmissionGrade,
     TEACHER_CASE_SUBMISSION_GRADE_QUERY_GC_TIME,
     UnsupportedTeacherCaseSubmissionGradePayloadVersionError,
@@ -37,6 +38,8 @@ interface UseTeacherManualGradingResult {
     banner: TeacherManualGradingBannerState | null;
     isDirty: boolean;
     isPublishing: boolean;
+    isRefreshing: boolean;
+    isSnapshotConflictOpen: boolean;
     missingQuestionCount: number;
     hasPublishedVersion: boolean;
     requiresRefresh: boolean;
@@ -53,13 +56,15 @@ function isFeatureDisabledError(error: unknown): boolean {
 }
 
 function buildBanner(error: unknown, intent: "draft" | "publish"): TeacherManualGradingBannerState {
-    const code = getApiErrorCode(error);
+    if (error instanceof IncompleteGradeError) {
+        const missingQuestionCount = error.missingQuestionIds.length;
 
-    if (code === "snapshot_changed") {
         return {
-            tone: "amber",
-            title: "La entrega cambió",
-            message: getApiErrorMessage(error),
+            tone: "red",
+            title: "Calificación incompleta",
+            message: missingQuestionCount === 1
+                ? "Falta calificar 1 pregunta antes de publicar."
+                : `Faltan calificar ${missingQuestionCount} preguntas antes de publicar.`,
         };
     }
 
@@ -71,6 +76,10 @@ function buildBanner(error: unknown, intent: "draft" | "publish"): TeacherManual
 }
 
 export function getTeacherManualGradingErrorMessage(error: unknown, fallback: string): string {
+    if (error instanceof IncompleteGradeError) {
+        return error.message;
+    }
+
     if (error instanceof UnsupportedTeacherCaseSubmissionGradePayloadVersionError) {
         return error.message;
     }
@@ -106,6 +115,8 @@ export function useTeacherManualGrading(
     const [banner, setBanner] = useState<TeacherManualGradingBannerState | null>(null);
     const [isDirty, setIsDirty] = useState(false);
     const [isPublishing, setIsPublishing] = useState(false);
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [isSnapshotConflictOpen, setIsSnapshotConflictOpen] = useState(false);
     const [requiresRefresh, setRequiresRefresh] = useState(false);
 
     const gradeRef = useRef<TeacherCaseSubmissionGradeResponse | null>(grade);
@@ -152,14 +163,23 @@ export function useTeacherManualGrading(
         gradeRef.current = cloned;
         setIsDirty(false);
         dirtyRef.current = false;
+        setIsSnapshotConflictOpen(false);
         setRequiresRefresh(false);
         setAutosaveState("saved");
     }, []);
 
     const handleMutationError = useCallback((error: unknown, intent: "draft" | "publish") => {
+        if (getApiErrorCode(error) === "snapshot_changed") {
+            setAutosaveState("error");
+            setBanner(null);
+            setRequiresRefresh(true);
+            setIsSnapshotConflictOpen(true);
+            return;
+        }
+
         setAutosaveState("error");
         setBanner(buildBanner(error, intent));
-        setRequiresRefresh(getApiErrorCode(error) === "snapshot_changed");
+        setRequiresRefresh(false);
     }, []);
 
     const flushDraft = useCallback(async () => {
@@ -233,6 +253,10 @@ export function useTeacherManualGrading(
     }, [clearAutosaveTimer]);
 
     const applyLocalUpdate = useCallback((recipe: (nextGrade: TeacherCaseSubmissionGradeResponse) => void) => {
+        if (requiresRefresh) {
+            return;
+        }
+
         setGrade((currentGrade) => {
             if (!currentGrade) {
                 return currentGrade;
@@ -253,7 +277,7 @@ export function useTeacherManualGrading(
         setIsDirty(true);
         dirtyRef.current = true;
         setAutosaveState("dirty");
-    }, []);
+    }, [requiresRefresh]);
 
     const publish = useCallback(async () => {
         if (!gradeRef.current || saveInFlightRef.current || requiresRefresh) {
@@ -306,8 +330,18 @@ export function useTeacherManualGrading(
     const refresh = useCallback(async () => {
         clearAutosaveTimer();
         setBanner(null);
-        setRequiresRefresh(false);
-        await gradeQuery.refetch();
+        setIsRefreshing(true);
+        try {
+            const response = await gradeQuery.refetch();
+            if (!response.error) {
+                setRequiresRefresh(false);
+                setIsSnapshotConflictOpen(false);
+            }
+        } finally {
+            if (!unmountedRef.current) {
+                setIsRefreshing(false);
+            }
+        }
     }, [clearAutosaveTimer, gradeQuery]);
 
     const mode: TeacherManualGradingMode = (() => {
@@ -339,6 +373,8 @@ export function useTeacherManualGrading(
         banner,
         isDirty,
         isPublishing,
+        isRefreshing,
+        isSnapshotConflictOpen,
         missingQuestionCount: grade ? countUngradedTeacherQuestions(grade) : 0,
         hasPublishedVersion: hasPublishedTeacherGrade(grade),
         requiresRefresh,

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.ts
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.ts
@@ -36,7 +36,9 @@ interface UseTeacherManualGradingResult {
     loadErrorMessage: string | null;
     autosaveState: TeacherManualGradingAutosaveState;
     banner: TeacherManualGradingBannerState | null;
+    refreshError: string | null;
     isDirty: boolean;
+    isLocked: boolean;
     isPublishing: boolean;
     isRefreshing: boolean;
     isSnapshotConflictOpen: boolean;
@@ -44,6 +46,8 @@ interface UseTeacherManualGradingResult {
     hasPublishedVersion: boolean;
     requiresRefresh: boolean;
     refresh: () => Promise<void>;
+    clearSnapshotConflict: () => void;
+    setRefreshError: (error: unknown | null) => void;
     publish: () => Promise<boolean>;
     setGlobalFeedback: (value: string) => void;
     setModuleFeedback: (moduleId: string, value: string) => void;
@@ -113,11 +117,13 @@ export function useTeacherManualGrading(
     const [grade, setGrade] = useState<TeacherCaseSubmissionGradeResponse | null>(null);
     const [autosaveState, setAutosaveState] = useState<TeacherManualGradingAutosaveState>("idle");
     const [banner, setBanner] = useState<TeacherManualGradingBannerState | null>(null);
+    const [refreshError, setRefreshErrorState] = useState<string | null>(null);
     const [isDirty, setIsDirty] = useState(false);
     const [isPublishing, setIsPublishing] = useState(false);
     const [isRefreshing, setIsRefreshing] = useState(false);
     const [isSnapshotConflictOpen, setIsSnapshotConflictOpen] = useState(false);
     const [requiresRefresh, setRequiresRefresh] = useState(false);
+    const isLocked = isPublishing || isSnapshotConflictOpen;
 
     const gradeRef = useRef<TeacherCaseSubmissionGradeResponse | null>(grade);
     const dirtyRef = useRef(isDirty);
@@ -158,6 +164,23 @@ export function useTeacherManualGrading(
         }
     }, []);
 
+    const setRefreshError = useCallback((error: unknown | null) => {
+        if (error === null) {
+            setRefreshErrorState(null);
+            return;
+        }
+
+        setRefreshErrorState(
+            getTeacherManualGradingErrorMessage(error, "No se pudo recargar la entrega."),
+        );
+    }, []);
+
+    const clearSnapshotConflict = useCallback(() => {
+        setIsSnapshotConflictOpen(false);
+        setRequiresRefresh(false);
+        setRefreshErrorState(null);
+    }, []);
+
     const syncFromServer = useCallback(
         (
             nextGrade: TeacherCaseSubmissionGradeResponse,
@@ -168,8 +191,6 @@ export function useTeacherManualGrading(
             gradeRef.current = cloned;
             setIsDirty(false);
             dirtyRef.current = false;
-            setIsSnapshotConflictOpen(false);
-            setRequiresRefresh(false);
             setAutosaveState(nextAutosaveState);
         },
         [],
@@ -179,6 +200,7 @@ export function useTeacherManualGrading(
         if (getApiErrorCode(error) === "snapshot_changed") {
             setAutosaveState("error");
             setBanner(null);
+            setRefreshErrorState(null);
             setRequiresRefresh(true);
             setIsSnapshotConflictOpen(true);
             return;
@@ -190,7 +212,7 @@ export function useTeacherManualGrading(
     }, []);
 
     const flushDraft = useCallback(async () => {
-        if (!canLoad || !gradeRef.current || !dirtyRef.current || requiresRefresh || isPublishing) {
+        if (!canLoad || !gradeRef.current || !dirtyRef.current || isLocked) {
             return;
         }
 
@@ -206,6 +228,7 @@ export function useTeacherManualGrading(
                 nextGrade: gradeRef.current,
                 intent: "save_draft",
             });
+
             if (unmountedRef.current) {
                 return;
             }
@@ -228,7 +251,7 @@ export function useTeacherManualGrading(
                 void flushDraft();
             }
         }
-    }, [assignmentId, canLoad, courseId, handleMutationError, isPublishing, membershipId, queryClient, requiresRefresh, saveMutation, syncFromServer]);
+    }, [assignmentId, canLoad, courseId, handleMutationError, isLocked, membershipId, queryClient, saveMutation, syncFromServer]);
 
     useEffect(() => {
         if (!gradeQuery.data) {
@@ -244,7 +267,7 @@ export function useTeacherManualGrading(
     }, [gradeQuery.data, syncFromServer]);
 
     useEffect(() => {
-        if (!canLoad || !grade || !isDirty || requiresRefresh || isPublishing) {
+        if (!canLoad || !grade || !isDirty || isLocked) {
             return;
         }
 
@@ -256,9 +279,11 @@ export function useTeacherManualGrading(
         return () => {
             clearAutosaveTimer();
         };
-    }, [canLoad, clearAutosaveTimer, flushDraft, grade, isDirty, isPublishing, requiresRefresh]);
+    }, [canLoad, clearAutosaveTimer, flushDraft, grade, isDirty, isLocked]);
 
     useEffect(() => {
+        unmountedRef.current = false;
+
         return () => {
             unmountedRef.current = true;
             clearAutosaveTimer();
@@ -266,7 +291,7 @@ export function useTeacherManualGrading(
     }, [clearAutosaveTimer]);
 
     const applyLocalUpdate = useCallback((recipe: (nextGrade: TeacherCaseSubmissionGradeResponse) => void) => {
-        if (requiresRefresh) {
+        if (isLocked) {
             return;
         }
 
@@ -290,14 +315,15 @@ export function useTeacherManualGrading(
         setIsDirty(true);
         dirtyRef.current = true;
         setAutosaveState("dirty");
-    }, [requiresRefresh]);
+    }, [isLocked]);
 
     const publish = useCallback(async () => {
-        if (!gradeRef.current || saveInFlightRef.current || requiresRefresh) {
+        if (!gradeRef.current || saveInFlightRef.current || isLocked) {
             return false;
         }
 
         clearAutosaveTimer();
+        setRefreshErrorState(null);
         setIsPublishing(true);
         try {
             const response = await saveMutation.mutateAsync({
@@ -339,17 +365,17 @@ export function useTeacherManualGrading(
                 setIsPublishing(false);
             }
         }
-    }, [assignmentId, clearAutosaveTimer, courseId, handleMutationError, membershipId, queryClient, requiresRefresh, saveMutation, syncFromServer]);
+    }, [assignmentId, clearAutosaveTimer, courseId, handleMutationError, isLocked, membershipId, queryClient, saveMutation, syncFromServer]);
 
     const refresh = useCallback(async () => {
         clearAutosaveTimer();
         setBanner(null);
+        setRefreshErrorState(null);
         setIsRefreshing(true);
         try {
             const response = await gradeQuery.refetch();
-            if (!response.error) {
-                setRequiresRefresh(false);
-                setIsSnapshotConflictOpen(false);
+            if (response.error) {
+                throw response.error;
             }
         } finally {
             if (!unmountedRef.current) {
@@ -385,7 +411,9 @@ export function useTeacherManualGrading(
             : null,
         autosaveState,
         banner,
+        refreshError,
         isDirty,
+        isLocked,
         isPublishing,
         isRefreshing,
         isSnapshotConflictOpen,
@@ -393,6 +421,8 @@ export function useTeacherManualGrading(
         hasPublishedVersion: hasPublishedTeacherGrade(grade),
         requiresRefresh,
         refresh,
+        clearSnapshotConflict,
+        setRefreshError,
         publish,
         setGlobalFeedback: (value: string) => {
             applyLocalUpdate((nextGrade) => {

--- a/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.ts
+++ b/frontend/src/features/teacher-case-submission-detail/useTeacherManualGrading.ts
@@ -125,6 +125,7 @@ export function useTeacherManualGrading(
     const queuedSaveRef = useRef(false);
     const autosaveTimerRef = useRef<number | null>(null);
     const unmountedRef = useRef(false);
+    const skipNextQueryHydrationRef = useRef(false);
 
     gradeRef.current = grade;
     dirtyRef.current = isDirty;
@@ -157,16 +158,22 @@ export function useTeacherManualGrading(
         }
     }, []);
 
-    const syncFromServer = useCallback((nextGrade: TeacherCaseSubmissionGradeResponse) => {
-        const cloned = cloneTeacherCaseSubmissionGrade(nextGrade);
-        setGrade(cloned);
-        gradeRef.current = cloned;
-        setIsDirty(false);
-        dirtyRef.current = false;
-        setIsSnapshotConflictOpen(false);
-        setRequiresRefresh(false);
-        setAutosaveState("saved");
-    }, []);
+    const syncFromServer = useCallback(
+        (
+            nextGrade: TeacherCaseSubmissionGradeResponse,
+            nextAutosaveState: TeacherManualGradingAutosaveState,
+        ) => {
+            const cloned = cloneTeacherCaseSubmissionGrade(nextGrade);
+            setGrade(cloned);
+            gradeRef.current = cloned;
+            setIsDirty(false);
+            dirtyRef.current = false;
+            setIsSnapshotConflictOpen(false);
+            setRequiresRefresh(false);
+            setAutosaveState(nextAutosaveState);
+        },
+        [],
+    );
 
     const handleMutationError = useCallback((error: unknown, intent: "draft" | "publish") => {
         if (getApiErrorCode(error) === "snapshot_changed") {
@@ -207,7 +214,8 @@ export function useTeacherManualGrading(
                 queryKeys.teacher.caseSubmissionGrade(courseId, assignmentId, membershipId),
                 response,
             );
-            syncFromServer(response);
+            skipNextQueryHydrationRef.current = true;
+            syncFromServer(response, response.publication_state === "published" ? "idle" : "saved");
             setBanner(null);
         } catch (error) {
             if (!unmountedRef.current) {
@@ -227,7 +235,12 @@ export function useTeacherManualGrading(
             return;
         }
 
-        syncFromServer(gradeQuery.data);
+        if (skipNextQueryHydrationRef.current) {
+            skipNextQueryHydrationRef.current = false;
+            return;
+        }
+
+        syncFromServer(gradeQuery.data, "idle");
     }, [gradeQuery.data, syncFromServer]);
 
     useEffect(() => {
@@ -299,7 +312,8 @@ export function useTeacherManualGrading(
                 queryKeys.teacher.caseSubmissionGrade(courseId, assignmentId, membershipId),
                 response,
             );
-            syncFromServer(response);
+            skipNextQueryHydrationRef.current = true;
+            syncFromServer(response, response.publication_state === "published" ? "idle" : "saved");
             setBanner({
                 tone: "emerald",
                 title: "Calificación publicada",

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -62,6 +62,8 @@ export type EDADepth = "charts_only" | "charts_plus_explanation" | "charts_plus_
 export type IntentType = "scenario" | "techniques" | "both";
 export type StudentProfile = "business" | "ml_ds";
 export type ModuleId = "m1" | "m2" | "m3" | "m4" | "m5" | "m6";
+export type TeacherGradeRubricLevel = "excelente" | "bien" | "aceptable" | "insuficiente" | "no_responde";
+export type TeacherGradePublicationState = "draft" | "published";
 export interface CaseFormData {
     courseId: string;
     subject: string;
@@ -904,6 +906,55 @@ export interface TeacherCaseSubmissionDetailResponse {
     response_state: TeacherCaseSubmissionDetailResponseState;
     grade_summary: TeacherCaseSubmissionDetailGradeSummary;
     modules: TeacherCaseSubmissionDetailModule[];
+}
+
+export interface TeacherCaseSubmissionGradeQuestion {
+    question_id: string;
+    rubric_level: TeacherGradeRubricLevel | null;
+    feedback_question: string | null;
+}
+
+export interface TeacherCaseSubmissionGradeModule {
+    module_id: "M1" | "M2" | "M3" | "M4" | "M5";
+    weight: number;
+    feedback_module: string | null;
+    questions: TeacherCaseSubmissionGradeQuestion[];
+}
+
+export interface TeacherCaseSubmissionGradeResponse {
+    payload_version: 1;
+    snapshot_hash: string;
+    publication_state: TeacherGradePublicationState;
+    version: number;
+    score_normalized: number | null;
+    score_display: number | null;
+    max_score_display: number;
+    modules: TeacherCaseSubmissionGradeModule[];
+    feedback_global: string | null;
+    graded_at: string | null;
+    published_at: string | null;
+    last_modified_at: string;
+    graded_by: "human" | "ai" | "hybrid";
+}
+
+export interface TeacherCaseSubmissionGradeRequest {
+    payload_version: 1;
+    snapshot_hash: string;
+    intent: "save_draft" | "publish";
+    graded_by: "human";
+    feedback_global: string | null;
+    modules: Array<{
+        module_id: "M1" | "M2" | "M3" | "M4" | "M5";
+        weight: number;
+        feedback_module: string | null;
+        source: "human";
+        questions: Array<{
+            question_id: string;
+            rubric_level: TeacherGradeRubricLevel | null;
+            feedback_question: string | null;
+            source: "human";
+        }>;
+    }>;
 }
 
 export interface DeadlineUpdateRequest {

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -835,6 +835,12 @@ describe("api auth + stream glue", () => {
         }])).toBe("Value error, semester must use YYYY-I or YYYY-II");
     });
 
+    it("maps payload_too_large consistently for 413 responses", () => {
+        expect(formatHttpError(413, "payload_too_large")).toBe(
+            "Tus respuestas exceden el tamano permitido.",
+        );
+    });
+
     it("serializes admin course filters into the expected query string", async () => {
         const fetchMock = vi.fn().mockResolvedValue(
             new Response(JSON.stringify({ items: [], page: 1, page_size: 8, total: 0, total_pages: 0 }), {

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -46,6 +46,8 @@ import type {
     SuggestRequest,
     SuggestResponse,
     TeacherCaseDetailResponse,
+    TeacherCaseSubmissionGradeRequest,
+    TeacherCaseSubmissionGradeResponse,
     TeacherCaseSubmissionDetailResponse,
     TeacherCaseSubmissionsResponse,
     TeacherCourseAccessLinkRegenerateResponse,
@@ -92,7 +94,12 @@ type ApiErrorCode =
     | "course_gradebook_inconsistent_max_score"
     | "course_gradebook_invalid_max_score"
     | "student_identity_unavailable"
-    | "case_canonical_output_invalid";
+    | "case_canonical_output_invalid"
+    | "snapshot_changed"
+    | "incomplete_grade"
+    | "feature_disabled"
+    | "graded_by_not_supported"
+    | "feedback_source_not_supported";
 
 export interface ProgressEvent {
     event: string;
@@ -219,6 +226,10 @@ export function formatHttpError(status: number, detail?: ApiErrorDetail) {
         return structuredMessage || "El caso no esta disponible o no existe.";
     }
 
+    if (status === 404 && code === "feature_disabled") {
+        return structuredMessage || "La calificacion manual no esta disponible en este entorno.";
+    }
+
     if (status === 403) {
         switch (code) {
             case "profile_incomplete":
@@ -256,6 +267,14 @@ export function formatHttpError(status: number, detail?: ApiErrorDetail) {
 
     if (status === 409 && code === "version_conflict") {
         return structuredMessage || "Tu borrador esta desactualizado frente a la version guardada.";
+    }
+
+    if (status === 409 && code === "snapshot_changed") {
+        return structuredMessage || "La entrega cambio mientras calificabas. Recarga para continuar.";
+    }
+
+    if (status === 409 && code === "incomplete_grade") {
+        return structuredMessage || "Debes calificar todas las preguntas antes de publicar.";
     }
 
     if (status === 422) {
@@ -1206,6 +1225,30 @@ export const api = {
         ): Promise<TeacherCaseSubmissionDetailResponse> {
             return parseJsonResponse<TeacherCaseSubmissionDetailResponse>(
                 `/teacher/cases/${assignmentId}/submissions/${membershipId}`,
+            );
+        },
+        async getCaseSubmissionGrade(
+            courseId: string,
+            assignmentId: string,
+            membershipId: string,
+        ): Promise<TeacherCaseSubmissionGradeResponse> {
+            return parseJsonResponse<TeacherCaseSubmissionGradeResponse>(
+                `/teacher/courses/${courseId}/cases/${assignmentId}/submissions/${membershipId}/grade`,
+            );
+        },
+        async saveCaseSubmissionGrade(
+            courseId: string,
+            assignmentId: string,
+            membershipId: string,
+            body: TeacherCaseSubmissionGradeRequest,
+        ): Promise<TeacherCaseSubmissionGradeResponse> {
+            return parseJsonResponse<TeacherCaseSubmissionGradeResponse>(
+                `/teacher/courses/${courseId}/cases/${assignmentId}/submissions/${membershipId}/grade`,
+                {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(body),
+                },
             );
         },
         async publishCase(assignmentId: string): Promise<TeacherCaseDetailResponse> {

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -273,7 +273,7 @@ export function formatHttpError(status: number, detail?: ApiErrorDetail) {
         return structuredMessage || "La entrega cambio mientras calificabas. Recarga para continuar.";
     }
 
-    if (status === 409 && code === "incomplete_grade") {
+    if (status === 422 && code === "incomplete_grade") {
         return structuredMessage || "Debes calificar todas las preguntas antes de publicar.";
     }
 

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -277,10 +277,12 @@ export function formatHttpError(status: number, detail?: ApiErrorDetail) {
         return structuredMessage || "Debes calificar todas las preguntas antes de publicar.";
     }
 
+    if ((status === 413 || status === 422) && code === "payload_too_large") {
+        return structuredMessage || "Tus respuestas exceden el tamano permitido.";
+    }
+
     if (status === 422) {
         switch (code) {
-            case "payload_too_large":
-                return structuredMessage || "Tus respuestas exceden el tamano permitido.";
             case "invalid_question_id":
                 return structuredMessage || "Se detecto una pregunta invalida en el borrador.";
             case "invalid_answer_value":

--- a/frontend/src/shared/case-viewer/CaseContentRenderer.test.tsx
+++ b/frontend/src/shared/case-viewer/CaseContentRenderer.test.tsx
@@ -98,12 +98,16 @@ describe("CaseContentRenderer", () => {
         expect(screen.getByPlaceholderText(/Escriba su respuesta aquí/i)).toHaveAttribute("readonly");
     });
 
-    it("renders a custom right panel in place of the default section rail", () => {
+    it("renders question supplements without reopening layout seams", () => {
         renderRenderer({
-            rightPanelSlot: <div data-testid="custom-right-panel">Custom panel</div>,
+            questionSupplement: (questionId) => (
+                questionId === "M1-Q1"
+                    ? <div data-testid="custom-question-supplement">Custom supplement</div>
+                    : null
+            ),
         });
 
-        expect(screen.getByTestId("custom-right-panel")).toBeTruthy();
-        expect(screen.queryByText(/En esta sección/i)).toBeNull();
+        expect(screen.getByTestId("custom-question-supplement")).toBeTruthy();
+        expect(screen.getByText(/En esta sección/i)).toBeTruthy();
     });
 });

--- a/frontend/src/shared/case-viewer/CaseContentRenderer.tsx
+++ b/frontend/src/shared/case-viewer/CaseContentRenderer.tsx
@@ -87,9 +87,6 @@ interface CaseContentRendererProps {
     onAnswersChange: (nextAnswers: Record<string, string>) => void;
     readOnly: boolean;
     showExpectedSolutions: boolean;
-    headerSlot?: ReactNode;
-    rightPanelSlot?: ReactNode;
-    supplementalRightPanelSlot?: ReactNode;
     questionSupplement?: (questionId: string) => ReactNode;
 }
 
@@ -252,9 +249,6 @@ export function CaseContentRenderer({
     onAnswersChange,
     readOnly,
     showExpectedSolutions,
-    headerSlot,
-    rightPanelSlot,
-    supplementalRightPanelSlot,
     questionSupplement,
 }: CaseContentRendererProps) {
     const content = result.content;
@@ -452,7 +446,7 @@ export function CaseContentRenderer({
         }
     }, [commonProps, resolvedActiveModule]);
 
-    const defaultRightPanel = navSections.length > 0 ? (
+    const rightPanel = navSections.length > 0 ? (
         <SectionRail
             sections={navSections}
             activeSection={activeSection}
@@ -460,25 +454,10 @@ export function CaseContentRenderer({
         />
     ) : null;
 
-    const rightPanel = supplementalRightPanelSlot
-        ? (
-            <div className="flex h-full min-h-0 flex-col gap-4">
-                {defaultRightPanel ? (
-                    <div className="min-h-0 flex-1 overflow-y-auto">
-                        {defaultRightPanel}
-                    </div>
-                ) : null}
-                <div className="shrink-0">{supplementalRightPanelSlot}</div>
-            </div>
-        )
-        : rightPanelSlot ?? defaultRightPanel;
-    const rightPanelWidthClassName = supplementalRightPanelSlot ? "w-80" : "w-44";
-
     return (
         <div className="flex flex-1 overflow-hidden">
             <div ref={paperRef} className="flex-1 overflow-y-auto overscroll-contain custom-scroll px-6 py-8 bg-[#F0F4F8]">
                 <div className="w-full">
-                    {headerSlot ? <div className="mb-6">{headerSlot}</div> : null}
                     <div className="paper-shadow bg-white rounded-xl overflow-hidden mb-8">
                         <div ref={caseContentRef} id="module-content-panel" className="px-14 py-12 fade-in">
                             <Suspense fallback={<PreviewModuleFallback />}>
@@ -490,7 +469,7 @@ export function CaseContentRenderer({
             </div>
 
             {rightPanel ? (
-                <div className={`${rightPanelWidthClassName} flex-shrink-0 hidden xl:flex flex-col py-8 pl-6 pr-4 border-l border-slate-200 bg-[#F0F4F8]`}>
+                <div className="w-44 flex-shrink-0 hidden xl:flex flex-col py-8 pl-6 pr-4 border-l border-slate-200 bg-[#F0F4F8]">
                     {rightPanel}
                 </div>
             ) : null}

--- a/frontend/src/shared/case-viewer/CaseContentRenderer.tsx
+++ b/frontend/src/shared/case-viewer/CaseContentRenderer.tsx
@@ -89,6 +89,8 @@ interface CaseContentRendererProps {
     showExpectedSolutions: boolean;
     headerSlot?: ReactNode;
     rightPanelSlot?: ReactNode;
+    supplementalRightPanelSlot?: ReactNode;
+    questionSupplement?: (questionId: string) => ReactNode;
 }
 
 interface MarkdownMap extends Record<string, string | null> {
@@ -252,6 +254,8 @@ export function CaseContentRenderer({
     showExpectedSolutions,
     headerSlot,
     rightPanelSlot,
+    supplementalRightPanelSlot,
+    questionSupplement,
 }: CaseContentRendererProps) {
     const content = result.content;
     const isEDA = result.caseType === "harvard_with_eda";
@@ -412,12 +416,13 @@ export function CaseContentRenderer({
                             onAnswerChange={(value) => onAnswersChange({ ...answers, [questionId]: value })}
                             readOnly={readOnly}
                             showExpectedSolutions={showExpectedSolutions}
+                            supplement={questionSupplement?.(questionId)}
                         />
                     );
                 })}
             </div>
         );
-    }, [answers, onAnswersChange, readOnly, showExpectedSolutions]);
+    }, [answers, onAnswersChange, questionSupplement, readOnly, showExpectedSolutions]);
 
     const commonProps = useMemo(() => ({
         result,
@@ -455,7 +460,19 @@ export function CaseContentRenderer({
         />
     ) : null;
 
-    const rightPanel = rightPanelSlot ?? defaultRightPanel;
+    const rightPanel = supplementalRightPanelSlot
+        ? (
+            <div className="flex h-full min-h-0 flex-col gap-4">
+                {defaultRightPanel ? (
+                    <div className="min-h-0 flex-1 overflow-y-auto">
+                        {defaultRightPanel}
+                    </div>
+                ) : null}
+                <div className="shrink-0">{supplementalRightPanelSlot}</div>
+            </div>
+        )
+        : rightPanelSlot ?? defaultRightPanel;
+    const rightPanelWidthClassName = supplementalRightPanelSlot ? "w-80" : "w-44";
 
     return (
         <div className="flex flex-1 overflow-hidden">
@@ -473,7 +490,7 @@ export function CaseContentRenderer({
             </div>
 
             {rightPanel ? (
-                <div className="w-44 flex-shrink-0 hidden xl:flex flex-col py-8 pl-6 pr-4 border-l border-slate-200 bg-[#F0F4F8]">
+                <div className={`${rightPanelWidthClassName} flex-shrink-0 hidden xl:flex flex-col py-8 pl-6 pr-4 border-l border-slate-200 bg-[#F0F4F8]`}>
                     {rightPanel}
                 </div>
             ) : null}

--- a/frontend/src/shared/case-viewer/PreguntaCard.tsx
+++ b/frontend/src/shared/case-viewer/PreguntaCard.tsx
@@ -1,5 +1,5 @@
 import { marked } from "marked";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import type { EDASocraticQuestion, ModuleId, PreguntaMinimalista } from "@/shared/adam-types";
 
@@ -18,6 +18,7 @@ export function PreguntaCard({
     onAnswerChange,
     readOnly,
     showExpectedSolutions,
+    supplement,
 }: {
     p: QuestionRenderable;
     questionId: string;
@@ -26,6 +27,7 @@ export function PreguntaCard({
     readOnly: boolean;
     showExpectedSolutions: boolean;
     moduleId?: ModuleId;
+    supplement?: ReactNode;
 }) {
     const [showSolucion, setShowSolucion] = useState(showExpectedSolutions);
     const formattedEnunciado = marked(p.enunciado) as string;
@@ -70,6 +72,7 @@ export function PreguntaCard({
                     value={answer}
                     onChange={(event) => onAnswerChange(event.target.value)}
                 />
+                {supplement ? <div className="mt-4">{supplement}</div> : null}
                 {showExpectedSolutions && hasSolution && (
                     <div className="mt-5 flex justify-end">
                         <button

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -93,5 +93,8 @@ export const queryKeys = {
         /** ["teacher", "case-submission-detail", assignmentId, membershipId] — detalle de una entrega docente */
         caseSubmissionDetail: (assignmentId: string, membershipId: string) =>
             ["teacher", "case-submission-detail", assignmentId, membershipId] as const,
+        /** ["teacher", "case-submission-grade", courseId, assignmentId, membershipId] — grading manual de una entrega docente */
+        caseSubmissionGrade: (courseId: string, assignmentId: string, membershipId: string) =>
+            ["teacher", "case-submission-grade", courseId, assignmentId, membershipId] as const,
     },
 } as const;


### PR DESCRIPTION
## Summary
- add the course-scoped teacher manual grading API and service flow with draft save, publish, republish, snapshot conflict handling, a feature flag rollback switch, and `payload_version=1` responses
- add the Issue 219 schema changes for per-module weights plus draft/published grading entries while preserving the currently published grade until an explicit republish
- integrate the teacher submission detail UI with autosaved manual grading, per-question rubric controls, module/global feedback, and additive case-viewer seams instead of changing `case-preview`
- cover the new workflow with backend and frontend tests and document the shared ownership boundaries for the grading runtime

## Validation Evidence
- [x] `uv run --directory backend alembic upgrade head`
- [x] `uv run --directory backend alembic downgrade -1`
- [x] `uv run --directory backend alembic upgrade head`
- [x] `uv run --directory backend pytest -q` (`407 passed, 12 skipped`)
- [x] `uv run --directory backend mypy src`
- [x] `npm --prefix frontend run lint`
- [x] `npm --prefix frontend run test` (`57/57` files, `405/405` tests)
- [x] `npm --prefix frontend run build`

## Notes
- the teacher submission detail route still does not carry `courseId`, so the frontend derives it from `detail.case.course_id` when calling the new grading endpoint
- no browser/manual QA evidence is included in this PR; the validation here is automated plus migration up/down verification

## References
- References #219

🤖 Generated with GitHub Copilot