### PR TITLE
feat(case_architect): Pro + thinking high con cadena de fallback

### DIFF
--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -936,7 +936,11 @@ class AuthoringService:
                     "configurable": {
                         "thread_id": job_id,
                         "writer_model": "gemini-3-flash-preview",
-                        "architect_model": "gemini-3-flash-preview",
+                        # architect_model: usar el default Pro de Configuration
+                        # (gemini-3.1-pro-preview) para case_architect / schema_designer.
+                        # Es un nodo crítico (Exhibits + code_execution) y el costo extra
+                        # se acepta por calidad pedagógica.
+                        "architect_model": "gemini-3.1-pro-preview",
                         "job_id": job_id,
                         "assignment_id": assignment_id,
                         "owner_id": owner_id,

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -227,7 +227,22 @@ def _get_architect_llm(
         rate_limiter=_rate_limiter,
         model_kwargs={"tools": [{"code_execution": {}}]},
     )
-    fallback = ChatGoogleGenerativeAI(
+    # Cadena de fallbacks ordenada:
+    #   1) Pro con thinking_level="medium": misma calidad de modelo, menos
+    #      reasoning tokens. Cubre fallos transitorios (rate limit, 5xx puntual,
+    #      parser error en una respuesta).
+    #   2) Flash: red de seguridad final por si Pro está caído globalmente.
+    pro_fallback_medium = ChatGoogleGenerativeAI(
+        model=model,
+        temperature=temperature,
+        thinking_level="medium",
+        max_retries=2,
+        max_output_tokens=16384,
+        api_key=os.getenv("GEMINI_API_KEY"),
+        rate_limiter=_rate_limiter,
+        model_kwargs={"tools": [{"code_execution": {}}]},
+    )
+    flash_fallback = ChatGoogleGenerativeAI(
         model="gemini-3-flash-preview",
         temperature=temperature,
         max_output_tokens=16384,
@@ -235,7 +250,7 @@ def _get_architect_llm(
         api_key=os.getenv("GEMINI_API_KEY"),
         rate_limiter=_rate_limiter,
     )
-    return primary.with_fallbacks([fallback])
+    return primary.with_fallbacks([pro_fallback_medium, flash_fallback])
 
 
 def _get_chart_llm(
@@ -721,7 +736,7 @@ def _build_base_context(state: ADAMState) -> dict:
 def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
     """Diseña los cimientos del caso: empresa, dilema, exhibits e instrucciones."""
     cfg = Configuration.from_runnable_config(config)
-    llm = _get_architect_llm(cfg.architect_model, temperature=0.3, thinking_level="medium")
+    llm = _get_architect_llm(cfg.architect_model, temperature=0.3, thinking_level="high")
 
     context = _build_base_context(state)
     context.update({


### PR DESCRIPTION
﻿## Resumen

Eleva la calidad del nodo `case_architect` (genera los 3 Exhibits del Modulo 1 y alimenta a todos los demas agentes del grafo) y de `schema_designer` (M2 dataset). Ambos nodos comparten `_get_architect_llm`.

## Motivacion

El `case_architect` es el nodo mas critico del pipeline: disena empresa, dilema, Exhibit financiero / operativo / stakeholders, y usa `code_execution` para validar coherencia numerica (Inversion menor o igual a `max_investment_pct` por ciento de Revenue, EBITDA = Ingresos - Costos, etc).

Hoy el override en `authoring.py` lo bajaba a `gemini-3-flash-preview`, perdiendo el razonamiento previo a la ejecucion de Python y degradando la consistencia de los Exhibits.

## Cambios

**`backend/src/case_generator/core/authoring.py`**
- Quitar override `architect_model = gemini-3-flash-preview` en `run_config`.
- Pasar a `gemini-3.1-pro-preview` (mismo valor que el default de `Configuration`).

**`backend/src/case_generator/graph.py`**
- `case_architect` sube `thinking_level` de `medium` a `high`.
- `_get_architect_llm` amplia `with_fallbacks` a cadena ordenada:
  1. Pro `thinking_level=high` + `code_execution` (primario)
  2. Pro `thinking_level=medium` + `code_execution` (fallback transitorio sin degradar modelo)
  3. Flash (red de seguridad final ante incidente global de Pro)

## Impacto

- Mayor calidad y consistencia de Exhibits del Modulo 1 y del schema del dataset M2.
- Mayor latencia y costo por job, aceptado conscientemente: nodo pedagogicamente critico, una vez por caso.
- Sin cambios de contrato, schema, ni interfaces publicas.

## Riesgos

Bajo. Cambios circunscritos a configuracion de modelo y cadena de fallback. No tocan prompts, schemas Pydantic, ni topologia del grafo. Si Pro sufre incidente global, `with_fallbacks` cae a Pro-medium y finalmente a Flash, manteniendo el comportamiento previo como ultima red.

## Validacion

Cambios de configuracion del LLM, sin nueva logica testeable. Sera validado en el siguiente run de authoring.
