### PR TITLE
feat(schema_designer): cadena de fallback resiliente para M2 dataset

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -1706,31 +1706,40 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
     })
     prompt = SCHEMA_DESIGNER_PROMPT.format(**context)
 
-    # Dos intentos: architect (Pro) → writer (Flash thinking OFF)
-    # gemini-3.1-pro-preview con thinking_level="medium" para mayor calidad de schema.
-    # max_output_tokens=16384: "medium" consume ~3-8k tokens de reasoning interno;
-    # con 16384 quedan ≥8k para el JSON de salida de 14 columnas (~4500-6000 tokens).
-    # .with_fallbacks() añade resiliencia: si el modelo está con 503, el fallback
-    # reintenta con el mismo modelo (max_retries=2 en cada nivel de la cadena).
-    _schema_llm_kwargs = dict(
+    # Cadena de fallback resiliente alineada con el patrón del case_architect (M1):
+    #   1) Pro thinking_level="medium" — primario (mantiene thinking; subir a "high"
+    #      arriesga truncar el JSON estructurado de 14 columnas por consumo de
+    #      reasoning interno).
+    #   2) Pro thinking_level="low"    — fallback transitorio sin degradar de modelo.
+    #   3) Flash                       — red de seguridad final ante incidente global
+    #      del Pro (sin response_mime_type estructurado, parser tolerante downstream).
+    # max_output_tokens=24576 da margen extra para el JSON (~5-6k tokens) sobre el
+    # reasoning de "medium" (~3-8k), reduciendo riesgo de truncamiento.
+    _common_kwargs = dict(
         model="gemini-3.1-pro-preview",
         temperature=0.2,
-        thinking_level="medium",
         max_retries=2,
-        max_output_tokens=16384,
+        max_output_tokens=24576,
         api_key=os.getenv("GEMINI_API_KEY"),
         rate_limiter=_rate_limiter,
         response_mime_type="application/json",
     )
-    candidates = [
-        ChatGoogleGenerativeAI(**_schema_llm_kwargs)
-            .with_fallbacks([ChatGoogleGenerativeAI(**_schema_llm_kwargs)]),
-        ChatGoogleGenerativeAI(**_schema_llm_kwargs)
-            .with_fallbacks([ChatGoogleGenerativeAI(**_schema_llm_kwargs)]),
-    ]
+    primary = ChatGoogleGenerativeAI(thinking_level="medium", **_common_kwargs)
+    pro_low_fallback = ChatGoogleGenerativeAI(thinking_level="low", **_common_kwargs)
+    flash_fallback = ChatGoogleGenerativeAI(
+        model="gemini-3-flash-preview",
+        temperature=0.2,
+        max_retries=2,
+        max_output_tokens=24576,
+        api_key=os.getenv("GEMINI_API_KEY"),
+        rate_limiter=_rate_limiter,
+    )
+    candidates = [primary.with_fallbacks([pro_low_fallback, flash_fallback])]
 
     for i, llm in enumerate(candidates):
-        model_label = "architect" if i == 0 else "writer-fallback"
+        # Solo 1 candidato compuesto; el fallback chain (Pro-medium → Pro-low → Flash)
+        # se resuelve internamente vía .with_fallbacks().
+        model_label = "pro-medium-chain" if i == 0 else f"candidate-{i}"
         try:
             response = llm.invoke(prompt)
             raw = _extract_text(response)


### PR DESCRIPTION
## Resumen

Aplica la misma logica de resiliencia del PR #221 (case_architect M1) al unico nodo LLM del pipeline M2 (`schema_designer`), con ajustes para su naturaleza distinta (output JSON estructurado, sin code_execution).

## Motivacion

El M2 tiene 3 nodos (`schema_designer -> data_generator -> data_validator`), pero solo el primero usa LLM. La cadena de fallback actual era cosmetica:

```python
candidates = [
    Pro-medium.with_fallbacks([Pro-medium]),  # mismo modelo, mismas params
    Pro-medium.with_fallbacks([Pro-medium]),  # idem
]
```

4 intentos contra el mismo modelo y misma config. Si Pro-medium tiene un incidente global o un parser issue, los 4 fallan.

## Por que NO subir a thinking=high (a diferencia del M1)

`schema_designer` exige `response_mime_type='application/json'` con un schema de ~14 columnas (~5-6k tokens de salida). Con `thinking=high` el reasoning interno consume ~8-12k tokens y arriesga **truncar el JSON**, rompiendo toda la cadena M2 (sin schema valido, `data_generator` y `data_validator` no producen nada). A diferencia del `case_architect`, este nodo no usa `code_execution` ni razonamiento narrativo complejo.

## Cambios

`backend/src/case_generator/graph.py` :: `schema_designer`
- Reemplazar la cadena duplicada por una cadena ordenada via `with_fallbacks`:
  1. Pro `thinking_level='medium'` (primario, sin cambios)
  2. Pro `thinking_level='low'` (fallback transitorio sin degradar de modelo)
  3. Flash (red de seguridad final ante incidente global de Pro)
- Mantener `thinking_level='medium'`: NO subir a `high` (riesgo de truncamiento).
- Subir `max_output_tokens` 16384 -> 24576: margen extra de seguridad para el JSON.
- Renombrar label de logging a `pro-medium-chain` (ahora 1 candidato compuesto).

## Impacto

- Mayor resiliencia ante incidentes transitorios de Pro (degradacion graceful en lugar de fallo total).
- Sin cambio de modelo primario ni de thinking. Latencia y costo del happy path son identicos al baseline.
- Sin cambios de contrato, schema, ni interfaces publicas.

## Riesgos

Bajo. Cambios circunscritos a la inicializacion del LLM y su cadena de fallback. La logica downstream (parsing del JSON, validacion `DatasetSchema`, normalizacion ml_ds, guard de revenue) es identica.

## Validacion

Smoke import OK (`from case_generator.graph import schema_designer`). Cambios de configuracion del LLM, sin nueva logica testeable. Sera validado en el siguiente run de authoring del demo.

## Relacionado

- Sigue el patron establecido en #221 (case_architect M1: Pro-high + cadena Pro-medium -> Flash).
- Cierra la observacion de que el M2 no heredaba la mejora del M1.
