### PR TITLE
feat(m3): cadena Pro resiliente y guardrails API estable para notebook

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -28,7 +28,13 @@ Modelos:
   m3 (Pro chain) : m3_content_generator (ml_ds), m3_notebook_generator
   writer_model (Flash): m3_content_generator (business), demás nodos LLM
   chart_llm (Flash, 16K tokens): chart generators (M2, M3, M4)
-  fallback: gemini-2.5-flash (activado automáticamente si primary falla)
+  Cadenas de fallback (depende del nodo, no es global):
+    - _get_writer_llm  / _get_chart_llm    : primary -> gemini-2.5-flash
+    - _get_architect_llm                   : Pro-high -> Pro-medium -> gemini-3-flash-preview
+    - _get_m5_llm                          : Pro -> gemini-3-flash-preview -> gemini-2.5-flash
+    - schema_designer (M2 inline)          : Pro-medium -> Pro-low -> gemini-3-flash-preview
+    - m3_content_generator (ml_ds inline)  : Pro-medium -> Pro-low -> gemini-3-flash-preview
+    - m3_notebook_generator (inline)       : Pro-medium -> Pro-low -> gemini-3-flash-preview
   Python puro (0 tokens): data_generator, data_validator, barriers sync
 
 Resiliencia (v9):
@@ -2569,9 +2575,11 @@ def m3_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
             # ml_ds: el m3_content alimenta directamente el prompt del notebook
             # generator. Calidad de razonamiento aquí ⇒ menos ambigüedad en la
             # sección 3 (hipótesis, criterio de descarte, sesgos). Por eso Pro-
-            # medium con cadena de fallback (Pro-low → Flash-medium).
+            # medium con cadena de fallback (Pro-low → Flash-low).
+            # Modelos vía Configuration para respetar overrides por env var
+            # (ARCHITECT_MODEL / WRITER_MODEL) — útil para rollouts y tests.
             _m3_common = dict(
-                model="gemini-3.1-pro-preview",
+                model=cfg.architect_model,
                 temperature=0.6,
                 max_retries=2,
                 max_output_tokens=16384,
@@ -2580,9 +2588,13 @@ def m3_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
             )
             primary = ChatGoogleGenerativeAI(thinking_level="medium", **_m3_common)
             pro_low = ChatGoogleGenerativeAI(thinking_level="low", **_m3_common)
+            # Flash fallback: thinking_level="low" explícito (no dependemos del
+            # default del SDK). "low" basta porque ya estamos en modo degradado
+            # por incidente global de Pro y queremos minimizar latencia extra.
             flash_fb = ChatGoogleGenerativeAI(
-                model="gemini-3-flash-preview",
+                model=cfg.writer_model,
                 temperature=0.6,
+                thinking_level="low",
                 max_retries=2,
                 max_output_tokens=16384,
                 api_key=os.getenv("GEMINI_API_KEY"),
@@ -2676,12 +2688,16 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
         #      familia algorítmica) por consumo de reasoning interno.
         #   2) Pro thinking_level="low"    — fallback transitorio sin degradar de
         #      modelo (cubre rate-limit, 5xx puntual, parser error de una vuelta).
-        #   3) Flash-medium                — red de seguridad final ante incidente
-        #      global de Pro. Mantiene thinking="medium" porque el output es código.
+        #   3) Flash thinking_level="medium" — red de seguridad final ante
+        #      incidente global de Pro. Mantenemos "medium" en Flash porque el
+        #      output es código y la consistencia importa más que la latencia.
+        # Modelos vía Configuration para respetar overrides por env var
+        # (ARCHITECT_MODEL / WRITER_MODEL) — el path notebook es el más sensible,
+        # imprescindible que los rollouts/canaries lleguen también aquí.
         # max_output_tokens=24576 da margen para reasoning (~3-8k) + Jupytext de
         # 3 celdas × N familias (~6-12k chars) sin truncamiento silencioso.
         _nb_common = dict(
-            model="gemini-3.1-pro-preview",
+            model=cfg.architect_model,
             temperature=0.3,
             max_retries=2,
             max_output_tokens=24576,
@@ -2691,8 +2707,9 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
         nb_primary = ChatGoogleGenerativeAI(thinking_level="medium", **_nb_common)
         nb_pro_low = ChatGoogleGenerativeAI(thinking_level="low", **_nb_common)
         nb_flash = ChatGoogleGenerativeAI(
-            model="gemini-3-flash-preview",
+            model=cfg.writer_model,
             temperature=0.3,
+            thinking_level="medium",
             max_retries=2,
             max_output_tokens=24576,
             api_key=os.getenv("GEMINI_API_KEY"),

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -25,7 +25,8 @@ Total nodos LLM por path:
 
 Modelos:
   architect_model (Pro): case_architect, schema_designer
-  writer_model (Flash): todos los demás nodos LLM
+  m3 (Pro chain) : m3_content_generator (ml_ds), m3_notebook_generator
+  writer_model (Flash): m3_content_generator (business), demás nodos LLM
   chart_llm (Flash, 16K tokens): chart generators (M2, M3, M4)
   fallback: gemini-2.5-flash (activado automáticamente si primary falla)
   Python puro (0 tokens): data_generator, data_validator, barriers sync
@@ -2553,7 +2554,6 @@ def m3_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
     """
     try:
         cfg = Configuration.from_runnable_config(config)
-        llm = _get_writer_llm(cfg.writer_model, temperature=0.6, thinking_level="medium")
 
         context = _build_base_context(state)
         context.update({
@@ -2566,10 +2566,36 @@ def m3_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
             prompt = M3_EXPERIMENT_PROMPT
             tag = "m3_experiment_engineer"
             m3_mode = "experiment"
+            # ml_ds: el m3_content alimenta directamente el prompt del notebook
+            # generator. Calidad de razonamiento aquí ⇒ menos ambigüedad en la
+            # sección 3 (hipótesis, criterio de descarte, sesgos). Por eso Pro-
+            # medium con cadena de fallback (Pro-low → Flash-medium).
+            _m3_common = dict(
+                model="gemini-3.1-pro-preview",
+                temperature=0.6,
+                max_retries=2,
+                max_output_tokens=16384,
+                api_key=os.getenv("GEMINI_API_KEY"),
+                rate_limiter=_rate_limiter,
+            )
+            primary = ChatGoogleGenerativeAI(thinking_level="medium", **_m3_common)
+            pro_low = ChatGoogleGenerativeAI(thinking_level="low", **_m3_common)
+            flash_fb = ChatGoogleGenerativeAI(
+                model="gemini-3-flash-preview",
+                temperature=0.6,
+                max_retries=2,
+                max_output_tokens=16384,
+                api_key=os.getenv("GEMINI_API_KEY"),
+                rate_limiter=_rate_limiter,
+            )
+            llm = primary.with_fallbacks([pro_low, flash_fb])
         else:
             prompt = M3_AUDIT_PROMPT
             tag = "m3_audit"
             m3_mode = "audit"
+            # business: contenido narrativo de auditoría sin notebook downstream;
+            # Flash-medium con fallback a 2.5-flash (ya en _get_writer_llm) basta.
+            llm = _get_writer_llm(cfg.writer_model, temperature=0.6, thinking_level="medium")
 
         response = llm.invoke(prompt.format(**context))
         m3 = sanitize_markdown(_extract_text(response))
@@ -2641,7 +2667,38 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
 
     try:
         cfg = Configuration.from_runnable_config(config)
-        llm = _get_writer_llm(cfg.writer_model, temperature=0.3, thinking_level="low")
+
+        # Notebook generator es el ÚNICO nodo del sistema que emite código Python
+        # ejecutable en Colab. Cualquier alucinación o truncamiento se traduce en
+        # un error visible al estudiante. Por eso usa cadena Pro resiliente:
+        #   1) Pro thinking_level="medium" — primario. Subir a "high" arriesga
+        #      truncar el Jupytext (muchas llaves, varios bloques try/except por
+        #      familia algorítmica) por consumo de reasoning interno.
+        #   2) Pro thinking_level="low"    — fallback transitorio sin degradar de
+        #      modelo (cubre rate-limit, 5xx puntual, parser error de una vuelta).
+        #   3) Flash-medium                — red de seguridad final ante incidente
+        #      global de Pro. Mantiene thinking="medium" porque el output es código.
+        # max_output_tokens=24576 da margen para reasoning (~3-8k) + Jupytext de
+        # 3 celdas × N familias (~6-12k chars) sin truncamiento silencioso.
+        _nb_common = dict(
+            model="gemini-3.1-pro-preview",
+            temperature=0.3,
+            max_retries=2,
+            max_output_tokens=24576,
+            api_key=os.getenv("GEMINI_API_KEY"),
+            rate_limiter=_rate_limiter,
+        )
+        nb_primary = ChatGoogleGenerativeAI(thinking_level="medium", **_nb_common)
+        nb_pro_low = ChatGoogleGenerativeAI(thinking_level="low", **_nb_common)
+        nb_flash = ChatGoogleGenerativeAI(
+            model="gemini-3-flash-preview",
+            temperature=0.3,
+            max_retries=2,
+            max_output_tokens=24576,
+            api_key=os.getenv("GEMINI_API_KEY"),
+            rate_limiter=_rate_limiter,
+        )
+        llm = nb_primary.with_fallbacks([nb_pro_low, nb_flash])
 
         context = _build_base_context(state)
         case_title = state.get("titulo", "Caso de Estudio") or "Caso de Estudio"

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -1785,17 +1785,27 @@ M3_NOTEBOOK_BASE_TEMPLATE = """\
 
 # %%
 import io
+import platform
 import warnings
 import numpy as np
 import pandas as pd
+import matplotlib
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sklearn
 
 warnings.filterwarnings("ignore")
 plt.style.use("default")
 sns.set_theme(style="whitegrid")
 
 print("✅ Librerías base cargadas.")
+print(f"   Python      : {platform.python_version()}")
+print(f"   pandas      : {pd.__version__}")
+print(f"   numpy       : {np.__version__}")
+print(f"   scikit-learn: {sklearn.__version__}")
+print(f"   matplotlib  : {matplotlib.__version__}")
+print(f"   seaborn     : {sns.__version__}")
+print("ℹ️  Si algún bloque falla por API de librería, verifica versiones arriba.")
 
 # %%
 def normalize_colname(col):
@@ -1980,6 +1990,30 @@ Genera SOLO la continuación del notebook, empezando después de la Sección 3 d
    una columna por alias. Siempre debes implementar un Fallback Heurístico por tipo de dato
    (df.select_dtypes) antes de rendirte. Solo imprime REQUISITO FALTANTE si df.select_dtypes()
    devuelve vacío para el tipo de dato estrictamente necesario.
+
+# Reglas de API ESTABLE (anti-alucinación de librerías)
+A. Usa SOLO API documentada y estable de scikit-learn ≥ 1.0:
+   - sklearn.cluster.KMeans(n_clusters=k, n_init=10, random_state=42)
+   - sklearn.preprocessing.StandardScaler()
+   - sklearn.decomposition.PCA(n_components=2)
+   - sklearn.ensemble.RandomForestClassifier(n_estimators=100, random_state=42)
+   - sklearn.ensemble.IsolationForest(contamination=0.05, random_state=42)
+   - sklearn.linear_model.LogisticRegression(max_iter=1000)
+   - sklearn.linear_model.LinearRegression()
+   - sklearn.feature_extraction.text.TfidfVectorizer(max_features=200, stop_words=None)
+   - sklearn.model_selection.train_test_split(..., test_size=0.2, random_state=42)
+   - sklearn.metrics: accuracy_score, confusion_matrix, mean_squared_error, r2_score
+B. Para RMSE usa: `np.sqrt(mean_squared_error(y_true, y_pred))`. NO inventes
+   `RootMeanSquaredError`, `root_mean_squared_error` ni `squared=False`.
+C. Para grafos: `import networkx as nx` dentro del try; usa nx.Graph(), nx.spring_layout(),
+   nx.draw(). Si networkx no está disponible, captura ImportError y degrada a print explicativo.
+D. NO uses argumentos experimentales (nada de `n_jobs=-1` salvo en RandomForest), nada de
+   APIs deprecated (`sklearn.cross_validation`, `from sklearn.externals import joblib`).
+E. Para matrices grandes, limita SIEMPRE: `df.sample(min(len(df), 5000), random_state=42)`.
+F. Toda llamada a `.fit()` debe ir precedida por dropna/imputación: usa
+   `df_X.dropna()` o `df_X.fillna(df_X.median(numeric_only=True))` antes del fit.
+G. NO importes nada que no esté en el set: numpy, pandas, matplotlib, seaborn, sklearn.*,
+   networkx, scipy.stats. Cualquier otra librería va dentro de try/except ImportError.
 
 # Estructura OBLIGATORIA: exactamente 3 celdas por familia (siempre las 3)
 


### PR DESCRIPTION
# M3 hardening — notebook resiliente para demo ante panel de DS

Tercer paso del audit por módulo del LangGraph (post #221 M1, #222 M2). M3 es
crítico porque emite el **único notebook ejecutable del sistema** (perfil
`ml_ds`, `output_depth=visual_plus_notebook`) y va a presentarse ante
profesores de ciencia de datos. Este PR endurece tanto el modelo que genera
el notebook como el contrato del prompt para minimizar alucinaciones de API.

## Cambios

### 1. `m3_notebook_generator` — cadena Pro con `with_fallbacks`
Antes: `_get_writer_llm(model=Flash, temperature=0.3, thinking_level="low")`
single-call. Si la respuesta venía vacía o el `_extract_text` fallaba, el
notebook caía a un comentario de error visible al alumno.

Ahora cadena explícita resuelta internamente vía `.with_fallbacks()`:

1. `gemini-3.1-pro-preview` thinking_level=`medium` (primary)
2. `gemini-3.1-pro-preview` thinking_level=`low` (fallback transitorio)
3. `gemini-3-flash-preview` (red de seguridad ante caída global de Pro)

`max_output_tokens=24576` para soportar reasoning (~3-8k) + Jupytext de
3 celdas × N familias algorítmicas (~6-12k chars) sin truncamiento silencioso.

Se mantiene `thinking_level="medium"` (no `high`) porque el output es Jupytext
con muchas llaves y bloques `try/except` por familia — `high` aumentaría el
riesgo de truncar al final del bloque.

### 2. `m3_content_generator` — Pro chain solo para `ml_ds`
El `m3_content` se inyecta luego como contexto del notebook generator
(`{m3_content}` en `M3_NOTEBOOK_ALGO_PROMPT`). Calidad de razonamiento aquí
⇒ menos ambigüedad en hipótesis, sesgos y criterio de descarte que el
notebook materializa.

- `studentProfile == "ml_ds"`  → cadena `Pro-medium → Pro-low → Flash-medium`
- `studentProfile == "business"` → sigue en `_get_writer_llm` Flash-medium
  (no hay notebook downstream que defender)

### 3. `M3_NOTEBOOK_BASE_TEMPLATE` — diagnóstico de versiones + sklearn
- Añadido `import sklearn` (ya lo usaba la sección 3 generada por LLM,
  pero no estaba en los imports base).
- Añadido `import matplotlib` y `import platform`.
- Nueva celda imprime versiones de Python / pandas / numpy / sklearn /
  matplotlib / seaborn al cargar. Si Colab cambia versiones y un bloque
  falla por API, el alumno ve la versión exacta sin abrir issues.

Es código **estático** del template — cero superficie de alucinación.

### 4. `M3_NOTEBOOK_ALGO_PROMPT` — reglas de API estable
Nuevo bloque "Reglas de API ESTABLE (anti-alucinación de librerías)" que
fija explícitamente:

- Subset documentado y estable de scikit-learn ≥ 1.0 con signatures
  exactas (KMeans, RandomForest, IsolationForest, LogReg, LinReg, TFIDF,
  train_test_split, métricas).
- Patrón canónico para RMSE: `np.sqrt(mean_squared_error(...))` (no
  `RootMeanSquaredError` ni `squared=False` que dependen de versión).
- Manejo de `networkx` con captura de `ImportError`.
- Prohibición de APIs deprecated (`sklearn.cross_validation`,
  `sklearn.externals.joblib`).
- Sample-cap obligatorio (`min(len(df), 5000)`) antes de fits costosos.
- dropna/imputación obligatoria antes de `.fit()`.
- Set cerrado de imports permitidos; cualquier otra librería va con
  `try/except ImportError`.

### 5. Header docstring de `graph.py`
Tabla de modelos refleja el nuevo perfil de M3:
```
m3 (Pro chain) : m3_content_generator (ml_ds), m3_notebook_generator
writer_model (Flash): m3_content_generator (business), demás nodos LLM
```

## Por qué medium y no high

- `case_architect` (M1) usa **high** porque hace verificación numérica con
  `code_execution` y produce 8 campos densos de narrativa. Reasoning interno
  es lo que da valor.
- `schema_designer` (M2) y M3 nodos usan **medium** porque generan output
  estructurado/código con presupuesto de tokens muy comprometido. `high`
  arriesga truncar al final.

## Validación

- Smoke import OK:
  `python -c "from src.case_generator import graph; ..."` → exit 0
- Sin nuevas dependencias.
- No toca `case_architect`, `schema_designer`, ni la fase de EDA — los
  contratos de estado (`m3_content`, `m3_mode`, `m3_notebook_code`,
  `m3_questions`) son idénticos.

## Riesgos

- Costo: M3 ml_ds pasa de 1×Flash + 1×Flash a (peor caso) 1×Pro-medium +
  1×Pro-medium. En éxito al primer intento es ~2× tokens vs antes pero
  sigue siendo solo el path `ml_ds + visual_plus_notebook`. Path business
  no cambia.
- Latencia: Pro-medium añade ~3-8s vs Flash-low. Aceptable porque M3 ya
  corre en paralelo con `m3_questions_generator` dentro de `m3_flow`.
