### PR TITLE
feat(m3): notebook quality hardening for demo readiness

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2743,8 +2743,10 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
                 a for a in algoritmos_raw
                 if any(kw in a.lower() for kw in keywords)
             ]
-            # Si no se pudo mapear ningún algo crudo (caso "unsupported" mezclado), conserva
-            # al menos el nombre de la familia para que el prompt pueda renderizar 1 bloque.
+            # Si esta familia fue detectada (está en ALGORITHM_REGISTRY) pero ningún algoritmo
+            # crudo coincide con sus keywords en este segundo paso, conserva al menos el nombre
+            # de la familia para que el prompt pueda renderizar 1 bloque genérico de la familia.
+            # Nota: "unsupported" ya quedó filtrado por el `continue` de arriba.
             if not algos_de_familia:
                 algos_de_familia = [f]
             familias_meta.append({

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2730,16 +2730,30 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
 
         # Build familias_meta: deterministic registry data per family so the LLM
         # doesn't need to recall visualization specs or fragment hints from its weights.
-        familias_meta = [
-            {
+        # `algoritmos`: lista de los algoritmos crudos del caso que activaron esta familia.
+        # El prompt ALGO renderiza UN bloque por algoritmo dentro de cada familia, así un
+        # caso que pide "Logistic + RF + SHAP" y "XGBoost con tuning" en clasificacion_tabular
+        # produce DOS bloques visuales y no uno colapsado.
+        familias_meta = []
+        for f in familias:
+            if f not in ALGORITHM_REGISTRY:
+                continue
+            keywords = ALGORITHM_REGISTRY[f]["keywords"]
+            algos_de_familia = [
+                a for a in algoritmos_raw
+                if any(kw in a.lower() for kw in keywords)
+            ]
+            # Si no se pudo mapear ningún algo crudo (caso "unsupported" mezclado), conserva
+            # al menos el nombre de la familia para que el prompt pueda renderizar 1 bloque.
+            if not algos_de_familia:
+                algos_de_familia = [f]
+            familias_meta.append({
                 "familia": f,
+                "algoritmos": algos_de_familia,
                 "visualizacion": ALGORITHM_REGISTRY[f]["visualization"],
                 "prerequisito": ALGORITHM_REGISTRY[f]["prerequisite_note"],
                 "fragments_hint": ALGORITHM_REGISTRY[f]["fragments_hint"],
-            }
-            for f in familias
-            if f in ALGORITHM_REGISTRY
-        ]
+            })
 
         algo_section = ""
         try:

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -879,6 +879,14 @@ Lema: "Correlación no implica causalidad."
 # GUARDRAILS ANTI-ALUCINACIÓN (obligatorios)
 - PROHIBIDO inventar columnas, scores, distribuciones, labels o resultados del dataset.
 - Toda referencia a datos DEBE derivarse del reporte EDA M2 o la narrativa M1.
+- En CADA "Hipótesis experimental" y "Variable / resultado objetivo" DEBES citar al menos
+  una columna real entre comillas inversas tomada literalmente del reporte EDA M2 que
+  recibes en la sección "Context" más abajo. PROHIBIDO referirte a variables genéricas
+  como "tiempos", "demoras", "costos operativos" si esa columna NO aparece textualmente
+  en el EDA M2.
+- Si la columna que necesitarías para probar la hipótesis NO existe en M2, declarar
+  explícitamente: "Variable objetivo pendiente — el dataset no contiene la columna
+  requerida (`<nombre_esperado>`); se recomienda enriquecer el dataset antes del experimento."
 - Si no hay evidencia suficiente para diseñar un módulo, declarar:
   "Evidencia insuficiente en M1/M2 para diseñar este módulo con certeza."
 - PROHIBIDO asumir nombres de columnas, sector específico ni tipo de datos no mencionados.
@@ -2014,18 +2022,82 @@ F. Toda llamada a `.fit()` debe ir precedida por dropna/imputación: usa
    `df_X.dropna()` o `df_X.fillna(df_X.median(numeric_only=True))` antes del fit.
 G. NO importes nada que no esté en el set: numpy, pandas, matplotlib, seaborn, sklearn.*,
    networkx, scipy.stats. Cualquier otra librería va dentro de try/except ImportError.
+H. Métricas OBLIGATORIAS por tipo de problema (imprímelas SIEMPRE, sin excepciones):
+   - Clasificación: `from sklearn.metrics import classification_report, f1_score, confusion_matrix`
+     y `print(classification_report(y_test, y_pred, zero_division=0))` +
+     `print("F1 macro:", f1_score(y_test, y_pred, average="macro", zero_division=0))`.
+   - Regresión: `from sklearn.metrics import mean_squared_error, r2_score` y
+     `print("RMSE:", float(np.sqrt(mean_squared_error(y_test, y_pred))))` +
+     `print("R2:", r2_score(y_test, y_pred))`.
+   - Clustering: `from sklearn.metrics import silhouette_score` y
+     `print("Silhouette:", silhouette_score(X, labels))` cuando hay >=2 clusters formados.
+I. Split anti-leakage para clasificación/regresión:
+   - Detecta columna temporal con `find_first_matching_column(df.columns, date_aliases)`.
+   - Si existe y `is_datetime_like(df, col)` o se puede convertir con `pd.to_datetime(..., errors="coerce")`:
+     ordena `df = df.sort_values(col)`, calcula `cut = int(len(df) * 0.8)` y haz split
+     cronológico: `X_train, X_test = X.iloc[:cut], X.iloc[cut:]` (idem `y`).
+     Imprime: `print("Split temporal por", col, "→ train hasta", df[col].iloc[cut-1])`.
+   - Si NO hay columna temporal: usa `train_test_split(X, y, test_size=0.2, random_state=42,
+     stratify=y if y.nunique() >= 2 and y.value_counts().min() >= 2 else None)`.
+   - Justifica en comentario por qué elegiste cada estrategia.
+J. SHAP es OPCIONAL y SIEMPRE en try/except:
+   - Si el nombre del algoritmo en `algoritmos` contiene "shap": intenta
+     `import shap; explainer = shap.TreeExplainer(model); shap.summary_plot(...)` con
+     `except ImportError: print("SHAP no disponible — usando feature_importances_ como fallback")`
+     y fallback a `pd.Series(model.feature_importances_, index=X.columns).nlargest(15).plot.barh()`.
+   - Si NO contiene "shap": ignora SHAP completamente, usa feature_importances_ directo.
+K. EDA Express (Sección 3.0) OBLIGATORIA antes del primer bloque de algoritmo:
+   - Distribución del target (si fue detectado): `target_col.value_counts(normalize=True)`.
+   - % missing por columna ordenado desc: `df.isna().mean().sort_values(ascending=False).head(10)`.
+   - Flag de outliers por IQR para columnas numéricas (sin imputar, solo reportar conteo):
+     `q1, q3 = df[c].quantile([0.25, 0.75]); iqr = q3 - q1; outliers = ((df[c] < q1 - 1.5*iqr) | (df[c] > q3 + 1.5*iqr)).sum()`
+     y print en formato tabular para top-5 columnas con más outliers.
 
-# Estructura OBLIGATORIA: exactamente 3 celdas por familia (siempre las 3)
+# Estructura OBLIGATORIA
 
-## Celda 1 — Concepto (markdown)
+## Sección 3.0 — EDA Express (UNA sola vez, antes del primer algoritmo)
 # %% [markdown]
-# ### [nombre de la familia]
-# **Algoritmos representados:** [solo los de esta familia, de {algoritmos}]
+# ## Sección 3 — Diseño Experimental
+# Antes de entrenar, validamos calidad y forma del dataset (regla K).
+
+# %%
+try:
+    # Distribución del target detectado por alias (label_aliases / churn_aliases) o último categórico.
+    target_col = find_first_matching_column(df.columns, label_aliases) or \
+                 find_first_matching_column(df.columns, churn_aliases)
+    if target_col is None:
+        cat_cols = df.select_dtypes(include=["object", "category"]).columns.tolist()
+        target_col = cat_cols[-1] if cat_cols else None
+    if target_col is not None:
+        print("Target candidato:", target_col)
+        print(df[target_col].value_counts(normalize=True).round(3))
+    print("\\nTop 10 columnas por % missing:")
+    print(df.isna().mean().sort_values(ascending=False).head(10).round(3))
+    print("\\nTop 5 columnas numéricas con más outliers (IQR 1.5x — solo reporte, no se imputan):")
+    num_cols = df.select_dtypes(include=np.number).columns.tolist()
+    out_counts = {{}}
+    for c in num_cols:
+        q1, q3 = df[c].quantile([0.25, 0.75])
+        iqr = q3 - q1
+        if iqr > 0:
+            out_counts[c] = int(((df[c] < q1 - 1.5*iqr) | (df[c] > q3 + 1.5*iqr)).sum())
+    for c, n in sorted(out_counts.items(), key=lambda kv: kv[1], reverse=True)[:5]:
+        print(f"  {{c}}: {{n}} outliers")
+except Exception as e:
+    print(f"⚠️ EDA Express falló: {{e}}")
+
+## Para CADA familia en {familias_meta}, y para CADA algoritmo dentro del campo
+## "algoritmos" de esa familia, emite EXACTAMENTE 3 celdas (no colapses dos algoritmos
+## en un solo bloque):
+
+## Celda 1 — Concepto (markdown) [una por algoritmo]
+# %% [markdown]
+# ### [familia] — [nombre exacto del algoritmo, tal como aparece en el campo "algoritmos"]
 # **Concepto:** [teoría en 2 líneas, sin jerga]
-# **Hipótesis experimental:** [extraída de {m3_content}, 1-2 líneas]
+# **Hipótesis experimental:** [extraída de {m3_content}, 1-2 líneas — NO inventes columnas]
 # **Prerequisitos:** [campo "prerequisito" del entry correspondiente en {familias_meta}]
 
-## Celda 2 — Gráfico Conceptual (código)
+## Celda 2 — Entrenamiento + Métricas (código) [una por algoritmo]
 # %%
 try:
     # 1. INTENTO PRIMARIO: Buscar por alias semántico usando helpers del base template
@@ -2046,16 +2118,19 @@ try:
     #     print("⚠️ REQUISITO FALTANTE — [descripción exacta de qué tipo de columna falta]")
     #     print_similar_columns(df.columns, <fragments_hint del entry en {familias_meta}>)
     #     # La celda TERMINA aquí
-    # 4. Si hay datos (por alias o por fallback): implementar la visualización del campo
-    #    "visualizacion" en {familias_meta}.
-    #    plt.tight_layout()
-    #    plt.show()
+    # 4. Si hay datos: implementa el algoritmo concreto del nombre (no genérico de la familia).
+    # 5. Para clasificación/regresión: aplica REGLA I (split temporal si hay fecha; si no,
+    #    train_test_split con stratify=y).
+    # 6. Imprime SIEMPRE las métricas obligatorias (REGLA H) para el tipo de problema.
+    # 7. Cierra con la visualización del campo "visualizacion" en {familias_meta}.
+    #    Para clasificación/regresión: feature_importances_ (o REGLA J si hay "shap" en el nombre).
+    #    plt.tight_layout(); plt.show()
 except Exception as e:
     print(f"⚠️ Error: {{e}}")
 
-## Celda 3 — Acción de Negocio (markdown)
+## Celda 3 — Acción de Negocio (markdown) [una por algoritmo]
 # %% [markdown]
-# **Explicación pedagógica:** [qué muestra el gráfico o la limitación detectada, 2 líneas]
+# **Explicación pedagógica:** [qué muestran las métricas y el gráfico, 2 líneas]
 # **Acción de negocio:** [próximo paso concreto basado en el resultado, 1 línea]
 
 # Helpers disponibles (del base template — NO los redefinas)

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -2031,21 +2031,35 @@ H. Métricas OBLIGATORIAS por tipo de problema (imprímelas SIEMPRE, sin excepci
      `print("R2:", r2_score(y_test, y_pred))`.
    - Clustering: `from sklearn.metrics import silhouette_score` y
      `print("Silhouette:", silhouette_score(X, labels))` cuando hay >=2 clusters formados.
-I. Split anti-leakage para clasificación/regresión:
+I. Split anti-leakage para clasificación/regresión (ORDEN OBLIGATORIO):
    - Detecta columna temporal con `find_first_matching_column(df.columns, date_aliases)`.
-   - Si existe y `is_datetime_like(df, col)` o se puede convertir con `pd.to_datetime(..., errors="coerce")`:
-     ordena `df = df.sort_values(col)`, calcula `cut = int(len(df) * 0.8)` y haz split
-     cronológico: `X_train, X_test = X.iloc[:cut], X.iloc[cut:]` (idem `y`).
+   - Si existe: SIEMPRE `df[col] = pd.to_datetime(df[col], errors="coerce")`, descarta filas
+     no convertibles con `df = df.dropna(subset=[col])`, y luego
+     `df = df.sort_values(col).reset_index(drop=True)`.
+   - PROHIBIDO mezclar `df.sort_values(col)` con `X.iloc[...]` / `y.iloc[...]` si X e y se
+     construyeron ANTES de ordenar `df`. Tras ordenar, DERIVA siempre X/y desde el df ordenado:
+     `X = df[feature_cols]; y = df[target_col]` (o reordena con `X = X.loc[df.index]`,
+     `y = y.loc[df.index]` y luego `reset_index(drop=True)`).
+   - Recién entonces `cut = int(len(df) * 0.8)` y split cronológico alineado:
+     `X_train, X_test = X.iloc[:cut], X.iloc[cut:]`; `y_train, y_test = y.iloc[:cut], y.iloc[cut:]`.
      Imprime: `print("Split temporal por", col, "→ train hasta", df[col].iloc[cut-1])`.
    - Si NO hay columna temporal: usa `train_test_split(X, y, test_size=0.2, random_state=42,
      stratify=y if y.nunique() >= 2 and y.value_counts().min() >= 2 else None)`.
    - Justifica en comentario por qué elegiste cada estrategia.
-J. SHAP es OPCIONAL y SIEMPRE en try/except:
+J. SHAP es OPCIONAL y SIEMPRE en try/except. Importancia de features con jerarquía estricta
+   (NO asumas `feature_importances_` para todo modelo — LogisticRegression no lo expone):
    - Si el nombre del algoritmo en `algoritmos` contiene "shap": intenta
-     `import shap; explainer = shap.TreeExplainer(model); shap.summary_plot(...)` con
-     `except ImportError: print("SHAP no disponible — usando feature_importances_ como fallback")`
-     y fallback a `pd.Series(model.feature_importances_, index=X.columns).nlargest(15).plot.barh()`.
-   - Si NO contiene "shap": ignora SHAP completamente, usa feature_importances_ directo.
+     `import shap; explainer = shap.TreeExplainer(model); shap.summary_plot(...)`; en
+     `except (ImportError, Exception)` cae al ladder de abajo.
+   - Ladder de fallback (úsalo siempre si SHAP no se ejecutó):
+     1) `if hasattr(model, "feature_importances_"):`
+          `pd.Series(model.feature_importances_, index=X.columns).nlargest(15).plot.barh()`
+     2) `elif hasattr(model, "coef_"):`
+          `coef = model.coef_; imp = np.abs(coef).mean(axis=0) if coef.ndim > 1 else np.abs(coef).ravel()`
+          `pd.Series(imp, index=X.columns).nlargest(15).plot.barh()`
+     3) `else:` intenta `from sklearn.inspection import permutation_importance` dentro de
+        try/except; si falla, imprime "Modelo sin importancias directas — revisar coeficientes/SHAP manualmente".
+   - `plt.tight_layout(); plt.show()` al final.
 K. EDA Express (Sección 3.0) OBLIGATORIA antes del primer bloque de algoritmo:
    - Distribución del target (si fue detectado): `target_col.value_counts(normalize=True)`.
    - % missing por columna ordenado desc: `df.isna().mean().sort_values(ascending=False).head(10)`.
@@ -2055,9 +2069,11 @@ K. EDA Express (Sección 3.0) OBLIGATORIA antes del primer bloque de algoritmo:
 
 # Estructura OBLIGATORIA
 
-## Sección 3.0 — EDA Express (UNA sola vez, antes del primer algoritmo)
+## Sección 3.0 — EDA Express (UNA sola vez, antes del primer algoritmo).
+## El base template ya abrió `## Sección 3: Módulos Experimentales`; aquí emite un H3,
+## NO un H2 nuevo, para no duplicar la jerarquía.
 # %% [markdown]
-# ## Sección 3 — Diseño Experimental
+# ### 3.0 EDA Express
 # Antes de entrenar, validamos calidad y forma del dataset (regla K).
 
 # %%


### PR DESCRIPTION
﻿# M3 notebook quality hardening for demo readiness

Tres cambios quirurgicos para elevar la calidad pedagogica del notebook M3, motivados por un dogfood real (caso LogiTech) que revelo brechas serias frente a lo que esperarian los profesores de Data Science.

## Motivacion

Test real genero un notebook que:
- Renderizo **un solo bloque de algoritmo** aunque el caso pedia 2 tecnicas (Logistic+RF+SHAP y XGBoost+tuning) — ambos algoritmos colapsaron a la misma familia `clasificacion_tabular` y el prompt iteraba "por familia", no "por algoritmo".
- **No imprimio metricas pedagogicas**: la pregunta guia citaba F1-score explicitamente, pero el notebook no llamaba a `classification_report` ni a `f1_score`.
- Hizo **`train_test_split` aleatorio sobre serie temporal** (columna `period` mensual 2023->2039), introduciendo data leakage que cualquier profesor de DS detecta inmediatamente.
- La hipotesis del Architect Engineer menciono variables ("tiempos") que **no existen en el dataset**, alucinacion cruda.
- No hubo EDA minimo (balance de target, missing %, outliers).

## Cambios

### 1. `graph.py` — `m3_notebook_generator`
Enriquece `familias_meta` con `algoritmos: list[str]` por familia. Cada entry de familia ahora lleva la lista de los algoritmos crudos del caso que la activaron, asi el LLM puede iterar uno por uno en lugar de colapsar.

### 2. `prompts.M3_NOTEBOOK_ALGO_PROMPT` — cuatro reglas nuevas + loop reestructurado
- **Regla H — Metricas obligatorias** por tipo de problema:
  - Clasificacion: `classification_report(zero_division=0)` + `f1_score(average="macro")`.
  - Regresion: `RMSE` (via `np.sqrt(mean_squared_error)`) + `R2`.
  - Clustering: `silhouette_score`.
- **Regla I — Split anti-leakage**:
  - Si hay columna temporal (`date_aliases`): split cronologico 80/20 con `df.sort_values(col)` + `iloc[:cut]`.
  - Si no: `train_test_split(stratify=y if y.nunique() >= 2 and value_counts().min() >= 2 else None)`.
- **Regla J — SHAP opcional**: solo si "shap" aparece en el nombre del algoritmo, y siempre con `try/except ImportError` y fallback a `feature_importances_`.
- **Regla K — Seccion 3.0 EDA Express** (una sola vez antes del loop): distribucion del target detectado, top-10 columnas por % missing, top-5 columnas por outliers IQR (solo reporte, sin imputar).
- **Loop reestructurado**: 3 celdas por **algoritmo** dentro de cada familia (Concepto -> Entrenamiento+Metricas -> Accion de Negocio), no 3 celdas por familia.

### 3. `prompts.M3_EXPERIMENT_PROMPT` — grounding de hipotesis
Cada `Hipotesis experimental` y `Variable / resultado objetivo` debe citar al menos una columna entre backticks que aparezca **textualmente** en el reporte EDA M2 recibido como contexto. Prohibe variables genericas inventadas como "tiempos", "demoras", "costos operativos" cuando esa columna no existe en el dataset.

## Validacion

- `prompts + graph` imports OK
- `M3_NOTEBOOK_ALGO_PROMPT.format(...)` -> 10507 chars
- `M3_EXPERIMENT_PROMPT.format(...)` -> 4158 chars
- `pytest test_case_sanitization + test_issue139_authoring_grounding + test_authoring_progress_resilience` -> 40 passed
- `pytest test_worker_app + test_harness_isolation` -> 10 passed

## Out of scope (issue separada)

El **mismatch caso <-> dataset** (caso pide prediccion de retraso de entregas; dataset solo tiene KPIs financieros) es un problema arquitectural en `case_architect` / `data_generator` y requiere ADR-level review. Tracked en issue separada.

## Riesgo

Bajo. Cambios solo en prompts (texto) + un build de dict en `m3_notebook_generator`. Sin cambios en orquestacion de grafo, sin nuevas dependencias, sin cambios de schema, sin tocar fallbacks LLM.
