### PR TITLE
fix(m3): grounding hardening for demo (4 surgical follow-ups to PR #224)

### DIFF
--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -1903,7 +1903,8 @@ churn_aliases = [
 ]
 
 date_aliases = [
-    "fecha", "date", "timestamp", "periodo", "mes", "dia", "created_at"
+    "fecha", "date", "timestamp", "periodo", "period", "mes", "month",
+    "dia", "day", "created_at", "fecha_periodo", "year_month", "yearmonth"
 ]
 
 source_aliases = ["origen", "source", "from", "source_id", "nodo_origen"]
@@ -2015,13 +2016,26 @@ B. Para RMSE usa: `np.sqrt(mean_squared_error(y_true, y_pred))`. NO inventes
    `RootMeanSquaredError`, `root_mean_squared_error` ni `squared=False`.
 C. Para grafos: `import networkx as nx` dentro del try; usa nx.Graph(), nx.spring_layout(),
    nx.draw(). Si networkx no está disponible, captura ImportError y degrada a print explicativo.
-D. NO uses argumentos experimentales (nada de `n_jobs=-1` salvo en RandomForest), nada de
-   APIs deprecated (`sklearn.cross_validation`, `from sklearn.externals import joblib`).
 E. Para matrices grandes, limita SIEMPRE: `df.sample(min(len(df), 5000), random_state=42)`.
-F. Toda llamada a `.fit()` debe ir precedida por dropna/imputación: usa
-   `df_X.dropna()` o `df_X.fillna(df_X.median(numeric_only=True))` antes del fit.
+F. Toda llamada a `.fit()` debe ir precedida por dropna/imputación SIN LEAKAGE:
+   - PROHIBIDO `X = X.fillna(X.median(...))` ANTES del split (eso fitea con info de
+     test). El orden correcto es: split primero → calcular `med = X_train.median(numeric_only=True)`
+     → `X_train = X_train.fillna(med)` y `X_test = X_test.fillna(med)`.
+   - Para `dropna()` aplica el mismo principio (dropna sobre `df`/`df_model` ANTES del split
+     es seguro porque elimina filas en bloque; imputar con estadísticos NO lo es).
+D. NO uses argumentos experimentales (nada de `n_jobs=-1` salvo en RandomForest), nada de
+   APIs deprecated. Lista NEGRA explícita (PROHIBIDOS, generan TypeError en versiones modernas):
+   - `XGBClassifier(use_label_encoder=...)`  → removido en xgboost ≥2.0; OMÍTELO siempre.
+   - `mean_squared_error(..., squared=False)` → removido en sklearn ≥1.6; usa `np.sqrt(mse)`.
+   - `from sklearn.externals import joblib` → usa `import joblib` directo.
+   - `sklearn.cross_validation` → usa `sklearn.model_selection`.
+   - `n_estimators` sin `random_state` en cualquier ensemble → siempre fija `random_state=42`.
 G. NO importes nada que no esté en el set: numpy, pandas, matplotlib, seaborn, sklearn.*,
    networkx, scipy.stats. Cualquier otra librería va dentro de try/except ImportError.
+   Para xgboost/lightgbm/catboost: `try: import xgboost as xgb` y captura
+   `except (ImportError, Exception)` (NO solo ImportError) para tolerar TypeErrors por
+   firmas de constructor que cambian entre versiones; en el except, fallback a
+   `GradientBoostingClassifier` / `GradientBoostingRegressor` de sklearn.
 H. Métricas OBLIGATORIAS por tipo de problema (imprímelas SIEMPRE, sin excepciones):
    - Clasificación: `from sklearn.metrics import classification_report, f1_score, confusion_matrix`
      y `print(classification_report(y_test, y_pred, zero_division=0))` +
@@ -2066,6 +2080,9 @@ K. EDA Express (Sección 3.0) OBLIGATORIA antes del primer bloque de algoritmo:
    - Flag de outliers por IQR para columnas numéricas (sin imputar, solo reportar conteo):
      `q1, q3 = df[c].quantile([0.25, 0.75]); iqr = q3 - q1; outliers = ((df[c] < q1 - 1.5*iqr) | (df[c] > q3 + 1.5*iqr)).sum()`
      y print en formato tabular para top-5 columnas con más outliers.
+   - GUARDA de tamaño mínimo: si `len(df) < 50`, imprime una ADVERTENCIA visible
+     ("⚠️ Dataset pequeño (n=<N>): los modelos posteriores son ilustrativos; las métricas
+     tienen alta varianza”) para que el estudiante interprete los resultados con cautela.
 
 # Estructura OBLIGATORIA
 
@@ -2087,6 +2104,9 @@ try:
     if target_col is not None:
         print("Target candidato:", target_col)
         print(df[target_col].value_counts(normalize=True).round(3))
+    if len(df) < 50:
+        print(f"\\n⚠️ Dataset pequeño (n={{len(df)}}): los modelos posteriores son ilustrativos; "
+              "las métricas tendrán alta varianza. Interprétalas con cautela.")
     print("\\nTop 10 columnas por % missing:")
     print(df.isna().mean().sort_values(ascending=False).head(10).round(3))
     print("\\nTop 5 columnas numéricas con más outliers (IQR 1.5x — solo reporte, no se imputan):")

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -1959,7 +1959,7 @@ country_candidates = find_columns_containing(df.columns, ["pais", "country", "re
 label_candidates = find_columns_containing(df.columns, ["categoria", "category", "label", "tipo", "segmento", "clase", "clasificacion", "target"])
 sentiment_candidates = find_columns_containing(df.columns, ["sentiment", "sentimiento", "polaridad"])
 churn_candidates = find_columns_containing(df.columns, ["churn", "abandono", "baja", "cancelacion"])
-date_candidates = find_columns_containing(df.columns, ["fecha", "date", "timestamp", "periodo", "mes", "dia"])
+date_candidates = find_columns_containing(df.columns, ["fecha", "date", "timestamp", "periodo", "period", "mes", "month", "dia", "day", "created_at", "year_month", "yearmonth"])
 graph_candidates = find_columns_containing(df.columns, ["origen", "source", "destino", "target", "edge", "nodo"])
 reco_candidates = find_columns_containing(df.columns, ["user", "usuario", "cliente", "customer", "item", "producto", "rating", "score"])
 numeric_candidates = list(df.select_dtypes(include=[np.number]).columns)
@@ -2016,14 +2016,14 @@ B. Para RMSE usa: `np.sqrt(mean_squared_error(y_true, y_pred))`. NO inventes
    `RootMeanSquaredError`, `root_mean_squared_error` ni `squared=False`.
 C. Para grafos: `import networkx as nx` dentro del try; usa nx.Graph(), nx.spring_layout(),
    nx.draw(). Si networkx no está disponible, captura ImportError y degrada a print explicativo.
-E. Para matrices grandes, limita SIEMPRE: `df.sample(min(len(df), 5000), random_state=42)`.
-F. Toda llamada a `.fit()` debe ir precedida por dropna/imputación SIN LEAKAGE:
+D. Para matrices grandes, limita SIEMPRE: `df.sample(min(len(df), 5000), random_state=42)`.
+E. Toda llamada a `.fit()` debe ir precedida por dropna/imputación SIN LEAKAGE:
    - PROHIBIDO `X = X.fillna(X.median(...))` ANTES del split (eso fitea con info de
      test). El orden correcto es: split primero → calcular `med = X_train.median(numeric_only=True)`
      → `X_train = X_train.fillna(med)` y `X_test = X_test.fillna(med)`.
    - Para `dropna()` aplica el mismo principio (dropna sobre `df`/`df_model` ANTES del split
      es seguro porque elimina filas en bloque; imputar con estadísticos NO lo es).
-D. NO uses argumentos experimentales (nada de `n_jobs=-1` salvo en RandomForest), nada de
+F. NO uses argumentos experimentales (nada de `n_jobs=-1` salvo en RandomForest), nada de
    APIs deprecated. Lista NEGRA explícita (PROHIBIDOS, generan TypeError en versiones modernas):
    - `XGBClassifier(use_label_encoder=...)`  → removido en xgboost ≥2.0; OMÍTELO siempre.
    - `mean_squared_error(..., squared=False)` → removido en sklearn ≥1.6; usa `np.sqrt(mse)`.
@@ -2033,9 +2033,10 @@ D. NO uses argumentos experimentales (nada de `n_jobs=-1` salvo en RandomForest)
 G. NO importes nada que no esté en el set: numpy, pandas, matplotlib, seaborn, sklearn.*,
    networkx, scipy.stats. Cualquier otra librería va dentro de try/except ImportError.
    Para xgboost/lightgbm/catboost: `try: import xgboost as xgb` y captura
-   `except (ImportError, Exception)` (NO solo ImportError) para tolerar TypeErrors por
-   firmas de constructor que cambian entre versiones; en el except, fallback a
-   `GradientBoostingClassifier` / `GradientBoostingRegressor` de sklearn.
+   `except (ImportError, TypeError, AttributeError)` (quirúrgico — NO uses `Exception`,
+   tragaría bugs reales del fit). Cubre: import faltante, firmas de constructor que
+   cambian entre versiones (ej. `use_label_encoder`), y atributos removidos. En el
+   except, fallback a `GradientBoostingClassifier` / `GradientBoostingRegressor` de sklearn.
 H. Métricas OBLIGATORIAS por tipo de problema (imprímelas SIEMPRE, sin excepciones):
    - Clasificación: `from sklearn.metrics import classification_report, f1_score, confusion_matrix`
      y `print(classification_report(y_test, y_pred, zero_division=0))` +
@@ -2064,7 +2065,7 @@ J. SHAP es OPCIONAL y SIEMPRE en try/except. Importancia de features con jerarqu
    (NO asumas `feature_importances_` para todo modelo — LogisticRegression no lo expone):
    - Si el nombre del algoritmo en `algoritmos` contiene "shap": intenta
      `import shap; explainer = shap.TreeExplainer(model); shap.summary_plot(...)`; en
-     `except (ImportError, Exception)` cae al ladder de abajo.
+     `except Exception` cae al ladder de abajo (SHAP es opcional y puede fallar en muchos\n     puntos: import, TreeExplainer incompatible, plot backend; broad catch es aceptable\n     porque cualquier fallo aquí es ruido pedagógico, no un bug que esconder).
    - Ladder de fallback (úsalo siempre si SHAP no se ejecutó):
      1) `if hasattr(model, "feature_importances_"):`
           `pd.Series(model.feature_importances_, index=X.columns).nlargest(15).plot.barh()`


### PR DESCRIPTION
﻿## Contexto
Demo para profesores de Data Science manana (29 abril 2026). Tras PR #224 (M3 hardening), un dogfood real con el caso `LogiTech Solutions` revelo 4 problemas reales en el notebook generado. Este PR los corrige de forma quirurgica, **sin ampliar el catalogo de algoritmos ni tocar logica de orquestacion**.

## Veredicto del dogfood (4 hallazgos validos, 0 falsos positivos)

| # | Problema observado en el notebook | Causa raiz | Fix en este PR |
|---|---|---|---|
| 2 | El time-split nunca se activa con datasets en ingles (columna `period`) | `date_aliases` solo conocia `periodo`/`mes`/`dia` | Agregados `period`, `month`, `day`, `fecha_periodo`, `year_month`, `yearmonth` |
| 3 | `X.fillna(X.median())` ejecutado **antes** del split -> leakage estadistico | Regla F del prompt sugeria imputar antes del fit sin distinguir antes/despues del split | Regla F reescrita: split primero, `med = X_train.median()`, aplicar a train y test |
| 4 | XGBoost 2.0 lanza `TypeError: use_label_encoder` y rompe el bloque sin caer al fallback | Regla D no listaba APIs removidas; regla G capturaba solo `ImportError` | Regla D con lista negra explicita; regla G amplia `except` a `(ImportError, Exception)` |
| 5 | Modelos entrenados con n=24 sin disclaimer | Regla K no tenia guarda de tamano | Si `len(df) < 50`, EDA Express imprime advertencia visible |

## Lo que NO toca este PR
- No cambia `case_generator/graph.py` ni la orquestacion LangGraph.
- No expande `ALGORITHM_REGISTRY` (sigue 9 familias).
- No toca grounding caso<->dataset (eso queda en issue #225, blocker arquitectonico separado).
- No toca `M3_EXPERIMENT_PROMPT`.

## Validacion
- `M3_NOTEBOOK_ALGO_PROMPT.format(...)` -> 13250 chars (vs 11692 en PR #224), import OK.
- `pytest tests/test_case_sanitization.py tests/test_issue139_authoring_grounding.py tests/test_worker_app.py tests/test_harness_isolation.py -q` -> **20 passed**.
- Diff: 1 archivo, +25/-5 lineas, todo en `backend/src/case_generator/prompts.py`.

## Riesgo
**Bajo.** Solo modifica strings de prompt + un alias list. Cero cambios a logica de runtime, schemas, o pipeline de generacion. Reversible con revert simple.

## Sigue pendiente (no bloquea demo si se usa caso con dataset alineado)
- Issue #225: grounding `case_architect` <-> `data_generator` (la causa raiz de que el dataset LogiTech fuera SaaS y no logistico).
