### PR TITLE
feat(arch): close #225 dataset_schema_required contract for case-dataset grounding

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -1703,7 +1703,13 @@ def _normalize_ml_ds_columns(schema_result: dict, profile: str) -> dict:
 # ─────────────────────────────────────────────────────────
 
 # Tipos válidos según ColumnDefinition.type — mantener sincronizado.
-_CONTRACT_TYPE_TO_SCHEMA_TYPE = {"int": "int", "float": "float", "str": "str"}
+# "date" alineado con ColumnDefinition.type (Issue #225 review follow-up).
+_CONTRACT_TYPE_TO_SCHEMA_TYPE = {
+    "int": "int",
+    "float": "float",
+    "str": "str",
+    "date": "date",
+}
 
 
 def _format_dataset_contract_block(contract: dict | None) -> str:
@@ -1808,6 +1814,8 @@ def _augment_schema_with_contract(schema: dict, contract: dict | None) -> dict:
         elif col_type == "int":
             col["range_min"] = 0
             col["range_max"] = 100
+        # "date" y "str" mantienen range_min/range_max=None (regla de
+        # SCHEMA_DESIGNER_PROMPT para columnas no numéricas).
         return col
 
     target = contract.get("target_column") or {}

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -786,6 +786,14 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
             "doc1_anexo_financiero": result.anexo_financiero,
             "doc1_anexo_operativo": result.anexo_operativo,
             "doc1_anexo_stakeholders": result.anexo_stakeholders,
+            # Issue #225 — persiste contrato dataset↔dilema (None-safe).
+            # downstream nodes leen state["dataset_schema_required"] y degradan
+            # gracefully al comportamiento previo si es None.
+            "dataset_schema_required": (
+                result.dataset_schema_required.model_dump()
+                if result.dataset_schema_required is not None
+                else None
+            ),
         }
     except Exception as e:
         logger.error("[case_architect] ERROR: %s", e, exc_info=True)
@@ -973,6 +981,13 @@ def eda_text_analyst(state: ADAMState, config: RunnableConfig) -> dict:
             "dataset_total_rows": dataset_total_rows,
             "financial_exhibit": state.get("doc1_anexo_financiero", ""),
             "operational_exhibit": state.get("doc1_anexo_operativo", ""),
+            # Issue #225 — brechas dilema↔dataset detectadas por validador.
+            # Si está vacío, el bloque indica al LLM que el dataset cubre el
+            # contrato y no debe inventar advertencias metodológicas.
+            "data_gap_warnings_block": (
+                "\n".join(f"- {w}" for w in (state.get("data_gap_warnings") or []))
+                or "(sin brechas detectadas — el dataset cubre el contrato dilema↔datos)"
+            ),
         })
 
         prompt = EDA_TEXT_ANALYST_PROMPT.format(**context)
@@ -1681,6 +1696,155 @@ def _normalize_ml_ds_columns(schema_result: dict, profile: str) -> dict:
 
 
 # ─────────────────────────────────────────────────────────
+# Issue #225 — Dataset Schema Required Contract: validator + augmenter
+# Funciones Python puras (cero tokens LLM, deterministas, sin I/O).
+# Mantienen el contrato dilema↔dataset alineado entre case_architect,
+# schema_designer, data_validator y m3_notebook_generator.
+# ─────────────────────────────────────────────────────────
+
+# Tipos válidos según ColumnDefinition.type — mantener sincronizado.
+_CONTRACT_TYPE_TO_SCHEMA_TYPE = {"int": "int", "float": "float", "str": "str"}
+
+
+def _format_dataset_contract_block(contract: dict | None) -> str:
+    """Renderiza el contrato como bloque legible para inyectar en SCHEMA_DESIGNER_PROMPT.
+
+    Devuelve un string vacío informativo cuando no hay contrato — el prompt
+    explica al LLM que en ese caso aplica las reglas heurísticas legacy.
+    """
+    if not contract:
+        return "(sin contrato — aplica las reglas heurísticas de columnas obligatorias por perfil)"
+    try:
+        return json.dumps(contract, ensure_ascii=False, indent=2)
+    except (TypeError, ValueError) as exc:
+        # Defensivo: si el contrato persistido no es JSON-serializable, no rompemos
+        # el grafo — degradamos al modo legacy con una advertencia visible.
+        logger.warning("[contract] no serializable, modo legacy: %s", exc)
+        return "(contrato corrupto — aplica las reglas heurísticas)"
+
+
+def _validate_schema_against_contract(
+    schema: dict, contract: dict | None
+) -> tuple[list[str], list[str]]:
+    """Compara columns del schema_designer contra el contrato del case_architect.
+
+    Returns:
+        (missing_required, leakage_warnings)
+        - missing_required: nombres de target/feature del contrato ausentes en columns.
+        - leakage_warnings: notas en español listas para inyectar en M2 EDA.
+
+    No muta el schema. La inyección de columnas faltantes la hace
+    `_augment_schema_with_contract`. Esta función es para reporting/observabilidad.
+    """
+    if not contract:
+        return [], []
+
+    schema_columns = {c.get("name", "") for c in schema.get("columns", [])}
+    missing: list[str] = []
+
+    target = contract.get("target_column") or {}
+    target_name = (target.get("name") or "").strip()
+    if target_name and target_name not in schema_columns:
+        missing.append(
+            f"target '{target_name}' (rol={target.get('role')}, dtype={target.get('dtype')}) "
+            "no fue producido por schema_designer"
+        )
+
+    for feat in contract.get("feature_columns") or []:
+        fname = (feat.get("name") or "").strip()
+        if fname and fname not in schema_columns:
+            missing.append(
+                f"feature '{fname}' (dtype={feat.get('dtype')}) no fue producido por schema_designer"
+            )
+
+    leakage: list[str] = []
+    for feat in contract.get("feature_columns") or []:
+        fname = (feat.get("name") or "").strip()
+        if not fname:
+            continue
+        offset = feat.get("temporal_offset_months")
+        if feat.get("is_leakage_risk") or (isinstance(offset, int) and offset > 0):
+            leakage.append(
+                f"feature '{fname}' marcada con riesgo de leakage "
+                f"(temporal_offset_months={offset}, is_leakage_risk={bool(feat.get('is_leakage_risk'))}). "
+                "El notebook M3 debe excluirla del entrenamiento o tratarla como variable de auditoría."
+            )
+
+    return missing, leakage
+
+
+def _augment_schema_with_contract(schema: dict, contract: dict | None) -> dict:
+    """Inyecta de forma determinista las columnas del contrato ausentes en el schema.
+
+    Cero tokens LLM. Idempotente. No muta el dict de entrada.
+    Estrategia conservadora:
+      - Si el contrato declara una columna que el schema NO tiene, se añade al final
+        de `columns` con rangos por defecto seguros según dtype.
+      - NUNCA renombra ni elimina columnas existentes — preserva el output del LLM.
+      - NUNCA toca constraints (revenue_annual_total, etc.).
+    """
+    if not contract:
+        return schema
+
+    new_schema = dict(schema)
+    columns = list(new_schema.get("columns", []))
+    existing_names = {c.get("name", "") for c in columns}
+
+    def _default_column(name: str, dtype: str, description: str, nullable: bool = False) -> dict:
+        col_type = _CONTRACT_TYPE_TO_SCHEMA_TYPE.get(dtype, "float")
+        col: dict = {
+            "name": name,
+            "type": col_type,
+            "description": description or f"Columna inyectada por contrato ({name})",
+            "range_min": None,
+            "range_max": None,
+            "nullable": nullable,
+            "trend": None,
+            "dependency": None,
+        }
+        if col_type == "float":
+            col["range_min"] = 0.0
+            col["range_max"] = 1.0
+        elif col_type == "int":
+            col["range_min"] = 0
+            col["range_max"] = 100
+        return col
+
+    target = contract.get("target_column") or {}
+    target_name = (target.get("name") or "").strip()
+    if target_name and target_name not in existing_names:
+        columns.append(_default_column(
+            name=target_name,
+            dtype=target.get("dtype", "float"),
+            description=target.get("description", "Variable objetivo declarada por contrato"),
+        ))
+        existing_names.add(target_name)
+        logger.warning(
+            "[contract.augment] target '%s' faltante — inyectado con defaults seguros",
+            target_name,
+        )
+
+    for feat in contract.get("feature_columns") or []:
+        fname = (feat.get("name") or "").strip()
+        if not fname or fname in existing_names:
+            continue
+        columns.append(_default_column(
+            name=fname,
+            dtype=feat.get("dtype", "float"),
+            description=feat.get("description", "Feature declarada por contrato"),
+            nullable=False,
+        ))
+        existing_names.add(fname)
+        logger.warning(
+            "[contract.augment] feature '%s' faltante — inyectada con defaults seguros",
+            fname,
+        )
+
+    new_schema["columns"] = columns
+    return new_schema
+
+
+# ─────────────────────────────────────────────────────────
 # NODO 1 — SCHEMA DESIGNER (Pro, thinking activo, output pequeño)
 # ─────────────────────────────────────────────────────────
 
@@ -1710,6 +1874,12 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
         "operational_data": state.get("doc1_anexo_operativo", ""),
         "max_rows": max_rows,
         "ml_required_families": ml_required_families,
+        # Issue #225 — inyecta contrato dilema↔dataset emitido por case_architect.
+        # Si es None (perfil business legado o architect no lo emitió), el bloque
+        # contiene un mensaje que activa las reglas heurísticas en el LLM.
+        "dataset_contract_block": _format_dataset_contract_block(
+            state.get("dataset_schema_required")
+        ),
     })
     prompt = SCHEMA_DESIGNER_PROMPT.format(**context)
 
@@ -1786,12 +1956,41 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
                 f"[schema_designer] OK ({model_label}) — {len(validated.columns)} columnas, "
                 f"{validated.n_rows} filas, granularidad={validated.time_granularity}"
             )
-            return {"dataset_schema": schema_result}
+            # Issue #225 — Aplica contrato del case_architect:
+            #   1) augmenter Python puro: añade columnas faltantes con defaults seguros
+            #      (idempotente, cero tokens, evita un retry LLM costoso).
+            #   2) validator: registra residuales (vacío post-augment) + leakage flags
+            #      como data_gap_warnings que M2 EDA y M3 notebook leerán.
+            contract = state.get("dataset_schema_required")
+            schema_result = _augment_schema_with_contract(schema_result, contract)
+            missing, leakage = _validate_schema_against_contract(schema_result, contract)
+            warnings_payload: list[str] = []
+            if missing:
+                warnings_payload.extend(missing)
+            if leakage:
+                warnings_payload.extend(leakage)
+            return {
+                "dataset_schema": schema_result,
+                "data_gap_warnings": warnings_payload,
+            }
         except (ValidationError, Exception) as e:
             logger.error("[schema_designer] %s ERROR: %s", model_label, e, exc_info=True)
 
     print("[schema_designer] todos los intentos fallaron — usando fallback schema")
-    return {"dataset_schema": _build_fallback_schema(state, max_rows, profile)}
+    fallback_schema = _build_fallback_schema(state, max_rows, profile)
+    # Issue #225 — incluso en fallback respetamos el contrato del architect.
+    contract = state.get("dataset_schema_required")
+    fallback_schema = _augment_schema_with_contract(fallback_schema, contract)
+    missing, leakage = _validate_schema_against_contract(fallback_schema, contract)
+    warnings_payload = []
+    if missing:
+        warnings_payload.extend(missing)
+    if leakage:
+        warnings_payload.extend(leakage)
+    return {
+        "dataset_schema": fallback_schema,
+        "data_gap_warnings": warnings_payload,
+    }
 
 
 # ─────────────────────────────────────────────────────────
@@ -2168,7 +2367,17 @@ def data_validator(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: A
     # Construir dataset_metadata para downstream (eda_text_analyst, eda_chart_generator)
     def _build_metadata(r: list) -> dict:
         columns = schema.get("columns", [])
-        target_var = next(
+        # Issue #225 — Prioridad para target_variable:
+        #   1) Contrato del case_architect (fuente canónica del dilema).
+        #   2) Heurística por descripción/nombre (legacy, casos sin contrato).
+        #   3) Fallback a revenue_column.
+        contract = state.get("dataset_schema_required") or {}
+        contract_target = (
+            (contract.get("target_column") or {}).get("name")
+            if isinstance(contract, dict)
+            else None
+        )
+        target_var = contract_target or next(
             (col["name"] for col in columns
              if "target" in col.get("description", "").lower()
              or "churn" in col["name"].lower()
@@ -2759,12 +2968,26 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
 
         algo_section = ""
         try:
+            # Issue #225 — pasa contrato + brechas al prompt para CONTRACT-FIRST
+            # target resolution. Si no hay contrato/brechas, los bloques quedan
+            # con texto neutro y el LLM aplica la lógica alias-first heredada.
+            contract_block = _format_dataset_contract_block(
+                state.get("dataset_schema_required")
+            )
+            gap_warnings = state.get("data_gap_warnings") or []
+            gaps_block = (
+                "\n".join(f"- {w}" for w in gap_warnings)
+                if gap_warnings
+                else "(sin brechas detectadas — schema cubre el contrato)"
+            )
             prompt = M3_NOTEBOOK_ALGO_PROMPT.format(
                 m3_content=(state.get("m3_content", "") or "")[:2000],
                 algoritmos=json.dumps(algoritmos_raw, ensure_ascii=False),
                 familias_meta=json.dumps(familias_meta, ensure_ascii=False),
                 case_title=case_title,
                 output_language=context.get("output_language", "es"),
+                dataset_contract_block=contract_block,
+                data_gap_warnings_block=gaps_block,
             )
             response = llm.invoke(prompt)
             algo_section = sanitize_markdown(_extract_text(response))

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -38,7 +38,8 @@ Generar los CIMIENTOS estructurales y numéricos del caso (Pre-M1 / Narrativa Ma
 #   "instrucciones_estudiante": str,
 #   "anexo_financiero": str,
 #   "anexo_operativo": str,
-#   "anexo_stakeholders": str
+#   "anexo_stakeholders": str,
+#   "dataset_schema_required": object|null  ← Issue #225 — contrato dataset↔dilema
 # }}
 # Si graph.py añade o elimina un campo, actualizar este bloque.
 
@@ -135,6 +136,55 @@ Si {student_profile}="ml_ds": incluir 2 métricas de calidad de datos como filas
 Encabezado: `### Exhibit 3 — Mapa de Stakeholders`
 Tabla: Actor | Interés | Incentivo | Riesgo | Postura (A/B/C)
 Mín 6 actores (mín 4 para "undergrad").
+
+## dataset_schema_required (Issue #225 — contrato dataset↔dilema)
+Objeto que declara qué dataset necesita el caso para que el dilema sea respondible
+con datos. **Obligatorio cuando {student_profile}="ml_ds"**. Para "business" puedes
+emitir `null` (el pipeline mantiene el comportamiento heurístico previo).
+
+Forma exacta del objeto (snake_case en inglés en todos los `name`):
+
+{{
+  "target_column": {{
+    "name": "<columna objetivo del dilema>",
+    "role": "classification_target|regression_target|clustering_target|anomaly_target|ranking_target|forecasting_target",
+    "dtype": "int|float|str",
+    "description": "qué representa la columna en negocio"
+  }},
+  "feature_columns": [
+    {{
+      "name": "<feature snake_case>",
+      "role": "feature|weak_feature|control",
+      "dtype": "int|float|str",
+      "description": "por qué importa al dilema",
+      "temporal_offset_months": 0,
+      "is_leakage_risk": false
+    }}
+    // 3-8 features que el dilema referencia explícitamente
+  ],
+  "domain_features_required": ["<categoria_semantica_1>", "<categoria_semantica_2>"],
+  "min_signal_strength": 0.15,
+  "notes": null
+}}
+
+Reglas duras:
+1. `target_column.name` DEBE coincidir conceptualmente con la decisión del `dilema_brief`.
+   Ej: si el dilema es "decidir cómo retener clientes", el target NO puede ser un
+   código aleatorio sin relación causal. Debe ser una variable medible y observable
+   en producción (ej: `churn_flag`, `delivery_delay_minutes`, `default_60d`).
+2. **Anti-leakage**: marca `is_leakage_risk=true` y/o `temporal_offset_months>0`
+   en cualquier feature que en operación real se conoce DESPUÉS del target.
+   Ej: al predecir `churn_flag` del mes 0, las columnas `retention_m3`, `retention_m6`,
+   `retention_m12` son leakage por construcción → marcarlas siempre.
+3. `feature_columns` debe contener entre 3 y 8 entradas. Mínimo 2 features con
+   `is_leakage_risk=false` para garantizar señal aprendible.
+4. `domain_features_required` lista categorías semánticas que `schema_designer` debe
+   cubrir aunque elija nombres específicos (ej: "delivery_time", "customer_segment",
+   "transaction_volume"). 0-5 entradas.
+5. `min_signal_strength` queda en 0.15 salvo justificación pedagógica explícita.
+6. NUNCA incluyas en `feature_columns` la misma `name` que `target_column.name`.
+7. Para "business" perfil puedes emitir `null` o un contrato simple con un único
+   target gerencial (ej: `revenue`, `margin_pct`).
 
 # Context — Datos del profesor
 {teacher_input}
@@ -319,6 +369,20 @@ SCHEMA_DESIGNER_PROMPT = """\
 Diseña el schema de un dataset sintético para el caso de negocio dado.
 Perfil: {student_profile} | Industria: {industria}
 
+## Contrato dataset_schema_required (Issue #225 — fuente de verdad)
+{dataset_contract_block}
+
+REGLAS DE COBERTURA DEL CONTRATO (cuando NO esté vacío):
+- Tu `columns` DEBE incluir, con el mismo `name` exacto, la `target_column.name`
+  del contrato y TODAS las `feature_columns[*].name`.
+- El `type` de cada columna debe coincidir con el `dtype` del contrato.
+- Si una feature del contrato tiene `is_leakage_risk=true` o
+  `temporal_offset_months>0`, igual debes incluirla con su nombre exacto:
+  el bloqueo de leakage se gestiona downstream en M3 (no la omitas aquí).
+- Las categorías de `domain_features_required` deben estar cubiertas por al menos
+  una columna semánticamente alineada (puedes elegir su nombre concreto).
+- Si el contrato es `null` o `{{}}`, opera con las reglas heurísticas de abajo.
+
 ## ESTRUCTURA DE OUTPUT OBLIGATORIA (JSON puro, sin markdown, sin claves extra)
 {{
   "columns": [
@@ -497,6 +561,17 @@ usando exclusivamente los datos del dataset y los Exhibits provistos.
 - {dataset_instruction}
 - Si una métrica no muestra tendencia clara o anomalía: repórtala como ESTABLE.
   NO fuerces un hallazgo donde los datos no lo soportan.
+
+## Brechas dilema↔dataset (Issue #225 — data_gap_warnings)
+{data_gap_warnings_block}
+
+REGLAS para brechas:
+- Si la lista NO está vacía, debes incluir en la sección 1 (Contexto) un bullet
+  con el título **"Brechas de datos detectadas"** y listar cada warning como un
+  ítem separado, en lenguaje accesible. Esto evita que las preguntas socráticas
+  o el M3 silenciosamente operen sobre columnas faltantes/leakage.
+- Si la lista está vacía o dice "(sin brechas detectadas...)", NO inventes
+  brechas: significa que el dataset cubre el contrato del Módulo 1.
 
 # Your Boundaries
 - **CERO ALUCINACIÓN MATEMÁTICA.** Prohibido inventar tendencias, montos o porcentajes.
@@ -1987,6 +2062,27 @@ M3_NOTEBOOK_ALGO_PROMPT = """\
 Eres un ML Engineer generando la Sección 3 de un notebook Jupytext Percent para Google Colab.
 El notebook sigue la estructura pedagógica ADAM M3: Concepto → Gráfico Conceptual → Acción de Negocio.
 Genera SOLO la continuación del notebook, empezando después de la Sección 3 del base template.
+
+# Contrato dataset_schema_required (Issue #225 — fuente canónica del target)
+{dataset_contract_block}
+
+# Brechas de datos detectadas por el validador (data_gap_warnings)
+{data_gap_warnings_block}
+
+# Reglas CONTRACT-FIRST (Issue #225 — prioridad máxima sobre toda heurística posterior)
+* Si el contrato declara `target_column.name`, USA ESE NOMBRE EXACTO como variable
+  objetivo en TODO el notebook. NO uses alias-matching, NO uses "último categórico"
+  ni ningún fallback heurístico para elegir el target.
+* Si el target del contrato NO está en `df.columns`, emite UNA línea
+  `print("⚠️ REQUISITO FALTANTE: target '<contract_target_name>' del contrato "
+  "no está presente en el dataset")` y SALTA el entrenamiento de ese bloque
+  (no entrenes contra una columna distinta).
+* Para cada feature con `is_leakage_risk=true` o `temporal_offset_months>0`:
+  EXCLÚYELA de `X` en clasificación/regresión y comenta brevemente por qué
+  (`# Excluida: feature de leakage según contrato`). Puedes mantenerla en
+  exploraciones de auditoría/EDA pero NUNCA en entrenamiento supervisado.
+* Si NO hay contrato (bloque vacío o "(sin contrato ...)"), aplica la lógica
+  alias-first heredada (label_aliases → churn_aliases → último categórico).
 
 # Reglas absolutas
 1. NUNCA uses np.random, pd.DataFrame() fabricado, columnas inventadas ni placeholders.

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -148,14 +148,14 @@ Forma exacta del objeto (snake_case en inglés en todos los `name`):
   "target_column": {{
     "name": "<columna objetivo del dilema>",
     "role": "classification_target|regression_target|clustering_target|anomaly_target|ranking_target|forecasting_target",
-    "dtype": "int|float|str",
+    "dtype": "int|float|str|date",
     "description": "qué representa la columna en negocio"
   }},
   "feature_columns": [
     {{
       "name": "<feature snake_case>",
       "role": "feature|weak_feature|control",
-      "dtype": "int|float|str",
+      "dtype": "int|float|str|date",
       "description": "por qué importa al dilema",
       "temporal_offset_months": 0,
       "is_leakage_risk": false

--- a/backend/src/case_generator/state.py
+++ b/backend/src/case_generator/state.py
@@ -168,3 +168,15 @@ class ADAMState(CanonicalInputState):
     dataset_metadata: NotRequired[dict]        # Metadata del dataset (rows, columns, target_variable…)
     ai_grounding_context: NotRequired[dict[str, Any]]
 
+    # ── Issue #225 — Dataset Schema Required Contract ──
+    # Emitido por case_architect (DatasetSchemaRequired serializado).
+    # Consumido por: schema_designer (prompt), validador post-schema (Python),
+    # data_validator (target canónico), m3_notebook_generator (prompt),
+    # eda_text_analyst (prompt: data_gap_warnings). None para perfil business
+    # legado o cuando architect lo omite — pipeline mantiene comportamiento previo.
+    dataset_schema_required: NotRequired[dict]
+    # Emitido por _validate_schema_against_contract tras schema_designer +
+    # augmenter. Lista de strings legibles (1 por gap) que se inyectan en M2 EDA
+    # como notas metodológicas y se exponen al docente para auditoría.
+    data_gap_warnings: NotRequired[list[str]]
+

--- a/backend/src/case_generator/state.py
+++ b/backend/src/case_generator/state.py
@@ -174,7 +174,7 @@ class ADAMState(CanonicalInputState):
     # data_validator (target canónico), m3_notebook_generator (prompt),
     # eda_text_analyst (prompt: data_gap_warnings). None para perfil business
     # legado o cuando architect lo omite — pipeline mantiene comportamiento previo.
-    dataset_schema_required: NotRequired[dict]
+    dataset_schema_required: NotRequired[dict | None]
     # Emitido por _validate_schema_against_contract tras schema_designer +
     # augmenter. Lista de strings legibles (1 por gap) que se inyectan en M2 EDA
     # como notas metodológicas y se exponen al docente para auditoría.

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -10,6 +10,121 @@ from pydantic import BaseModel, Field
 
 
 # ═══════════════════════════════════════════════════════
+# ISSUE #225 — Dataset Schema Required Contract
+# Emitido por case_architect, consumido por schema_designer + data_validator
+# + m3_notebook_generator + EDA prompts. Garantiza que el dilema declarado en
+# M1 esté soportado por columnas reales del dataset y que las features con
+# riesgo de leakage temporal queden señaladas explícitamente.
+# Ver: https://github.com/4Tech-Labs/ADAM-EDU/issues/225
+# ═══════════════════════════════════════════════════════
+
+
+class DatasetTargetSpec(BaseModel):
+    """Variable objetivo declarada por case_architect para el dilema del caso.
+
+    name: snake_case en inglés (ej: 'churn_flag', 'delivery_delay_minutes').
+    role: tipo de problema ML que el dilema plantea.
+    dtype: tipo de dato esperado en el dataset.
+    description: qué representa la columna en negocio (1 línea).
+    """
+
+    name: str = Field(description="Nombre snake_case en inglés de la columna objetivo")
+    role: Literal[
+        "classification_target",
+        "regression_target",
+        "clustering_target",
+        "anomaly_target",
+        "ranking_target",
+        "forecasting_target",
+    ] = Field(description="Rol pedagógico/ML de la columna objetivo")
+    dtype: Literal["int", "float", "str"] = Field(description="Tipo de dato Python esperado")
+    description: str = Field(description="Qué representa esta columna en negocio")
+
+
+class DatasetFeatureSpec(BaseModel):
+    """Feature declarada por case_architect como necesaria para resolver el dilema.
+
+    temporal_offset_months: 0 = mismo período que el target, <0 = pasado (válida),
+    >0 = futuro respecto al target → LEAKAGE por construcción.
+    is_leakage_risk: marca explícita por nombre semántico (ej: 'retention_m12'
+    cuando se predice churn del mes 0 es leakage aunque el offset no se conozca).
+    """
+
+    name: str = Field(description="Nombre snake_case en inglés de la columna feature")
+    role: Literal["feature", "weak_feature", "control"] = Field(
+        default="feature", description="Rol pedagógico de la feature"
+    )
+    dtype: Literal["int", "float", "str"] = Field(description="Tipo de dato Python esperado")
+    description: str = Field(description="Qué representa la feature y por qué importa al dilema")
+    temporal_offset_months: Optional[int] = Field(
+        default=None,
+        description=(
+            "Offset temporal vs período del target: 0=mismo período, <0=pasado (válida), "
+            ">0=futuro (LEAKAGE)."
+        ),
+    )
+    is_leakage_risk: bool = Field(
+        default=False,
+        description=(
+            "Marca explícita: True si la feature es proxy del target o se mide después "
+            "de que se conoce el target en producción."
+        ),
+    )
+
+
+class DatasetSchemaRequired(BaseModel):
+    """Contrato emitido por case_architect: declara qué dataset necesita el caso.
+
+    Este contrato es la única fuente de verdad para el alineamiento dilema↔dataset:
+      * schema_designer lo consume al diseñar columns/constraints.
+      * Un validador Python (post-schema_designer) verifica cobertura y aumenta
+        el schema con columnas faltantes de forma determinista (cero tokens LLM).
+      * data_validator usa target_column.name como variable objetivo canónica
+        (en lugar de heurística por palabras clave).
+      * m3_notebook_generator pasa target + leakage flags al prompt ALGO para
+        evitar fallback silencioso al elegir target/features.
+      * EDA prompts incorporan data_gap_warnings emitidos por el validador.
+
+    Para perfil 'business' este campo es opcional. Para 'ml_ds' es obligatorio:
+    sin contrato no hay garantía de que las preguntas socráticas y el notebook
+    M3 puedan ejecutarse sobre el dataset generado.
+    """
+
+    target_column: DatasetTargetSpec = Field(
+        description="Variable objetivo única que el dilema obliga a predecir/explicar"
+    )
+    feature_columns: list[DatasetFeatureSpec] = Field(
+        default_factory=list,
+        description=(
+            "3-8 features que el dilema referencia explícitamente. Marcar "
+            "is_leakage_risk=True para columnas que en producción se conocen "
+            "después del target (ej: retention_m12 al predecir churn del mes 0)."
+        ),
+    )
+    domain_features_required: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Categorías semánticas de features que deben existir aunque sus nombres "
+            "exactos los decida schema_designer (ej: 'delivery_time', 'customer_segment'). "
+            "Permite cobertura por significado, no solo por nombre."
+        ),
+    )
+    min_signal_strength: float = Field(
+        default=0.15,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Umbral mínimo aceptable de |correlación| entre target y mejor feature "
+            "no-leakage. Usado por validador para detectar targets sintéticos sin señal."
+        ),
+    )
+    notes: Optional[str] = Field(
+        default=None,
+        description="Notas opcionales del architect sobre el diseño del contrato",
+    )
+
+
+# ═══════════════════════════════════════════════════════
 # DOCUMENTO 1 — Caso de Negocio (3 agentes)
 # ═══════════════════════════════════════════════════════
 
@@ -71,6 +186,18 @@ class CaseArchitectOutput(BaseModel):
             "Columnas: Actor | Interés | Incentivo | Riesgo | Postura (A/B/C). "
             "Mínimo 6 actores."
         )
+    )
+    # Issue #225 — Contrato dataset↔dilema. Optional para no romper perfil
+    # 'business' ni casos legados. Para ml_ds, schema_designer + validador
+    # garantizan cobertura cuando está presente; cuando es None, el pipeline
+    # opera con el comportamiento heurístico previo.
+    dataset_schema_required: Optional[DatasetSchemaRequired] = Field(
+        default=None,
+        description=(
+            "Contrato que declara variable objetivo y features que el dilema requiere "
+            "del dataset. Obligatorio para perfil 'ml_ds'. Consumido por schema_designer, "
+            "data_validator, m3_notebook_generator y prompts EDA."
+        ),
     )
 
 

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -37,7 +37,11 @@ class DatasetTargetSpec(BaseModel):
         "ranking_target",
         "forecasting_target",
     ] = Field(description="Rol pedagógico/ML de la columna objetivo")
-    dtype: Literal["int", "float", "str"] = Field(description="Tipo de dato Python esperado")
+    # Issue #225 follow-up: "date" añadido para alinear con ColumnDefinition.type
+    # (forecasting con índice temporal, targets de horizonte fechado).
+    dtype: Literal["int", "float", "str", "date"] = Field(
+        description="Tipo de dato Python esperado (alineado con ColumnDefinition.type)"
+    )
     description: str = Field(description="Qué representa esta columna en negocio")
 
 
@@ -54,7 +58,11 @@ class DatasetFeatureSpec(BaseModel):
     role: Literal["feature", "weak_feature", "control"] = Field(
         default="feature", description="Rol pedagógico de la feature"
     )
-    dtype: Literal["int", "float", "str"] = Field(description="Tipo de dato Python esperado")
+    # Issue #225 follow-up: "date" añadido para features temporales reales
+    # (índice de tiempo en split temporal, lag features fechados).
+    dtype: Literal["int", "float", "str", "date"] = Field(
+        description="Tipo de dato Python esperado (alineado con ColumnDefinition.type)"
+    )
     description: str = Field(description="Qué representa la feature y por qué importa al dilema")
     temporal_offset_months: Optional[int] = Field(
         default=None,

--- a/backend/tests/test_issue225_dataset_schema_contract.py
+++ b/backend/tests/test_issue225_dataset_schema_contract.py
@@ -257,6 +257,35 @@ def test_augment_respects_dtype_mapping() -> None:
     assert by_name["amount"]["type"] == "int"
 
 
+def test_augment_supports_date_dtype_with_null_ranges() -> None:
+    """Issue #225 review follow-up: date debe alinearse con ColumnDefinition.type
+    y respetar la regla "no range_min/range_max en columnas no numéricas"."""
+    contract = DatasetSchemaRequired(
+        target_column=DatasetTargetSpec(
+            name="forecast_horizon",
+            role="forecasting_target",
+            dtype="date",
+            description="fecha objetivo del forecast",
+        ),
+        feature_columns=[
+            DatasetFeatureSpec(
+                name="event_ts",
+                dtype="date",
+                description="timestamp del evento",
+            ),
+        ],
+    ).model_dump()
+    schema = _schema_with("revenue")
+    out = _augment_schema_with_contract(schema, contract)
+    by_name = {c["name"]: c for c in out["columns"]}
+    assert by_name["forecast_horizon"]["type"] == "date"
+    assert by_name["forecast_horizon"]["range_min"] is None
+    assert by_name["forecast_horizon"]["range_max"] is None
+    assert by_name["event_ts"]["type"] == "date"
+    assert by_name["event_ts"]["range_min"] is None
+    assert by_name["event_ts"]["range_max"] is None
+
+
 def test_augment_does_not_mutate_input() -> None:
     contract = _make_minimal_contract().model_dump()
     schema = _schema_with("revenue")

--- a/backend/tests/test_issue225_dataset_schema_contract.py
+++ b/backend/tests/test_issue225_dataset_schema_contract.py
@@ -1,0 +1,323 @@
+"""Tests for Issue #225 — dataset_schema_required contract.
+
+Surface tested:
+  - Pydantic models (DatasetSchemaRequired, DatasetTargetSpec, DatasetFeatureSpec)
+  - CaseArchitectOutput backward-compatibility (contract is Optional)
+  - _format_dataset_contract_block (None-safe + JSON serializable)
+  - _validate_schema_against_contract (missing + leakage detection)
+  - _augment_schema_with_contract (deterministic injection, idempotent)
+  - Prompt rendering smoke tests (CASE_ARCHITECT_PROMPT, SCHEMA_DESIGNER_PROMPT,
+    EDA_TEXT_ANALYST_PROMPT, M3_NOTEBOOK_ALGO_PROMPT) — guarantees that the new
+    placeholders resolve and no curly-brace mismatch was introduced.
+
+Cero LLMs, cero red, cero DB. Estos tests son puros y rápidos.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from case_generator.graph import (
+    _augment_schema_with_contract,
+    _format_dataset_contract_block,
+    _validate_schema_against_contract,
+)
+from case_generator.prompts import (
+    CASE_ARCHITECT_PROMPT,
+    EDA_TEXT_ANALYST_PROMPT,
+    M3_NOTEBOOK_ALGO_PROMPT,
+    SCHEMA_DESIGNER_PROMPT,
+)
+from case_generator.tools_and_schemas import (
+    CaseArchitectOutput,
+    DatasetFeatureSpec,
+    DatasetSchemaRequired,
+    DatasetTargetSpec,
+)
+
+
+# ─────────────────────────────────────────────────────────
+# Pydantic models
+# ─────────────────────────────────────────────────────────
+
+
+def _make_minimal_contract() -> DatasetSchemaRequired:
+    return DatasetSchemaRequired(
+        target_column=DatasetTargetSpec(
+            name="churn_flag",
+            role="classification_target",
+            dtype="int",
+            description="1 si el cliente churneó en los próximos 30 días",
+        ),
+        feature_columns=[
+            DatasetFeatureSpec(
+                name="nps",
+                role="feature",
+                dtype="float",
+                description="Net Promoter Score del cliente",
+                temporal_offset_months=0,
+                is_leakage_risk=False,
+            ),
+            DatasetFeatureSpec(
+                name="retention_m12",
+                role="feature",
+                dtype="float",
+                description="Retención al mes 12 — leakage cuando se predice churn del mes 0",
+                temporal_offset_months=12,
+                is_leakage_risk=True,
+            ),
+        ],
+        domain_features_required=["customer_engagement", "transaction_volume"],
+        min_signal_strength=0.20,
+        notes="Contrato mínimo para test de Issue #225",
+    )
+
+
+def test_dataset_schema_required_round_trip() -> None:
+    contract = _make_minimal_contract()
+    payload = contract.model_dump()
+    restored = DatasetSchemaRequired(**payload)
+    assert restored.target_column.name == "churn_flag"
+    assert len(restored.feature_columns) == 2
+    assert restored.feature_columns[1].is_leakage_risk is True
+    assert restored.min_signal_strength == 0.20
+
+
+def test_target_role_validation_rejects_unknown_role() -> None:
+    with pytest.raises(Exception):
+        DatasetTargetSpec(
+            name="x",
+            role="not_a_real_role",  # type: ignore[arg-type]
+            dtype="int",
+            description="x",
+        )
+
+
+def test_min_signal_strength_must_be_in_unit_interval() -> None:
+    with pytest.raises(Exception):
+        DatasetSchemaRequired(
+            target_column=DatasetTargetSpec(
+                name="y", role="regression_target", dtype="float", description="y"
+            ),
+            min_signal_strength=1.5,
+        )
+
+
+def test_case_architect_output_accepts_contract_and_legacy_none() -> None:
+    base = dict(
+        titulo="ACME — dilema",
+        industria="retail",
+        company_profile="x" * 50,
+        dilema_brief="x" * 50,
+        instrucciones_estudiante="x",
+        anexo_financiero="x",
+        anexo_operativo="x",
+        anexo_stakeholders="x",
+    )
+    # Backward compat: missing field defaults to None.
+    legacy = CaseArchitectOutput(**base)
+    assert legacy.dataset_schema_required is None
+
+    contract = _make_minimal_contract()
+    enriched = CaseArchitectOutput(**base, dataset_schema_required=contract)
+    assert enriched.dataset_schema_required is not None
+    assert enriched.dataset_schema_required.target_column.name == "churn_flag"
+
+
+# ─────────────────────────────────────────────────────────
+# _format_dataset_contract_block
+# ─────────────────────────────────────────────────────────
+
+
+def test_format_block_none_returns_neutral_marker() -> None:
+    out = _format_dataset_contract_block(None)
+    assert "sin contrato" in out
+
+
+def test_format_block_renders_json_for_contract_dict() -> None:
+    contract = _make_minimal_contract().model_dump()
+    out = _format_dataset_contract_block(contract)
+    parsed = json.loads(out)
+    assert parsed["target_column"]["name"] == "churn_flag"
+
+
+def test_format_block_handles_non_serializable_input() -> None:
+    class Unserializable:
+        pass
+
+    out = _format_dataset_contract_block({"target_column": Unserializable()})  # type: ignore[dict-item]
+    assert "corrupto" in out or "heurísticas" in out
+
+
+# ─────────────────────────────────────────────────────────
+# _validate_schema_against_contract
+# ─────────────────────────────────────────────────────────
+
+
+def _schema_with(*column_names: str) -> dict:
+    return {
+        "columns": [
+            {"name": n, "type": "float", "description": n} for n in column_names
+        ],
+        "n_rows": 100,
+        "time_granularity": "monthly",
+        "constraints": {"revenue_annual_total": 1_000_000.0, "tolerance_pct": 0.05, "revenue_column": "revenue"},
+    }
+
+
+def test_validate_no_contract_returns_empty_lists() -> None:
+    missing, leakage = _validate_schema_against_contract(_schema_with("revenue"), None)
+    assert missing == []
+    assert leakage == []
+
+
+def test_validate_reports_missing_target_and_features() -> None:
+    contract = _make_minimal_contract().model_dump()
+    schema = _schema_with("revenue", "nps")  # missing churn_flag and retention_m12
+    missing, _leakage = _validate_schema_against_contract(schema, contract)
+    assert any("churn_flag" in m for m in missing)
+    assert any("retention_m12" in m for m in missing)
+
+
+def test_validate_reports_leakage_features() -> None:
+    contract = _make_minimal_contract().model_dump()
+    schema = _schema_with("churn_flag", "nps", "retention_m12")
+    missing, leakage = _validate_schema_against_contract(schema, contract)
+    assert missing == []
+    assert any("retention_m12" in w and "leakage" in w for w in leakage)
+
+
+def test_validate_treats_positive_temporal_offset_as_leakage_even_without_flag() -> None:
+    contract = DatasetSchemaRequired(
+        target_column=DatasetTargetSpec(
+            name="churn_flag", role="classification_target", dtype="int", description="t"
+        ),
+        feature_columns=[
+            DatasetFeatureSpec(
+                name="future_revenue",
+                dtype="float",
+                description="known after target",
+                temporal_offset_months=3,
+                is_leakage_risk=False,  # not flagged, but offset > 0
+            ),
+        ],
+    ).model_dump()
+    schema = _schema_with("churn_flag", "future_revenue")
+    _missing, leakage = _validate_schema_against_contract(schema, contract)
+    assert any("future_revenue" in w for w in leakage)
+
+
+# ─────────────────────────────────────────────────────────
+# _augment_schema_with_contract
+# ─────────────────────────────────────────────────────────
+
+
+def test_augment_no_contract_is_identity() -> None:
+    schema = _schema_with("revenue", "nps")
+    out = _augment_schema_with_contract(schema, None)
+    assert [c["name"] for c in out["columns"]] == ["revenue", "nps"]
+
+
+def test_augment_injects_missing_target_and_features() -> None:
+    contract = _make_minimal_contract().model_dump()
+    schema = _schema_with("revenue", "nps")
+    out = _augment_schema_with_contract(schema, contract)
+    names = [c["name"] for c in out["columns"]]
+    assert "churn_flag" in names
+    assert "retention_m12" in names
+    # nps was already present — must not be duplicated
+    assert names.count("nps") == 1
+    # constraints untouched
+    assert out["constraints"]["revenue_annual_total"] == 1_000_000.0
+
+
+def test_augment_is_idempotent() -> None:
+    contract = _make_minimal_contract().model_dump()
+    schema = _schema_with("revenue", "nps")
+    once = _augment_schema_with_contract(schema, contract)
+    twice = _augment_schema_with_contract(once, contract)
+    assert [c["name"] for c in twice["columns"]] == [c["name"] for c in once["columns"]]
+
+
+def test_augment_respects_dtype_mapping() -> None:
+    contract = DatasetSchemaRequired(
+        target_column=DatasetTargetSpec(
+            name="label", role="classification_target", dtype="str", description="y"
+        ),
+        feature_columns=[
+            DatasetFeatureSpec(name="amount", dtype="int", description="amt"),
+        ],
+    ).model_dump()
+    schema = _schema_with("revenue")
+    out = _augment_schema_with_contract(schema, contract)
+    by_name = {c["name"]: c for c in out["columns"]}
+    assert by_name["label"]["type"] == "str"
+    assert by_name["amount"]["type"] == "int"
+
+
+def test_augment_does_not_mutate_input() -> None:
+    contract = _make_minimal_contract().model_dump()
+    schema = _schema_with("revenue")
+    original_len = len(schema["columns"])
+    _augment_schema_with_contract(schema, contract)
+    assert len(schema["columns"]) == original_len
+
+
+# ─────────────────────────────────────────────────────────
+# Prompt rendering smoke tests — guard against curly-brace regressions
+# ─────────────────────────────────────────────────────────
+
+
+def _safe_format(template: str, **overrides: str) -> str:
+    """Format a prompt template by auto-filling all placeholders with empty
+    defaults, then overriding with values we want to assert on. Lets us do a
+    smoke test for placeholder additions without needing to enumerate every
+    legacy variable each time the prompt grows."""
+    import string
+
+    fields = {
+        name
+        for _lit, name, _spec, _conv in string.Formatter().parse(template)
+        if name
+    }
+    payload = {name: "" for name in fields}
+    payload.update(overrides)
+    return template.format(**payload)
+
+
+def test_case_architect_prompt_contains_contract_section() -> None:
+    out = _safe_format(CASE_ARCHITECT_PROMPT)
+    assert "dataset_schema_required" in out
+    assert "Issue #225" in out
+
+
+def test_schema_designer_prompt_renders_with_contract_block() -> None:
+    contract_json = _format_dataset_contract_block(
+        _make_minimal_contract().model_dump()
+    )
+    out = _safe_format(SCHEMA_DESIGNER_PROMPT, dataset_contract_block=contract_json)
+    assert "churn_flag" in out
+    assert "Contrato dataset_schema_required" in out
+
+
+def test_eda_text_analyst_prompt_renders_with_gap_warnings_block() -> None:
+    out = _safe_format(
+        EDA_TEXT_ANALYST_PROMPT,
+        data_gap_warnings_block="- feature 'retention_m12' marcada con riesgo de leakage",
+    )
+    assert "retention_m12" in out
+    assert "data_gap_warnings" in out
+
+
+def test_m3_notebook_algo_prompt_renders_with_contract_and_gaps() -> None:
+    out = _safe_format(
+        M3_NOTEBOOK_ALGO_PROMPT,
+        dataset_contract_block=_format_dataset_contract_block(
+            _make_minimal_contract().model_dump()
+        ),
+        data_gap_warnings_block="(sin brechas detectadas — schema cubre el contrato)",
+    )
+    assert "CONTRACT-FIRST" in out
+    assert "churn_flag" in out


### PR DESCRIPTION
﻿# feat(arch): dataset_schema_required contract for case↔dataset grounding

Closes #225

## Problem

Until now, `case_architect` (M1) and `schema_designer` (M2/M3) operated as
loosely coupled LLM nodes. The dilema_brief routinely mentioned columns that
the schema designer never produced, and `m3_notebook_generator` silently fell
back to wrong target columns or trained on leakage features (e.g. predicting
`churn_flag` at month 0 with `retention_m12` as a feature).

This created a sharp pedagogical contradiction: the M1 narrative would ask the
student to model X, but the dataset and notebook would model Y. Worst case the
notebook would train, score, and report metrics with no warning that the
modeled target had no relationship to the M1 dilema.

## Solution

Introduce a typed, optional, end-to-end **dataset contract** that flows from
case_architect to state to schema_designer to data_validator to eda_text_analyst
to m3_notebook_generator.

The contract is **defense in depth** with four layers:

1. **Architect emits the contract** (`CaseArchitectOutput.dataset_schema_required`)
   as a structured Pydantic field declaring the canonical target column,
   feature columns with leakage flags, required domain coverage, and a minimum
   signal strength.
2. **schema_designer prompt consumes it** as a coverage requirement (LLM-side).
3. **Pure-Python augmenter** (`_augment_schema_with_contract`) deterministically
   injects any missing target/feature columns the LLM forgot, with safe defaults
   per dtype. **No retry loop, no extra LLM cost, no demo-time latency.**
4. **Validator** (`_validate_schema_against_contract`) emits residual gaps and
   leakage warnings into `state.data_gap_warnings`, which propagate to the M2
   EDA report and the M3 notebook prompt as explicit methodological notes
   (no silent fallback).

`m3_notebook_generator` now pins the target column and excludes leakage
features by contract instead of by alias matching.

`data_validator._build_metadata` now resolves `target_variable` from the
contract first and falls back to the legacy heuristic only when no contract
is present.

## Backward compatibility

Every code path **gracefully degrades to None** when `dataset_schema_required`
is absent (e.g. legacy in-flight cases, business-profile flows). The legacy
alias-first heuristics remain intact as the documented fallback.

All 419 pre-existing tests stay green. No state field renames, no contract
changes to Pydantic models other than the new optional field.

## Files touched

- `backend/src/case_generator/tools_and_schemas.py` — 3 new Pydantic models
  (`DatasetTargetSpec`, `DatasetFeatureSpec`, `DatasetSchemaRequired`) +
  optional `CaseArchitectOutput.dataset_schema_required`.
- `backend/src/case_generator/state.py` — 2 new `NotRequired` fields:
  `dataset_schema_required` and `data_gap_warnings`.
- `backend/src/case_generator/graph.py`:
  - 3 new helpers: `_format_dataset_contract_block`,
    `_validate_schema_against_contract`, `_augment_schema_with_contract`.
  - `case_architect` persists the contract via `model_dump`.
  - `schema_designer` (success + fallback) applies augment + validate.
  - `data_validator._build_metadata` is contract-first for `target_variable`.
  - `m3_notebook_generator` injects contract block + gap warnings into the
    ALGO prompt.
  - `eda_text_analyst` injects gap warnings into the EDA prompt context.
- `backend/src/case_generator/prompts.py`:
  - `CASE_ARCHITECT_PROMPT`: new section with 7 hard rules and a JSON skeleton.
  - `SCHEMA_DESIGNER_PROMPT`: new contract block at top + 5 coverage rules,
    accepts `{dataset_contract_block}` placeholder.
  - `EDA_TEXT_ANALYST_PROMPT`: new gap-warnings section with rules to surface
    brechas in the M2 contexto, accepts `{data_gap_warnings_block}`.
  - `M3_NOTEBOOK_ALGO_PROMPT`: CONTRACT-FIRST target resolution at top,
    explicit leakage exclusion rules, accepts both new placeholders.
- `backend/tests/test_issue225_dataset_schema_contract.py` — 20 new tests:
  Pydantic round-trips, validation rules, helper purity (idempotent,
  non-mutating, dtype-mapping-aware), prompt placeholder smoke tests.

## Validation

- `uv run --directory backend pytest -q` -> **419 passed, 12 skipped** (no regressions, +20 new).
- `uv run --directory backend mypy src` -> **Success: no issues found in 44 source files**.

## Demo-safety

- All contract paths are guarded for `None` and dict shape variations.
- Augmenter is idempotent — re-running on already-augmented schemas is a no-op.
- No live LLM tests added; everything is pure unit.
- No prompt token-budget regression: contract block is appended once, gap
  warnings are short bullet lists.

## Why deterministic augmentation instead of an LLM retry loop

A retry loop would have added 2-15s per generation, doubled the chance of a
generation failure right before the customer demo, and still required the
augmenter as a safety net for the second LLM attempt. Deterministic Python
injection has zero new failure modes, zero new latency, and zero new tokens.
The LLM is still asked to satisfy the contract through the prompt, but the
Python layer guarantees coverage even when it doesn't.
