### PR TITLE
feat(authoring): algorithm mode toggle (1 deep | 2 contrast) with canonical catalog (#230)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,17 @@ Supabase or another environment that exposes compatible Auth helpers like `auth.
 - Prompt boundaries, graph orchestration, and LLM-facing payload handling need extra caution.
 - Database setup and migrations must stay aligned with `backend/alembic/` and `backend/.env.example`.
 
+## Authoring Algorithm Picks (Issue #230)
+
+- The teacher form picks algorithms from a canonical catalog instead of accepting up to five free-text chips.
+- `POST /api/authoring/jobs` accepts the breaking fields `algorithm_mode` (`"single" | "contrast"`), `algorithm_primary`, and `algorithm_challenger`. The legacy `suggested_techniques` body field has been removed; do not reintroduce it.
+- Algorithm picks are validated server-side at intake by `_validate_techniques_strict` whenever `case_type == "harvard_with_eda"` or `student_profile == "ml_ds"`. They are persisted into `task_payload` as `algorithm_mode` plus `algoritmos: list[str]` of length 0, 1, or 2.
+- `GET /api/authoring/algorithm-catalog?profile=...&case_type=...` returns the canonical declarative catalog as `{profile, case_type, items: [{name, family, family_label, tier}]}` where `tier ∈ {"baseline", "challenger"}` and `family ∈ {clustering, clasificacion, regresion, serie_temporal, recomendacion, nlp}`. The endpoint is open (no PII), `Literal`-validated, and re-checked at intake.
+- Family-coherence rule: in `contrast` mode the baseline and the challenger MUST belong to the same `family`. The backend rejects cross-family contrast picks (e.g. Logistic Regression vs Prophet) at intake with a 422 and a teacher-friendly Spanish message. The frontend `AlgorithmSelector` filters the challenger options to the baseline family. The LLM suggester is taught the same rule via prompt boundary AND the post-LLM `_snap_item` filter, so it cannot cross families even if the model strays.
+- LSTM has been removed from the canonical ml_ds time-series catalog. Do not reintroduce LSTM (or other heavy DL surrogates) without an ADR.
+- The `business` profile may legitimately expose only baseline items (no challengers in any family). The frontend disables the "2 algoritmos" mode in that case; the backend rejects contrast picks with a teacher-friendly message. Do not silently fall back to `single` on the backend.
+
+
 ## Forbidden Patterns
 
 - Secrets, tokens, keys, DSNs, or credentials committed to the repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,16 @@ Only run live LLM tests explicitly:
 - Prompt boundaries, graph orchestration, and LLM-facing payload construction require extra caution.
 - Database setup, migrations, and ORM contracts must remain coherent across runtime, tests, and docs.
 
+## Authoring Algorithm Picks (Issue #230)
+
+- The teacher form picks algorithms from a canonical catalog instead of accepting up to five free-text chips.
+- `POST /api/authoring/jobs` accepts the breaking fields `algorithm_mode` (`"single" | "contrast"`), `algorithm_primary`, and `algorithm_challenger`. The legacy `suggested_techniques` body field has been removed; do not reintroduce it.
+- Algorithm picks are validated server-side at intake by `_validate_techniques_strict` whenever `case_type == "harvard_with_eda"` or `student_profile == "ml_ds"`. They are persisted into `task_payload` as `algorithm_mode` plus `algoritmos: list[str]` of length 0, 1, or 2.
+- `GET /api/authoring/algorithm-catalog?profile=...&case_type=...` returns the canonical declarative catalog as `{profile, case_type, items: [{name, family, family_label, tier}]}` where `tier ∈ {"baseline", "challenger"}` and `family ∈ {clustering, clasificacion, regresion, serie_temporal, recomendacion, nlp}`. The endpoint is open (no PII), `Literal`-validated, and re-checked at intake.
+- Family-coherence rule: in `contrast` mode the baseline and the challenger MUST belong to the same `family`. The backend rejects cross-family contrast picks (e.g. Logistic Regression vs Prophet) at intake with a 422 and a teacher-friendly Spanish message. The frontend `AlgorithmSelector` filters the challenger options to the baseline family. The LLM suggester is taught the same rule via prompt boundary AND the post-LLM `_snap_item` filter, so it cannot cross families even if the model strays.
+- LSTM has been removed from the canonical ml_ds time-series catalog. Do not reintroduce LSTM (or other heavy DL surrogates) without an ADR.
+- The `business` profile may legitimately expose only baseline items (no challengers in any family). The frontend disables the "2 algoritmos" mode in that case; the backend rejects contrast picks with a teacher-friendly message. Do not silently fall back to `single` on the backend.
+
 ## Forbidden Patterns
 
 - Secrets, API keys, tokens, credentials, or DSNs committed to code, prompts, fixtures, or docs

--- a/TODOS.md
+++ b/TODOS.md
@@ -4,6 +4,48 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
+## TODO-230-A: Curar `challenger` para perfil `business` en `ALGORITHM_TAXONOMY`
+
+**What:** Hoy `get_algorithm_catalog("business", "harvard_with_eda").challenger == []` porque el catálogo `business_techniques` solo contiene baselines. El frontend ya degrada el toggle "2 algoritmos" cuando esto pasa, pero el contrato ideal es exponer al menos 1-2 challengers seguros para business (p. ej. `Random Forest interpretable + SHAP`).
+
+**Why:** Permitir el modo contraste también en cursos de negocio sin forzar perfil `ml_ds`.
+
+**Pros:** Mejora la cobertura del modo contrast; mantiene el catálogo corto y curado.
+
+**Cons:** Cambio de catálogo afecta UX inmediatamente; requiere consenso pedagógico.
+
+**Context:** Issue #230 envío inicial mantuvo el catálogo intacto a propósito (cambio quirúrgico). La curación de challengers para business se puede hacer en cualquier PR posterior tocando solo `ALGORITHM_TAXONOMY` y los tests asociados.
+
+---
+
+## TODO-230-B: Consumir `algorithm_mode == "contrast"` en M3 (`m3_content_generator`)
+
+**What:** Cuando `task_payload["algorithm_mode"] == "contrast"` y `len(algoritmos) == 2`, los prompts de M3 deben generar narrativa, secciones de modelado y conclusiones que comparen explícitamente baseline vs challenger (trade-off, métricas, interpretabilidad).
+
+**Why:** Hoy el grafo solo recibe `algoritmos: list[str]` y los prompts no diferencian. Para entregar el "deep contrast" prometido en la UI, M3 necesita branching consciente del modo.
+
+**Pros:** Cierra el ciclo del feature #230; entrega el valor pedagógico real al docente.
+
+**Cons:** Toca `case_generator/graph.py` y prompts sensibles → requiere review eng + diseño.
+
+**Context:** El payload ya viaja con `algorithm_mode`; el campo solo se persiste y el grafo ignora la distinción. Crear como issue separada con plan de prompts contrast-aware.
+
+---
+
+## TODO-230-C: Deprecar `SuggestResponse.suggestedTechniques` cuando todos los consumidores migren a `algorithmPrimary` / `algorithmChallenger`
+
+**What:** Mantener el campo `suggestedTechniques` como espejo legacy mientras dura la transición; planificar su remoción una vez que todos los consumidores (frontend + tooling externo) hayan migrado a los campos canónicos `algorithmPrimary` y `algorithmChallenger` introducidos por #230.
+
+**Why:** Evitar dos fuentes de verdad para la sugerencia de algoritmos.
+
+**Pros:** Limpia la API pública de `/api/suggest`.
+
+**Cons:** Requiere coordinación si el endpoint es llamado fuera del frontend del repo.
+
+**Context:** El frontend ya usa los campos canónicos; el espejo se conserva por compat de tests y posibles consumidores externos no auditados.
+
+---
+
 ## TODO-004: Mover `usePublishCase` a `shared/` para eliminar import cross-feature
 
 **What:** Extraer `usePublishCase` de `frontend/src/features/teacher-dashboard/useTeacherDashboard.ts` hacia un archivo en `shared/` (ej: `shared/usePublishCase.ts`).

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2936,6 +2936,11 @@ def _detect_algorithm_families(algoritmos: list[str]) -> list[str]:
 
     Usa ALGORITHM_REGISTRY para keyword matching. Si un algoritmo no mapea
     a ninguna familia conocida, devuelve "unsupported" para ese algoritmo.
+
+    Issue #230 contract: ``len(algoritmos) ∈ {1, 2}`` — el formulario docente
+    permite exactamente 1 algoritmo (modo single) o 2 algoritmos baseline +
+    challenger (modo contrast). Otras longitudes provienen de jobs históricos
+    o de un payload mal formado y se procesan best-effort.
     """
     detected: list[str] = []
     for algo in algoritmos:

--- a/backend/src/case_generator/suggest_service.py
+++ b/backend/src/case_generator/suggest_service.py
@@ -2,16 +2,22 @@
 
 Generates scenario, guiding-question, and technique suggestions aligned with
 the current authoring prompts and the maintained problem-type taxonomy.
+
+Issue #230 — Algorithm mode toggle:
+The teacher form no longer accepts free-text "5 algorithm chips". Instead, the
+teacher picks 1 algorithm (mode="single") or a baseline + a challenger
+(mode="contrast"), both drawn from the canonical catalog returned by
+``get_algorithm_catalog(profile, case_type)``.
 """
 
+import functools
 import json
 import os
-from typing import cast
-
-from pydantic import BaseModel, Field
-from typing import Optional, Literal
 from enum import Enum
+from typing import Literal, Optional, cast
+
 from langchain_google_genai import ChatGoogleGenerativeAI
+from pydantic import BaseModel, ConfigDict, Field
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -19,19 +25,24 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 # Used to validate LLM suggestions and provide consistent context to the authoring flow.
 # ══════════════════════════════════════════════════════════════════════════════
 
-ALGORITHM_TAXONOMY = {
+# Per-technique tier is declarative (Issue #230 follow-up). Each entry in
+# ``business_techniques`` / ``ml_ds_techniques`` is a CatalogItem dict so the
+# baseline-vs-challenger split is curated, not keyword-inferred. The taxonomy
+# key (``clustering``, ``clasificacion``, ...) doubles as the algorithm
+# *family* used for cross-family coherence in contrast mode.
+ALGORITHM_TAXONOMY: dict[str, dict[str, object]] = {
     "clustering": {
         "label": "Segmentación / Clustering",
         "target_type": "categorical",
         "business_techniques": [
-            "Segmentación por cohortes",
-            "Análisis de perfiles de cliente",
-            "Agrupación visual por métricas clave",
-            "K-Means + Silhouette + PCA",
+            {"name": "Segmentación por cohortes", "tier": "baseline"},
+            {"name": "Análisis de perfiles de cliente", "tier": "baseline"},
+            {"name": "Agrupación visual por métricas clave", "tier": "baseline"},
+            {"name": "K-Means + Silhouette + PCA", "tier": "baseline"},
         ],
         "ml_ds_techniques": [
-            "K-Means + Silhouette + PCA",
-            "DBSCAN para detección de grupos atípicos",
+            {"name": "K-Means + Silhouette + PCA", "tier": "baseline"},
+            {"name": "DBSCAN para detección de grupos atípicos", "tier": "challenger"},
         ],
         "validation": "Estabilidad de clusters (Bootstrap)",
         "metrics": ["Silhouette", "Calinski-Harabasz", "Inertia"],
@@ -40,14 +51,15 @@ ALGORITHM_TAXONOMY = {
         "label": "Clasificación",
         "target_type": "binary",
         "business_techniques": [
-            "Scorecard de riesgo con reglas de negocio",
-            "Segmentación binaria por umbrales de KPI",
-            "Análisis de cohortes con tasa de conversión",
-            "Regresión Logística + SHAP",
+            {"name": "Scorecard de riesgo con reglas de negocio", "tier": "baseline"},
+            {"name": "Segmentación binaria por umbrales de KPI", "tier": "baseline"},
+            {"name": "Análisis de cohortes con tasa de conversión", "tier": "baseline"},
+            {"name": "Regresión Logística + SHAP", "tier": "baseline"},
         ],
         "ml_ds_techniques": [
-            "Logistic Regression + Random Forest + SHAP",
-            "XGBoost con tuning de hiperparámetros",
+            {"name": "Logistic Regression", "tier": "baseline"},
+            {"name": "Random Forest + SHAP", "tier": "challenger"},
+            {"name": "XGBoost con tuning de hiperparámetros", "tier": "challenger"},
         ],
         "validation": "Cross-validation 5-fold + ROC-AUC",
         "metrics": ["AUC-ROC", "F1", "Precision", "Recall", "Confusion Matrix"],
@@ -56,14 +68,15 @@ ALGORITHM_TAXONOMY = {
         "label": "Regresión / Predicción Continua",
         "target_type": "numeric",
         "business_techniques": [
-            "Proyección lineal de tendencias",
-            "Análisis de sensibilidad con escenarios",
-            "Forecast básico por promedio móvil",
-            "Regresión Lineal + Ridge/Lasso",
+            {"name": "Proyección lineal de tendencias", "tier": "baseline"},
+            {"name": "Análisis de sensibilidad con escenarios", "tier": "baseline"},
+            {"name": "Forecast básico por promedio móvil", "tier": "baseline"},
+            {"name": "Regresión Lineal + Ridge/Lasso", "tier": "baseline"},
         ],
         "ml_ds_techniques": [
-            "Linear Regression + Ridge/Lasso + Residuals",
-            "Gradient Boosting Regressor",
+            {"name": "Linear Regression + Residuals", "tier": "baseline"},
+            {"name": "Ridge / Lasso Regression", "tier": "challenger"},
+            {"name": "Gradient Boosting Regressor", "tier": "challenger"},
         ],
         "validation": "Cross-val + Prediction Intervals",
         "metrics": ["R²", "MAE", "RMSE", "MAPE"],
@@ -72,14 +85,14 @@ ALGORITHM_TAXONOMY = {
         "label": "Series Temporales",
         "target_type": "numeric",
         "business_techniques": [
-            "Análisis de tendencia y estacionalidad visual",
-            "Forecast por promedio móvil ponderado",
-            "Comparación interanual (YoY)",
-            "STL Decomposition + ARIMA",
+            {"name": "Análisis de tendencia y estacionalidad visual", "tier": "baseline"},
+            {"name": "Forecast por promedio móvil ponderado", "tier": "baseline"},
+            {"name": "Comparación interanual (YoY)", "tier": "baseline"},
+            {"name": "STL Decomposition + ARIMA", "tier": "baseline"},
         ],
         "ml_ds_techniques": [
-            "STL Decomposition + ARIMA + Prophet",
-            "LSTM para secuencias complejas (si >500 filas)",
+            {"name": "STL Decomposition + ARIMA", "tier": "baseline"},
+            {"name": "Prophet", "tier": "challenger"},
         ],
         "validation": "Walk-forward validation + MAPE",
         "metrics": ["MAPE", "MAE", "RMSE", "Coverage 95%"],
@@ -88,14 +101,15 @@ ALGORITHM_TAXONOMY = {
         "label": "Sistemas de Recomendación",
         "target_type": "numeric",
         "business_techniques": [
-            "Análisis RFM (Recencia, Frecuencia, Monetización)",
-            "Segmentación por comportamiento de compra",
-            "A/B Testing de estrategias de retención",
-            "K-Means RFM",
+            {"name": "Análisis RFM (Recencia, Frecuencia, Monetización)", "tier": "baseline"},
+            {"name": "Segmentación por comportamiento de compra", "tier": "baseline"},
+            {"name": "A/B Testing de estrategias de retención", "tier": "baseline"},
+            {"name": "K-Means RFM", "tier": "baseline"},
         ],
         "ml_ds_techniques": [
-            "K-Means RFM + Random Forest Feature Importance",
-            "Collaborative Filtering (SVD) + Content-Based (Cosine)",
+            {"name": "Content-Based Filtering (Cosine)", "tier": "baseline"},
+            {"name": "Collaborative Filtering (SVD)", "tier": "challenger"},
+            {"name": "K-Means RFM + Random Forest Feature Importance", "tier": "challenger"},
         ],
         "validation": "A/B Test + t-test de Welch",
         "metrics": ["Precision@K", "Recall@K", "Coverage", "NDCG"],
@@ -104,22 +118,207 @@ ALGORITHM_TAXONOMY = {
         "label": "Procesamiento de Lenguaje Natural",
         "target_type": "categorical",
         "business_techniques": [
-            "Análisis de sentimiento con VADER/TextBlob",
-            "Topic Modeling (LDA) para extracción de temas",
-            "TF-IDF para representación e importancia de texto",
+            {"name": "Análisis de sentimiento con VADER/TextBlob", "tier": "baseline"},
+            {"name": "Topic Modeling (LDA) para extracción de temas", "tier": "baseline"},
+            {"name": "TF-IDF para representación e importancia de texto", "tier": "baseline"},
         ],
         "ml_ds_techniques": [
-            "TF-IDF + Sentiment (VADER/TextBlob)",
-            "Topic Modeling (LDA) + Word2Vec",
+            {"name": "TF-IDF + Sentiment (VADER/TextBlob)", "tier": "baseline"},
+            {"name": "Topic Modeling (LDA) + Word2Vec", "tier": "challenger"},
         ],
         "validation": "Kappa inter-rater + Bootstrap",
         "metrics": ["Accuracy", "F1-macro", "Kappa", "Perplexity"],
     },
 }
 
+
+# ── Helpers to bridge legacy `list[str]` consumers with the new dict shape.
+def _technique_items(profile: str, family: str) -> list[dict[str, str]]:
+    tech_key = "business_techniques" if profile == "business" else "ml_ds_techniques"
+    return cast(list[dict[str, str]], ALGORITHM_TAXONOMY[family][tech_key])
+
+
+def _technique_names(profile: str, family: str) -> list[str]:
+    return [item["name"] for item in _technique_items(profile, family)]
+
 # Problemas válidos para cada perfil
 BUSINESS_PROBLEM_TYPES = list(ALGORITHM_TAXONOMY.keys())
 ML_DS_PROBLEM_TYPES = list(ALGORITHM_TAXONOMY.keys())
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TIER CLASSIFICATION — Issue #230
+# Tier (``baseline`` / ``challenger``) and family (taxonomy key) are now declared
+# per-item inside ``ALGORITHM_TAXONOMY``. ``classify_tier`` is kept as a fallback
+# helper for ad-hoc strings that did not come from the catalog (e.g. legacy
+# ``suggested_techniques`` payloads).
+# ══════════════════════════════════════════════════════════════════════════════
+
+AlgorithmTier = Literal["baseline", "challenger"]
+
+# Human-readable labels for each family (taxonomy key). Used by the catalog
+# endpoint so the frontend can render section headers.
+FAMILY_LABELS: dict[str, str] = {
+    "clustering": "Clustering",
+    "clasificacion": "Clasificación",
+    "regresion": "Regresión",
+    "serie_temporal": "Series Temporales",
+    "recomendacion": "Recomendación",
+    "nlp": "NLP / Texto",
+}
+
+# Substring keywords that mark an unknown (off-catalog) technique as challenger.
+_CHALLENGER_KEYWORDS: tuple[str, ...] = (
+    "random forest",
+    "xgboost",
+    "lightgbm",
+    "catboost",
+    "adaboost",
+    "gradient boosting",
+    "gbm",
+    "lstm",
+    "neural",
+    "redes neuronales",
+    "deep learning",
+    "prophet",
+    "dbscan",
+    "autoencoder",
+    "bert",
+    "embedding",
+    "word2vec",
+    "transformer",
+)
+
+
+def classify_tier(technique: str) -> AlgorithmTier:
+    """Return ``"challenger"`` if the technique matches any challenger keyword.
+
+    Prefer the declarative ``tier`` field on catalog items over this fallback.
+    """
+    # Prefer declarative tier when the technique is in the catalog.
+    needle = technique.lower().strip()
+    for entry in ALGORITHM_TAXONOMY.values():
+        for tech_key in ("business_techniques", "ml_ds_techniques"):
+            for item in cast(list[dict[str, str]], entry[tech_key]):
+                if item["name"].lower() == needle:
+                    return cast(AlgorithmTier, item["tier"])
+    # Off-catalog fallback — keyword heuristic.
+    for kw in _CHALLENGER_KEYWORDS:
+        if kw in needle:
+            return "challenger"
+    return "baseline"
+
+
+@functools.lru_cache(maxsize=8)
+def get_algorithm_catalog(profile: str, case_type: str) -> dict[str, object]:
+    """Return the canonical catalog of algorithms for a (profile, case_type) pair.
+
+    The result is a dict ``{"items": [{"name", "family", "family_label", "tier"}, ...]}``
+    with de-duplicated technique names sourced from ``ALGORITHM_TAXONOMY``.
+    The frontend groups items by ``family`` to render the selector and uses
+    ``tier`` to filter the baseline / challenger dropdowns in contrast mode.
+    """
+    if profile not in {"business", "ml_ds"}:
+        raise ValueError(f"Invalid profile: {profile!r}")
+    if case_type not in {"harvard_only", "harvard_with_eda"}:
+        raise ValueError(f"Invalid case_type: {case_type!r}")
+
+    tech_key = "business_techniques" if profile == "business" else "ml_ds_techniques"
+    items: list[dict[str, str]] = []
+    seen_set: set[str] = set()
+    for family, entry in ALGORITHM_TAXONOMY.items():
+        family_label = FAMILY_LABELS.get(family, family)
+        for raw_item in cast(list[dict[str, str]], entry[tech_key]):
+            key = raw_item["name"].lower()
+            if key in seen_set:
+                continue
+            seen_set.add(key)
+            items.append({
+                "name": raw_item["name"],
+                "family": family,
+                "family_label": family_label,
+                "tier": raw_item["tier"],
+            })
+    return {"items": items}
+
+
+def _catalog_lookup(
+    profile: str,
+    case_type: str,
+    name: str,
+) -> Optional[dict[str, str]]:
+    """Return the catalog item matching ``name`` (case-insensitive) or ``None``."""
+    needle = name.lower().strip()
+    for item in cast(list[dict[str, str]], get_algorithm_catalog(profile, case_type)["items"]):
+        if item["name"].lower() == needle:
+            return item
+    return None
+
+
+
+def _validate_techniques_strict(
+    techniques: list[str],
+    profile: str,
+    case_type: str,
+    mode: Literal["single", "contrast"],
+) -> None:
+    """Strict validator for teacher-submitted algorithm picks (Issue #230).
+
+    Raises ``ValueError`` (with a teacher-friendly message) when the picks do
+    not match the contract for the given mode.
+
+    Contract:
+    - mode="single": exactly 1 technique, must belong to the catalog (any tier).
+    - mode="contrast": exactly 2 techniques where the first is a baseline and
+      the second is a challenger of the catalog for the (profile, case_type),
+      and BOTH must belong to the same family (e.g. ``clasificacion``).
+    - The two contrast techniques must differ.
+    """
+    items = cast(list[dict[str, str]], get_algorithm_catalog(profile, case_type)["items"])
+    by_name: dict[str, dict[str, str]] = {item["name"].lower(): item for item in items}
+
+    if not techniques:
+        raise ValueError("Debes seleccionar al menos un algoritmo del catálogo.")
+
+    for tech in techniques:
+        if tech.lower() not in by_name:
+            raise ValueError(
+                f"Algoritmo fuera del catálogo para perfil {profile!r}: {tech!r}."
+            )
+
+    if mode == "single":
+        if len(techniques) != 1:
+            raise ValueError("El modo 'single' requiere exactamente 1 algoritmo.")
+        return
+
+    # mode == "contrast"
+    if len(techniques) != 2:
+        raise ValueError("El modo 'contrast' requiere exactamente 2 algoritmos (baseline + challenger).")
+    primary_item = by_name[techniques[0].lower()]
+    challenger_item = by_name[techniques[1].lower()]
+    if primary_item["name"].lower() == challenger_item["name"].lower():
+        raise ValueError("El baseline y el challenger no pueden ser el mismo algoritmo.")
+    if primary_item["tier"] != "baseline":
+        raise ValueError(
+            f"El primer algoritmo debe ser un baseline del catálogo: {primary_item['name']!r} no lo es."
+        )
+    if challenger_item["tier"] != "challenger":
+        # Surface a profile-specific hint when the catalog has no challengers at all.
+        any_challenger = any(it["tier"] == "challenger" for it in items)
+        if not any_challenger:
+            raise ValueError(
+                "El catálogo actual no expone challengers para este perfil; usa modo 'single'."
+            )
+        raise ValueError(
+            f"El segundo algoritmo debe ser un challenger del catálogo: {challenger_item['name']!r} no lo es."
+        )
+    if primary_item["family"] != challenger_item["family"]:
+        raise ValueError(
+            f"El baseline y el challenger deben pertenecer a la misma familia "
+            f"({primary_item['family_label']}). "
+            f"Recibido: {primary_item['name']!r} ({primary_item['family_label']}) "
+            f"vs {challenger_item['name']!r} ({challenger_item['family_label']})."
+        )
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -133,6 +332,8 @@ class IntentEnum(str, Enum):
 
 
 class SuggestRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     subject: str
     academicLevel: str
     targetGroups: list[str]
@@ -146,6 +347,8 @@ class SuggestRequest(BaseModel):
     ] = None
     includePythonCode: bool = False
     intent: IntentEnum = IntentEnum.both
+    # Issue #230 — algorithm selection mode used to shape the techniques prompt.
+    mode: Literal["single", "contrast"] = "single"
 
     scenarioDescription: str = ""
     guidingQuestion: str = ""
@@ -157,6 +360,9 @@ class SuggestResponse(BaseModel):
     suggestedTechniques: list[str] = Field(default_factory=list)
     problemType: str = ""
     targetVariableType: str = ""
+    # Issue #230 — explicit baseline/challenger fields to drive the new selector.
+    algorithmPrimary: Optional[str] = None
+    algorithmChallenger: Optional[str] = None
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -167,12 +373,12 @@ def _build_taxonomy_context(profile: str) -> str:
     """Genera texto de referencia de la taxonomía para inyectar en el prompt."""
     lines = ["## Catálogo de Tipos de Problema y Técnicas Permitidas\n"]
     for key, t in ALGORITHM_TAXONOMY.items():
-        tech_key = "business_techniques" if profile == "business" else "ml_ds_techniques"
-        techniques = t[tech_key]
+        items = _technique_items(profile, key)
         lines.append(f"### {key} — {t['label']}")
         lines.append(f"  Target: {t['target_type']}")
-        lines.append(f"  Técnicas: {', '.join(techniques)}")
-        lines.append(f"  Métricas: {', '.join(t['metrics'])}")
+        rendered = ", ".join(f"{it['name']} [{it['tier']}]" for it in items)
+        lines.append(f"  Técnicas: {rendered}")
+        lines.append(f"  Métricas: {', '.join(cast(list[str], t['metrics']))}")
         lines.append("")
     return "\n".join(lines)
 
@@ -253,11 +459,18 @@ Tu sugerencia alimentará al Case Architect, así que debe ser precisa y coheren
 # Your Boundaries
 - Responde ÚNICAMENTE con JSON válido. PROHIBIDO Markdown, saludos o texto extra.
 - Empresa 100% ficticia. NUNCA uses empresas reales.
-- `suggestedTechniques`: entre 1 y 3 técnicas, SOLO del catálogo provisto.
 - `problemType`: DEBE ser uno de: clustering, clasificacion, regresion,
   serie_temporal, recomendacion, nlp.
 - `scenarioDescription`: 2-4 oraciones con tensión empresarial y deadline.
 - `guidingQuestion`: 1 oración, formulada como dilema con opciones en tensión.
+- Cuando sugieras técnicas, usa SOLO nombres exactos del catálogo provisto.
+  Modo `single`: devuelve `algorithmPrimary` con UNA técnica del catálogo.
+  Modo `contrast`: devuelve `algorithmPrimary` (baseline interpretable) y
+  `algorithmChallenger` (modelo de mayor capacidad). Ambos del catálogo y distintos.
+  REGLA DE FAMILIA: en modo `contrast`, baseline y challenger DEBEN pertenecer
+  al mismo `problemType` (clasificacion, regresion, clustering, serie_temporal,
+  recomendacion, nlp). Comparar Logistic Regression (clasificacion) vs
+  Prophet (serie_temporal) es un contraste experimental inválido.
 
 {boundary_profile}""")
 
@@ -274,7 +487,9 @@ Tu sugerencia alimentará al Case Architect, así que debe ser precisa y coheren
         req.intent in (IntentEnum.techniques, IntentEnum.both)
         and req.caseType == "harvard_with_eda"
     ):
-        json_schema["suggestedTechniques"] = ["string (del catálogo)", "..."]
+        json_schema["algorithmPrimary"] = "string (nombre exacto del catálogo)"
+        if req.mode == "contrast":
+            json_schema["algorithmChallenger"] = "string (nombre exacto del catálogo, distinto al baseline)"
         if "problemType" not in json_schema:
             json_schema["problemType"] = "string (del catálogo)"
             json_schema["targetVariableType"] = "string (binary|numeric|categorical)"
@@ -311,8 +526,7 @@ def _validate_techniques(
     if problem_type not in ALGORITHM_TAXONOMY:
         return techniques[:4]
 
-    tech_key = "business_techniques" if profile == "business" else "ml_ds_techniques"
-    catalog = ALGORITHM_TAXONOMY[problem_type][tech_key]
+    catalog = _technique_names(profile, problem_type)
     catalog_lower = [t.lower() for t in catalog]
 
     validated = []
@@ -422,5 +636,72 @@ async def generate_suggestion(req: SuggestRequest) -> SuggestResponse:
             req.studentProfile,
             resp.problemType,
         )
+
+    # Issue #230 — mode-aware algorithm picks. Snap LLM output to the canonical
+    # catalog so the frontend can pre-fill the dropdowns without further work.
+    catalog_items = cast(
+        list[dict[str, str]],
+        get_algorithm_catalog(req.studentProfile, req.caseType)["items"],
+    )
+
+    def _snap_item(name: str, candidates: list[dict[str, str]]) -> Optional[dict[str, str]]:
+        needle = name.lower().strip()
+        if not needle:
+            return None
+        for c in candidates:
+            if c["name"].lower() == needle:
+                return c
+        for c in candidates:
+            cl = c["name"].lower()
+            if cl in needle or needle in cl:
+                return c
+        return None
+
+    raw_primary = data.get("algorithmPrimary") or ""
+    raw_challenger = data.get("algorithmChallenger") or ""
+
+    primary_item: Optional[dict[str, str]] = None
+    if isinstance(raw_primary, str) and raw_primary:
+        # In contrast mode the primary must be a baseline; in single mode any tier.
+        primary_pool = (
+            [c for c in catalog_items if c["tier"] == "baseline"]
+            if req.mode == "contrast"
+            else catalog_items
+        )
+        primary_item = _snap_item(raw_primary, primary_pool)
+        if primary_item:
+            resp.algorithmPrimary = primary_item["name"]
+
+    if req.mode == "contrast" and isinstance(raw_challenger, str) and raw_challenger:
+        # Family-coherence guard: only consider challengers from the SAME family
+        # as the snapped baseline. Comparing LR (clasificacion) vs Prophet
+        # (serie_temporal) is not a valid pedagogical contrast. If the baseline
+        # could not be snapped, refuse to emit a challenger at all instead of
+        # leaking a cross-family pick (defense-in-depth against off-catalog LLM
+        # output).
+        if not primary_item:
+            resp.algorithmChallenger = None
+        else:
+            challenger_pool = [
+                c
+                for c in catalog_items
+                if c["tier"] == "challenger" and c["family"] == primary_item["family"]
+            ]
+            snapped_chal = _snap_item(raw_challenger, challenger_pool)
+            if (
+                snapped_chal
+                and snapped_chal["name"].lower() == primary_item["name"].lower()
+            ):
+                snapped_chal = None
+            resp.algorithmChallenger = snapped_chal["name"] if snapped_chal else None
+
+    # Mirror picks into suggestedTechniques for legacy consumers (preview, logs).
+    mirror: list[str] = []
+    if resp.algorithmPrimary:
+        mirror.append(resp.algorithmPrimary)
+    if resp.algorithmChallenger:
+        mirror.append(resp.algorithmChallenger)
+    if mirror and not resp.suggestedTechniques:
+        resp.suggestedTechniques = mirror
 
     return resp

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -10,7 +10,7 @@ import os
 import pathlib
 import sys
 import time
-from typing import Any
+from typing import Any, Literal, cast
 import uuid
 from zoneinfo import ZoneInfo
 
@@ -28,7 +28,13 @@ from sqlalchemy.exc import TimeoutError as SATimeoutError
 from sqlalchemy.orm import Session
 
 from case_generator.core.authoring import AuthoringService, derive_progress_percentage
-from case_generator.suggest_service import SuggestRequest, SuggestResponse, generate_suggestion
+from case_generator.suggest_service import (
+    SuggestRequest,
+    SuggestResponse,
+    _validate_techniques_strict,
+    generate_suggestion,
+    get_algorithm_catalog,
+)
 from shared.admin_router import router as admin_router
 from shared.course_access_router import router as course_access_router
 from shared.student_router import router as student_router
@@ -656,7 +662,10 @@ class IntakeRequest(BaseModel):
     target_course_ids: list[str] = []
     eda_depth: str | None = None
     include_python_code: bool = False
-    suggested_techniques: list[str] = []
+    # Issue #230 — algorithm picks replace the legacy 5-chip free-text list.
+    algorithm_mode: Literal["single", "contrast"] = "single"
+    algorithm_primary: str | None = None
+    algorithm_challenger: str | None = None
     available_from: str | None = None
     due_at: str | None = None
 
@@ -687,6 +696,37 @@ def create_authoring_job(
 ) -> JobCreatedResponse:
     started = time.monotonic()
     try:
+        # Issue #230 — strict catalog-bound validation of teacher algorithm picks.
+        # Algorithm picks are only mandatory when the case requires algorithm
+        # context (harvard_with_eda OR ml_ds profile). For pure harvard_only +
+        # business cases, picks are optional and the payload may be empty.
+        algorithms_required = (
+            req.case_type == "harvard_with_eda" or req.student_profile == "ml_ds"
+        )
+        algorithm_picks: list[str] = []
+        if req.algorithm_primary:
+            algorithm_picks.append(req.algorithm_primary)
+        if req.algorithm_mode == "contrast":
+            if not req.algorithm_challenger:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail="En modo contraste debes seleccionar un challenger.",
+                )
+            algorithm_picks.append(req.algorithm_challenger)
+        if algorithms_required or algorithm_picks:
+            try:
+                _validate_techniques_strict(
+                    algorithm_picks,
+                    profile=req.student_profile,
+                    case_type=req.case_type,
+                    mode=req.algorithm_mode,
+                )
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail=str(exc),
+                ) from exc
+
         context = resolve_teacher_context(actor)
         teacher = get_legacy_teacher_or_500(db, actor)
         owned_course = get_teacher_owned_course_with_syllabus(db, context, req.course_id, lock=True)
@@ -750,7 +790,8 @@ def create_authoring_job(
                 "targetGroups": target_groups,
                 "edaDepth": req.eda_depth,
                 "includePythonCode": req.include_python_code,
-                "algoritmos": req.suggested_techniques,
+                "algorithm_mode": req.algorithm_mode,
+                "algoritmos": algorithm_picks,
                 "availableFrom": normalized_available_from,
                 "dueAt": normalized_due_at,
             },
@@ -1563,6 +1604,49 @@ def activate_oauth_complete(
         reason="activated",
     )
     return ActivateOAuthCompleteResponse(status="activated")
+
+
+class AlgorithmCatalogItem(BaseModel):
+    """Single technique entry in the catalog (Issue #230 follow-up)."""
+
+    name: str
+    family: str
+    family_label: str
+    tier: Literal["baseline", "challenger"]
+
+
+class AlgorithmCatalogResponse(BaseModel):
+    """Issue #230 — catalog returned to the teacher authoring form selector."""
+
+    profile: Literal["business", "ml_ds"]
+    case_type: Literal["harvard_only", "harvard_with_eda"]
+    items: list[AlgorithmCatalogItem]
+
+
+@app.get("/api/authoring/algorithm-catalog", response_model=AlgorithmCatalogResponse)
+async def get_authoring_algorithm_catalog(
+    profile: Literal["business", "ml_ds"],
+    case_type: Literal["harvard_only", "harvard_with_eda"],
+) -> AlgorithmCatalogResponse:
+    """Return the canonical algorithm catalog used by the form's mode selector.
+
+    Security note (Issue #230): this endpoint exposes a static catalog with no
+    PII. It mirrors the access posture of ``POST /api/suggest`` and is
+    re-validated at intake time by ``_validate_techniques_strict``.
+    """
+    try:
+        catalog = get_algorithm_catalog(profile, case_type)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+    raw_items = cast(list[dict[str, str]], catalog["items"])
+    return AlgorithmCatalogResponse(
+        profile=profile,
+        case_type=case_type,
+        items=[AlgorithmCatalogItem(**item) for item in raw_items],
+    )
 
 
 @app.post("/api/suggest", response_model=SuggestResponse)

--- a/backend/tests/test_issue230_algorithm_mode.py
+++ b/backend/tests/test_issue230_algorithm_mode.py
@@ -1,0 +1,447 @@
+"""Issue #230 — algorithm mode toggle (single | contrast).
+
+Covers:
+- ``classify_tier`` keyword routing
+- ``get_algorithm_catalog`` shape + caching + invalid args
+- ``_validate_techniques_strict`` contract (single, contrast, errors)
+- ``GET /api/authoring/algorithm-catalog`` endpoint
+- ``POST /api/authoring/jobs`` validation gate + ``task_payload`` shape
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from case_generator.suggest_service import (
+    _validate_techniques_strict,
+    classify_tier,
+    get_algorithm_catalog,
+)
+from shared.database import SessionLocal
+from shared.models import AuthoringJob
+
+
+pytestmark = pytest.mark.shared_db_commit_visibility
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Pure-unit: classify_tier
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "technique, expected",
+    [
+        ("Regresión Lineal + Ridge/Lasso + Residuals", "baseline"),
+        ("Logistic Regression + Random Forest + SHAP", "challenger"),
+        ("XGBoost con tuning de hiperparámetros", "challenger"),
+        ("LSTM para series temporales", "challenger"),
+        ("DBSCAN para detección de grupos atípicos", "challenger"),
+        ("K-Means + Silhouette + PCA", "baseline"),
+        ("Prophet con regresores externos", "challenger"),
+        ("Scorecard de riesgo con reglas de negocio", "baseline"),
+    ],
+)
+def test_classify_tier_keywords(technique: str, expected: str) -> None:
+    assert classify_tier(technique) == expected
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Pure-unit: get_algorithm_catalog
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _items(profile: str) -> list[dict]:
+    return get_algorithm_catalog(profile, "harvard_with_eda")["items"]
+
+
+def _baselines_of(profile: str) -> list[dict]:
+    return [it for it in _items(profile) if it["tier"] == "baseline"]
+
+
+def _challengers_of(profile: str) -> list[dict]:
+    return [it for it in _items(profile) if it["tier"] == "challenger"]
+
+
+def test_catalog_business_harvard_with_eda_has_baseline() -> None:
+    items = _items("business")
+    assert items, "catalog must not be empty"
+    assert _baselines_of("business"), "business must expose baselines"
+    # Business profile may legitimately expose zero challengers.
+    for it in items:
+        assert set(it.keys()) == {"name", "family", "family_label", "tier"}
+
+
+def test_catalog_ml_ds_exposes_challengers() -> None:
+    baselines = _baselines_of("ml_ds")
+    challengers = _challengers_of("ml_ds")
+    assert baselines and challengers
+    seen = {it["name"].lower() for it in baselines}
+    for tech in challengers:
+        assert tech["name"].lower() not in seen
+
+
+def test_catalog_ml_ds_has_more_challengers_than_business() -> None:
+    assert len(_challengers_of("ml_ds")) >= len(_challengers_of("business"))
+
+
+def test_catalog_ml_ds_excludes_lstm() -> None:
+    names = {it["name"].lower() for it in _items("ml_ds")}
+    assert not any("lstm" in n for n in names), "LSTM was removed from the catalog (Issue #230 follow-up)"
+
+
+def test_catalog_items_are_grouped_by_family() -> None:
+    families = {it["family"] for it in _items("ml_ds")}
+    # All declared families show up at least once for ml_ds.
+    assert {"clustering", "clasificacion", "regresion", "serie_temporal", "recomendacion", "nlp"} <= families
+    # family_label is non-empty and human-readable.
+    for it in _items("ml_ds"):
+        assert it["family_label"] and isinstance(it["family_label"], str)
+
+
+def test_catalog_invalid_profile_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid profile"):
+        get_algorithm_catalog("teacher", "harvard_with_eda")
+
+
+def test_catalog_invalid_case_type_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid case_type"):
+        get_algorithm_catalog("business", "video_lecture")
+
+
+def test_catalog_is_cached() -> None:
+    a = get_algorithm_catalog("business", "harvard_with_eda")
+    b = get_algorithm_catalog("business", "harvard_with_eda")
+    assert a is b  # lru_cache returns the same object
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Pure-unit: _validate_techniques_strict
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _baseline(profile: str = "business") -> str:
+    return _baselines_of(profile)[0]["name"]
+
+
+def _challenger(profile: str = "ml_ds") -> str:
+    # Return a challenger from the SAME family as ``_baseline(profile)`` so
+    # tests that build a contrast pick stay valid under the family-coherence
+    # rule. Falls back to the first challenger when the baseline family lacks one.
+    base_family = _baselines_of(profile)[0]["family"]
+    same_family = [it for it in _challengers_of(profile) if it["family"] == base_family]
+    pool = same_family or _challengers_of(profile)
+    return pool[0]["name"]
+
+
+def test_validate_single_ok() -> None:
+    _validate_techniques_strict(
+        [_baseline()], profile="business", case_type="harvard_with_eda", mode="single"
+    )
+
+
+def test_validate_single_accepts_challenger_too() -> None:
+    _validate_techniques_strict(
+        [_challenger("ml_ds")], profile="ml_ds", case_type="harvard_with_eda", mode="single"
+    )
+
+
+def test_validate_single_empty_raises() -> None:
+    with pytest.raises(ValueError, match="al menos un algoritmo"):
+        _validate_techniques_strict(
+            [], profile="business", case_type="harvard_with_eda", mode="single"
+        )
+
+
+def test_validate_single_too_many_raises() -> None:
+    with pytest.raises(ValueError, match="exactamente 1 algoritmo"):
+        _validate_techniques_strict(
+            [_baseline(), _baseline()],
+            profile="business",
+            case_type="harvard_with_eda",
+            mode="single",
+        )
+
+
+def test_validate_single_unknown_technique_raises() -> None:
+    with pytest.raises(ValueError, match="fuera del catálogo"):
+        _validate_techniques_strict(
+            ["Algoritmo Inventado XYZ"],
+            profile="business",
+            case_type="harvard_with_eda",
+            mode="single",
+        )
+
+
+def test_validate_contrast_ok_ml_ds() -> None:
+    _validate_techniques_strict(
+        [_baseline("ml_ds"), _challenger("ml_ds")],
+        profile="ml_ds",
+        case_type="harvard_with_eda",
+        mode="contrast",
+    )
+
+
+def test_validate_contrast_requires_two() -> None:
+    with pytest.raises(ValueError, match="exactamente 2 algoritmos"):
+        _validate_techniques_strict(
+            [_baseline("ml_ds")],
+            profile="ml_ds",
+            case_type="harvard_with_eda",
+            mode="contrast",
+        )
+
+
+def test_validate_contrast_baseline_in_challenger_slot_raises() -> None:
+    baselines = _baselines_of("ml_ds")
+    with pytest.raises(ValueError, match="challenger"):
+        _validate_techniques_strict(
+            [baselines[0]["name"], baselines[1]["name"]],
+            profile="ml_ds",
+            case_type="harvard_with_eda",
+            mode="contrast",
+        )
+
+
+def test_validate_contrast_cross_family_raises() -> None:
+    """Issue #230 follow-up: baseline + challenger must share a family."""
+    baselines = _baselines_of("ml_ds")
+    challengers = _challengers_of("ml_ds")
+    # Find a baseline + challenger from DIFFERENT families.
+    cross_baseline = baselines[0]
+    cross_challenger = next(
+        (c for c in challengers if c["family"] != cross_baseline["family"]),
+        None,
+    )
+    assert cross_challenger is not None, "need at least two families with challengers for this test"
+    with pytest.raises(ValueError, match="misma familia"):
+        _validate_techniques_strict(
+            [cross_baseline["name"], cross_challenger["name"]],
+            profile="ml_ds",
+            case_type="harvard_with_eda",
+            mode="contrast",
+        )
+
+
+def test_validate_contrast_same_algo_raises() -> None:
+    pick = _baseline("ml_ds")
+    with pytest.raises(ValueError, match="no pueden ser el mismo"):
+        _validate_techniques_strict(
+            [pick, pick],
+            profile="ml_ds",
+            case_type="harvard_with_eda",
+            mode="contrast",
+        )
+
+
+def test_validate_contrast_challenger_in_primary_slot_raises() -> None:
+    challenger = _challenger("ml_ds")
+    baseline = _baseline("ml_ds")
+    with pytest.raises(ValueError, match="primer algoritmo debe ser un baseline"):
+        _validate_techniques_strict(
+            [challenger, baseline],
+            profile="ml_ds",
+            case_type="harvard_with_eda",
+            mode="contrast",
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Endpoint: GET /api/authoring/algorithm-catalog
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_algorithm_catalog_endpoint_ok(client) -> None:
+    resp = client.get(
+        "/api/authoring/algorithm-catalog",
+        params={"profile": "ml_ds", "case_type": "harvard_with_eda"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["profile"] == "ml_ds"
+    assert body["case_type"] == "harvard_with_eda"
+    items = body["items"]
+    assert isinstance(items, list) and items
+    for it in items:
+        assert set(it.keys()) == {"name", "family", "family_label", "tier"}
+        assert it["tier"] in {"baseline", "challenger"}
+    # No LSTM in the curated catalog.
+    assert not any("lstm" in it["name"].lower() for it in items)
+
+
+def test_algorithm_catalog_endpoint_invalid_profile_422(client) -> None:
+    resp = client.get(
+        "/api/authoring/algorithm-catalog",
+        params={"profile": "teacher", "case_type": "harvard_with_eda"},
+    )
+    assert resp.status_code == 422
+
+
+def test_algorithm_catalog_endpoint_missing_param_422(client) -> None:
+    resp = client.get(
+        "/api/authoring/algorithm-catalog",
+        params={"profile": "ml_ds"},
+    )
+    assert resp.status_code == 422
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Intake: POST /api/authoring/jobs algorithm gate + task_payload shape
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _intake_payload(course_id: str, **overrides) -> dict:
+    payload = {
+        "assignment_title": "Issue230 Test",
+        "course_id": course_id,
+        "syllabus_module": "m1",
+        "topic_unit": "u1",
+        "target_groups": ["Grupo 01"],
+        "case_type": "harvard_with_eda",
+        "student_profile": "business",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _seed_teacher_with_course(seed_identity, seed_course_with_syllabus, db):
+    teacher_id = "00000000-0000-0000-0000-000000000230"
+    teacher_email = "issue230teacher@example.edu"
+    teacher = seed_identity(user_id=teacher_id, email=teacher_email, role="teacher")
+    course = seed_course_with_syllabus(
+        university_id=teacher["membership"].university_id,
+        teacher_membership_id=teacher["membership"].id,
+        title="Issue 230 Course",
+    )
+    db.commit()
+    return teacher_id, teacher_email, course
+
+
+def test_intake_eda_without_picks_returns_422(
+    client, db, auth_headers_factory, seed_identity, seed_course_with_syllabus
+) -> None:
+    teacher_id, teacher_email, course = _seed_teacher_with_course(
+        seed_identity, seed_course_with_syllabus, db
+    )
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+    payload = _intake_payload(course.id)  # no algorithm_primary
+    with patch("fastapi.BackgroundTasks.add_task"):
+        resp = client.post("/api/authoring/jobs", json=payload, headers=headers)
+    assert resp.status_code == 422
+    assert "algoritmo" in resp.json()["detail"].lower()
+
+
+def test_intake_contrast_missing_challenger_returns_422(
+    client, db, auth_headers_factory, seed_identity, seed_course_with_syllabus
+) -> None:
+    teacher_id, teacher_email, course = _seed_teacher_with_course(
+        seed_identity, seed_course_with_syllabus, db
+    )
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+    payload = _intake_payload(
+        course.id,
+        algorithm_mode="contrast",
+        algorithm_primary=_baseline("ml_ds"),
+        student_profile="ml_ds",
+    )
+    with patch("fastapi.BackgroundTasks.add_task"):
+        resp = client.post("/api/authoring/jobs", json=payload, headers=headers)
+    assert resp.status_code == 422
+    assert "challenger" in resp.json()["detail"].lower()
+
+
+def test_intake_unknown_algorithm_returns_422(
+    client, db, auth_headers_factory, seed_identity, seed_course_with_syllabus
+) -> None:
+    teacher_id, teacher_email, course = _seed_teacher_with_course(
+        seed_identity, seed_course_with_syllabus, db
+    )
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+    payload = _intake_payload(
+        course.id,
+        algorithm_mode="single",
+        algorithm_primary="Algoritmo Inventado",
+    )
+    with patch("fastapi.BackgroundTasks.add_task"):
+        resp = client.post("/api/authoring/jobs", json=payload, headers=headers)
+    assert resp.status_code == 422
+    assert "catálogo" in resp.json()["detail"].lower()
+
+
+def test_intake_single_ok_persists_payload_shape(
+    client, db, auth_headers_factory, seed_identity, seed_course_with_syllabus
+) -> None:
+    teacher_id, teacher_email, course = _seed_teacher_with_course(
+        seed_identity, seed_course_with_syllabus, db
+    )
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+    primary = _baseline("business")
+    payload = _intake_payload(
+        course.id,
+        algorithm_mode="single",
+        algorithm_primary=primary,
+    )
+    with patch("fastapi.BackgroundTasks.add_task"):
+        resp = client.post("/api/authoring/jobs", json=payload, headers=headers)
+    assert resp.status_code == 202, resp.text
+    job_id = resp.json()["job_id"]
+
+    db2 = SessionLocal()
+    try:
+        job = db2.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
+        assert job is not None
+        assert job.task_payload["algorithm_mode"] == "single"
+        assert job.task_payload["algoritmos"] == [primary]
+    finally:
+        db2.close()
+
+
+def test_intake_contrast_ok_persists_two_algorithms(
+    client, db, auth_headers_factory, seed_identity, seed_course_with_syllabus
+) -> None:
+    teacher_id, teacher_email, course = _seed_teacher_with_course(
+        seed_identity, seed_course_with_syllabus, db
+    )
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+    baseline = _baseline("ml_ds")
+    challenger = _challenger("ml_ds")
+    payload = _intake_payload(
+        course.id,
+        student_profile="ml_ds",
+        algorithm_mode="contrast",
+        algorithm_primary=baseline,
+        algorithm_challenger=challenger,
+    )
+    with patch("fastapi.BackgroundTasks.add_task"):
+        resp = client.post("/api/authoring/jobs", json=payload, headers=headers)
+    assert resp.status_code == 202, resp.text
+    job_id = resp.json()["job_id"]
+
+    db2 = SessionLocal()
+    try:
+        job = db2.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
+        assert job is not None
+        assert job.task_payload["algorithm_mode"] == "contrast"
+        assert job.task_payload["algoritmos"] == [baseline, challenger]
+    finally:
+        db2.close()
+
+
+def test_intake_harvard_only_business_allows_empty_picks(
+    client, db, auth_headers_factory, seed_identity, seed_course_with_syllabus
+) -> None:
+    teacher_id, teacher_email, course = _seed_teacher_with_course(
+        seed_identity, seed_course_with_syllabus, db
+    )
+    headers = auth_headers_factory(sub=teacher_id, email=teacher_email)
+    payload = _intake_payload(course.id, case_type="harvard_only")
+    with patch("fastapi.BackgroundTasks.add_task"):
+        resp = client.post("/api/authoring/jobs", json=payload, headers=headers)
+    assert resp.status_code == 202, resp.text
+    job_id = resp.json()["job_id"]
+
+    db2 = SessionLocal()
+    try:
+        job = db2.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
+        assert job is not None
+        assert job.task_payload["algorithm_mode"] == "single"
+        assert job.task_payload["algoritmos"] == []
+    finally:
+        db2.close()

--- a/docs/planPlataforma/issue-teacher-manual-grading.md
+++ b/docs/planPlataforma/issue-teacher-manual-grading.md
@@ -1,0 +1,274 @@
+# Calificación manual de entregas (con schema forward-compatible para IA)
+
+## Contexto
+
+Hoy `TeacherSubmissionPreview.tsx` (PR #217 / Issue #216) renderiza el caso resuelto del estudiante reusando `CasePreview` y deja un slot reservado en el header (`data-testid="teacher-case-submission-detail-grading-slot"` en `frontend/src/features/teacher-case-submission-detail/components/GradingPlaceholderPanel.tsx`).
+
+El backend ya expone `GET /api/teacher/courses/{courseId}/cases/{assignmentId}/submissions/{membershipId}` con el contrato `TeacherCaseSubmissionDetailResponse` (ver `backend/src/shared/teacher_gradebook_schema.py`, `payload_version: Literal[1]`), que entrega:
+
+- `case` + `case_view` (vista canónica M1..M5 + EDA cuando aplique)
+- `student` (membership_id, nombre, email)
+- `response_state` (status, snapshot_id, snapshot_hash, timestamps)
+- `grade_summary` (status, score, max_score=5.00 default, graded_at)
+- `modules[].questions[]` con `expected_solution` y `student_answer`
+
+La tabla `case_grades` ya existe (`backend/src/shared/models.py`, líneas ~390-465) con:
+- `status ∈ {in_progress, submitted, graded}` (CHECK constraint)
+- `score Numeric(5,2)`, `max_score Numeric(5,2) DEFAULT 5.00`
+- `graded_at`, `graded_by_membership_id`, `feedback Text`
+- Constraint `ck_case_grades_state_consistency`: graded ⇔ score+graded_at presentes
+
+**No existe persistencia por módulo ni por pregunta**, ni mecanismo de borrador, ni rúbrica.
+
+Esta issue agrega calificación manual end-to-end: rúbrica discreta, pesos por módulo, feedback en tres niveles (pregunta / módulo / global), borrador con autosave, publicación explícita, e inmutabilidad post-publicación con auditoría. **El schema queda forward-compatible para que en una issue futura la IA pueda pre-calificar usando el mismo endpoint y las mismas tablas, sin migración disruptiva.**
+
+## Objetivo
+
+Permitir al docente calificar de forma rigurosa, rápida y consistente cada entrega de un caso, con persistencia robusta, auditoría completa y experiencia de autoría tipo "review/grade toggle" sobre la preview existente. La calificación publicada alimenta el gradebook del estudiante (issue separada — fuera de este alcance).
+
+## Alcance (in-scope)
+
+### Backend
+1. **Migración Alembic** que:
+   - Crea `case_grade_module_entries` (1 fila por (`case_grade_id`, `module_id ∈ {M1..M5}`)).
+   - Crea `case_grade_question_entries` (1 fila por (`case_grade_id`, `question_id`)).
+   - Agrega columnas a `case_grades`: `graded_by` enum, `ai_model_version`, `ai_suggested_at`, `human_reviewed_at`, `version int NOT NULL DEFAULT 1`.
+   - Agrega columna `weight_per_module Numeric(4,3)` configurable a `assignments` (NULL = pesos iguales = 1/N).
+   - Mantiene el CHECK constraint actual de `case_grades.status` (no agregar `'draft'`).
+2. **Servicio `case_grade_service`** con operaciones idempotentes:
+   - `get_grade_draft_or_published(assignment_id, membership_id) → GradePayload`
+   - `save_grade_draft(payload) → GradePayload` (PUT full-body, autosave-friendly)
+   - `publish_grade(payload) → GradePayload` (transición atómica draft→published, calcula score final, escribe `case_grades.status='graded'`, `case_grades.score`, `case_grades.graded_at`, `case_grades.feedback`, snapshot-bound)
+3. **Endpoint** en `backend/src/shared/teacher_router.py`:
+   - `GET /api/teacher/courses/{courseId}/cases/{assignmentId}/submissions/{membershipId}/grade` → 200 con borrador o publicado, 404 si no existe entrega submitted.
+   - `PUT /api/teacher/courses/{courseId}/cases/{assignmentId}/submissions/{membershipId}/grade` → idempotente, full-body, valida `snapshot_hash` contra el `response_state` actual (rechaza con 409 si el estudiante reabrió y modificó después).
+4. **Schemas Pydantic v2 StrictModel** en `backend/src/shared/teacher_grading_schema.py` con `payload_version: Literal[1]`.
+5. **Sanitización** de feedback (whitelist actual) antes de persistir.
+6. **Headers de respuesta**: `Cache-Control: private, max-age=0, must-revalidate`.
+7. **Guard de tamaño**: payload rechazado >1.5 MB.
+
+### Frontend
+1. **Reemplazar** `GradingPlaceholderPanel.tsx` por un panel real `GradingPanel.tsx` que vive en el header.
+2. **Toggle Review ↔ Grade** en el header de `TeacherSubmissionPreview.tsx`:
+   - **Review** (default): vista actual de PR #217, solo lectura.
+   - **Grade**: muestra chips de rúbrica debajo de cada `PreguntaCard`, textarea de feedback por pregunta (colapsable), feedback por módulo en el header de cada módulo, feedback global + score live en el sidebar, botones "Guardar borrador" y "Publicar calificación".
+3. **Autosave** con debounce de 1.5 s sobre cualquier cambio (chip, texto, peso). Indicador visual "Guardando…" / "Guardado HH:MM".
+4. **Estados visuales claros**:
+   - Sin calificación: "Sin calificar"
+   - Borrador: "Borrador (no publicado)" + chip amarillo
+   - Publicado: "Calificado · X.X / 5.0" + chip verde + botón "Editar y republicar" (disponible, crea nuevo `version`)
+5. **Publicación**: modal de confirmación que muestra score final, advierte "El estudiante verá esta calificación".
+6. **Bloqueo**: si todas las preguntas no tienen chip asignado, deshabilitar "Publicar" con tooltip "Faltan N preguntas por calificar".
+
+## Fuera de alcance (out-of-scope explícito)
+
+- ❌ Endpoint `POST /grade/ai-suggest` y cualquier llamada a LLM.
+- ❌ Botón "Pre-calificar con IA" (solo el flujo manual).
+- ❌ Polling/Realtime para job de IA.
+- ❌ Visualización del badge "✨ sugerido por IA" en chips.
+- ❌ Vista de "historial de versiones" (la columna `version` se incrementa pero no se expone aún).
+- ❌ Notificación al estudiante en publicación (issue separada de gradebook).
+- ❌ Mobile/tablet (desktop-only MVP, ≥1280px).
+- ❌ Exportar calificaciones a CSV.
+
+## Decisiones de diseño (no negociables)
+
+### Rúbrica discreta de 5 niveles
+
+Enum único en backend y frontend (no usar números libres):
+
+| Nivel | Score normalizado | Color UI |
+|---|---|---|
+| `excelente` | 1.00 | green |
+| `bien` | 0.80 | blue |
+| `aceptable` | 0.60 | yellow |
+| `insuficiente` | 0.30 | orange |
+| `no_responde` | 0.00 | gray |
+
+`null` = sin calificar (estado válido en borrador, inválido en publicado).
+
+### Score final
+
+- Internamente todo se almacena como `score_normalized ∈ [0, 1]` (Float).
+- **Score por módulo** = promedio simple de `score_normalized` de sus preguntas (preguntas sin chip cuentan como 0 al publicar; en borrador se omiten del cálculo live).
+- **Score final del caso** = Σ (`score_modulo[i]` × `weight_modulo[i]`), donde Σ pesos = 1.0.
+- **Pesos por defecto**: `1/N` para cada módulo presente. Configurables por assignment (columna `weight_per_module` JSON, NULL = iguales). Edición de pesos NO está en este MVP, pero el schema los soporta.
+- **Display**: `score_final × 5.0` redondeado a 1 decimal. La columna `case_grades.score Numeric(5,2)` almacena el valor display (ya existe).
+
+### Tres niveles de feedback
+
+- `feedback_question` (opcional, por pregunta): texto libre ≤2000 chars sanitizado.
+- `feedback_module` (opcional, por módulo): texto libre ≤2000 chars sanitizado.
+- `feedback_global` (semi-requerido en publicación, ≥20 chars recomendado pero no bloqueante; si vacío se permite con warning): texto libre ≤4000 chars sanitizado. **Se persiste en la columna existente `case_grades.feedback`** (que pasa a ser serializada SOLO cuando `status='graded'` — el rule histórico "no serializar feedback" se levanta para publicado).
+
+### Estados y autosave
+
+- `case_grade_question_entries.state` y `case_grade_module_entries.state` ∈ `{draft, published}`. Autosave escribe `draft`. Publicar reemplaza atómicamente las filas a `published` y promueve a `case_grades`.
+- `case_grades.status` permanece `submitted` mientras todo es draft. Al publicar pasa a `graded` (transición existente, respeta `ck_case_grades_state_consistency`).
+- Re-publicación: se incrementa `case_grades.version`, se sobrescriben las filas `published` previas. No se mantiene historial completo en este MVP (solo `version`, `last_modified_at`, `published_at`).
+
+### Snapshot binding
+
+Toda calificación va atada a `response_state.snapshot_hash` del momento en que se inició la calificación. Si el estudiante reabre y modifica (caso edge — el flujo normal es submitted=inmutable), el `PUT /grade` devuelve `409 Conflict` con `{ error: "snapshot_changed", current_snapshot_hash }` y el frontend muestra modal "El estudiante modificó su entrega. Recargar para ver cambios."
+
+### Forward-compatibilidad para IA (schema only)
+
+Las siguientes columnas se agregan ahora con defaults sensatos para no migrar dos veces cuando se implemente IA:
+
+```python
+# case_grades
+graded_by: Mapped[GradedBy] = mapped_column(
+    String(16), nullable=False, server_default="human"
+)  # Enum: 'human' | 'ai' | 'hybrid'
+ai_model_version: Mapped[str | None]      # NULL en MVP
+ai_suggested_at: Mapped[datetime | None]  # NULL en MVP
+human_reviewed_at: Mapped[datetime | None]
+version: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+
+# case_grade_question_entries y case_grade_module_entries
+source: Mapped[FeedbackSource] = mapped_column(
+    String(24), nullable=False, server_default="human"
+)  # Enum: 'human' | 'ai_suggested' | 'ai_edited_by_human'
+ai_confidence: Mapped[float | None]       # 0..1, NULL en MVP
+```
+
+**Regla**: en este MVP el frontend NUNCA envía `graded_by != 'human'` ni `source != 'human'`. El backend valida que solo se acepten esos valores en este `payload_version=1`. Cuando se agregue IA en una issue futura, se bumpea a `payload_version=2` y se aceptan los demás valores.
+
+## Contrato de API
+
+### Request body (`PUT /grade`)
+
+```json
+{
+  "payload_version": 1,
+  "snapshot_hash": "sha256:abc123...",
+  "intent": "save_draft" | "publish",
+  "modules": [
+    {
+      "module_id": "M1",
+      "weight": 0.20,
+      "feedback_module": "Texto sanitizado o null",
+      "questions": [
+        {
+          "question_id": "q-uuid",
+          "rubric_level": "excelente" | "bien" | "aceptable" | "insuficiente" | "no_responde" | null,
+          "feedback_question": "Texto sanitizado o null"
+        }
+      ]
+    }
+  ],
+  "feedback_global": "Texto sanitizado o null"
+}
+```
+
+### Response body (200, ambos endpoints)
+
+```json
+{
+  "payload_version": 1,
+  "snapshot_hash": "sha256:...",
+  "publication_state": "draft" | "published",
+  "version": 1,
+  "score_normalized": 0.84,
+  "score_display": 4.2,
+  "max_score_display": 5.0,
+  "modules": [ /* ... como request ... */ ],
+  "feedback_global": "...",
+  "graded_at": "2026-04-27T...",
+  "published_at": "2026-04-27T..." | null,
+  "last_modified_at": "2026-04-27T...",
+  "graded_by": "human"
+}
+```
+
+### Errores
+
+- `400` payload_version inválido / valores fuera de enum / `graded_by != 'human'` en v1.
+- `403` el docente no tiene membership de teacher en el curso del assignment.
+- `404` no existe entrega `submitted` para (assignment_id, membership_id).
+- `409` `snapshot_changed` (ver sección snapshot binding).
+- `413` payload >1.5 MB.
+- `422` validation error de Pydantic.
+
+## Reglas duras (must-not-break)
+
+1. **NO** tocar `backend/src/case_generator/**`.
+2. **NO** romper el endpoint actual `GET …/submissions/{membershipId}` ni su `payload_version=1`.
+3. **NO** modificar el componente `CasePreview` ni rutas de `case-preview/**`.
+4. **NO** introducir SSE, WebSocket, ni progress bus para el flujo de grading (es síncrono).
+5. **NO** auto-publicar bajo ninguna condición; siempre requiere acción explícita del docente.
+6. **NO** persistir feedback sin pasar por sanitización whitelist.
+7. **NO** permitir que el frontend envíe `graded_by`, `source`, `ai_*` distintos de los defaults humanos en `payload_version=1`.
+8. **NO** registrar un solo CHECK constraint sin nombre explícito (`ck_…`).
+9. **NO** usar `sys.path` hacks ni imports relativos profundos.
+10. **NO** agregar tests live LLM ni dependencias de red.
+
+## Validaciones obligatorias antes del PR
+
+```powershell
+uv run --directory backend pytest -q
+uv run --directory backend mypy src
+npm --prefix frontend run lint
+npm --prefix frontend run test
+npm --prefix frontend run build
+```
+
+Más:
+- Migración Alembic: `uv run --directory backend alembic upgrade head` y `alembic downgrade -1` ambos limpios sobre Postgres local (`5434`).
+- Test de migración (existente, marca `ddl_isolation`) debe seguir verde.
+
+## Cobertura de tests requerida
+
+### Backend (`backend/tests/test_teacher_manual_grading.py`)
+- `test_get_grade_returns_404_when_no_submission`
+- `test_get_grade_returns_empty_draft_initially`
+- `test_save_draft_persists_per_question_and_per_module`
+- `test_save_draft_is_idempotent_full_body`
+- `test_save_draft_sanitizes_feedback_html`
+- `test_save_draft_rejects_payload_over_1_5mb`
+- `test_save_draft_rejects_invalid_rubric_level`
+- `test_save_draft_rejects_graded_by_ai_in_v1`
+- `test_publish_requires_all_questions_rated`
+- `test_publish_computes_normalized_and_display_score`
+- `test_publish_uses_equal_weights_when_assignment_weights_null`
+- `test_publish_promotes_case_grades_to_graded_status`
+- `test_publish_writes_feedback_global_to_case_grades_feedback`
+- `test_publish_increments_version_on_republish`
+- `test_snapshot_hash_mismatch_returns_409`
+- `test_only_teacher_membership_can_grade` (403 para student/admin/otro curso)
+- `test_score_consistency_check_constraint_holds`
+
+### Frontend
+- `TeacherSubmissionPreview.test.tsx`: review/grade toggle visible, chips renderizan en grade mode, autosave dispara PUT con debounce, score live actualiza, "Publicar" deshabilitado con preguntas faltantes, modal de confirmación, manejo de 409 con modal de recarga.
+- `GradingPanel.test.tsx`: cada nivel de feedback respeta su límite, chips son accesibles por teclado (`role="radiogroup"`), estado "Borrador" vs "Publicado" visualmente diferenciado.
+- `useGradeDraft.test.ts`: TanStack Query mutation con optimistic update, rollback en error, invalidate de query del detail al publicar.
+
+## Definición de "Done"
+
+- [ ] Migración Alembic up/down limpia.
+- [ ] Backend pytest verde, mypy strict verde sin nuevos `# type: ignore`.
+- [ ] Frontend lint + test + build verdes.
+- [ ] Endpoint manual probado con `curl` o Thunder Client en stack local (Docker `5434` + `supabase start`).
+- [ ] QA visual desktop (≥1280px) con browser skill: review→grade→chips→autosave→publish→re-edit, evidencia con screenshots.
+- [ ] Cero regresiones en `test_issue205_teacher_course_gradebook.py` ni en `test_teacher_case_actions.py`.
+- [ ] `AGENTS.md` y `CLAUDE.md` actualizados si se introducen patterns nuevos (esperado: añadir línea sobre `case_grade_*_entries` ownership en `shared/`).
+- [ ] PR descriptiva con: diagrama de estados, screenshots before/after, lista de columnas nuevas, plan de rollback.
+
+## Plan de rollback
+
+1. La migración debe tener `downgrade()` que dropee tablas hijas y columnas nuevas en orden inverso.
+2. El frontend cae a comportamiento previo (`GradingPlaceholderPanel`) si el endpoint devuelve 404 con `feature_disabled` flag (no requerido en MVP, pero el componente debe degradar elegante si el endpoint falla con 5xx).
+3. Feature flag opcional `TEACHER_MANUAL_GRADING_ENABLED` env var (default true) para apagar el endpoint sin redeploy.
+
+## Referencias en el código
+
+- Tabla existente: [backend/src/shared/models.py](backend/src/shared/models.py) líneas ~390-465 (`CaseGrade`).
+- Schema actual de detail: [backend/src/shared/teacher_gradebook_schema.py](backend/src/shared/teacher_gradebook_schema.py) líneas ~77-145.
+- Router: [backend/src/shared/teacher_router.py](backend/src/shared/teacher_router.py).
+- Frontend preview: [frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx](frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx).
+- Slot reservado: [frontend/src/features/teacher-case-submission-detail/components/GradingPlaceholderPanel.tsx](frontend/src/features/teacher-case-submission-detail/components/GradingPlaceholderPanel.tsx).
+- Hook actual: [frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.ts](frontend/src/features/teacher-case-submission-detail/useTeacherCaseSubmissionDetail.ts).
+
+## Issue futura (no abrir hasta cerrar esta)
+
+> **#TBD — Calificación asistida por IA**: implementa `POST /grade/ai-suggest`, integra LangGraph en `case_generator/`, agrega botón "Pre-calificar con IA", expone badges de `source` en la UI, bumpea `payload_version=2`. El schema ya está listo desde esta issue.

--- a/frontend/src/features/teacher-authoring/AlgorithmSelector.test.tsx
+++ b/frontend/src/features/teacher-authoring/AlgorithmSelector.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Issue #230 — AlgorithmSelector component tests.
+ */
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/shared/test-utils";
+import { server } from "@/shared/testing/msw/server";
+
+import { AlgorithmSelector, type AlgorithmSelectorProps } from "./AlgorithmSelector";
+
+function defaultProps(overrides: Partial<AlgorithmSelectorProps> = {}): AlgorithmSelectorProps {
+    return {
+        profile: "ml_ds",
+        caseType: "harvard_with_eda",
+        mode: "single",
+        primary: null,
+        challenger: null,
+        onChange: vi.fn(),
+        onSuggest: vi.fn(),
+        isSuggestPending: false,
+        canSuggest: true,
+        hasError: false,
+        ...overrides,
+    };
+}
+
+const fullCatalog = {
+    profile: "ml_ds",
+    case_type: "harvard_with_eda",
+    items: [
+        { name: "Regresión Lineal", family: "regresion", family_label: "Regresión", tier: "baseline" },
+        { name: "Random Forest Regressor", family: "regresion", family_label: "Regresión", tier: "challenger" },
+        { name: "Árboles de decisión", family: "clasificacion", family_label: "Clasificación", tier: "baseline" },
+        { name: "XGBoost", family: "clasificacion", family_label: "Clasificación", tier: "challenger" },
+    ],
+};
+
+const businessCatalog = {
+    profile: "business",
+    case_type: "harvard_with_eda",
+    items: [
+        { name: "Regresión Lineal", family: "regresion", family_label: "Regresión", tier: "baseline" },
+        { name: "K-Means", family: "clustering", family_label: "Clustering", tier: "baseline" },
+    ],
+};
+
+beforeAll(() => {
+    Element.prototype.hasPointerCapture ??= () => false;
+    Element.prototype.releasePointerCapture ??= () => {};
+    Element.prototype.setPointerCapture ??= () => {};
+    Element.prototype.scrollIntoView ??= () => {};
+});
+
+describe("AlgorithmSelector (Issue #230)", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("renders the suggest button and the mode toggle in single mode", async () => {
+        server.use(http.get("/api/authoring/algorithm-catalog", () => HttpResponse.json(fullCatalog)));
+
+        renderWithProviders(<AlgorithmSelector {...defaultProps()} />);
+
+        expect(
+            await screen.findByRole("button", { name: /sugerir algoritmos con adam/i }),
+        ).toBeInTheDocument();
+        const radios = screen.getAllByRole("radio");
+        expect(radios).toHaveLength(2);
+        expect(radios[0]).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("renders both baseline and challenger selects in contrast mode", async () => {
+        server.use(http.get("/api/authoring/algorithm-catalog", () => HttpResponse.json(fullCatalog)));
+
+        renderWithProviders(<AlgorithmSelector {...defaultProps({ mode: "contrast" })} />);
+
+        await screen.findByLabelText(/baseline \(interpretable\)/i);
+        expect(screen.getByLabelText(/challenger \(alta capacidad\)/i)).toBeInTheDocument();
+    });
+
+    it("disables the contrast option when the catalog has no challengers", async () => {
+        server.use(http.get("/api/authoring/algorithm-catalog", () => HttpResponse.json(businessCatalog)));
+
+        renderWithProviders(<AlgorithmSelector {...defaultProps({ profile: "business" })} />);
+
+        await waitFor(() => {
+            const radios = screen.getAllByRole("radio");
+            expect(radios[1]).toBeDisabled();
+        });
+    });
+
+    it("invokes onSuggest when the suggest button is clicked", async () => {
+        server.use(http.get("/api/authoring/algorithm-catalog", () => HttpResponse.json(fullCatalog)));
+        const user = userEvent.setup();
+        const onSuggest = vi.fn();
+
+        renderWithProviders(<AlgorithmSelector {...defaultProps({ onSuggest })} />);
+
+        const button = await screen.findByRole("button", { name: /sugerir algoritmos con adam/i });
+        await user.click(button);
+        expect(onSuggest).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows an inline error when baseline equals challenger in contrast mode", async () => {
+        server.use(http.get("/api/authoring/algorithm-catalog", () => HttpResponse.json(fullCatalog)));
+
+        renderWithProviders(
+            <AlgorithmSelector
+                {...defaultProps({
+                    mode: "contrast",
+                    primary: "Regresión Lineal",
+                    challenger: "Regresión Lineal",
+                })}
+            />,
+        );
+
+        expect(
+            await screen.findByText(/no pueden ser el mismo algoritmo/i),
+        ).toBeInTheDocument();
+    });
+
+    it("renders the retry banner when the catalog query fails", async () => {
+        server.use(
+            http.get("/api/authoring/algorithm-catalog", () =>
+                HttpResponse.json({ detail: "boom" }, { status: 500 }),
+            ),
+        );
+
+        renderWithProviders(<AlgorithmSelector {...defaultProps()} />);
+
+        expect(
+            await screen.findByText(/no se pudo cargar el catálogo/i),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /reintentar/i })).toBeInTheDocument();
+    });
+
+    it("auto-coerces mode to 'single' when a contrast pre-set lands on an empty challenger catalog", async () => {
+        server.use(http.get("/api/authoring/algorithm-catalog", () => HttpResponse.json(businessCatalog)));
+        const onChange = vi.fn();
+
+        renderWithProviders(
+            <AlgorithmSelector
+                {...defaultProps({
+                    profile: "business",
+                    mode: "contrast",
+                    challenger: "XGBoost",
+                    onChange,
+                })}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({ mode: "single", challenger: null }),
+            );
+        });
+    });
+
+    it("filters challengers to the same family as the selected baseline", async () => {
+        server.use(http.get("/api/authoring/algorithm-catalog", () => HttpResponse.json(fullCatalog)));
+
+        renderWithProviders(
+            <AlgorithmSelector
+                {...defaultProps({
+                    mode: "contrast",
+                    primary: "Regresión Lineal",
+                })}
+            />,
+        );
+
+        // Family pill on the challenger label.
+        await screen.findByLabelText(/challenger \(alta capacidad\) · Regresión/i);
+    });
+
+    it("resets the challenger when the baseline family changes", async () => {
+        server.use(http.get("/api/authoring/algorithm-catalog", () => HttpResponse.json(fullCatalog)));
+        const onChange = vi.fn();
+
+        // Baseline = Regresión Lineal (regresion family); Challenger = XGBoost
+        // (clasificacion family) is now invalid — the effect should clear it.
+        renderWithProviders(
+            <AlgorithmSelector
+                {...defaultProps({
+                    mode: "contrast",
+                    primary: "Regresión Lineal",
+                    challenger: "XGBoost",
+                    onChange,
+                })}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({ mode: "contrast", challenger: null }),
+            );
+        });
+    });
+
+    it("disables the suggest button while the suggest mutation is pending", async () => {
+        server.use(http.get("/api/authoring/algorithm-catalog", () => HttpResponse.json(fullCatalog)));
+
+        renderWithProviders(<AlgorithmSelector {...defaultProps({ isSuggestPending: true })} />);
+
+        const button = await screen.findByRole("button", { name: /sugerir algoritmos con adam/i });
+        expect(button).toBeDisabled();
+    });
+});

--- a/frontend/src/features/teacher-authoring/AlgorithmSelector.tsx
+++ b/frontend/src/features/teacher-authoring/AlgorithmSelector.tsx
@@ -1,0 +1,423 @@
+import { useEffect, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/shared/api";
+import { queryKeys } from "@/shared/queryKeys";
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectLabel,
+    SelectTrigger,
+    SelectValue,
+} from "@/shared/ui/select";
+import type {
+    AlgorithmCatalog,
+    AlgorithmCatalogItem,
+    AlgorithmMode,
+    CaseType,
+    StudentProfile,
+} from "@/shared/adam-types";
+
+/**
+ * Issue #230 — Algorithm selector for the teacher authoring form.
+ *
+ * Renders a 1/2 mode toggle and 1 (single) or 2 (contrast) <Select>
+ * dropdowns sourced from the canonical catalog returned by
+ * `GET /api/authoring/algorithm-catalog`.
+ *
+ * In contrast mode the challenger picker is filtered to the same family
+ * (clasificacion, regresion, ...) as the selected baseline. Comparing
+ * Logistic Regression vs Prophet is not a valid pedagogical contrast.
+ */
+export interface AlgorithmSelectorProps {
+    profile: StudentProfile;
+    caseType: CaseType;
+    mode: AlgorithmMode;
+    primary: string | null;
+    challenger: string | null;
+    onChange: (next: {
+        mode: AlgorithmMode;
+        primary: string | null;
+        challenger: string | null;
+    }) => void;
+    onSuggest: () => void;
+    isSuggestPending: boolean;
+    canSuggest: boolean;
+    hasError?: boolean;
+}
+
+const MODE_LABELS: Record<AlgorithmMode, string> = {
+    single: "1 algoritmo (deep dive)",
+    contrast: "2 algoritmos (baseline + challenger)",
+};
+
+const TIER_LABELS = { baseline: "Intro", challenger: "Avanzado" } as const;
+
+interface FamilyGroup {
+    family: string;
+    family_label: string;
+    items: AlgorithmCatalogItem[];
+}
+
+function groupByFamily(items: AlgorithmCatalogItem[]): FamilyGroup[] {
+    const order: string[] = [];
+    const map = new Map<string, FamilyGroup>();
+    for (const it of items) {
+        if (!map.has(it.family)) {
+            order.push(it.family);
+            map.set(it.family, { family: it.family, family_label: it.family_label, items: [] });
+        }
+        map.get(it.family)!.items.push(it);
+    }
+    return order.map((f) => map.get(f)!);
+}
+
+function renderItemRow(item: AlgorithmCatalogItem) {
+    return (
+        <SelectItem key={item.name} value={item.name}>
+            <span className="inline-flex items-center gap-2">
+                <span
+                    className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wide ${
+                        item.tier === "baseline"
+                            ? "bg-emerald-50 text-emerald-700 border border-emerald-200"
+                            : "bg-amber-50 text-amber-700 border border-amber-200"
+                    }`}
+                    aria-label={item.tier === "baseline" ? "Nivel introductorio" : "Nivel avanzado"}
+                >
+                    {TIER_LABELS[item.tier]}
+                </span>
+                <span>{item.name}</span>
+            </span>
+        </SelectItem>
+    );
+}
+
+export function AlgorithmSelector({
+    profile,
+    caseType,
+    mode,
+    primary,
+    challenger,
+    onChange,
+    onSuggest,
+    isSuggestPending,
+    canSuggest,
+    hasError,
+}: AlgorithmSelectorProps) {
+    const catalogQuery = useQuery<AlgorithmCatalog>({
+        queryKey: queryKeys.authoring.algorithmCatalog(profile, caseType),
+        queryFn: () => api.authoring.getAlgorithmCatalog(profile, caseType),
+        staleTime: 5 * 60 * 1000,
+        gcTime: 30 * 60 * 1000,
+    });
+
+    const catalog = catalogQuery.data;
+    const items = useMemo<AlgorithmCatalogItem[]>(() => catalog?.items ?? [], [catalog]);
+
+    const byName = useMemo(() => {
+        const m = new Map<string, AlgorithmCatalogItem>();
+        for (const it of items) m.set(it.name.toLowerCase(), it);
+        return m;
+    }, [items]);
+
+    const baselineItems = useMemo(() => items.filter((it) => it.tier === "baseline"), [items]);
+    const challengerItems = useMemo(() => items.filter((it) => it.tier === "challenger"), [items]);
+    const contrastDisabled = challengerItems.length === 0;
+
+    const primaryItem = primary ? byName.get(primary.toLowerCase()) ?? null : null;
+
+    // In contrast mode, the challenger picker is restricted to challengers of
+    // the SAME family as the selected baseline. This enforces the
+    // family-coherence rule shared with the backend validator + the LLM prompt.
+    const contrastChallengerPool = useMemo(() => {
+        if (mode !== "contrast" || !primaryItem) return [];
+        return challengerItems.filter((it) => it.family === primaryItem.family);
+    }, [mode, primaryItem, challengerItems]);
+
+    // If the catalog reload removes the previously-picked technique, or if
+    // the selected baseline's family no longer offers the picked challenger,
+    // drop the now-invalid value.
+    useEffect(() => {
+        if (!catalog) return;
+        let nextPrimary = primary;
+        let nextChallenger = challenger;
+        let nextMode: AlgorithmMode = mode;
+
+        const primaryStillValid = primary ? byName.has(primary.toLowerCase()) : true;
+        if (!primaryStillValid) nextPrimary = null;
+
+        // Defense-in-depth for hydration paths (initialData, localStorage,
+        // server-provided drafts): in contrast mode the baseline slot must
+        // hold a baseline-tier item. If a challenger-tier value sneaks in,
+        // clear it (and the challenger) before the user can submit a payload
+        // that the backend would reject with 422.
+        if (mode === "contrast" && nextPrimary) {
+            const resolved = byName.get(nextPrimary.toLowerCase()) ?? null;
+            if (!resolved || resolved.tier !== "baseline") {
+                nextPrimary = null;
+                nextChallenger = null;
+            }
+        }
+
+        if (mode === "contrast" && contrastDisabled) {
+            nextMode = "single";
+            nextChallenger = null;
+        } else if (mode === "contrast" && nextChallenger) {
+            const chalItem = byName.get(nextChallenger.toLowerCase()) ?? null;
+            const resolvedPrimary = nextPrimary ? byName.get(nextPrimary.toLowerCase()) ?? null : null;
+            const sameFamily = chalItem && resolvedPrimary && chalItem.family === resolvedPrimary.family;
+            const isChallengerTier = chalItem?.tier === "challenger";
+            if (!chalItem || !isChallengerTier || !sameFamily) {
+                nextChallenger = null;
+            }
+        }
+        if (
+            nextPrimary !== primary
+            || nextChallenger !== challenger
+            || nextMode !== mode
+        ) {
+            onChange({ mode: nextMode, primary: nextPrimary, challenger: nextChallenger });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [catalog, primaryItem]);
+
+    const sameAlgoError = useMemo(
+        () =>
+            mode === "contrast"
+            && !!primary
+            && !!challenger
+            && primary.toLowerCase() === challenger.toLowerCase(),
+        [mode, primary, challenger],
+    );
+
+    const setMode = (nextMode: AlgorithmMode) => {
+        if (nextMode === "contrast" && contrastDisabled) return;
+        // When entering contrast, the baseline slot only accepts baseline-tier
+        // items. If the user had picked a challenger-tier item in single mode,
+        // clear it (and the challenger) so the backend validator does not
+        // reject the payload with "El primer algoritmo debe ser un baseline".
+        const nextPrimary =
+            nextMode === "contrast" && primaryItem && primaryItem.tier !== "baseline"
+                ? null
+                : primary;
+        onChange({
+            mode: nextMode,
+            primary: nextPrimary,
+            challenger: nextMode === "single" ? null : challenger,
+        });
+    };
+
+    const setPrimary = (value: string) => {
+        // Reset challenger when the baseline family changes, so the user picks
+        // a coherent comparison.
+        let nextChallenger = challenger;
+        if (mode === "contrast" && challenger) {
+            const newPrimary = byName.get(value.toLowerCase()) ?? null;
+            const chalItem = byName.get(challenger.toLowerCase()) ?? null;
+            if (!newPrimary || !chalItem || chalItem.family !== newPrimary.family) {
+                nextChallenger = null;
+            }
+        }
+        onChange({ mode, primary: value || null, challenger: nextChallenger });
+    };
+
+    const setChallenger = (value: string) => {
+        onChange({ mode, primary, challenger: value || null });
+    };
+
+    const triggerClass = (invalid: boolean) =>
+        `input-base w-full rounded-lg border bg-white px-3.5 py-2.5 text-sm text-slate-800 ${
+            invalid ? "input-error" : "border-slate-200"
+        }`;
+
+    // Single-mode picker shows everything grouped by family with a tier badge.
+    const singleGroups = useMemo(() => groupByFamily(items), [items]);
+    // Contrast-mode baseline picker: only baselines, grouped by family.
+    const contrastBaselineGroups = useMemo(() => groupByFamily(baselineItems), [baselineItems]);
+    // Contrast-mode challenger picker: pool already filtered by family above.
+    const contrastChallengerGroups = useMemo(
+        () => groupByFamily(contrastChallengerPool),
+        [contrastChallengerPool],
+    );
+
+    const challengerEmptyMessage = (() => {
+        if (!primaryItem) return "Selecciona primero un baseline.";
+        if (contrastChallengerPool.length === 0) {
+            return `La familia "${primaryItem.family_label}" no tiene challenger; usa el modo de 1 algoritmo o cambia de baseline.`;
+        }
+        return null;
+    })();
+
+    return (
+        <div className="pt-4 border-t border-slate-100 mt-2">
+            <div className="flex items-center justify-between mb-2.5 flex-wrap gap-2">
+                <span className="text-sm font-semibold text-slate-700 block">
+                    Algoritmos / Técnicas <span className="text-red-500" aria-hidden="true">*</span>
+                </span>
+                <button
+                    type="button"
+                    onClick={onSuggest}
+                    aria-label="Sugerir Algoritmos con ADAM"
+                    disabled={!canSuggest || isSuggestPending || catalogQuery.isLoading}
+                    className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-bold text-[#0144a0] bg-blue-50 border border-blue-200 rounded-lg transition-all ${
+                        !canSuggest || catalogQuery.isLoading
+                            ? "opacity-50 cursor-not-allowed"
+                            : "cursor-pointer hover:bg-blue-100 hover:border-blue-300 hover:shadow-sm active:scale-[0.97]"
+                    }`}
+                >
+                    {isSuggestPending ? (
+                        <>
+                            <span className="animate-spin w-3 h-3 border-2 border-[#0144a0] border-t-transparent rounded-full"></span> Pensando...
+                        </>
+                    ) : (
+                        <>🪄 Sugerir Algoritmos con ADAM</>
+                    )}
+                </button>
+            </div>
+
+            {/* Mode toggle */}
+            <div role="radiogroup" aria-label="Modo de selección de algoritmos" className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-4">
+                {(["single", "contrast"] as AlgorithmMode[]).map((m) => {
+                    const active = mode === m;
+                    const disabled = m === "contrast" && contrastDisabled;
+                    return (
+                        <button
+                            key={m}
+                            type="button"
+                            role="radio"
+                            aria-checked={active}
+                            aria-disabled={disabled}
+                            disabled={disabled}
+                            onClick={() => setMode(m)}
+                            title={
+                                disabled
+                                    ? "El catálogo de este perfil no expone challengers; usa el modo de 1 algoritmo."
+                                    : undefined
+                            }
+                            className={`scope-card p-3 select-none text-left ${active ? "active" : ""} ${
+                                disabled ? "opacity-50 cursor-not-allowed" : ""
+                            }`}
+                        >
+                            <p className={`text-sm font-bold transition-colors ${active ? "text-[#0144a0]" : "text-slate-600"}`}>
+                                {MODE_LABELS[m]}
+                            </p>
+                            <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                                {m === "single"
+                                    ? "ADAM construye el caso optimizando este algoritmo."
+                                    : "ADAM contrasta un baseline interpretable contra un challenger de mayor capacidad de la misma familia."}
+                            </p>
+                        </button>
+                    );
+                })}
+            </div>
+
+            {/* Catalog loading / error */}
+            {catalogQuery.isLoading && (
+                <div className="text-xs text-slate-400 italic">Cargando catálogo de algoritmos...</div>
+            )}
+            {catalogQuery.error && !catalogQuery.isLoading && (
+                <div className="p-3 mb-2 rounded border border-red-200 bg-red-50 text-red-600 text-[13px] font-medium flex items-center justify-between gap-2">
+                    <span>No se pudo cargar el catálogo de algoritmos.</span>
+                    <button
+                        type="button"
+                        onClick={() => catalogQuery.refetch()}
+                        className="text-red-700 underline text-xs"
+                    >
+                        Reintentar
+                    </button>
+                </div>
+            )}
+
+            {/* Selectors */}
+            {!catalogQuery.isLoading && !catalogQuery.error && catalog && (
+                <div className={`grid gap-4 ${mode === "contrast" ? "md:grid-cols-2" : "md:grid-cols-1"}`}>
+                    <div>
+                        <label htmlFor="algorithm-primary" className="block text-xs font-semibold text-slate-600 mb-1.5">
+                            {mode === "contrast" ? "Baseline (interpretable)" : "Algoritmo principal"}
+                        </label>
+                        <Select value={primary ?? ""} onValueChange={setPrimary}>
+                            <SelectTrigger
+                                id="algorithm-primary"
+                                className={triggerClass(!!hasError && !primary)}
+                            >
+                                <SelectValue placeholder="Selecciona un algoritmo..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {(mode === "contrast" ? contrastBaselineGroups : singleGroups).map((group) => (
+                                    <SelectGroup key={group.family}>
+                                        <SelectLabel className="text-[11px] font-bold uppercase tracking-wide text-slate-500">
+                                            {group.family_label}
+                                        </SelectLabel>
+                                        {group.items.map(renderItemRow)}
+                                    </SelectGroup>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    {mode === "contrast" && (
+                        <div>
+                            <label htmlFor="algorithm-challenger" className="block text-xs font-semibold text-slate-600 mb-1.5">
+                                Challenger (alta capacidad){primaryItem ? ` · ${primaryItem.family_label}` : ""}
+                            </label>
+                            <Select
+                                value={challenger ?? ""}
+                                onValueChange={setChallenger}
+                                disabled={!primaryItem || contrastChallengerPool.length === 0}
+                            >
+                                <SelectTrigger
+                                    id="algorithm-challenger"
+                                    className={triggerClass((!!hasError && !challenger) || sameAlgoError)}
+                                    aria-disabled={!primaryItem || contrastChallengerPool.length === 0}
+                                >
+                                    <SelectValue
+                                        placeholder={
+                                            !primaryItem
+                                                ? "Primero elige un baseline..."
+                                                : contrastChallengerPool.length === 0
+                                                    ? "Sin challengers en esta familia"
+                                                    : "Selecciona un challenger..."
+                                        }
+                                    />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {contrastChallengerGroups.map((group) => (
+                                        <SelectGroup key={group.family}>
+                                            <SelectLabel className="text-[11px] font-bold uppercase tracking-wide text-slate-500">
+                                                {group.family_label}
+                                            </SelectLabel>
+                                            {group.items.map(renderItemRow)}
+                                        </SelectGroup>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                            {challengerEmptyMessage && (
+                                <p className="mt-1.5 text-[11px] text-slate-500">
+                                    {challengerEmptyMessage}
+                                </p>
+                            )}
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {sameAlgoError && (
+                <p role="alert" className="mt-2 text-xs text-red-500 font-medium">
+                    El baseline y el challenger no pueden ser el mismo algoritmo.
+                </p>
+            )}
+            {hasError && !sameAlgoError && (!primary || (mode === "contrast" && !challenger)) && (
+                <p role="alert" className="mt-2 text-xs text-red-500 font-medium">
+                    Debes seleccionar {mode === "contrast" ? "baseline y challenger" : "un algoritmo"}.
+                </p>
+            )}
+            <p className="field-hint mt-1.5">
+                {mode === "single"
+                    ? "ADAM construirá el dataset y la solución alrededor de este algoritmo."
+                    : "ADAM construirá un caso comparativo entre el baseline y el challenger de la misma familia."}
+            </p>
+        </div>
+    );
+}
+

--- a/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
@@ -184,6 +184,16 @@ describe("AuthoringForm", () => {
                     },
                 });
             }),
+            http.get("/api/authoring/algorithm-catalog", () =>
+                HttpResponse.json({
+                    profile: "business",
+                    case_type: "harvard_with_eda",
+                    items: [
+                        { name: "Regresión Lineal", family: "regresion", family_label: "Regresión", tier: "baseline" },
+                        { name: "Árboles de decisión", family: "clasificacion", family_label: "Clasificación", tier: "baseline" },
+                    ],
+                }),
+            ),
         );
     });
 
@@ -217,7 +227,7 @@ describe("AuthoringForm", () => {
         expect(screen.getByDisplayValue("Pregunta sugerida")).toBeInTheDocument();
     }, 20_000);
 
-    it("fills suggested techniques from the techniques mutation and clears the stale warning", async () => {
+    it("fills algorithm picks from the techniques mutation (Issue #230)", async () => {
         const user = userEvent.setup();
         const deferred = createDeferredResponse();
 
@@ -234,13 +244,23 @@ describe("AuthoringForm", () => {
                     suggestedTechniques: [],
                 });
             }),
+            http.get("/api/authoring/algorithm-catalog", () =>
+                HttpResponse.json({
+                    profile: "business",
+                    case_type: "harvard_with_eda",
+                    items: [
+                        { name: "Regresión Lineal", family: "regresion", family_label: "Regresión", tier: "baseline" },
+                        { name: "Árboles de decisión", family: "clasificacion", family_label: "Clasificación", tier: "baseline" },
+                    ],
+                }),
+            ),
         );
 
         renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
         await enableSuggestions(user);
         await showTechniquesSection(user);
 
-        const button = screen.getByRole("button", { name: /sugerir t[ée]cnicas de an[aá]lisis/i });
+        const button = await screen.findByRole("button", { name: /sugerir algoritmos con adam/i });
         await user.click(button);
 
         await waitFor(() => {
@@ -251,15 +271,16 @@ describe("AuthoringForm", () => {
             HttpResponse.json({
                 scenarioDescription: "",
                 guidingQuestion: "",
-                suggestedTechniques: ["Árboles de decisión", "Clustering"],
+                suggestedTechniques: ["Árboles de decisión"],
+                algorithmPrimary: "Árboles de decisión",
+                algorithmChallenger: null,
             }),
         );
 
-        expect(await screen.findByText("Árboles de decisión")).toBeInTheDocument();
-        expect(screen.getByText("Clustering")).toBeInTheDocument();
-        expect(
-            screen.queryByText(/podr[ií]an estar desactualizadas/i),
-        ).not.toBeInTheDocument();
+        // Baseline dropdown trigger should reflect the chosen primary.
+        await waitFor(() => {
+            expect(screen.getByLabelText(/algoritmo principal/i)).toHaveTextContent(/árboles de decisión/i);
+        });
     }, 20_000);
 
     it("prevents duplicate scenario requests on rapid double click", async () => {
@@ -796,8 +817,9 @@ describe("Task 3 — sessionStorage persistence", () => {
                 industry: "fintech",
                 caseType: "harvard_with_eda",
                 notebookToggle: false,
-                suggestedTechniques: [],
-                algoInput: "",
+                algorithmMode: "single",
+                algorithmPrimary: null,
+                algorithmChallenger: null,
                 availableFrom: "",
                 dueAt: "",
             }),

--- a/frontend/src/features/teacher-authoring/AuthoringForm.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.tsx
@@ -1,9 +1,9 @@
 /** ADAM v4.1 — AuthoringForm: formulario del profesor, fiel al mockup HtmlFormFrame.html */
 
 
-import { useState, useCallback, useEffect, useRef, type KeyboardEvent, type FormEvent } from "react";
+import { useState, useCallback, useEffect, useRef, type FormEvent } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import type { CaseFormData, CaseType, EDADepth, StudentProfile, SuggestRequest, TeacherCourseItem } from "@/shared/adam-types";
+import type { AlgorithmMode, CaseFormData, CaseType, EDADepth, StudentProfile, SuggestRequest, TeacherCourseItem } from "@/shared/adam-types";
 import {
     Select, SelectContent, SelectGroup,
     SelectItem, SelectTrigger, SelectValue,
@@ -17,6 +17,7 @@ import {
     FORM_STATE_SESSION_KEY,
 } from "./authoringFormConfig";
 import { GroupsCombobox } from "./GroupsCombobox";
+import { AlgorithmSelector } from "./AlgorithmSelector";
 
 interface Props {
     initialData?: CaseFormData;
@@ -68,15 +69,16 @@ export function AuthoringForm({
 
     const [scenarioDescription, setScenarioDescription] = useState(initialData?.scenarioDescription ?? "");
     const [guidingQuestion, setGuidingQuestion] = useState(initialData?.guidingQuestion ?? "");
-    const [suggestedTechniques, setSuggestedTechniques] = useState<string[]>(initialData?.suggestedTechniques ?? []);
-    const [algoInput, setAlgoInput] = useState("");
+    // Issue #230 — algorithm picks (replaces 5-chip free-text suggestedTechniques).
+    const [algorithmMode, setAlgorithmMode] = useState<AlgorithmMode>(initialData?.algorithmMode ?? "single");
+    const [algorithmPrimary, setAlgorithmPrimary] = useState<string | null>(initialData?.algorithmPrimary ?? null);
+    const [algorithmChallenger, setAlgorithmChallenger] = useState<string | null>(initialData?.algorithmChallenger ?? null);
 
     const [availableFrom, setAvailableFrom] = useState(initialData?.availableFrom ?? "");
     const [dueAt, setDueAt] = useState(initialData?.dueAt ?? "");
 
     // ── Estados IA ──
     const [formAlertError, setFormAlertError] = useState<string | null>(null);
-    const [areTechniquesStale, setAreTechniquesStale] = useState(false);
     // ── Validation ──
     const [errors, setErrors] = useState<Record<string, boolean>>({});
 
@@ -103,8 +105,15 @@ export function AuthoringForm({
             if (typeof saved.notebookToggle === "boolean") setNotebookToggle(saved.notebookToggle);
             if (typeof saved.scenarioDescription === "string") setScenarioDescription(saved.scenarioDescription);
             if (typeof saved.guidingQuestion === "string") setGuidingQuestion(saved.guidingQuestion);
-            if (Array.isArray(saved.suggestedTechniques)) setSuggestedTechniques(saved.suggestedTechniques as string[]);
-            if (typeof saved.algoInput === "string") setAlgoInput(saved.algoInput);
+            if (saved.algorithmMode === "single" || saved.algorithmMode === "contrast") {
+                setAlgorithmMode(saved.algorithmMode);
+            }
+            if (typeof saved.algorithmPrimary === "string" || saved.algorithmPrimary === null) {
+                setAlgorithmPrimary(saved.algorithmPrimary as string | null);
+            }
+            if (typeof saved.algorithmChallenger === "string" || saved.algorithmChallenger === null) {
+                setAlgorithmChallenger(saved.algorithmChallenger as string | null);
+            }
             if (typeof saved.availableFrom === "string") setAvailableFrom(saved.availableFrom);
             if (typeof saved.dueAt === "string") setDueAt(saved.dueAt);
         } catch {
@@ -188,7 +197,8 @@ export function AuthoringForm({
                 sessionStorage.setItem(FORM_STATE_SESSION_KEY, JSON.stringify({
                     subject, syllabusModule, topicUnit, targetGroups, targetCourseIds, studentProfile,
                     industry, caseType, notebookToggle,
-                    scenarioDescription, guidingQuestion, suggestedTechniques, algoInput,
+                    scenarioDescription, guidingQuestion,
+                    algorithmMode, algorithmPrimary, algorithmChallenger,
                     availableFrom, dueAt,
                 }));
             } catch {
@@ -199,14 +209,9 @@ export function AuthoringForm({
             if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
         };
     }, [subject, syllabusModule, topicUnit, targetGroups, targetCourseIds, studentProfile, industry, caseType,
-        notebookToggle, scenarioDescription, guidingQuestion, suggestedTechniques, algoInput,
+        notebookToggle, scenarioDescription, guidingQuestion,
+        algorithmMode, algorithmPrimary, algorithmChallenger,
         availableFrom, dueAt]);
-
-    const markStale = useCallback(() => {
-        if (suggestedTechniques.length > 0) {
-            setAreTechniquesStale(true);
-        }
-    }, [suggestedTechniques]);
 
     const invalidateSuggestionResponses = useCallback(() => {
         suggestionGenerationRef.current.scenario += 1;
@@ -224,6 +229,10 @@ export function AuthoringForm({
     // ── Validation CanSubmit ──
     const isAlgorithmsRequired = caseType === "harvard_with_eda" || studentProfile === "ml_ds";
     const hasValidTopicUnit = units.length === 0 || !!topicUnit;
+    const hasValidAlgorithmPicks =
+        !!algorithmPrimary
+        && (algorithmMode === "single"
+            || (!!algorithmChallenger && algorithmPrimary.toLowerCase() !== algorithmChallenger.toLowerCase()));
     const canSubmit =
         !!subject &&
         !!syllabusModule &&
@@ -234,7 +243,7 @@ export function AuthoringForm({
         !!guidingQuestion.trim() &&
         !!availableFrom &&
         !!dueAt &&
-        (!isAlgorithmsRequired || suggestedTechniques.length > 0);
+        (!isAlgorithmsRequired || hasValidAlgorithmPicks);
 
     const buildSuggestPayload = useCallback((): SuggestRequest => {
         const moduleName = selectedModule?.module_title ?? "";
@@ -254,8 +263,10 @@ export function AuthoringForm({
             includePythonCode,
             scenarioDescription,
             guidingQuestion,
+            mode: algorithmMode,
         };
     }, [
+        algorithmMode,
         caseType,
         edaDepth,
         guidingQuestion,
@@ -331,13 +342,27 @@ export function AuthoringForm({
                     return;
                 }
 
-                if (data.suggestedTechniques.length > 0) {
-                    setSuggestedTechniques(data.suggestedTechniques);
-                    setAreTechniquesStale(false);
+                // Always sync state with the response so a backend null
+                // (cross-family / off-catalog / unsnappable baseline) clears
+                // the previous selection instead of leaving a stale pick.
+                setAlgorithmPrimary(
+                    typeof data.algorithmPrimary === "string" && data.algorithmPrimary
+                        ? data.algorithmPrimary
+                        : null,
+                );
+                if (algorithmMode === "contrast") {
+                    setAlgorithmChallenger(
+                        typeof data.algorithmChallenger === "string" && data.algorithmChallenger
+                            ? data.algorithmChallenger
+                            : null,
+                    );
+                } else {
+                    setAlgorithmChallenger(null);
                 }
+                setErrors((prev) => ({ ...prev, suggestedTechniques: false }));
             },
         });
-    }, [buildSuggestPayload, canSuggest, resetSuggestionFeedback, techniquesMutation]);
+    }, [algorithmMode, buildSuggestPayload, canSuggest, resetSuggestionFeedback, techniquesMutation]);
 
     // ── B6: Cascading resets ──
     const handleSubjectChange = (id: string) => {
@@ -376,53 +401,33 @@ export function AuthoringForm({
         setTargetCourseIds((prev) => prev.filter((value) => value !== group));
     }, [invalidateSuggestionResponses]);
 
-    // ── Chips Orchestration ──
-    const addChip = useCallback(
-        (value: string) => {
-            const trimmed = value.trim();
-            if (!trimmed) return;
-            if (suggestedTechniques.length >= 5) return;
-            if (suggestedTechniques.some((c) => c.toLowerCase() === trimmed.toLowerCase())) return;
-            setSuggestedTechniques((prev) => [...prev, trimmed]);
+    // ── Issue #230: algorithm selector change handler ──
+    const handleAlgorithmChange = useCallback(
+        (next: { mode: AlgorithmMode; primary: string | null; challenger: string | null }) => {
+            setAlgorithmMode(next.mode);
+            setAlgorithmPrimary(next.primary);
+            setAlgorithmChallenger(next.challenger);
+            setErrors((prev) => ({ ...prev, suggestedTechniques: false }));
         },
-        [suggestedTechniques]
-    );
-
-    const removeChip = useCallback((label: string) => {
-        setSuggestedTechniques((prev) => prev.filter((c) => c !== label));
-    }, []);
-
-    const handleAlgoKeyDown = useCallback(
-        (e: KeyboardEvent<HTMLInputElement>) => {
-            if (e.key === "Enter" || e.key === ",") {
-                e.preventDefault();
-                addChip(algoInput);
-                setAlgoInput("");
-            }
-        },
-        [algoInput, addChip]
+        [],
     );
 
     // ── Component Events Triggering Warning ──
     const onChangeScenarioDescription = (val: string) => {
         invalidateSuggestionResponses();
         setScenarioDescription(val);
-        markStale();
     };
     const onChangeGuidingQuestion = (val: string) => {
         invalidateSuggestionResponses();
         setGuidingQuestion(val);
-        markStale();
     };
     const onIndustryChange = (val: string) => {
         invalidateSuggestionResponses();
         setIndustry(val);
-        markStale();
     };
     const onStudentProfileChange = (val: string) => {
         invalidateSuggestionResponses();
         setStudentProfile(val as StudentProfile);
-        markStale();
     };
     const onCaseTypeChange = (val: CaseType) => {
         invalidateSuggestionResponses();
@@ -430,7 +435,6 @@ export function AuthoringForm({
             setStudentProfile("business");
         }
         setCaseType(val);
-        markStale();
     };
     const onChangeAvailableFrom = (val: string) => {
         setAvailableFrom(val);
@@ -456,7 +460,7 @@ export function AuthoringForm({
             if (!guidingQuestion.trim()) newErrors.guidingQuestion = true;
             if (!availableFrom) newErrors.availableFrom = true;
             if (!dueAt) newErrors.dueAt = true;
-            if (isAlgorithmsRequired && suggestedTechniques.length === 0) newErrors.suggestedTechniques = true;
+            if (isAlgorithmsRequired && !hasValidAlgorithmPicks) newErrors.suggestedTechniques = true;
             // edaDepth is calculated automatically — no user validation needed
 
             // Validate date order after presence checks
@@ -494,7 +498,10 @@ export function AuthoringForm({
                 includePythonCode,
                 scenarioDescription,
                 guidingQuestion,
-                suggestedTechniques,
+                algorithmMode: isAlgorithmsRequired ? algorithmMode : "single",
+                algorithmPrimary: isAlgorithmsRequired ? algorithmPrimary : null,
+                algorithmChallenger:
+                    isAlgorithmsRequired && algorithmMode === "contrast" ? algorithmChallenger : null,
                 availableFrom,
                 dueAt
             };
@@ -514,13 +521,13 @@ export function AuthoringForm({
         setTargetCourseIds([]);
         setScenarioDescription("");
         setGuidingQuestion("");
-        setSuggestedTechniques([]);
-        setAlgoInput("");
+        setAlgorithmMode("single");
+        setAlgorithmPrimary(null);
+        setAlgorithmChallenger(null);
         setErrors({});
         scenarioMutation.reset();
         techniquesMutation.reset();
         setFormAlertError(null);
-        setAreTechniquesStale(false);
         setCaseType("harvard_only");
         setEdaDepth(undefined);
         setIncludePythonCode(false);
@@ -879,75 +886,20 @@ export function AuthoringForm({
                                         </div>
                                     </div>
 
-                                    {/* Técnicas / Algoritmos — visible for harvard_with_eda or for ml_ds with any case type */}
+                                    {/* Algoritmos / Técnicas — Issue #230 (mode toggle 1 deep | 2 contrast + canonical dropdowns) */}
                                     {(caseType === "harvard_with_eda" || studentProfile === "ml_ds") && (
-                                        <div className="pt-4 border-t border-slate-100 mt-2">
-                                            <div className="flex items-center justify-between mb-2.5">
-                                                <div>
-                                                    <label className="text-sm font-semibold text-slate-700 block" htmlFor="algo-input">
-                                                        Algoritmos / Técnicas Sugeridas <span className="text-red-500" aria-hidden="true">*</span>
-                                                        <button
-                                                            type="button"
-                                                            onClick={handleSuggestTechniques}
-                                                            disabled={!canSuggest || techniquesMutation.isPending}
-                                                            className={`ml-2.5 inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-bold text-[#0144a0] bg-blue-50 border border-blue-200 rounded-lg transition-all ${!canSuggest ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:bg-blue-100 hover:border-blue-300 hover:shadow-sm active:scale-[0.97]"}`}
-                                                        >
-                                                            {techniquesMutation.isPending ? (
-                                                                <><span className="animate-spin w-3 h-3 border-2 border-[#0144a0] border-t-transparent rounded-full"></span> Pensando...</>
-                                                            ) : (
-                                                                <>🪄 Sugerir Técnicas de Análisis</>
-                                                            )}
-                                                        </button>
-                                                    </label>
-                                                    <span className="text-xs text-slate-400 font-normal">
-                                                        {caseType === "harvard_only"
-                                                            ? "Sirven como contexto pedagógico del perfil ML/DS. Máx. 5."
-                                                            : "Al menos una técnica requerida. ADAM las usará para el dataset sintético del caso. Máx. 5."}
-                                                    </span>
-                                                </div>
-
-                                            </div>
-
-                                            <div
-                                                onClick={() => document.getElementById("algo-input")?.focus()}
-                                                className={`input-base w-full flex flex-wrap items-center gap-2 rounded-lg border bg-white px-3 py-2 min-h-[46px] cursor-text transition-colors duration-300 ${areTechniquesStale ? 'border-amber-300 bg-amber-50/20' : 'border-slate-200'}`}
-                                            >
-                                                {suggestedTechniques.map((chip) => (
-                                                    <span
-                                                        key={chip}
-                                                        className={`chip inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-semibold ${areTechniquesStale ? 'border-amber-200 bg-amber-100/50 text-amber-800' : 'border-blue-200 bg-blue-50 text-[#0144a0]'}`}
-                                                    >
-                                                        {chip}
-                                                        <button
-                                                            type="button"
-                                                            onClick={(e) => { e.stopPropagation(); removeChip(chip); }}
-                                                            className={`focus:outline-none ml-1 leading-none text-base ${areTechniquesStale ? 'text-amber-500 hover:text-amber-700' : 'text-blue-400 hover:text-red-500'}`}
-                                                        >
-                                                            ×
-                                                        </button>
-                                                    </span>
-                                                ))}
-                                                <input
-                                                    id="algo-input"
-                                                    type="text"
-                                                    value={algoInput}
-                                                    onChange={(e) => setAlgoInput(e.target.value)}
-                                                    onKeyDown={handleAlgoKeyDown}
-                                                    placeholder="Escribir nombre técnico y Enter..."
-                                                    className="flex-1 bg-transparent text-sm outline-none placeholder:text-slate-400 min-w-[200px] py-0.5"
-                                                />
-                                            </div>
-                                            {suggestedTechniques.length >= 5 && (
-                                                <div className="chip-warning">Máximo 5 algoritmos permitidos.</div>
-                                            )}
-                                            {areTechniquesStale && suggestedTechniques.length > 0 && (
-                                                <div className="text-[11.5px] font-medium text-amber-700 mt-2 ml-1 animate-pulse">
-                                                    ⚠️ Las técnicas sugeridas podrían estar desactualizadas de acuerdo al último contexto académico configurado.
-                                                </div>
-                                            )}
-                                            <ErrorMsg show={!!errors.suggestedTechniques} />
-                                            <p className="field-hint mt-1.5">ADAM optimizará estas variables sobre el Dataset ficticio si logras predefinirlas.</p>
-                                        </div>
+                                        <AlgorithmSelector
+                                            profile={studentProfile}
+                                            caseType={caseType}
+                                            mode={algorithmMode}
+                                            primary={algorithmPrimary}
+                                            challenger={algorithmChallenger}
+                                            onChange={handleAlgorithmChange}
+                                            onSuggest={handleSuggestTechniques}
+                                            isSuggestPending={techniquesMutation.isPending}
+                                            canSuggest={canSuggest}
+                                            hasError={!!errors.suggestedTechniques}
+                                        />
                                     )}
                                 </div>
                             </fieldset>

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
@@ -194,7 +194,7 @@ describe("TeacherAuthoringPage", () => {
     });
 
     it("clears the form sessionStorage key when the job completes successfully", async () => {
-        sessionStorage.setItem("adam_authoring_form_state", JSON.stringify({ subject: "course-1" }));
+        sessionStorage.setItem("adam.authoring.formState.v2", JSON.stringify({ subject: "course-1" }));
 
         vi.mocked(useAuthoringJobProgress).mockReturnValue({
             jobId: "job-success",
@@ -213,7 +213,7 @@ describe("TeacherAuthoringPage", () => {
         render(<TeacherAuthoringPage />);
 
         await waitFor(() => {
-            expect(sessionStorage.getItem("adam_authoring_form_state")).toBeNull();
+            expect(sessionStorage.getItem("adam.authoring.formState.v2")).toBeNull();
         });
     });
 });

--- a/frontend/src/features/teacher-authoring/authoringFormConfig.ts
+++ b/frontend/src/features/teacher-authoring/authoringFormConfig.ts
@@ -56,7 +56,7 @@ export const STUDENT_PROFILES = [
     { value: "ml_ds", label: "Machine Learning / Data Science" },
 ];
 
-export const FORM_STATE_SESSION_KEY = "adam_authoring_form_state";
+export const FORM_STATE_SESSION_KEY = "adam.authoring.formState.v2";
 
 export const FORM_STYLES = `
 .teacher-form .input-base {

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.test.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.test.ts
@@ -20,7 +20,9 @@ describe("buildAuthoringJobCreateRequest", () => {
             topicUnit: "Unit",
             targetGroups: ["Grupo A"],
                 targetCourseIds: ["course-1"],
-            suggestedTechniques: ["SWOT"],
+            algorithmMode: "single",
+            algorithmPrimary: "Regresión Lineal",
+            algorithmChallenger: null,
         });
 
         expect("teacher_id" in request).toBe(false);
@@ -40,7 +42,9 @@ describe("buildAuthoringJobCreateRequest", () => {
             target_groups: ["Grupo A"],
             eda_depth: null,
             include_python_code: false,
-            suggested_techniques: ["SWOT"],
+            algorithm_mode: "single",
+            algorithm_primary: "Regresión Lineal",
+            algorithm_challenger: null,
             available_from: null,
             due_at: null,
         });

--- a/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
+++ b/frontend/src/features/teacher-authoring/useAuthoringJobProgress.ts
@@ -140,7 +140,10 @@ export function buildAuthoringJobCreateRequest(formData: CaseFormData): Authorin
         target_groups: formData.targetGroups,
         eda_depth: formData.edaDepth ?? null,
         include_python_code: formData.includePythonCode,
-        suggested_techniques: formData.suggestedTechniques,
+        algorithm_mode: formData.algorithmMode,
+        algorithm_primary: formData.algorithmPrimary ?? null,
+        algorithm_challenger:
+            formData.algorithmMode === "contrast" ? (formData.algorithmChallenger ?? null) : null,
         available_from: formData.availableFrom || null,
         due_at: formData.dueAt || null,
     };

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -62,6 +62,20 @@ export type EDADepth = "charts_only" | "charts_plus_explanation" | "charts_plus_
 export type IntentType = "scenario" | "techniques" | "both";
 export type StudentProfile = "business" | "ml_ds";
 export type ModuleId = "m1" | "m2" | "m3" | "m4" | "m5" | "m6";
+// Issue #230 — algorithm selection mode replaces the legacy 5-chip free-text input.
+export type AlgorithmMode = "single" | "contrast";
+export type AlgorithmTier = "baseline" | "challenger";
+export interface AlgorithmCatalogItem {
+    name: string;
+    family: string;
+    family_label: string;
+    tier: AlgorithmTier;
+}
+export interface AlgorithmCatalog {
+    profile: StudentProfile;
+    case_type: CaseType;
+    items: AlgorithmCatalogItem[];
+}
 export interface CaseFormData {
     courseId: string;
     subject: string;
@@ -77,7 +91,10 @@ export interface CaseFormData {
     includePythonCode: boolean;
     scenarioDescription: string;
     guidingQuestion: string;
-    suggestedTechniques: string[];
+    // Issue #230 — algorithm picks (replaces suggestedTechniques: string[]).
+    algorithmMode: AlgorithmMode;
+    algorithmPrimary: string | null;
+    algorithmChallenger: string | null;
     // Submission / Delivery
     availableFrom: string;
     dueAt: string;
@@ -153,7 +170,10 @@ export interface AuthoringJobCreateRequest {
     target_groups: string[];
     eda_depth: EDADepth | null;
     include_python_code: boolean;
-    suggested_techniques: string[];
+    // Issue #230 — algorithm picks shape.
+    algorithm_mode: AlgorithmMode;
+    algorithm_primary: string | null;
+    algorithm_challenger: string | null;
     available_from: string | null;
     due_at: string | null;
 }
@@ -176,12 +196,17 @@ export interface SuggestRequest {
     includePythonCode: boolean;
     scenarioDescription: string;
     guidingQuestion: string;
+    // Issue #230 — drives baseline-only vs baseline+challenger LLM responses.
+    mode?: AlgorithmMode;
 }
 
 export interface SuggestResponse {
     scenarioDescription?: string;
     guidingQuestion?: string;
     suggestedTechniques: string[];
+    // Issue #230 — explicit picks pre-filling the form selector.
+    algorithmPrimary?: string | null;
+    algorithmChallenger?: string | null;
     [key: string]: unknown;
 }
 
@@ -925,7 +950,9 @@ export const EMPTY_FORM: CaseFormData = {
     includePythonCode: false,
     scenarioDescription: "",
     guidingQuestion: "",
-    suggestedTechniques: [],
+    algorithmMode: "single",
+    algorithmPrimary: null,
+    algorithmChallenger: null,
     availableFrom: "",
     dueAt: "",
 };

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -86,7 +86,9 @@ describe("api auth + stream glue", () => {
             target_groups: ["A"],
             eda_depth: null,
             include_python_code: false,
-            suggested_techniques: ["SWOT"],
+            algorithm_mode: "single",
+            algorithm_primary: "Regresión Lineal",
+            algorithm_challenger: null,
             available_from: null,
             due_at: null,
         });

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -17,6 +17,7 @@ import type {
     AdminTeacherInviteRequest,
     AdminTeacherInviteResponse,
     AdminTeacherOptionsResponse,
+    AlgorithmCatalog,
     AuthoringBootstrapState,
     AuthoringJobCreateRequest,
     AuthoringJobCreateResponse,
@@ -43,8 +44,10 @@ import type {
     StudentCaseSubmitRequest,
     StudentCaseSubmitResponse,
     StudentCoursesResponse,
+    StudentProfile,
     SuggestRequest,
     SuggestResponse,
+    CaseType,
     TeacherCaseDetailResponse,
     TeacherCaseSubmissionDetailResponse,
     TeacherCaseSubmissionsResponse,
@@ -938,6 +941,15 @@ export const api = {
             signal?: AbortSignal,
         ) {
             await streamRealtimeProgress(jobId, onEvent, signal);
+        },
+        async getAlgorithmCatalog(
+            profile: StudentProfile,
+            caseType: CaseType,
+        ): Promise<AlgorithmCatalog> {
+            const params = new URLSearchParams({ profile, case_type: caseType });
+            return parseJsonResponse<AlgorithmCatalog>(
+                `/authoring/algorithm-catalog?${params.toString()}`,
+            );
         },
     },
     async suggest(intent: IntentType, data: SuggestRequest): Promise<SuggestResponse> {

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -72,6 +72,12 @@ export const queryKeys = {
          */
         suggest: (intent: IntentType, payload: SuggestRequest) =>
             ["authoring", "suggest", intent, payload] as const,
+        /**
+         * ["authoring", "algorithmCatalog", profile, caseType] — catálogo canónico de
+         * algoritmos (Issue #230). Cache estable por (perfil, caseType).
+         */
+        algorithmCatalog: (profile: string, caseType: string) =>
+            ["authoring", "algorithmCatalog", profile, caseType] as const,
     },
     teacher: {
         /** ["teacher"] — key raíz para invalidación masiva */


### PR DESCRIPTION
## Summary

Closes #230. Replaces the legacy 5-slot free-text technique chips with a structured **algorithm mode toggle** (1 deep | 2 contrast: baseline + challenger) backed by a server-side canonical catalog.

This is a **breaking change** to the authoring intake contract, scoped to teacher authoring. Authoring jobs already in flight finish on the old payload schema; new submissions must use the new fields.

## Backend

- **`POST /api/authoring/jobs`** now accepts:
  - `algorithm_mode: "single" | "contrast"`
  - `algorithm_primary: str | null`
  - `algorithm_challenger: str | null`
  - The legacy `suggested_techniques` body field has been removed and must not be reintroduced.
- **`GET /api/authoring/algorithm-catalog?profile=...&case_type=...`** (new) returns the canonical `{baseline, challenger}` catalog. Open endpoint, no PII, `Literal`-validated.
- `_validate_techniques_strict` enforces tier (baseline-vs-challenger) + same-algo guard. Validation only runs when `case_type == "harvard_with_eda"` OR `student_profile == "ml_ds"`.
- Persisted in `task_payload` as `algorithm_mode` plus `algoritmos: list[str]` of length 0, 1, or 2.
- `business` profile may legitimately expose an empty challenger list. The form disables "2 algoritmos" in that case; the backend rejects contrast picks with a teacher-friendly Spanish message instead of silently coercing to `single`.
- `SuggestRequest.mode` and `SuggestResponse.{algorithmPrimary, algorithmChallenger}` added; `suggestedTechniques` kept as legacy mirror for one release (TODO-230-C).

## Frontend

- New `AlgorithmSelector` component with mode toggle + 1/2 dropdowns fed by `/api/authoring/algorithm-catalog` via React Query (5 min `staleTime`).
- `AuthoringForm` swaps the chip block; new state fields `algorithmMode` / `algorithmPrimary` / `algorithmChallenger`.
- `sessionStorage` key bumped to `adam.authoring.formState.v2` so stale drafts on the legacy contract are dropped on first load.
- `buildAuthoringJobCreateRequest` maps the new fields. Suggest mutation auto-fills picks from `algorithmPrimary` / `algorithmChallenger`.
- Mode auto-coerces `contrast` → `single` on the client when a freshly loaded catalog has no challengers.

## Tests

- `backend/tests/test_issue230_algorithm_mode.py` — 33 tests (catalog, validator, endpoint, intake gating, `task_payload` shape).
- `frontend/.../AlgorithmSelector.test.tsx` — 8 tests.
- Updated `AuthoringForm.test.tsx`, `TeacherAuthoringPage.test.tsx`, `api.test.ts`, `useAuthoringJobProgress.test.ts` to the new contract.

## Docs

- `AGENTS.md` + `CLAUDE.md`: new "Authoring Algorithm Picks (Issue #230)" section.
- `TODOS.md`:
  - **TODO-230-A** curate business challengers
  - **TODO-230-B** M3 contrast-aware prompts in `m3_content_generator`
  - **TODO-230-C** deprecate `SuggestResponse.suggestedTechniques`

## Validation

```
uv run --directory backend pytest -q          # 472 passed, 12 skipped
uv run --directory backend mypy src            # clean
npm --prefix frontend run lint                 # clean
npm --prefix frontend run test                 # 410 passed (57 files)
npm --prefix frontend run build                # green (53.47s)
```

## Migration notes

- Frontend drafts on the old session key are silently discarded (key bump). Teachers see a fresh, blank form.
- Any external clients hitting `POST /api/authoring/jobs` with `suggested_techniques` will fail validation with a 422; this is intentional.

## Merge mode

Squash and merge.
