### PR TITLE
feat(m3): notebook hygiene fixes for classification/regression empty-charts

### DIFF
--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -1900,7 +1900,12 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 import sklearn
 
-warnings.filterwarnings("ignore")
+# NO silenciamos warnings globalmente: sklearn emite UndefinedMetricWarning
+# ("Only one class present in y_true") cuando un split queda degenerado, y esa
+# se\u00f1al es exactamente lo que diagnostica gr\u00e1ficos de m\u00e9tricas vac\u00edos.
+# Filtramos solo DeprecationWarning ruidosos de dependencias.
+warnings.filterwarnings("default")
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 plt.style.use("default")
 sns.set_theme(style="whitegrid")
 
@@ -2106,6 +2111,13 @@ Genera SOLO la continuación del notebook, empezando después de la Sección 3 d
   exploraciones de auditoría/EDA pero NUNCA en entrenamiento supervisado.
 * Si NO hay contrato (bloque vacío o "(sin contrato ...)"), aplica la lógica
   alias-first heredada (label_aliases → churn_aliases → último categórico).
+* **Defensa extra anti-leakage (aplica SIEMPRE, con o sin contrato):** además de
+  las features marcadas por contrato, EXCLUYE de `X` cualquier columna cuyo
+  nombre normalizado coincida con patrones temporales-posteriores comunes:
+  prefijos/sufijos `retention_m`, `churn_date`, `churned_at`, `cancellation`,
+  `days_to_churn`, `days_to_cancel`, `_post_`, `_after_`, `m3_`, `m6_`, `m12_`
+  (excepto si esa columna ES el target del contrato). Documenta en comentario
+  `# Excluida por patrón temporal-posterior (anti-leakage defensivo)`.
 
 # Reglas absolutas
 1. NUNCA uses np.random, pd.DataFrame() fabricado, columnas inventadas ni placeholders.
@@ -2114,6 +2126,12 @@ Genera SOLO la continuación del notebook, empezando después de la Sección 3 d
 4. NO redefinas funciones del base template (normalize_colname, find_first_matching_column, etc.).
 5. Idioma de salida: {output_language}.
 6. Cada bloque falla de forma aislada — encapsula en try/except local.
+   **EXCEPCIÓN al try/except (anti-silenciamiento):** las guardas explícitas
+   de pre-fit (split degenerado de Regla I, feature_cols vacío de Regla K-bis,
+   target ausente del contrato) NO deben quedar tragadas por un `except
+   Exception`. Su `print("⚠️ ...")` debe ser visible y la celda debe terminar
+   limpiamente sin lanzar excepción. El try/except local cubre fallos
+   inesperados de librerías, NO debe ocultar guardas de validación de datos.
 7. Eres un sistema ZERO-ERRORS. Está PROHIBIDO imprimir REQUISITO FALTANTE solo porque no encontraste
    una columna por alias. Siempre debes implementar un Fallback Heurístico por tipo de dato
    (df.select_dtypes) antes de rendirte. Solo imprime REQUISITO FALTANTE si df.select_dtypes()
@@ -2160,9 +2178,24 @@ H. Métricas OBLIGATORIAS por tipo de problema (imprímelas SIEMPRE, sin excepci
    - Clasificación: `from sklearn.metrics import classification_report, f1_score, confusion_matrix`
      y `print(classification_report(y_test, y_pred, zero_division=0))` +
      `print("F1 macro:", f1_score(y_test, y_pred, average="macro", zero_division=0))`.
-   - Regresión: `from sklearn.metrics import mean_squared_error, r2_score` y
+     **Para CLASIFICACIÓN BINARIA añade SIEMPRE AUC-ROC y AUC-PR** (las únicas
+     métricas que delatan un modelo que predice solo la clase mayoritaria; el
+     accuracy y la confusion_matrix sin AUC pueden disfrazar un fit degenerado):
+       `from sklearn.metrics import roc_auc_score, average_precision_score`
+       `if hasattr(model, "predict_proba") and y_test.nunique() == 2:`
+           `proba = model.predict_proba(X_test)[:, 1]`
+           `print("AUC-ROC:", roc_auc_score(y_test, proba))`
+           `print("AUC-PR :", average_precision_score(y_test, proba))`
+     **Pesos de clase OBLIGATORIOS para problemas con desbalance (>1.5x entre clases):**
+       - LogisticRegression / RandomForestClassifier / SVC → `class_weight="balanced"`
+       - XGBClassifier → `scale_pos_weight=float((y_train==0).sum()) / max(int((y_train==1).sum()), 1)`
+         (calcúlalo SIEMPRE para binario; NUNCA hardcodees 1.0).
+     Imprime ANTES del fit la distribución de clases en train con
+     `print("Distribución y_train:", y_train.value_counts(normalize=True).round(3).to_dict())`.
+   - Regresión: `from sklearn.metrics import mean_squared_error, r2_score, mean_absolute_error` y
      `print("RMSE:", float(np.sqrt(mean_squared_error(y_test, y_pred))))` +
-     `print("R2:", r2_score(y_test, y_pred))`.
+     `print("MAE :", mean_absolute_error(y_test, y_pred))` +
+     `print("R2  :", r2_score(y_test, y_pred))`.
    - Clustering: `from sklearn.metrics import silhouette_score` y
      `print("Silhouette:", silhouette_score(X, labels))` cuando hay >=2 clusters formados.
 I. Split anti-leakage para clasificación/regresión (ORDEN OBLIGATORIO):
@@ -2180,6 +2213,20 @@ I. Split anti-leakage para clasificación/regresión (ORDEN OBLIGATORIO):
    - Si NO hay columna temporal: usa `train_test_split(X, y, test_size=0.2, random_state=42,
      stratify=y if y.nunique() >= 2 and y.value_counts().min() >= 2 else None)`.
    - Justifica en comentario por qué elegiste cada estrategia.
+   - **GUARDA POST-SPLIT OBLIGATORIA (anti-fit-degenerado — Issue empty-charts):**
+     después del split y ANTES de `.fit()`, valida que ambas particiones tengan
+     ≥2 clases (clasificación) o tamaño suficiente (regresión). Patrón canónico:
+       `if y_train.nunique() < 2 or y_test.nunique() < 2:`
+           `print("⚠️ SPLIT DEGENERADO — y_train clases:", y_train.value_counts().to_dict(),
+                  "| y_test clases:", y_test.value_counts().to_dict())`
+           `print("   El split (temporal o aleatorio) dejó una sola clase en train o test.")`
+           `print("   No se entrena el modelo: cualquier métrica/gráfico sería engañoso.")`
+           `model = None`
+           `# salir de la celda — NO ejecutar .fit() ni los plots posteriores`
+       Si `model is None` al inicio de las celdas 2b/2c/2d, deben imprimir
+       `"Saltado por split degenerado"` y NO intentar plotear. Esta guarda evita
+       el bug de gráficos vacíos: feature_importances todo en 0 y matriz de
+       confusión 1×1 cuando train/test colapsan a una sola clase.
 J. SHAP es OPCIONAL y SIEMPRE en try/except. Importancia de features con jerarquía estricta
    (NO asumas `feature_importances_` para todo modelo — LogisticRegression no lo expone):
    - **Issue #228 — SHAP atómico (CRÍTICO)**: `shap.summary_plot()` crea su propia
@@ -2215,6 +2262,39 @@ J. SHAP es OPCIONAL y SIEMPRE en try/except. Importancia de features con jerarqu
      3) `else:` intenta `from sklearn.inspection import permutation_importance` dentro de
         try/except; si falla, imprime "Modelo sin importancias directas — revisar coeficientes/SHAP manualmente".
    - `plt.tight_layout(); plt.show()` al final de la celda.
+K-bis. **Higiene de feature_cols OBLIGATORIA antes de construir X (anti-features-basura):**
+   Construye `feature_cols` con esta receta determinista, NO uses
+   `df.select_dtypes(include=np.number).columns.tolist()` directo (eso arrastra
+   IDs, constantes y residuos):
+     ```
+     # 1) Candidatas: numéricas + categóricas de baja/media cardinalidad
+     num_cols = df.select_dtypes(include=np.number).columns.tolist()
+     cat_cols = [c for c in df.select_dtypes(include=["object", "category"]).columns
+                 if df[c].nunique(dropna=True) <= 20]
+     candidates = [c for c in (num_cols + cat_cols) if c != target_col]
+     # 2) Drop ID-like (cardinalidad == n_filas) y nombres con "id"
+     n = len(df)
+     candidates = [c for c in candidates
+                   if df[c].nunique(dropna=True) < n
+                   and "id" not in normalize_colname(c).split("_")]
+     # 3) Drop near-constants (nunique <= 1) y high-null (>50% NaN)
+     candidates = [c for c in candidates
+                   if df[c].nunique(dropna=True) > 1
+                   and df[c].isna().mean() <= 0.5]
+     # 4) Drop features de leakage según contrato + patrones temporal-posteriores
+     #    (ver "Defensa extra anti-leakage" en Reglas CONTRACT-FIRST)
+     feature_cols = candidates
+     print("feature_cols efectivos:", feature_cols)
+     # 5) Construye X. Si hay categóricas, one-hot ANTES del split:
+     X = pd.get_dummies(df[feature_cols], drop_first=True, dummy_na=False)
+     y = df[target_col]
+     assert X.shape[1] >= 1, "feature_cols vacío tras higiene — revisa el dataset."
+     ```
+   Si `X.shape[1] == 0` o `assert` falla, imprime `"⚠️ REQUISITO FALTANTE: sin
+   features útiles tras higiene"` y SALTA el algoritmo. Esto evita los gráficos
+   de feature_importance con barras todas en 0 (que indican que el modelo
+   trabajó solo con ruido o constantes).
+
 K. EDA Express (Sección 3.0) OBLIGATORIA antes del primer bloque de algoritmo:
    - Distribución del target (si fue detectado): `target_col.value_counts(normalize=True)`.
    - % missing por columna ordenado desc: `df.isna().mean().sort_values(ascending=False).head(10)`.

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -2180,16 +2180,38 @@ H. Métricas OBLIGATORIAS por tipo de problema (imprímelas SIEMPRE, sin excepci
      `print("F1 macro:", f1_score(y_test, y_pred, average="macro", zero_division=0))`.
      **Para CLASIFICACIÓN BINARIA añade SIEMPRE AUC-ROC y AUC-PR** (las únicas
      métricas que delatan un modelo que predice solo la clase mayoritaria; el
-     accuracy y la confusion_matrix sin AUC pueden disfrazar un fit degenerado):
+     accuracy y la confusion_matrix sin AUC pueden disfrazar un fit degenerado).
+     ATENCIÓN — dos trampas frecuentes que debes evitar SIEMPRE en este bloque:
+       (a) `predict_proba` puede no existir (p.ej. SVC con `probability=False`).
+           Si no existe, intenta `decision_function` antes de saltar AUC.
+       (b) `roc_auc_score` falla con targets binarios string ("yes"/"no") si no
+           binarizas o no fijas `pos_label`. Binariza `y_test` SIEMPRE a 0/1
+           antes del cálculo, usando como clase positiva la última en orden
+           ascendente de `model.classes_` (consistente con la columna 1 de
+           `predict_proba`).
+     Patrón canónico (úsalo literalmente, ajustando solo nombres si fuese
+     necesario):
        `from sklearn.metrics import roc_auc_score, average_precision_score`
-       `if hasattr(model, "predict_proba") and y_test.nunique() == 2:`
-           `proba = model.predict_proba(X_test)[:, 1]`
-           `print("AUC-ROC:", roc_auc_score(y_test, proba))`
-           `print("AUC-PR :", average_precision_score(y_test, proba))`
+       `if y_test.nunique() == 2:`
+           `pos_label = model.classes_[1] if hasattr(model, "classes_") and len(model.classes_) == 2 else sorted(pd.Series(y_train).dropna().unique().tolist())[-1]`
+           `if hasattr(model, "predict_proba"):`
+               `scores = model.predict_proba(X_test)[:, 1]`
+           `elif hasattr(model, "decision_function"):`
+               `scores = model.decision_function(X_test)`
+           `else:`
+               `scores = None; print("AUC omitido: el modelo no expone predict_proba ni decision_function.")`
+           `if scores is not None:`
+               `y_test_bin = (pd.Series(y_test).reset_index(drop=True) == pos_label).astype(int)`
+               `print("AUC-ROC:", roc_auc_score(y_test_bin, scores))`
+               `print("AUC-PR :", average_precision_score(y_test_bin, scores))`
      **Pesos de clase OBLIGATORIOS para problemas con desbalance (>1.5x entre clases):**
        - LogisticRegression / RandomForestClassifier / SVC → `class_weight="balanced"`
-       - XGBClassifier → `scale_pos_weight=float((y_train==0).sum()) / max(int((y_train==1).sum()), 1)`
-         (calcúlalo SIEMPRE para binario; NUNCA hardcodees 1.0).
+         (para SVC que requiera AUC, además `probability=True`).
+       - XGBClassifier → NO asumas labels `0/1`. Calcula `scale_pos_weight`
+         desde `y_train.value_counts()` como ratio mayoritaria/minoritaria,
+         coherente con la `pos_label` usada para AUC. Patrón:
+         `vc = y_train.value_counts(); scale_pos_weight = float(vc.max()) / float(max(vc.min(), 1))`.
+         NUNCA hardcodees `1.0` ni asumas `(y_train==0).sum()/(y_train==1).sum()`.
      Imprime ANTES del fit la distribución de clases en train con
      `print("Distribución y_train:", y_train.value_counts(normalize=True).round(3).to_dict())`.
    - Regresión: `from sklearn.metrics import mean_squared_error, r2_score, mean_absolute_error` y
@@ -2263,36 +2285,30 @@ J. SHAP es OPCIONAL y SIEMPRE en try/except. Importancia de features con jerarqu
         try/except; si falla, imprime "Modelo sin importancias directas — revisar coeficientes/SHAP manualmente".
    - `plt.tight_layout(); plt.show()` al final de la celda.
 K-bis. **Higiene de feature_cols OBLIGATORIA antes de construir X (anti-features-basura):**
-   Construye `feature_cols` con esta receta determinista, NO uses
-   `df.select_dtypes(include=np.number).columns.tolist()` directo (eso arrastra
-   IDs, constantes y residuos):
-     ```
-     # 1) Candidatas: numéricas + categóricas de baja/media cardinalidad
-     num_cols = df.select_dtypes(include=np.number).columns.tolist()
-     cat_cols = [c for c in df.select_dtypes(include=["object", "category"]).columns
-                 if df[c].nunique(dropna=True) <= 20]
-     candidates = [c for c in (num_cols + cat_cols) if c != target_col]
-     # 2) Drop ID-like (cardinalidad == n_filas) y nombres con "id"
-     n = len(df)
-     candidates = [c for c in candidates
-                   if df[c].nunique(dropna=True) < n
-                   and "id" not in normalize_colname(c).split("_")]
-     # 3) Drop near-constants (nunique <= 1) y high-null (>50% NaN)
-     candidates = [c for c in candidates
-                   if df[c].nunique(dropna=True) > 1
-                   and df[c].isna().mean() <= 0.5]
-     # 4) Drop features de leakage según contrato + patrones temporal-posteriores
-     #    (ver "Defensa extra anti-leakage" en Reglas CONTRACT-FIRST)
-     feature_cols = candidates
-     print("feature_cols efectivos:", feature_cols)
-     # 5) Construye X. Si hay categóricas, one-hot ANTES del split:
-     X = pd.get_dummies(df[feature_cols], drop_first=True, dummy_na=False)
-     y = df[target_col]
-     assert X.shape[1] >= 1, "feature_cols vacío tras higiene — revisa el dataset."
-     ```
-   Si `X.shape[1] == 0` o `assert` falla, imprime `"⚠️ REQUISITO FALTANTE: sin
+   Construye `feature_cols` con esta receta determinista en cinco pasos. NO uses
+   `df.select_dtypes(include=np.number).columns.tolist()` directo (arrastra IDs,
+   constantes y residuos). NO emitas estos pasos como bloque cercado con triple
+   backtick — emítelos como código Python normal de la celda (Regla absoluta 3):
+     1) Candidatas = numéricas + categóricas de cardinalidad ≤ 20.
+        `num_cols = df.select_dtypes(include=np.number).columns.tolist()`
+        `cat_cols = [c for c in df.select_dtypes(include=["object", "category"]).columns if df[c].nunique(dropna=True) <= 20]`
+        `candidates = [c for c in (num_cols + cat_cols) if c != target_col]`
+     2) Drop ID-like (cardinalidad == n_filas o token `"id"` en el nombre normalizado).
+        `n = len(df)`
+        `candidates = [c for c in candidates if df[c].nunique(dropna=True) < n and "id" not in normalize_colname(c).split("_")]`
+     3) Drop near-constants (`nunique <= 1`) y high-null (`>50%` NaN).
+        `candidates = [c for c in candidates if df[c].nunique(dropna=True) > 1 and df[c].isna().mean() <= 0.5]`
+     4) Drop features de leakage por contrato + patrones temporal-posteriores
+        (ver "Defensa extra anti-leakage" en Reglas CONTRACT-FIRST).
+        `feature_cols = candidates`
+        `print("feature_cols efectivos:", feature_cols)`
+     5) Construye X con one-hot ANTES del split (categóricas codificadas):
+        `X = pd.get_dummies(df[feature_cols], drop_first=True, dummy_na=False)`
+        `y = df[target_col]`
+        `assert X.shape[1] >= 1, "feature_cols vacío tras higiene — revisa el dataset."`
+   Si `X.shape[1] == 0` o el `assert` falla, imprime `"⚠️ REQUISITO FALTANTE: sin
    features útiles tras higiene"` y SALTA el algoritmo. Esto evita los gráficos
-   de feature_importance con barras todas en 0 (que indican que el modelo
+   de feature_importance con barras todas en 0 (síntoma de que el modelo
    trabajó solo con ruido o constantes).
 
 K. EDA Express (Sección 3.0) OBLIGATORIA antes del primer bloque de algoritmo:

--- a/backend/tests/test_m3_notebook_classification_hygiene.py
+++ b/backend/tests/test_m3_notebook_classification_hygiene.py
@@ -85,7 +85,10 @@ def test_prompt_carves_out_validation_guards_from_silent_except() -> None:
 
 
 def test_prompt_still_renders_with_existing_substitution_vars() -> None:
-    """Smoke: las nuevas reglas no rompen el .format() existente."""
+    """Smoke real: .format() no lanza, los placeholders desaparecen y los
+    valores sustituidos sí aparecen literalmente. El check anterior
+    (`'{' not in ... or '{{' not in ...`) era una tautología: tras .format()
+    `{{` ya se transforma en `{`, así que la rama derecha siempre era True."""
     rendered = M3_NOTEBOOK_ALGO_PROMPT.format(
         m3_content="contenido m3",
         algoritmos='["LogisticRegression", "XGBoost"]',
@@ -95,5 +98,22 @@ def test_prompt_still_renders_with_existing_substitution_vars() -> None:
         dataset_contract_block="(sin contrato)",
         data_gap_warnings_block="(sin brechas)",
     )
-    assert len(rendered) > 5000
-    assert "{" not in rendered.split("---")[0] or "{{" not in rendered  # placeholders bien escapados
+    # 1) Ningún placeholder canónico debe sobrevivir al .format()
+    for placeholder in (
+        "{m3_content}",
+        "{algoritmos}",
+        "{familias_meta}",
+        "{case_title}",
+        "{output_language}",
+        "{dataset_contract_block}",
+        "{data_gap_warnings_block}",
+    ):
+        assert placeholder not in rendered, f"placeholder sin sustituir: {placeholder}"
+    # 2) Los valores sustituidos deben aparecer literalmente.
+    assert "contenido m3" in rendered
+    assert "Caso Test" in rendered
+    assert "(sin contrato)" in rendered
+    assert "(sin brechas)" in rendered
+    assert "LogisticRegression" in rendered
+    # 3) Sigue siendo un prompt sustancial (sanidad gruesa, no fragil a refactor).
+    assert len(rendered) > 1000

--- a/backend/tests/test_m3_notebook_classification_hygiene.py
+++ b/backend/tests/test_m3_notebook_classification_hygiene.py
@@ -1,0 +1,99 @@
+"""Tests for transversal classification-hygiene fixes in M3 notebook prompts.
+
+Closes the empty-charts symptom (LR + XGB feature_importance todo en 0,
+matriz de confusión 1x1) by enforcing five rules in the prompt:
+
+  1. Defensa extra anti-leakage por naming (retention_m*, days_to_*, etc.)
+  2. AUC-ROC + AUC-PR + class_weight/scale_pos_weight para binario
+  3. Guarda post-split contra y_train/y_test degenerado
+  4. Higiene de feature_cols (drop IDs/constantes, one-hot categóricas)
+  5. UndefinedMetricWarning ya no se silencia globalmente
+
+Cero LLMs, cero red, cero DB.
+"""
+
+from __future__ import annotations
+
+from case_generator.prompts import (
+    M3_NOTEBOOK_ALGO_PROMPT,
+    M3_NOTEBOOK_BASE_TEMPLATE,
+)
+
+
+def test_base_template_does_not_silence_all_warnings() -> None:
+    """warnings.filterwarnings('ignore') ocultaba UndefinedMetricWarning,
+    que es la señal canónica de fit degenerado. Debe ser narrowing."""
+    assert 'warnings.filterwarnings("ignore")\n' not in M3_NOTEBOOK_BASE_TEMPLATE
+    assert 'warnings.filterwarnings("default")' in M3_NOTEBOOK_BASE_TEMPLATE
+    # DeprecationWarning sí se sigue silenciando (ruido de dependencias).
+    assert 'category=DeprecationWarning' in M3_NOTEBOOK_BASE_TEMPLATE
+
+
+def test_prompt_extends_leakage_defense_with_naming_patterns() -> None:
+    """Sin contrato, el prompt debe excluir features con nombres
+    temporal-posteriores comunes (retention_m6, days_to_churn, etc.)."""
+    assert "Defensa extra anti-leakage" in M3_NOTEBOOK_ALGO_PROMPT
+    for pattern in (
+        "retention_m",
+        "days_to_churn",
+        "cancellation",
+        "_post_",
+    ):
+        assert pattern in M3_NOTEBOOK_ALGO_PROMPT, f"falta patrón {pattern!r}"
+
+
+def test_prompt_requires_auc_and_class_weights_for_binary() -> None:
+    """Sin AUC-ROC/AUC-PR un modelo que predice solo la mayoritaria
+    queda disfrazado. Sin class_weight/scale_pos_weight nunca aprende
+    la minoritaria en datasets desbalanceados."""
+    assert "roc_auc_score" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "average_precision_score" in M3_NOTEBOOK_ALGO_PROMPT
+    assert 'class_weight="balanced"' in M3_NOTEBOOK_ALGO_PROMPT
+    assert "scale_pos_weight" in M3_NOTEBOOK_ALGO_PROMPT
+    # Distribución de clases debe imprimirse antes del fit.
+    assert "y_train.value_counts" in M3_NOTEBOOK_ALGO_PROMPT
+
+
+def test_prompt_enforces_post_split_degeneracy_guard() -> None:
+    """La causa raíz del bug de gráficos vacíos: split deja una sola
+    clase en train o test. La guarda debe abortar el fit y marcar
+    el modelo como None para que las celdas de plot lo respeten."""
+    assert "SPLIT DEGENERADO" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "y_train.nunique() < 2" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "y_test.nunique() < 2" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "model = None" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "Saltado por split degenerado" in M3_NOTEBOOK_ALGO_PROMPT
+
+
+def test_prompt_enforces_feature_cols_hygiene() -> None:
+    """feature_cols sin filtro arrastra IDs, constantes y high-null,
+    produciendo feature_importance todo en 0. Higiene obligatoria
+    + one-hot de categóricas antes del split."""
+    assert "Higiene de feature_cols" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "Drop near-constants" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "Drop ID-like" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "pd.get_dummies" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "REQUISITO FALTANTE: sin" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "features útiles tras higiene" in M3_NOTEBOOK_ALGO_PROMPT
+
+
+def test_prompt_carves_out_validation_guards_from_silent_except() -> None:
+    """Las guardas explícitas de validación NO deben quedar tragadas
+    por un `except Exception` opaco — su print(⚠️) debe ser visible."""
+    assert "EXCEPCIÓN al try/except" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "anti-silenciamiento" in M3_NOTEBOOK_ALGO_PROMPT
+
+
+def test_prompt_still_renders_with_existing_substitution_vars() -> None:
+    """Smoke: las nuevas reglas no rompen el .format() existente."""
+    rendered = M3_NOTEBOOK_ALGO_PROMPT.format(
+        m3_content="contenido m3",
+        algoritmos='["LogisticRegression", "XGBoost"]',
+        familias_meta='[{"familia": "clasificacion_tabular"}]',
+        case_title="Caso Test",
+        output_language="es",
+        dataset_contract_block="(sin contrato)",
+        data_gap_warnings_block="(sin brechas)",
+    )
+    assert len(rendered) > 5000
+    assert "{" not in rendered.split("---")[0] or "{{" not in rendered  # placeholders bien escapados


### PR DESCRIPTION
## Resumen

Cierra el síntoma recurrente del notebook generado: gráficos vacíos en clasificación binaria (feature_importance todo en 0, matriz de confusión 1×1) que se observó hoy en QA del end-product.

## Diagnóstico

Origen real (no cosmético):

1. El split temporal podía dejar **una sola clase** en `y_train` o `y_test`.
2. sklearn emitía `UndefinedMetricWarning("Only one class present in y_true")`.
3. La señal quedaba **silenciada globalmente** por `warnings.filterwarnings("ignore")` en el preámbulo.
4. Sin AUC-ROC/AUC-PR, las métricas reportadas (accuracy, classification_report) **disfrazaban** un fit donde el modelo predecía una sola clase con accuracy "perfecto" sobre un test colapsado.
5. Los gráficos posteriores se renderizaban con `feature_importances_ = [0, 0, 0, ...]` o matrices `[[40, 0]]`.

## Cinco fixes transversales (LLM-instruction layer, sin cambios en Python)

Aplicados en `M3_NOTEBOOK_ALGO_PROMPT` y `M3_NOTEBOOK_BASE_TEMPLATE`:

### 1. Defensa extra anti-leakage por naming
Aun con contrato, excluir features cuyo nombre coincida con patrones temporales-posteriores (`retention_m*`, `days_to_*`, `cancellation*`, `_post_*`, `m3_/m6_/m12_`) salvo que sean el target.

### 2. Métricas obligatorias para binario (Regla H reforzada)
- **AUC-ROC + AUC-PR obligatorios** vía `predict_proba` cuando `y_test.nunique() == 2` (las únicas métricas que delatan un predictor de clase mayoritaria).
- **Pesos de clase obligatorios:** `class_weight="balanced"` para LR/RF/SVC; `scale_pos_weight = (y_train==0).sum() / (y_train==1).sum()` para XGBoost.
- Imprimir `y_train.value_counts(normalize=True)` antes del fit.
- MAE añadido a regresión.

### 3. Guarda post-split obligatoria (Regla I reforzada)
```python
if y_train.nunique() < 2 or y_test.nunique() < 2:
    print("⚠️ SPLIT DEGENERADO ...")
    model = None
    # salir, NO ejecutar .fit() ni los plots
```
Las celdas 2b/2c/2d deben respetar `if model is None`.

### 4. Higiene de feature_cols (nueva Regla K-bis)
Receta determinista antes de construir `X`:
- Numéricas + categóricas con cardinalidad ≤ 20.
- Drop ID-like (cardinalidad == n_filas o nombre con "id").
- Drop near-constants (`nunique <= 1`) y high-null (>50% NaN).
- One-hot via `pd.get_dummies(..., drop_first=True, dummy_na=False)`.
- `assert X.shape[1] >= 1` o saltar el algoritmo.

Elimina la clase de bug `feature_importance` todo en 0.

### 5. Carve-out al try/except (Regla 6 ampliada)
Las guardas explícitas de pre-fit (split degenerado, feature_cols vacío, target ausente) **no deben** quedar tragadas por `except Exception`. Su `print("⚠️ ...")` debe ser visible.

### Bonus en BASE_TEMPLATE
`warnings.filterwarnings("ignore")` → `"default"`. Solo `DeprecationWarning` se sigue silenciando. Ahora `UndefinedMetricWarning` aflora.

## Tests

- Nuevos: `backend/tests/test_m3_notebook_classification_hygiene.py` (7 tests, cero LLM/red/DB).
- Smoke de `.format(**)` con todas las claves esperadas para detectar `{}` mal escapado.

## Validación

- ✅ `uv run --directory backend pytest -q` → **446 passed, 12 skipped**
- ✅ `uv run --directory backend mypy src` → **Success: no issues found in 44 source files**
- Frontend no tocado (sin cambios en `frontend/`).

## Scope explícito

- Es una intervención **transversal** (un solo prompt, todos los algoritmos heredan).
- **NO** introduce templates por familia (clasificación / regresión / time-series / clustering / recommendation / NLP). Ese trabajo es PR B y se trackeará en una issue separada.
- **NO** reduce el catálogo de algoritmos (Issue #230 sigue intacto).

## Sensitive area

Toca `backend/src/case_generator/prompts.py`. Todos los cambios son aditivos sobre reglas existentes; no se altera la orquestación del grafo ni los contratos `studentProfile` / `M1..M6`.
