### PR TITLE
feat(case_generator): M3 per-family dispatch + canonical 4x2 algorithm catalog (#233)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,11 +126,19 @@ Supabase or another environment that exposes compatible Auth helpers like `auth.
 - The teacher form picks algorithms from a canonical catalog instead of accepting up to five free-text chips.
 - `POST /api/authoring/jobs` accepts the breaking fields `algorithm_mode` (`"single" | "contrast"`), `algorithm_primary`, and `algorithm_challenger`. The legacy `suggested_techniques` body field has been removed; do not reintroduce it.
 - Algorithm picks are validated server-side at intake by `_validate_techniques_strict` whenever `case_type == "harvard_with_eda"` or `student_profile == "ml_ds"`. They are persisted into `task_payload` as `algorithm_mode` plus `algoritmos: list[str]` of length 0, 1, or 2.
-- `GET /api/authoring/algorithm-catalog?profile=...&case_type=...` returns the canonical declarative catalog as `{profile, case_type, items: [{name, family, family_label, tier}]}` where `tier ∈ {"baseline", "challenger"}` and `family ∈ {clustering, clasificacion, regresion, serie_temporal, recomendacion, nlp}`. The endpoint is open (no PII), `Literal`-validated, and re-checked at intake.
+- `GET /api/authoring/algorithm-catalog?profile=...&case_type=...` returns the canonical declarative catalog as `{profile, case_type, items: [{name, family, family_label, tier}]}` where `tier ∈ {"baseline", "challenger"}` and `family ∈ {clasificacion, regresion, clustering, serie_temporal}` (Issue #233 — 4×2 catalog, max 2 algorithms per family, exactly 1 baseline per family). The endpoint is open (no PII), `Literal`-validated, and re-checked at intake.
 - Family-coherence rule: in `contrast` mode the baseline and the challenger MUST belong to the same `family`. The backend rejects cross-family contrast picks (e.g. Logistic Regression vs Prophet) at intake with a 422 and a teacher-friendly Spanish message. The frontend `AlgorithmSelector` filters the challenger options to the baseline family. The LLM suggester is taught the same rule via prompt boundary AND the post-LLM `_snap_item` filter, so it cannot cross families even if the model strays.
 - LSTM has been removed from the canonical ml_ds time-series catalog. Do not reintroduce LSTM (or other heavy DL surrogates) without an ADR.
 - The `business` profile may legitimately expose only baseline items (no challengers in any family). The frontend disables the "2 algoritmos" mode in that case; the backend rejects contrast picks with a teacher-friendly message. Do not silently fall back to `single` on the backend.
 
+## M3 Notebook Per-Family Dispatch (Issue #233)
+
+- The M3 notebook generator (`m3_notebook_generator` in `backend/src/case_generator/graph.py`) dispatches to ONE specialized prompt per algorithm family instead of a single monolithic prompt.
+- `case_generator.prompts.PROMPT_BY_FAMILY` exposes exactly 4 keys: `clasificacion`, `regresion`, `clustering`, `serie_temporal`. The legacy `M3_NOTEBOOK_ALGO_PROMPT` symbol is preserved as a back-compat alias for `M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION`.
+- Family is resolved with `family_of(name)` first, then `resolve_legacy_family(name)` for historical task_payloads (XGBoost, Ridge, NLP, etc.). On no match the dispatcher falls back to `clasificacion` and emits a `legacy_warning` appended to the data-gap block.
+- After the LLM call, `_validate_notebook_family_consistency(family, code)` checks the output against `_FAMILY_PROHIBITED_PATTERNS` (other-family API tokens like `train_test_split(` in clustering, `roc_auc_score` in regression). On violation the dispatcher reprompts ONCE with the explicit forbidden-tokens list; if the second attempt also violates, it raises `RuntimeError` and the job is marked failed. Never ship a runtime-broken notebook.
+- The single registry of truth lives in `case_generator.suggest_service.ALGORITHM_CATALOG`. The legacy `ALGORITHM_REGISTRY` dict in `graph.py` has been removed.
+- Deprecated families (`nlp`, `recomendacion`, `grafos`, `anomalias`, `segmentacion`, `clasificacion_tabular`, `regresion_tabular`, `nlp_text_mining`) are no longer exposed by the catalog and degrade to `clasificacion` via the legacy resolver. Do not reintroduce them without an ADR.
 
 ## Forbidden Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,10 +133,19 @@ Only run live LLM tests explicitly:
 - The teacher form picks algorithms from a canonical catalog instead of accepting up to five free-text chips.
 - `POST /api/authoring/jobs` accepts the breaking fields `algorithm_mode` (`"single" | "contrast"`), `algorithm_primary`, and `algorithm_challenger`. The legacy `suggested_techniques` body field has been removed; do not reintroduce it.
 - Algorithm picks are validated server-side at intake by `_validate_techniques_strict` whenever `case_type == "harvard_with_eda"` or `student_profile == "ml_ds"`. They are persisted into `task_payload` as `algorithm_mode` plus `algoritmos: list[str]` of length 0, 1, or 2.
-- `GET /api/authoring/algorithm-catalog?profile=...&case_type=...` returns the canonical declarative catalog as `{profile, case_type, items: [{name, family, family_label, tier}]}` where `tier ∈ {"baseline", "challenger"}` and `family ∈ {clustering, clasificacion, regresion, serie_temporal, recomendacion, nlp}`. The endpoint is open (no PII), `Literal`-validated, and re-checked at intake.
+- `GET /api/authoring/algorithm-catalog?profile=...&case_type=...` returns the canonical declarative catalog as `{profile, case_type, items: [{name, family, family_label, tier}]}` where `tier ∈ {"baseline", "challenger"}` and `family ∈ {clasificacion, regresion, clustering, serie_temporal}` (Issue #233 — 4×2 catalog, max 2 algorithms per family, exactly 1 baseline per family). The endpoint is open (no PII), `Literal`-validated, and re-checked at intake.
 - Family-coherence rule: in `contrast` mode the baseline and the challenger MUST belong to the same `family`. The backend rejects cross-family contrast picks (e.g. Logistic Regression vs Prophet) at intake with a 422 and a teacher-friendly Spanish message. The frontend `AlgorithmSelector` filters the challenger options to the baseline family. The LLM suggester is taught the same rule via prompt boundary AND the post-LLM `_snap_item` filter, so it cannot cross families even if the model strays.
 - LSTM has been removed from the canonical ml_ds time-series catalog. Do not reintroduce LSTM (or other heavy DL surrogates) without an ADR.
 - The `business` profile may legitimately expose only baseline items (no challengers in any family). The frontend disables the "2 algoritmos" mode in that case; the backend rejects contrast picks with a teacher-friendly message. Do not silently fall back to `single` on the backend.
+
+## M3 Notebook Per-Family Dispatch (Issue #233)
+
+- The M3 notebook generator (`m3_notebook_generator` in `backend/src/case_generator/graph.py`) dispatches to ONE specialized prompt per algorithm family instead of a single monolithic prompt.
+- `case_generator.prompts.PROMPT_BY_FAMILY` exposes exactly 4 keys: `clasificacion`, `regresion`, `clustering`, `serie_temporal`. The legacy `M3_NOTEBOOK_ALGO_PROMPT` symbol is preserved as a back-compat alias for `M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION`.
+- Family is resolved with `family_of(name)` first, then `resolve_legacy_family(name)` for historical task_payloads (XGBoost, Ridge, NLP, etc.). On no match the dispatcher falls back to `clasificacion` and emits a `legacy_warning` appended to the data-gap block.
+- After the LLM call, `_validate_notebook_family_consistency(family, code)` checks the output against `_FAMILY_PROHIBITED_PATTERNS` (other-family API tokens like `train_test_split(` in clustering, `roc_auc_score` in regression). On violation the dispatcher reprompts ONCE with the explicit forbidden-tokens list; if the second attempt also violates, it raises `RuntimeError` and the job is marked failed. Never ship a runtime-broken notebook.
+- The single registry of truth lives in `case_generator.suggest_service.ALGORITHM_CATALOG`. The legacy `ALGORITHM_REGISTRY` dict in `graph.py` has been removed.
+- Deprecated families (`nlp`, `recomendacion`, `grafos`, `anomalias`, `segmentacion`, `clasificacion_tabular`, `regresion_tabular`, `nlp_text_mining`) are no longer exposed by the catalog and degrade to `clasificacion` via the legacy resolver. Do not reintroduce them without an ADR.
 
 ## Forbidden Patterns
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -4,9 +4,9 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
-## TODO-230-A: Curar `challenger` para perfil `business` en `ALGORITHM_TAXONOMY`
+## TODO-230-A: Curar `challenger` para perfil `business` en `ALGORITHM_CATALOG`
 
-**What:** Hoy `get_algorithm_catalog("business", "harvard_with_eda").challenger == []` porque el catálogo `business_techniques` solo contiene baselines. El frontend ya degrada el toggle "2 algoritmos" cuando esto pasa, pero el contrato ideal es exponer al menos 1-2 challengers seguros para business (p. ej. `Random Forest interpretable + SHAP`).
+**What:** Hoy `get_algorithm_catalog("business", "harvard_with_eda")` devuelve solo baselines (4 entradas: 1 por familia). El frontend ya degrada el toggle "2 algoritmos" cuando esto pasa, pero el contrato ideal es exponer al menos 1-2 challengers seguros para business (p. ej. `Random Forest interpretable + SHAP`).
 
 **Why:** Permitir el modo contraste también en cursos de negocio sin forzar perfil `ml_ds`.
 
@@ -14,7 +14,7 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 **Cons:** Cambio de catálogo afecta UX inmediatamente; requiere consenso pedagógico.
 
-**Context:** Issue #230 envío inicial mantuvo el catálogo intacto a propósito (cambio quirúrgico). La curación de challengers para business se puede hacer en cualquier PR posterior tocando solo `ALGORITHM_TAXONOMY` y los tests asociados.
+**Context:** Issue #233 (`ALGORITHM_CATALOG` 4×2) preserva la decisión de #230 de mantener business solo con baselines. La curación de challengers para business se puede hacer en cualquier PR posterior tocando solo `ALGORITHM_CATALOG` (campo `profile_visibility`) y los tests asociados.
 
 ---
 

--- a/backend/src/case_generator/AGENTS.md
+++ b/backend/src/case_generator/AGENTS.md
@@ -26,6 +26,19 @@ This directory contains the core teacher authoring logic: prompts, graph executi
 
 These files require extra caution because small edits can change generated output quality, safety posture, and job execution behavior.
 
+## Algorithm Catalog (Issue #233)
+
+- `suggest_service.ALGORITHM_CATALOG` is the single source of truth for the 4×2 algorithm taxonomy: `clasificacion`, `regresion`, `clustering`, `serie_temporal` (8 entries total: 1 baseline + 1 challenger per family for `ml_ds`; baselines only for `business`).
+- Public helpers exposed for downstream consumers: `family_of(name)`, `resolve_legacy_family(name)`, `get_dispatch_meta(family)`, `FAMILY_LABELS`, `FAMILY_META`.
+- The legacy `ALGORITHM_REGISTRY` dict in `graph.py` has been removed. Do not reintroduce a parallel registry — extend the catalog instead.
+- Adding a new family or breaking the 4×2 invariant requires an ADR.
+
+## M3 Notebook Per-Family Dispatch (Issue #233)
+
+- `m3_notebook_generator` resolves a single family from the algorithm picks and dispatches to `prompts.PROMPT_BY_FAMILY[family]`. There is exactly one specialized prompt per canonical family.
+- Post-LLM, `_validate_notebook_family_consistency(family, code)` enforces the per-family forbidden-token list (`_FAMILY_PROHIBITED_PATTERNS`). On violation: reprompt ONCE with the explicit list; on second violation: raise `RuntimeError` to fail the job. Never ship a notebook that mixes families.
+- Legacy algorithm names (XGBoost, Ridge, NLP, etc.) in historical `task_payload` rows are mapped via `resolve_legacy_family`. Unknown names fall back to `clasificacion` and emit a warning into the data-gap block.
+
 ## Validation Expectations
 
 After changing this area, at minimum run:

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2978,8 +2978,10 @@ def m3_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
 
 # Substrings whose presence in the generated notebook proves a family violation.
 # Kept narrow on purpose (only API tokens unique to other families) to minimize
-# false positives. Comments inside try/except blocks do NOT count — we look for
-# import statements and call sites only.
+# false positives. The validator strips Jupytext markdown cells and code-comment
+# lines before scanning (see ``_strip_jupytext_for_validation``), so pedagogical
+# echoes of these tokens in markdown/comments do NOT count — only executable
+# import statements and call sites do.
 _FAMILY_PROHIBITED_PATTERNS: dict[str, tuple[str, ...]] = {
     "clustering": (
         "train_test_split(",
@@ -3022,15 +3024,67 @@ _FAMILY_PROHIBITED_PATTERNS: dict[str, tuple[str, ...]] = {
 }
 
 
+def _strip_jupytext_for_validation(notebook_text: str) -> str:
+    """Return only the executable Python from a Jupytext Percent notebook.
+
+    The per-family prompts enumerate forbidden tokens in their ``Lista NEGRA``
+    sections, so an obedient LLM frequently echoes those names back as
+    pedagogical markdown or as ``#``-prefixed code comments. Scanning the
+    raw notebook would treat such pedagogy as a violation and trigger a
+    false-positive reprompt → potential job failure on a clean notebook.
+
+    Strategy:
+      * Drop every ``# %% [markdown]`` cell (everything until the next ``# %%``
+        header or EOF).
+      * Inside ``# %%`` code cells, drop pure comment lines (``^\\s*#``) and
+        strip ``#``-suffix inline comments from non-empty code lines.
+      * Keep string literals untouched — they can still smuggle a forbidden
+        call (e.g. ``eval("roc_auc_score(...)")``) and the validator should
+        catch that.
+
+    Returns the stripped text, ready for substring scanning.
+    """
+    lines = notebook_text.splitlines()
+    out: list[str] = []
+    in_markdown = False
+    for raw in lines:
+        stripped = raw.lstrip()
+        if stripped.startswith("# %% [markdown]"):
+            in_markdown = True
+            continue
+        if stripped.startswith("# %%"):
+            in_markdown = False
+            continue
+        if in_markdown:
+            continue
+        # Skip pure-comment lines inside code cells.
+        if stripped.startswith("#"):
+            continue
+        # Strip trailing inline comments (``code  # comment``) — naive split
+        # on " #" is enough; we don't try to preserve "#" inside strings
+        # because the inline-comment heuristic is intentionally conservative.
+        if " #" in raw:
+            raw = raw.split(" #", 1)[0]
+        out.append(raw)
+    return "\n".join(out)
+
+
 def _validate_notebook_family_consistency(family: str, code: str) -> list[str]:
-    """Return a list of prohibited tokens found in ``code`` for ``family``.
+    """Return a list of prohibited tokens found in executable code for ``family``.
+
+    Strips Jupytext markdown cells and code-comment lines first, then runs a
+    substring scan against ``_FAMILY_PROHIBITED_PATTERNS[family]``. This avoids
+    flagging the prompt's own ``Lista NEGRA`` echoes that the LLM may legitimately
+    include as documentation.
 
     Empty list = pass. Non-empty = the LLM strayed; caller should reprompt
-    once with the explicit list, then fail-job if the second attempt also
-    contains forbidden tokens.
+    once and fail-job if the second attempt also contains forbidden tokens.
     """
     patterns = _FAMILY_PROHIBITED_PATTERNS.get(family, ())
-    return [p for p in patterns if p in code]
+    if not patterns:
+        return []
+    scannable = _strip_jupytext_for_validation(code)
+    return [p for p in patterns if p in scannable]
 
 
 def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
@@ -3197,12 +3251,19 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
                     f"[m3_notebook_generator] Violación de familia detectada (familia={family}, "
                     f"tokens={violations}). Reprompt explícito (1/1)."
                 )
+                # Belt-and-suspenders against reprompt amplification: we do NOT
+                # echo the offending token strings in the corrective message
+                # (the LLM might politely repeat them in its acknowledgement,
+                # which would re-trip the validator and fail the job). Instead
+                # we reference the prompt's own ``Lista NEGRA`` section.
                 reprompt = (
                     prompt
                     + "\n\n# CORRECCIÓN OBLIGATORIA\n"
-                    + f"# Tu salida anterior contenía tokens de OTRAS familias prohibidos para '{family}': "
-                    + ", ".join(violations)
-                    + "\n# Reescribe la salida COMPLETA respetando estrictamente la lista NEGRA del prompt."
+                    + f"# Tu salida anterior emitió código ejecutable de OTRAS familias prohibidas para '{family}'.\n"
+                    + "# Releé la sección 'Lista NEGRA' del prompt y reescribe la salida COMPLETA\n"
+                    + "# usando EXCLUSIVAMENTE la API estable declarada para esta familia.\n"
+                    + "# Los nombres prohibidos pueden aparecer en celdas markdown como advertencia pedagógica,\n"
+                    + "# pero NUNCA como import, call site, ni dentro de un string ejecutable."
                 )
                 response2 = llm.invoke(reprompt)
                 algo_section = sanitize_markdown(_extract_text(response2))

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -88,13 +88,18 @@ from case_generator.prompts import (
     M3_AUDIT_QUESTIONS_PROMPT,
     M3_EXPERIMENT_QUESTIONS_PROMPT,
     M3_NOTEBOOK_BASE_TEMPLATE,
-    M3_NOTEBOOK_ALGO_PROMPT,
+    PROMPT_BY_FAMILY,
     M4_CONTENT_GENERATOR_PROMPT,
     M4_CHART_GENERATOR_PROMPT,
     M5_CONTENT_GENERATOR_PROMPT,
     TEACHING_NOTE_PART1_PROMPT,
     TEACHING_NOTE_PART2_PROMPT,
     SCHEMA_DESIGNER_PROMPT,
+)
+from case_generator.suggest_service import (
+    family_of,
+    get_dispatch_meta,
+    resolve_legacy_family,
 )
 from case_generator.tools_and_schemas import (
     CaseArchitectOutput,
@@ -2048,11 +2053,11 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
     max_rows = 200 if profile == "ml_ds" else 100
 
     # Extraer familias ML requeridas para el Módulo 3 a partir del input del usuario.
-    # _detect_algorithm_families usa ALGORITHM_REGISTRY (keyword matching).
+    # _detect_algorithm_families resuelve por catálogo (Issue #233) con fallback legacy.
     algoritmos_raw = state.get("algoritmos", [])
     familias_detectadas = _detect_algorithm_families(algoritmos_raw) if algoritmos_raw else []
     ml_required_families = (
-        ", ".join(familias_detectadas) if familias_detectadas else "nlp_text_mining, clasificacion_tabular"
+        ", ".join(familias_detectadas) if familias_detectadas else "clasificacion"
     )
 
     context = _build_base_context(state)
@@ -2827,133 +2832,35 @@ def m5_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
 # ─────────────────────────────────────────────────────────
 
 # ══════════════════════════════════════════════════════════════════════════════
-# ALGORITHM REGISTRY — mapeo determinístico de algoritmos → familias
-# Usado por m3_notebook_generator para detectar familias y prerrequisitos.
-# Fuente de verdad para toda lógica de notebook en el sistema.
+# ALGORITHM FAMILY DETECTION — Issue #233
+# Single source of truth lives in suggest_service.ALGORITHM_CATALOG. The legacy
+# graph-local ALGORITHM_REGISTRY (9 keys with `_tabular` suffixes) was deleted
+# so we cannot drift from the catalog the teacher form actually exposes.
 # ══════════════════════════════════════════════════════════════════════════════
-ALGORITHM_REGISTRY: dict[str, dict] = {
-    "clasificacion_tabular": {
-        "keywords": [
-            "clasificacion", "classification", "classifier", "logistic",
-            "random forest", "xgboost", "decision tree", "svm", "naive bayes",
-            "gradient boosting", "catboost", "lightgbm", "adaboost",
-        ],
-        "imports_needed": ["sklearn.model_selection", "sklearn.metrics"],
-        "prerequisite_note": "Requiere columnas numéricas como features y una columna categórica como target.",
-        "visualization": "Feature Importance (barh) + Confusion Matrix",
-        "fragments_hint": ["categoria", "category", "label", "tipo", "clase", "clasificacion", "target"],
-    },
-    "regresion_tabular": {
-        "keywords": [
-            "regresion", "regression", "regressor", "linear regression",
-            "ridge", "lasso", "elastic net", "svr",
-        ],
-        "imports_needed": ["sklearn.model_selection", "sklearn.metrics"],
-        "prerequisite_note": "Requiere columnas numéricas como features y una columna continua como target.",
-        "visualization": "Scatter real vs predicho + línea 45°",
-        "fragments_hint": ["precio", "valor", "monto", "revenue", "ventas", "importe", "score"],
-    },
-    "clustering": {
-        "keywords": [
-            "clustering", "kmeans", "k-means", "dbscan",
-            "hierarchical", "agglomerative", "cluster",
-        ],
-        "imports_needed": ["sklearn.cluster", "sklearn.preprocessing"],
-        "prerequisite_note": "Requiere al menos 2 columnas numéricas. No requiere columna target.",
-        "visualization": "Elbow method (inercia vs k) + Scatter 2D con colores por cluster",
-        "fragments_hint": ["valor", "monto", "cantidad", "score", "precio", "edad", "ingreso"],
-    },
-    "nlp_text_mining": {
-        "keywords": [
-            "nlp", "text mining", "text analysis", "topic modeling", "lda",
-            "tfidf", "tf-idf", "sentiment", "ner", "named entity",
-            "word2vec", "bert", "embeddings", "procesamiento lenguaje",
-        ],
-        "imports_needed": ["sklearn.feature_extraction.text"],
-        "prerequisite_note": "Requiere una columna de texto libre en el dataset.",
-        "visualization": "Bar de términos más frecuentes (TF-IDF)",
-        "fragments_hint": ["ticket", "queja", "texto", "descripcion", "comentario", "mensaje", "detalle"],
-    },
-    "grafos": {
-        "keywords": [
-            "graph", "grafo", "network", "red", "networkx",
-            "node", "nodo", "link", "edge", "arista", "community detection",
-            "graph neural", "gnn",
-        ],
-        "imports_needed": ["networkx"],
-        "prerequisite_note": "Requiere columnas de origen y destino (y opcionalmente peso).",
-        "visualization": "networkx.draw con nodos, aristas y pesos de afinidad",
-        "fragments_hint": ["origen", "source", "destino", "target", "nodo", "edge", "from", "to"],
-    },
-    "recomendacion": {
-        "keywords": [
-            "recommendation", "recomendacion", "collaborative filtering",
-            "content-based", "matrix factorization", "svd", "als",
-            "cosine similarity", "filtrado colaborativo",
-        ],
-        "imports_needed": [],
-        "prerequisite_note": "Requiere columnas de entidad_A (usuario), entidad_B (ítem) y score/interacción.",
-        "visualization": "Heatmap de afinidad (seaborn) con entidades en ejes",
-        "fragments_hint": ["usuario", "user", "cliente", "item", "producto", "rating", "score", "afinidad"],
-    },
-    "anomalias": {
-        "keywords": [
-            "anomaly", "anomalia", "anomaly detection", "outlier",
-            "isolation forest", "one-class svm", "autoencoder", "fraud detection",
-            "deteccion anomalias",
-        ],
-        "imports_needed": ["sklearn.ensemble"],
-        "prerequisite_note": "Requiere columnas numéricas. No requiere columna target.",
-        "visualization": "Scatter con puntos normales vs anomalías en distinto color",
-        "fragments_hint": ["valor", "monto", "cantidad", "score", "importe", "transaccion"],
-    },
-    "serie_temporal": {
-        "keywords": [
-            "time series", "serie temporal", "arima", "prophet", "lstm",
-            "forecasting", "forecast", "prediccion temporal", "time-series",
-            "seasonality", "estacionalidad",
-        ],
-        "imports_needed": [],
-        "prerequisite_note": "Requiere columna de fecha/periodo y al menos una variable numérica.",
-        "visualization": "plt.plot con fecha/periodo en eje X y variable objetivo en eje Y",
-        "fragments_hint": ["fecha", "date", "timestamp", "periodo", "mes", "dia", "created"],
-    },
-    "segmentacion": {
-        "keywords": [
-            "segmentacion", "segmentation", "segment", "rfm",
-            "customer segment", "market segment", "perfil cliente",
-        ],
-        "imports_needed": ["sklearn.cluster", "sklearn.preprocessing"],
-        "prerequisite_note": "Requiere columnas numéricas para calcular perfiles por segmento.",
-        "visualization": "K-Means + comparación de perfiles por cluster (barh)",
-        "fragments_hint": ["rfm", "valor", "frecuencia", "recencia", "segmento", "monto", "cliente"],
-    },
-}
 
 
 def _detect_algorithm_families(algoritmos: list[str]) -> list[str]:
-    """Detecta las familias algorítmicas para un listado de algoritmos.
+    """Return the canonical 4-family keys for a list of algorithms.
 
-    Usa ALGORITHM_REGISTRY para keyword matching. Si un algoritmo no mapea
-    a ninguna familia conocida, devuelve "unsupported" para ese algoritmo.
+    Resolution order per algorithm:
+      1. ``family_of(name)``     — exact catalog match (Issue #233 catalog).
+      2. ``resolve_legacy_family(name)`` — substring fallback for historical
+         jobs (XGBoost, Ridge, Prophet pre-rename, NLP/recomendación, ...).
+      3. ``"unsupported"``       — surfaces as a notebook warning.
 
-    Issue #230 contract: ``len(algoritmos) ∈ {1, 2}`` — el formulario docente
-    permite exactamente 1 algoritmo (modo single) o 2 algoritmos baseline +
-    challenger (modo contrast). Otras longitudes provienen de jobs históricos
-    o de un payload mal formado y se procesan best-effort.
+    Issue #230 contract: ``len(algoritmos) ∈ {1, 2}`` — the teacher form picks
+    exactly 1 (single mode) or 2 (contrast mode) algorithms. In contrast mode
+    the family-coherence rule guarantees both share the same family, so the
+    returned list is always length 1 (or ["unsupported"] if neither resolves).
     """
     detected: list[str] = []
     for algo in algoritmos:
-        algo_lower = algo.lower()
-        matched = False
-        for family, config in ALGORITHM_REGISTRY.items():
-            if any(kw in algo_lower for kw in config["keywords"]):
-                if family not in detected:
-                    detected.append(family)
-                matched = True
-                break
-        if not matched and "unsupported" not in detected:
-            detected.append("unsupported")
+        family = family_of(algo)
+        if family is None:
+            legacy = resolve_legacy_family(algo)
+            family = legacy[0] if legacy else "unsupported"
+        if family not in detected:
+            detected.append(family)
     return detected
 
 # Issue 4.1 — M3 CONTENT GENERATOR
@@ -3060,6 +2967,72 @@ def m3_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
         return {"m3_questions": [], "current_agent": "m3_questions_generator"}
 
 
+# ══════════════════════════════════════════════════════════════════════════════
+# Issue #233 — Post-LLM family-consistency validator
+# Catches the rare case where the specialized prompt strays into another
+# family's API surface (e.g. a clustering notebook emitting `train_test_split`
+# or a regression notebook emitting `roc_auc_score`). The notebook generator
+# reprompts ONCE on violation and fails the job if a second attempt also
+# strays — better to fail loudly than ship a runtime-broken notebook.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Substrings whose presence in the generated notebook proves a family violation.
+# Kept narrow on purpose (only API tokens unique to other families) to minimize
+# false positives. Comments inside try/except blocks do NOT count — we look for
+# import statements and call sites only.
+_FAMILY_PROHIBITED_PATTERNS: dict[str, tuple[str, ...]] = {
+    "clustering": (
+        "train_test_split(",
+        "roc_auc_score",
+        "confusion_matrix",
+        "classification_report",
+        "f1_score(",
+        "mean_squared_error(",
+        "r2_score(",
+        "from sklearn.model_selection import train_test_split",
+    ),
+    "serie_temporal": (
+        "train_test_split(",
+        "roc_auc_score",
+        "confusion_matrix",
+        "classification_report",
+        "silhouette_score(",
+        "davies_bouldin_score(",
+        "from sklearn.cluster import",
+        "from sklearn.model_selection import train_test_split",
+    ),
+    "regresion": (
+        "roc_auc_score",
+        "confusion_matrix",
+        "classification_report",
+        "silhouette_score(",
+        "davies_bouldin_score(",
+        "auto_arima",
+        "from prophet import",
+        "from sklearn.cluster import",
+    ),
+    "clasificacion": (
+        "silhouette_score(",
+        "davies_bouldin_score(",
+        "auto_arima",
+        "from prophet import",
+        "from sklearn.cluster import",
+        "from statsmodels.tsa.arima",
+    ),
+}
+
+
+def _validate_notebook_family_consistency(family: str, code: str) -> list[str]:
+    """Return a list of prohibited tokens found in ``code`` for ``family``.
+
+    Empty list = pass. Non-empty = the LLM strayed; caller should reprompt
+    once with the explicit list, then fail-job if the second attempt also
+    contains forbidden tokens.
+    """
+    patterns = _FAMILY_PROHIBITED_PATTERNS.get(family, ())
+    return [p for p in patterns if p in code]
+
+
 def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
     """Genera el notebook del Experiment Engineer — ÚNICO notebook del sistema.
 
@@ -3069,9 +3042,17 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
     Si cualquiera falla → noop. Ningún otro nodo del sistema genera notebooks.
 
     Output: m3_notebook_code (Jupytext Percent → frontend convierte a .ipynb)
-    Arquitectura:
-      - Sección base: M3_NOTEBOOK_BASE_TEMPLATE (estático, cero alucinaciones)
-      - Sección módulos: M3_NOTEBOOK_ALGO_PROMPT (LLM, usa ALGORITHM_REGISTRY)
+
+    Arquitectura (Issue #233 — per-family dispatch):
+      - Sección base : M3_NOTEBOOK_BASE_TEMPLATE (estático, cero alucinaciones).
+      - Sección módulos: PROMPT_BY_FAMILY[family] — UN prompt especializado por
+        familia (clasificacion / regresion / clustering / serie_temporal). El
+        contrato Issue #230 garantiza que los algoritmos del caso comparten
+        familia (en contrast mode), así que SIEMPRE hay un único prompt.
+      - Post-LLM: ``_validate_notebook_family_consistency`` revisa que el código
+        no contenga API de otras familias (anti-alucinación). Si hay violación,
+        se hace UN reprompt explícito; si vuelve a fallar, el job falla con un
+        mensaje en español y un log estructurado.
     """
     profile = state.get("studentProfile", "business")
     output_depth = state.get("output_depth", "")
@@ -3129,39 +3110,50 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
         # with curly braces (dict comprehensions, f-strings) that .format() misparses.
         base_template = M3_NOTEBOOK_BASE_TEMPLATE.replace("{case_title}", case_title)
 
-        # Detectar familias algorítmicas para informar al LLM
+        # ── Family dispatch (Issue #233) ─────────────────────────────────────
+        # The teacher form (Issue #230) guarantees algoritmos share a family
+        # in contrast mode. We resolve the first algorithm to its family,
+        # falling back to the legacy substring map for historical jobs.
         algoritmos_raw: list[str] = state.get("algoritmos", [])
-        familias = _detect_algorithm_families(algoritmos_raw)
-        print(f"[m3_notebook_generator] Familias detectadas: {familias}")
+        legacy_warning: str | None = None
+        family: str | None = None
+        for algo in algoritmos_raw:
+            family = family_of(algo)
+            if family is not None:
+                break
+        if family is None:
+            for algo in algoritmos_raw:
+                legacy = resolve_legacy_family(algo)
+                if legacy is not None:
+                    family, legacy_warning = legacy
+                    break
+        if family is None or family not in PROMPT_BY_FAMILY:
+            print(
+                f"[m3_notebook_generator] Familia no resuelta para algoritmos="
+                f"{algoritmos_raw!r} — usando fallback 'clasificacion'"
+            )
+            family = "clasificacion"
+            legacy_warning = (
+                f"Algoritmos {algoritmos_raw!r} no mapearon a ninguna familia "
+                f"del catálogo Issue #233; se generó notebook con plantilla de clasificación."
+            )
 
-        # Build familias_meta: deterministic registry data per family so the LLM
-        # doesn't need to recall visualization specs or fragment hints from its weights.
-        # `algoritmos`: lista de los algoritmos crudos del caso que activaron esta familia.
-        # El prompt ALGO renderiza UN bloque por algoritmo dentro de cada familia, así un
-        # caso que pide "Logistic + RF + SHAP" y "XGBoost con tuning" en clasificacion_tabular
-        # produce DOS bloques visuales y no uno colapsado.
-        familias_meta = []
-        for f in familias:
-            if f not in ALGORITHM_REGISTRY:
-                continue
-            keywords = ALGORITHM_REGISTRY[f]["keywords"]
-            algos_de_familia = [
-                a for a in algoritmos_raw
-                if any(kw in a.lower() for kw in keywords)
-            ]
-            # Si esta familia fue detectada (está en ALGORITHM_REGISTRY) pero ningún algoritmo
-            # crudo coincide con sus keywords en este segundo paso, conserva al menos el nombre
-            # de la familia para que el prompt pueda renderizar 1 bloque genérico de la familia.
-            # Nota: "unsupported" ya quedó filtrado por el `continue` de arriba.
-            if not algos_de_familia:
-                algos_de_familia = [f]
-            familias_meta.append({
-                "familia": f,
-                "algoritmos": algos_de_familia,
-                "visualizacion": ALGORITHM_REGISTRY[f]["visualization"],
-                "prerequisito": ALGORITHM_REGISTRY[f]["prerequisite_note"],
-                "fragments_hint": ALGORITHM_REGISTRY[f]["fragments_hint"],
-            })
+        print(f"[m3_notebook_generator] Familia despachada: {family!r} (algoritmos={algoritmos_raw!r})")
+
+        # Single-entry familias_meta: the prompt expects a list with metadata
+        # for the active family; we collapse to one entry because per-family
+        # dispatch makes multi-family notebooks impossible by construction.
+        meta = get_dispatch_meta(family)
+        familias_meta = [
+            {
+                "familia": meta["familia"],
+                "family_label": meta["family_label"],
+                "algoritmos": list(algoritmos_raw) if algoritmos_raw else [meta["familia"]],
+                "visualizacion": meta["visualizacion"],
+                "prerequisito": meta["prerequisito"],
+                "fragments_hint": meta["fragments_hint"],
+            }
+        ]
 
         algo_section = ""
         try:
@@ -3171,24 +3163,67 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
             contract_block = _format_dataset_contract_block(
                 state.get("dataset_schema_required")
             )
-            gap_warnings = state.get("data_gap_warnings") or []
+            gap_warnings = list(state.get("data_gap_warnings") or [])
+            if legacy_warning:
+                gap_warnings.append(legacy_warning)
             gaps_block = (
                 "\n".join(f"- {w}" for w in gap_warnings)
                 if gap_warnings
                 else "(sin brechas detectadas — schema cubre el contrato)"
             )
-            prompt = M3_NOTEBOOK_ALGO_PROMPT.format(
-                m3_content=(state.get("m3_content", "") or "")[:2000],
-                algoritmos=json.dumps(algoritmos_raw, ensure_ascii=False),
-                familias_meta=json.dumps(familias_meta, ensure_ascii=False),
-                case_title=case_title,
-                output_language=context.get("output_language", "es"),
-                dataset_contract_block=contract_block,
-                data_gap_warnings_block=gaps_block,
-            )
+
+            prompt_template = PROMPT_BY_FAMILY[family]
+
+            def _render(template: str) -> str:
+                return template.format(
+                    m3_content=(state.get("m3_content", "") or "")[:2000],
+                    algoritmos=json.dumps(algoritmos_raw, ensure_ascii=False),
+                    familias_meta=json.dumps(familias_meta, ensure_ascii=False),
+                    case_title=case_title,
+                    output_language=context.get("output_language", "es"),
+                    dataset_contract_block=contract_block,
+                    data_gap_warnings_block=gaps_block,
+                )
+
+            prompt = _render(prompt_template)
             response = llm.invoke(prompt)
             algo_section = sanitize_markdown(_extract_text(response))
-            print(f"[m3_notebook_generator] Sección módulos LLM: {len(algo_section)} chars")
+            print(f"[m3_notebook_generator] Sección módulos LLM (1ª pasada): {len(algo_section)} chars")
+
+            # Issue #233 — post-LLM family-consistency check + reprompt-once.
+            violations = _validate_notebook_family_consistency(family, algo_section)
+            if violations:
+                print(
+                    f"[m3_notebook_generator] Violación de familia detectada (familia={family}, "
+                    f"tokens={violations}). Reprompt explícito (1/1)."
+                )
+                reprompt = (
+                    prompt
+                    + "\n\n# CORRECCIÓN OBLIGATORIA\n"
+                    + f"# Tu salida anterior contenía tokens de OTRAS familias prohibidos para '{family}': "
+                    + ", ".join(violations)
+                    + "\n# Reescribe la salida COMPLETA respetando estrictamente la lista NEGRA del prompt."
+                )
+                response2 = llm.invoke(reprompt)
+                algo_section = sanitize_markdown(_extract_text(response2))
+                violations2 = _validate_notebook_family_consistency(family, algo_section)
+                if violations2:
+                    logger.error(
+                        "[m3_notebook_generator] Reprompt falló — familia=%s tokens=%s",
+                        family, violations2,
+                    )
+                    raise RuntimeError(
+                        f"M3 notebook generator emitió código de otras familias para "
+                        f"'{family}' incluso tras un reprompt: {violations2}. "
+                        f"Job marcado como fallido para evitar shipping de notebook roto."
+                    )
+                print(
+                    f"[m3_notebook_generator] Reprompt OK — familia={family}, "
+                    f"chars={len(algo_section)}"
+                )
+        except RuntimeError:
+            # Re-raise to fail the job — the validator policy demands it.
+            raise
         except Exception as e:
             logger.error("[m3_notebook_generator] Error en LLM módulos: %s", e, exc_info=True)
             algo_section = (
@@ -3201,6 +3236,10 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
         final_notebook = base_template + "\n\n" + algo_section
         print(f"[m3_notebook_generator] Notebook ensamblado: {len(final_notebook)} chars")
         return {"m3_notebook_code": final_notebook, "current_agent": "m3_notebook_generator"}
+    except RuntimeError:
+        # Issue #233 — family-consistency violation after reprompt. Re-raise so
+        # the worker can mark the job as failed; never ship a runtime-broken notebook.
+        raise
     except Exception as e:
         logger.error("[m3_notebook_generator] ERROR: %s", e, exc_info=True)
         return {"m3_notebook_code": "# ⚠️ Error generando notebook M3. Revisa el Módulo 3."}

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -2086,7 +2086,7 @@ print("🔢 Numéricas:", numeric_candidates[:20] if numeric_candidates else "No
 
 
 
-M3_NOTEBOOK_ALGO_PROMPT = """\
+M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION = """\
 Eres un ML Engineer generando la Sección 3 de un notebook Jupytext Percent para Google Colab.
 El notebook sigue la estructura pedagógica ADAM M3: Concepto → Gráfico Conceptual → Acción de Negocio.
 Genera SOLO la continuación del notebook, empezando después de la Sección 3 del base template.
@@ -2488,3 +2488,631 @@ Familias con metadata (visualizacion, prerequisito, fragments_hint): {familias_m
 Algoritmos detectados: {algoritmos}
 Contexto M3 (extracto): {m3_content}
 """
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+# Issue #233 — Per-family M3 notebook prompts
+#
+# The classification prompt above is the canonical home of all PR #232 hygiene
+# fixes (anti-leakage naming, AUC-ROC + class_weight, post-split degeneracy
+# guard, feature_cols hygiene) and Issue #228 atomic charting. The 3 prompts
+# below mirror that structure but specialize the algorithm-specific contract:
+#
+#   - REGRESSION: RMSE/MAE/R², residuals scatter, np.isfinite guard, no AUC.
+#   - CLUSTERING: StandardScaler obligatorio, no train_test_split, silhouette
+#                 + davies_bouldin, elbow/k-distance + PCA scatter.
+#   - TIMESERIES: split por corte temporal (último 20%), nunca random;
+#                 MAPE/sMAPE/RMSE; ARIMA(1,1,1) default; Prophet en try/except.
+#
+# .format() contract (idéntico en los 4 prompts, no romper este shape):
+#   m3_content, algoritmos, familias_meta, case_title, output_language,
+#   dataset_contract_block, data_gap_warnings_block.
+# ════════════════════════════════════════════════════════════════════════════════
+
+
+M3_NOTEBOOK_ALGO_PROMPT_REGRESSION = """\
+Eres un ML Engineer generando la Sección 3 de un notebook Jupytext Percent para Google Colab.
+El notebook resuelve un problema de REGRESIÓN (target numérico continuo).
+Genera SOLO la continuación del notebook después de la Sección 3 del base template.
+
+# Contrato dataset_schema_required (Issue #225 — fuente canónica del target)
+{dataset_contract_block}
+
+# Brechas de datos detectadas por el validador (data_gap_warnings)
+{data_gap_warnings_block}
+
+# Reglas CONTRACT-FIRST (Issue #225 — prioridad máxima)
+* Si el contrato declara `target_column.name`, usa ese nombre EXACTO. NO uses alias-matching.
+* Si el target del contrato no está en `df.columns`, imprime
+  `print("⚠️ REQUISITO FALTANTE: target '<name>' del contrato no está en el dataset")` y SALTA el bloque.
+* Excluye features con `is_leakage_risk=true` o `temporal_offset_months>0` de `X`.
+* Sin contrato: aplica fallback heurístico (último numérico continuo NO-id).
+* Defensa extra anti-leakage (siempre): excluye columnas con patrones temporal-posteriores
+  (`retention_m`, `churn_date`, `churned_at`, `cancellation`, `days_to_churn`, `days_to_cancel`,
+  `_post_`, `_after_`, `m3_`, `m6_`, `m12_`) salvo que sean el target del contrato.
+
+# Reglas absolutas
+1. NUNCA uses np.random, pd.DataFrame() fabricado, columnas inventadas ni placeholders.
+2. SOLO trabaja con columnas reales de `df`. Resuelve por alias con helpers del base template.
+3. Formato SOLO Jupytext Percent: `# %%` y `# %% [markdown]`. Sin fences ```python.
+4. NO redefinas funciones del base template.
+5. Idioma de salida: {output_language}.
+6. Cada bloque falla de forma aislada — encapsula en try/except local.
+   EXCEPCIÓN al try/except (anti-silenciamiento): las guardas explícitas
+   (target ausente del contrato, target no finito, feature_cols vacío) NO deben
+   quedar tragadas por un `except Exception`. Su `print("⚠️ ...")` debe ser visible.
+
+# Reglas de API estable (anti-alucinación de librerías)
+A. Usa SOLO API documentada y estable de scikit-learn ≥ 1.0:
+   - sklearn.linear_model.LinearRegression()
+   - sklearn.ensemble.GradientBoostingRegressor(n_estimators=100, random_state=42)
+   - sklearn.preprocessing.StandardScaler() (opcional, recomendado para Linear)
+   - sklearn.model_selection.train_test_split(..., test_size=0.25, random_state=42)
+   - sklearn.metrics: mean_squared_error, mean_absolute_error, r2_score
+B. Para RMSE usa: `float(np.sqrt(mean_squared_error(y_true, y_pred)))`.
+   PROHIBIDO `mean_squared_error(..., squared=False)` (removido en sklearn ≥1.6).
+   PROHIBIDO `RootMeanSquaredError`, `root_mean_squared_error`.
+C. Lista NEGRA explícita (PROHIBIDOS en este prompt — pertenecen a otras familias):
+   - `from sklearn.metrics import roc_auc_score, classification_report, confusion_matrix, f1_score, accuracy_score`
+   - `from sklearn.cluster import KMeans, DBSCAN` ; `silhouette_score, davies_bouldin_score`
+   - `import statsmodels`, `from statsmodels...`, `import pmdarima`, `auto_arima`
+   - `import prophet`, `from prophet import Prophet`
+   Si los detectas en tu salida, REESCRIBE — este prompt es solo regresión.
+D. NO importes nada que no esté en: numpy, pandas, matplotlib, seaborn, sklearn.{{linear_model,ensemble,model_selection,metrics,preprocessing}}, scipy.stats.
+
+# Métricas OBLIGATORIAS (regresión)
+- `from sklearn.metrics import mean_squared_error, r2_score, mean_absolute_error`
+- Imprime SIEMPRE las TRES:
+  - `print("RMSE:", float(np.sqrt(mean_squared_error(y_test, y_pred))))`
+  - `print("MAE :", float(mean_absolute_error(y_test, y_pred)))`
+  - `print("R²  :", float(r2_score(y_test, y_pred)))`
+- Antes del fit, imprime estadísticos del target en train:
+  `print("y_train describe:", y_train.describe().round(3).to_dict())`
+
+# Guardas obligatorias para regresión (anti-fit-degenerado)
+- ANTES del fit, valida que `y` sea numérico, finito y con varianza > 0:
+  `if not np.isfinite(y).all(): print("⚠️ TARGET NO FINITO — y contiene NaN/inf"); return / skip`
+  `if y.std() == 0: print("⚠️ TARGET SIN VARIANZA — y es constante"); return / skip`
+- Si `len(df) < 30`: imprime advertencia visible "⚠️ Dataset muy pequeño (n=<N>) — métricas inestables".
+
+# Split (regresión)
+- Si hay columna fecha (`find_first_matching_column(df.columns, date_aliases)`): split temporal
+  (orden por fecha, primer 75% train, último 25% test). Justifica en comentario.
+- Sin columna fecha: `train_test_split(X, y, test_size=0.25, random_state=42)` (sin stratify — es regresión).
+- ORDEN OBLIGATORIO: split primero → `med = X_train.median(numeric_only=True)` → imputar X_train y X_test
+  con `med`. PROHIBIDO `X.fillna(X.median())` antes del split (leakage).
+
+# Higiene de feature_cols (anti-features-basura)
+1. Candidatas = numéricas + categóricas con cardinalidad ≤ 20.
+2. Drop ID-like (cardinalidad == n_filas o token "id" en nombre normalizado).
+3. Drop near-constants (`nunique <= 1`) y high-null (`>50% NaN`).
+4. Drop features de leakage (contrato + patrones temporal-posteriores).
+5. One-hot ANTES del split: `X = pd.get_dummies(df[feature_cols], drop_first=True, dummy_na=False)`.
+6. Si `X.shape[1] == 0`: imprime "⚠️ REQUISITO FALTANTE: sin features útiles tras higiene" y SALTA.
+
+# Atomic Cell Charting (Issue #228 — un gráfico por celda)
+- PROHIBIDO `plt.subplots(1, N)` o `plt.subplots(N, M)` para mezclar gráficos heterogéneos.
+- Cada celda de visualización contiene exactamente UNA `plt.figure(...)` y UN `plt.show()`.
+- Por algoritmo, parte el bloque en sub-celdas:
+  (2a) Entrenamiento + métricas — celda SIN plots, solo `print(...)`.
+  (2b) Scatter real vs predicho con línea 45° — celda dedicada.
+  (2c) Residuals vs predicho — celda dedicada (la otra mitad de la viz canónica).
+  (2d) Feature importance — celda dedicada (solo si el modelo expone `feature_importances_` o `coef_`).
+- Cada celda termina con `plt.tight_layout(); plt.show()`.
+
+# EDA Express (Sección 3.0) OBLIGATORIA antes del primer bloque de algoritmo
+
+## El base template ya abrió `## Sección 3: Módulos Experimentales`; aquí emite un H3,
+## NO un H2 nuevo, para no duplicar la jerarquía.
+# %% [markdown]
+# ### 3.0 EDA Express
+# Antes de entrenar, validamos calidad y forma del dataset (regresión).
+
+# %%
+try:
+    target_col = find_first_matching_column(df.columns, ["precio", "valor", "monto", "revenue", "ventas", "importe", "score", "target"])
+    if target_col is None:
+        num_cols = df.select_dtypes(include=np.number).columns.tolist()
+        target_col = num_cols[-1] if num_cols else None
+    if target_col is not None and is_numeric_col(df, target_col):
+        print("Target candidato (regresión):", target_col)
+        print(df[target_col].describe().round(3))
+        if not np.isfinite(df[target_col].dropna()).all():
+            print("⚠️ TARGET NO FINITO — contiene NaN/inf en algunas filas.")
+        if df[target_col].std() == 0:
+            print("⚠️ TARGET SIN VARIANZA — la columna es constante; el modelo no puede aprender.")
+    if len(df) < 30:
+        print(f"\\n⚠️ Dataset muy pequeño (n={{len(df)}}): métricas de regresión muy inestables.")
+    print("\\nTop 10 columnas por % missing:")
+    print(df.isna().mean().sort_values(ascending=False).head(10).round(3))
+except Exception as e:
+    print(f"⚠️ EDA Express falló: {{e}}")
+
+## Para CADA familia en {familias_meta} (regresión: una sola familia por contrato Issue #230),
+## y para CADA algoritmo dentro del campo "algoritmos", emite las siguientes celdas EN ORDEN:
+
+## Celda 1 — Concepto (markdown)
+# %% [markdown]
+# ### regresion — [nombre exacto del algoritmo]
+# **Concepto:** [teoría en 2 líneas, sin jerga]
+# **Hipótesis experimental:** [extraída de {m3_content}, 1-2 líneas — NO inventes columnas]
+# **Prerequisitos:** [campo "prerequisito" del entry en {familias_meta}]
+
+## Celda 2a — Entrenamiento + Métricas (código, SIN plots)
+# %%
+try:
+    # 1. Resolver target_col por contrato/alias/fallback heurístico (último numérico).
+    # 2. Aplicar higiene de feature_cols (5 pasos).
+    # 3. Validar y finito + varianza > 0.
+    # 4. Split (temporal si hay fecha; sino train_test_split test_size=0.25).
+    # 5. Imputar con mediana de X_train (anti-leakage).
+    # 6. Fit y predict. Imprimir RMSE, MAE, R².
+    # 7. NO emitir plots aquí — la viz va en 2b/2c/2d.
+    # 8. Asignar `model`, `X_train`, `X_test`, `y_train`, `y_test`, `y_pred` a nombres reutilizables.
+    pass
+except Exception as e:
+    print(f"⚠️ Error: {{e}}")
+
+## Celda 2b — Scatter real vs predicho con línea 45° (código, exactamente UN plt.show())
+# %%
+try:
+    plt.figure(figsize=(7, 7))
+    # plt.scatter(y_test, y_pred, alpha=0.6)
+    # lo, hi = min(y_test.min(), y_pred.min()), max(y_test.max(), y_pred.max())
+    # plt.plot([lo, hi], [lo, hi], 'r--', lw=1)
+    # plt.xlabel("y real"); plt.ylabel("y predicho"); plt.title("Real vs Predicho")
+    # plt.tight_layout(); plt.show()
+    pass
+except Exception as e:
+    print(f"⚠️ Error scatter real-vs-pred: {{e}}")
+
+## Celda 2c — Residuals vs predicho (código, exactamente UN plt.show())
+# %%
+try:
+    plt.figure(figsize=(8, 5))
+    # residuals = y_test - y_pred
+    # plt.scatter(y_pred, residuals, alpha=0.6)
+    # plt.axhline(0, color='r', linestyle='--', lw=1)
+    # plt.xlabel("y predicho"); plt.ylabel("residual (y_real - y_pred)"); plt.title("Residuals vs Predicho")
+    # plt.tight_layout(); plt.show()
+    pass
+except Exception as e:
+    print(f"⚠️ Error residuals: {{e}}")
+
+## Celda 2d — Feature importance (código, OPCIONAL — salta si el modelo no la expone)
+# %%
+try:
+    plt.figure(figsize=(8, 5))
+    # if hasattr(model, "feature_importances_"):
+    #     pd.Series(model.feature_importances_, index=X_train.columns).nlargest(15).plot.barh()
+    # elif hasattr(model, "coef_"):
+    #     coef = model.coef_; imp = np.abs(coef).ravel()
+    #     pd.Series(imp, index=X_train.columns).nlargest(15).plot.barh()
+    # else:
+    #     print("Modelo sin importancias directas.")
+    # plt.tight_layout(); plt.show()
+    pass
+except Exception as e:
+    print(f"⚠️ Error importancia features: {{e}}")
+
+## Celda 3 — Acción de Negocio (markdown)
+# %% [markdown]
+# **Explicación pedagógica:** [qué muestran R²/RMSE y los gráficos, 2 líneas]
+# **Acción de negocio:** [próximo paso concreto basado en el resultado, 1 línea]
+
+# Sección final OBLIGATORIA — agregar SIEMPRE después del último bloque
+# %% [markdown]
+# ## Evaluación M3 — Diseño Experimental
+# Responde en la plataforma ADAM las preguntas del Módulo 3 sobre hipótesis, sesgos y descarte.
+
+---
+Caso: {case_title}
+Familias con metadata: {familias_meta}
+Algoritmos detectados: {algoritmos}
+Contexto M3 (extracto): {m3_content}
+"""
+
+
+M3_NOTEBOOK_ALGO_PROMPT_CLUSTERING = """\
+Eres un ML Engineer generando la Sección 3 de un notebook Jupytext Percent para Google Colab.
+El notebook resuelve un problema de CLUSTERING NO SUPERVISADO.
+Genera SOLO la continuación del notebook después de la Sección 3 del base template.
+
+# Contrato dataset_schema_required (Issue #225)
+{dataset_contract_block}
+
+# Brechas de datos detectadas por el validador (data_gap_warnings)
+{data_gap_warnings_block}
+
+# Reglas CONTRACT-FIRST
+* Clustering NO usa target. Si el contrato declara un `target_column`, IGNÓRALO en el fit
+  (puedes mostrarlo a posteriori para colorear los clusters como diagnóstico, pero NO lo uses como `y`).
+* Sin contrato: usa todas las columnas numéricas de `df` como features.
+
+# Reglas absolutas
+1. NUNCA uses np.random, pd.DataFrame() fabricado, columnas inventadas ni placeholders.
+2. SOLO trabaja con columnas reales de `df`. Resuelve por alias con helpers del base template.
+3. Formato SOLO Jupytext Percent: `# %%` y `# %% [markdown]`.
+4. NO redefinas funciones del base template.
+5. Idioma de salida: {output_language}.
+6. Cada bloque falla de forma aislada — encapsula en try/except local.
+   EXCEPCIÓN al try/except (anti-silenciamiento): las guardas explícitas
+   (n_samples insuficiente, sin features numéricas, todos los puntos en 1 cluster)
+   NO deben quedar tragadas por un `except Exception`.
+
+# Reglas de API estable
+A. Usa SOLO API documentada y estable de scikit-learn ≥ 1.0:
+   - sklearn.cluster.KMeans(n_clusters=k, n_init=10, random_state=42)
+   - sklearn.cluster.DBSCAN(eps=<value>, min_samples=5)
+   - sklearn.preprocessing.StandardScaler()  ← OBLIGATORIO antes de fit
+   - sklearn.decomposition.PCA(n_components=2, random_state=42)
+   - sklearn.metrics: silhouette_score, davies_bouldin_score
+B. Lista NEGRA explícita (PROHIBIDOS en este prompt — pertenecen a otras familias):
+   - `from sklearn.model_selection import train_test_split`  ← clustering NO usa split
+   - `from sklearn.metrics import roc_auc_score, classification_report, confusion_matrix, f1_score`
+   - `from sklearn.metrics import mean_squared_error, r2_score, mean_absolute_error`
+   - `import statsmodels`, `import pmdarima`, `auto_arima`, `import prophet`
+   Si los detectas en tu salida, REESCRIBE — este prompt es solo clustering.
+C. NO importes nada que no esté en: numpy, pandas, matplotlib, seaborn,
+   sklearn.{{cluster,preprocessing,decomposition,metrics}}, scipy.stats.
+
+# Métricas OBLIGATORIAS (clustering)
+- `from sklearn.metrics import silhouette_score, davies_bouldin_score`
+- Después del fit, SI hay ≥2 clusters formados:
+  - `print("Silhouette:", float(silhouette_score(X_scaled, labels)))`
+  - `print("Davies-Bouldin:", float(davies_bouldin_score(X_scaled, labels)))`
+- Imprime SIEMPRE el conteo por cluster: `print(pd.Series(labels).value_counts().to_dict())`
+
+# Guardas obligatorias para clustering (anti-fit-degenerado)
+- ANTES del fit, valida tamaño mínimo: `if len(df) < 10: print("⚠️ Dataset muy pequeño (n=<N>): clustering no representativo"); skip`.
+- Valida que haya ≥2 columnas numéricas tras higiene. Si no, imprime
+  `print("⚠️ REQUISITO FALTANTE: se requieren ≥2 columnas numéricas para clustering")` y SALTA.
+- DESPUÉS del fit, valida que se formaron ≥2 clusters:
+  `if len(set(labels) - {{-1}}) < 2: print("⚠️ Solo se formó 1 cluster real; revisa hiperparámetros (k, eps)"); skip métricas y plots`.
+  (Para DBSCAN, label `-1` significa ruido y NO cuenta como cluster).
+
+# StandardScaler OBLIGATORIO
+- ANTES de cualquier fit:
+  `from sklearn.preprocessing import StandardScaler`
+  `scaler = StandardScaler()`
+  `X_scaled = scaler.fit_transform(X)`
+- TODO el clustering trabaja sobre `X_scaled`, no sobre `X` cruda. Las distancias sin escalar
+  hacen que las features con mayor magnitud dominen y los clusters resulten arbitrarios.
+
+# Higiene de feature_cols
+1. Candidatas = SOLO columnas numéricas de `df` (sin one-hot de categóricas para mantener interpretabilidad de PCA).
+2. Drop ID-like (cardinalidad == n_filas o token "id" en nombre normalizado).
+3. Drop near-constants y high-null (>50% NaN).
+4. Drop el target del contrato (si existe) — clustering NO supervisado.
+5. `X = df[feature_cols].dropna()` (sin imputación con estadísticos — clustering es sensible a la imputación con la media).
+6. Si `X.shape[1] < 2` o `X.shape[0] < 10`: imprime "⚠️ REQUISITO FALTANTE..." y SALTA.
+
+# Atomic Cell Charting (Issue #228 — un gráfico por celda)
+- PROHIBIDO `plt.subplots(1, N)` o `plt.subplots(N, M)` para mezclar gráficos heterogéneos.
+- Cada celda de visualización contiene exactamente UNA `plt.figure(...)` y UN `plt.show()`.
+- Por algoritmo, parte el bloque en sub-celdas:
+  (2a) Selección de hiperparámetro (elbow para K-Means, k-distance para DBSCAN) — celda dedicada con UN plot.
+  (2b) Fit final + métricas — celda SIN plots.
+  (2c) Scatter 2D PCA con colores por cluster — celda dedicada con UN plot.
+- Cada celda termina con `plt.tight_layout(); plt.show()`.
+
+# EDA Express (Sección 3.0) OBLIGATORIA antes del primer bloque de algoritmo
+
+## El base template ya abrió `## Sección 3: Módulos Experimentales`; aquí emite un H3.
+# %% [markdown]
+# ### 3.0 EDA Express
+# Antes de hacer clustering, validamos calidad y forma del dataset.
+
+# %%
+try:
+    num_cols = df.select_dtypes(include=np.number).columns.tolist()
+    print(f"Columnas numéricas disponibles: {{len(num_cols)}}")
+    print(num_cols)
+    if len(num_cols) < 2:
+        print("⚠️ REQUISITO FALTANTE: clustering requiere ≥2 columnas numéricas.")
+    if len(df) < 10:
+        print(f"⚠️ Dataset muy pequeño (n={{len(df)}}): clustering no representativo.")
+    print("\\nTop 10 columnas por % missing:")
+    print(df.isna().mean().sort_values(ascending=False).head(10).round(3))
+except Exception as e:
+    print(f"⚠️ EDA Express falló: {{e}}")
+
+## Para CADA algoritmo en el campo "algoritmos" del único entry en {familias_meta},
+## emite las siguientes celdas EN ORDEN:
+
+## Celda 1 — Concepto (markdown)
+# %% [markdown]
+# ### clustering — [nombre exacto del algoritmo]
+# **Concepto:** [teoría en 2 líneas]
+# **Hipótesis experimental:** [extraída de {m3_content}, 1-2 líneas]
+# **Prerequisitos:** [campo "prerequisito" del entry en {familias_meta}]
+
+## Celda 2a — Selección de hiperparámetro (UN plot por celda)
+# %%
+try:
+    plt.figure(figsize=(8, 5))
+    # K-Means: elbow method
+    #   inertias = []
+    #   K = range(2, min(11, len(df)))
+    #   for k in K:
+    #       km = KMeans(n_clusters=k, n_init=10, random_state=42).fit(X_scaled)
+    #       inertias.append(km.inertia_)
+    #   plt.plot(list(K), inertias, marker='o'); plt.xlabel("k"); plt.ylabel("inercia")
+    #   plt.title("Elbow Method"); plt.tight_layout(); plt.show()
+    # DBSCAN: k-distance plot (k=min_samples-1) para elegir epsilon
+    #   from sklearn.neighbors import NearestNeighbors
+    #   nn = NearestNeighbors(n_neighbors=5).fit(X_scaled)
+    #   dists, _ = nn.kneighbors(X_scaled)
+    #   plt.plot(np.sort(dists[:, -1])); plt.xlabel("punto"); plt.ylabel("dist al 5º vecino")
+    #   plt.title("k-distance plot — busca el codo para epsilon"); plt.tight_layout(); plt.show()
+    pass
+except Exception as e:
+    print(f"⚠️ Error selección hiperparámetro: {{e}}")
+
+## Celda 2b — Fit final + Métricas (código, SIN plots)
+# %%
+try:
+    # 1. Higiene de features (5 pasos), `X = df[feature_cols].dropna()`.
+    # 2. StandardScaler → X_scaled.
+    # 3. Fit (K-Means con k del elbow / DBSCAN con eps del k-distance).
+    # 4. labels = model.labels_ (o model.fit_predict(X_scaled)).
+    # 5. Validar ≥2 clusters reales (descartando -1 de DBSCAN).
+    # 6. Imprimir silhouette_score y davies_bouldin_score.
+    # 7. Imprimir conteo por cluster.
+    pass
+except Exception as e:
+    print(f"⚠️ Error fit clustering: {{e}}")
+
+## Celda 2c — Scatter 2D PCA con colores por cluster (UN plot por celda)
+# %%
+try:
+    plt.figure(figsize=(8, 6))
+    # from sklearn.decomposition import PCA
+    # pca = PCA(n_components=2, random_state=42)
+    # X_pca = pca.fit_transform(X_scaled)
+    # plt.scatter(X_pca[:, 0], X_pca[:, 1], c=labels, cmap='tab10', alpha=0.7, s=20)
+    # plt.xlabel(f"PC1 ({{pca.explained_variance_ratio_[0]:.0%}})")
+    # plt.ylabel(f"PC2 ({{pca.explained_variance_ratio_[1]:.0%}})")
+    # plt.title("Clusters proyectados en 2D (PCA)")
+    # plt.tight_layout(); plt.show()
+    pass
+except Exception as e:
+    print(f"⚠️ Error scatter PCA: {{e}}")
+
+## Celda 3 — Acción de Negocio (markdown)
+# %% [markdown]
+# **Explicación pedagógica:** [qué muestran silhouette/Davies-Bouldin y los clusters, 2 líneas]
+# **Acción de negocio:** [próximo paso concreto basado en los segmentos descubiertos, 1 línea]
+
+# Sección final OBLIGATORIA
+# %% [markdown]
+# ## Evaluación M3 — Diseño Experimental
+# Responde en la plataforma ADAM las preguntas del Módulo 3 sobre hipótesis, sesgos y descarte.
+
+---
+Caso: {case_title}
+Familias con metadata: {familias_meta}
+Algoritmos detectados: {algoritmos}
+Contexto M3 (extracto): {m3_content}
+"""
+
+
+M3_NOTEBOOK_ALGO_PROMPT_TIMESERIES = """\
+Eres un ML Engineer generando la Sección 3 de un notebook Jupytext Percent para Google Colab.
+El notebook resuelve un problema de SERIES TEMPORALES (forecasting).
+Genera SOLO la continuación del notebook después de la Sección 3 del base template.
+
+# Contrato dataset_schema_required (Issue #225)
+{dataset_contract_block}
+
+# Brechas de datos detectadas por el validador (data_gap_warnings)
+{data_gap_warnings_block}
+
+# Reglas CONTRACT-FIRST
+* Si el contrato declara `target_column.name`, usa ese nombre EXACTO como serie objetivo.
+* El target DEBE ser numérico continuo. Si no lo es, imprime "⚠️ REQUISITO FALTANTE..." y SALTA.
+* Detección de columna fecha: alias-first (date_aliases), fallback heurístico (`pd.to_datetime` aplicable).
+* Sin contrato: usa la última columna numérica como target y la primera fecha-parseable como índice.
+
+# Reglas absolutas
+1. NUNCA uses np.random, pd.DataFrame() fabricado, columnas inventadas ni placeholders.
+2. SOLO trabaja con columnas reales de `df`. Resuelve por alias con helpers del base template.
+3. Formato SOLO Jupytext Percent: `# %%` y `# %% [markdown]`.
+4. NO redefinas funciones del base template.
+5. Idioma de salida: {output_language}.
+6. Cada bloque falla de forma aislada — encapsula en try/except local.
+   EXCEPCIÓN al try/except (anti-silenciamiento): las guardas explícitas
+   (sin columna fecha, n_points<30, target no numérico) NO deben quedar tragadas
+   por un `except Exception`.
+
+# Reglas de API estable
+A. ARIMA: usa `statsmodels.tsa.arima.model.ARIMA` con default `order=(1,1,1)`.
+   `from statsmodels.tsa.arima.model import ARIMA`
+   `model = ARIMA(y_train, order=(1, 1, 1)).fit()`
+   `y_pred = model.forecast(steps=len(y_test))`
+   PROHIBIDO `auto_arima` salvo dentro de un try/except con fallback explícito a `ARIMA(1,1,1)`.
+B. Prophet: import OPCIONAL, SIEMPRE en try/except. Si falla, fallback a ARIMA(1,1,1).
+   Patrón canónico:
+     `try:`
+         `from prophet import Prophet`
+         `prophet_df = pd.DataFrame({{"ds": train_index, "y": y_train.values}})`
+         `m = Prophet(); m.fit(prophet_df)`
+         `future = pd.DataFrame({{"ds": test_index}})`
+         `forecast = m.predict(future)`
+         `y_pred = forecast["yhat"].values`
+     `except (ImportError, Exception) as e:`
+         `print(f"⚠️ Prophet no disponible ({{e}}), fallback a ARIMA(1,1,1)")`
+         `from statsmodels.tsa.arima.model import ARIMA`
+         `y_pred = ARIMA(y_train, order=(1, 1, 1)).fit().forecast(steps=len(y_test))`
+C. Lista NEGRA explícita (PROHIBIDOS en este prompt — pertenecen a otras familias):
+   - `from sklearn.model_selection import train_test_split`  ← series temporales NO usan split aleatorio
+   - `from sklearn.metrics import roc_auc_score, classification_report, confusion_matrix, f1_score`
+   - `from sklearn.metrics import silhouette_score, davies_bouldin_score`
+   - `from sklearn.cluster import KMeans, DBSCAN`
+   Si los detectas en tu salida, REESCRIBE — este prompt es solo series temporales.
+D. NO importes nada que no esté en: numpy, pandas, matplotlib, seaborn,
+   statsmodels.tsa.*, prophet (opcional con try/except), scipy.stats.
+
+# Métricas OBLIGATORIAS (series temporales)
+- Define las funciones MAPE y sMAPE en una celda inicial:
+  `def mape(y_true, y_pred):`
+      `mask = y_true != 0`
+      `return float(np.mean(np.abs((y_true[mask] - y_pred[mask]) / y_true[mask])) * 100)`
+  `def smape(y_true, y_pred):`
+      `denom = (np.abs(y_true) + np.abs(y_pred)) / 2`
+      `denom = np.where(denom == 0, 1, denom)`
+      `return float(np.mean(np.abs(y_true - y_pred) / denom) * 100)`
+- Después del forecast, imprime SIEMPRE las TRES:
+  - `print("MAPE :", mape(y_test.values, y_pred), "%")`
+  - `print("sMAPE:", smape(y_test.values, y_pred), "%")`
+  - `print("RMSE :", float(np.sqrt(np.mean((y_test.values - y_pred) ** 2))))`
+
+# Guardas obligatorias (series temporales)
+- ANTES del fit, valida:
+  - Columna fecha presente y parseable (`pd.to_datetime(df[col], errors="coerce")` no devuelve todo NaT).
+  - Target numérico continuo (`pd.api.types.is_numeric_dtype(df[target])`).
+  - `len(df) >= 30` puntos. Si no, imprime "⚠️ Serie muy corta (n=<N>) — forecast no confiable" y SALTA.
+- Si la serie tiene gaps temporales: imprime un aviso pero continúa con el dato disponible.
+
+# Split por corte temporal (NUNCA random)
+- ORDEN OBLIGATORIO:
+  1. `df[date_col] = pd.to_datetime(df[date_col], errors="coerce")`
+  2. `df = df.dropna(subset=[date_col, target_col]).sort_values(date_col).reset_index(drop=True)`
+  3. `cut = int(len(df) * 0.8)`
+  4. `y_train, y_test = df[target_col].iloc[:cut], df[target_col].iloc[cut:]`
+  5. `train_index, test_index = df[date_col].iloc[:cut], df[date_col].iloc[cut:]`
+  6. `print("Split temporal:", "train hasta", df[date_col].iloc[cut-1], "→ test desde", df[date_col].iloc[cut])`
+- PROHIBIDO `train_test_split(X, y, ...)` con `random_state` — se permite SOLO `TimeSeriesSplit` para CV.
+
+# Atomic Cell Charting (Issue #228 — un gráfico por celda)
+- PROHIBIDO `plt.subplots(1, N)` o `plt.subplots(N, M)` para mezclar gráficos heterogéneos.
+- Cada celda de visualización contiene exactamente UNA `plt.figure(...)` y UN `plt.show()`.
+- Por algoritmo, parte el bloque en sub-celdas:
+  (2a) Fit + forecast + métricas — celda SIN plots.
+  (2b) Forecast vs actual con eje fecha — celda dedicada con UN plot.
+  (2c) Residuals vs tiempo — celda dedicada con UN plot.
+- Cada celda termina con `plt.tight_layout(); plt.show()`.
+
+# EDA Express (Sección 3.0) OBLIGATORIA antes del primer bloque de algoritmo
+
+## El base template ya abrió `## Sección 3: Módulos Experimentales`; aquí emite un H3.
+# %% [markdown]
+# ### 3.0 EDA Express
+# Antes de modelar, validamos que el dataset tenga forma de serie temporal.
+
+# %%
+try:
+    date_col = find_first_matching_column(df.columns, date_aliases)
+    target_col = find_first_matching_column(df.columns, ["valor", "monto", "ventas", "demanda", "score", "target", "y"])
+    if target_col is None:
+        num_cols = df.select_dtypes(include=np.number).columns.tolist()
+        target_col = num_cols[-1] if num_cols else None
+    if date_col is None:
+        print("⚠️ REQUISITO FALTANTE: no se detectó columna de fecha parseable.")
+    if target_col is None or not is_numeric_col(df, target_col):
+        print("⚠️ REQUISITO FALTANTE: no se detectó target numérico continuo.")
+    if date_col and target_col and is_numeric_col(df, target_col):
+        print("Fecha:", date_col, "| Target:", target_col)
+        print(df[target_col].describe().round(3))
+    if len(df) < 30:
+        print(f"\\n⚠️ Serie muy corta (n={{len(df)}}): forecast con alta varianza, interpreta con cautela.")
+except Exception as e:
+    print(f"⚠️ EDA Express falló: {{e}}")
+
+## Definición de métricas (UNA sola vez antes del primer algoritmo)
+# %%
+def mape(y_true, y_pred):
+    y_true = np.asarray(y_true, dtype=float); y_pred = np.asarray(y_pred, dtype=float)
+    mask = y_true != 0
+    if mask.sum() == 0:
+        return float("nan")
+    return float(np.mean(np.abs((y_true[mask] - y_pred[mask]) / y_true[mask])) * 100)
+
+def smape(y_true, y_pred):
+    y_true = np.asarray(y_true, dtype=float); y_pred = np.asarray(y_pred, dtype=float)
+    denom = (np.abs(y_true) + np.abs(y_pred)) / 2
+    denom = np.where(denom == 0, 1, denom)
+    return float(np.mean(np.abs(y_true - y_pred) / denom) * 100)
+
+## Para CADA algoritmo en el campo "algoritmos" del único entry en {familias_meta},
+## emite las siguientes celdas EN ORDEN:
+
+## Celda 1 — Concepto (markdown)
+# %% [markdown]
+# ### serie_temporal — [nombre exacto del algoritmo]
+# **Concepto:** [teoría en 2 líneas]
+# **Hipótesis experimental:** [extraída de {m3_content}, 1-2 líneas]
+# **Prerequisitos:** [campo "prerequisito" del entry en {familias_meta}]
+
+## Celda 2a — Fit + Forecast + Métricas (código, SIN plots)
+# %%
+try:
+    # 1. Resolver date_col + target_col por contrato/alias/fallback.
+    # 2. Validar fecha parseable + target numérico + n>=30.
+    # 3. Split temporal (último 20% test).
+    # 4. Fit (ARIMA(1,1,1) o Prophet en try/except).
+    # 5. Forecast steps=len(y_test).
+    # 6. Imprimir MAPE, sMAPE, RMSE.
+    # 7. NO emitir plots aquí — la viz va en 2b/2c.
+    pass
+except Exception as e:
+    print(f"⚠️ Error fit serie temporal: {{e}}")
+
+## Celda 2b — Forecast vs actual con eje fecha (UN plot por celda)
+# %%
+try:
+    plt.figure(figsize=(11, 5))
+    # plt.plot(train_index, y_train.values, label="Train", color="steelblue")
+    # plt.plot(test_index, y_test.values, label="Real", color="black")
+    # plt.plot(test_index, y_pred, label="Forecast", color="orange", linestyle="--")
+    # plt.xlabel("Fecha"); plt.ylabel(target_col); plt.title("Forecast vs Real")
+    # plt.legend(); plt.tight_layout(); plt.show()
+    pass
+except Exception as e:
+    print(f"⚠️ Error forecast vs actual: {{e}}")
+
+## Celda 2c — Residuals vs tiempo (UN plot por celda)
+# %%
+try:
+    plt.figure(figsize=(11, 4))
+    # residuals = y_test.values - y_pred
+    # plt.plot(test_index, residuals, marker='o', linestyle='-', color='crimson')
+    # plt.axhline(0, color='gray', linestyle='--', lw=1)
+    # plt.xlabel("Fecha"); plt.ylabel("residual"); plt.title("Residuals vs Tiempo")
+    # plt.tight_layout(); plt.show()
+    pass
+except Exception as e:
+    print(f"⚠️ Error residuals vs tiempo: {{e}}")
+
+## Celda 3 — Acción de Negocio (markdown)
+# %% [markdown]
+# **Explicación pedagógica:** [qué muestran MAPE/sMAPE y los gráficos, 2 líneas]
+# **Acción de negocio:** [próximo paso concreto basado en el forecast, 1 línea]
+
+# Sección final OBLIGATORIA
+# %% [markdown]
+# ## Evaluación M3 — Diseño Experimental
+# Responde en la plataforma ADAM las preguntas del Módulo 3 sobre hipótesis, sesgos y descarte.
+
+---
+Caso: {case_title}
+Familias con metadata: {familias_meta}
+Algoritmos detectados: {algoritmos}
+Contexto M3 (extracto): {m3_content}
+"""
+
+
+# ── PROMPT_BY_FAMILY — dispatch table consumed by graph.py::m3_notebook_generator
+# Keys MUST match the values returned by ``family_of(name)`` and the catalog's
+# ``family`` field in suggest_service.py.
+PROMPT_BY_FAMILY: dict[str, str] = {
+    "clasificacion": M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION,
+    "regresion": M3_NOTEBOOK_ALGO_PROMPT_REGRESSION,
+    "clustering": M3_NOTEBOOK_ALGO_PROMPT_CLUSTERING,
+    "serie_temporal": M3_NOTEBOOK_ALGO_PROMPT_TIMESERIES,
+}
+
+# Backwards-compatible alias for tests / external callers that imported the
+# pre-Issue-#233 monolithic prompt symbol. The classification prompt is the
+# canonical home of all PR #232 hygiene fixes, so it remains the default.
+M3_NOTEBOOK_ALGO_PROMPT = M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION

--- a/backend/src/case_generator/suggest_service.py
+++ b/backend/src/case_generator/suggest_service.py
@@ -21,188 +21,347 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# TAXONOMY OF TECHNIQUES BY PROBLEM TYPE
-# Used to validate LLM suggestions and provide consistent context to the authoring flow.
-# ══════════════════════════════════════════════════════════════════════════════
-
-# Per-technique tier is declarative (Issue #230 follow-up). Each entry in
-# ``business_techniques`` / ``ml_ds_techniques`` is a CatalogItem dict so the
-# baseline-vs-challenger split is curated, not keyword-inferred. The taxonomy
-# key (``clustering``, ``clasificacion``, ...) doubles as the algorithm
-# *family* used for cross-family coherence in contrast mode.
-ALGORITHM_TAXONOMY: dict[str, dict[str, object]] = {
-    "clustering": {
-        "label": "Segmentación / Clustering",
-        "target_type": "categorical",
-        "business_techniques": [
-            {"name": "Segmentación por cohortes", "tier": "baseline"},
-            {"name": "Análisis de perfiles de cliente", "tier": "baseline"},
-            {"name": "Agrupación visual por métricas clave", "tier": "baseline"},
-            {"name": "K-Means + Silhouette + PCA", "tier": "baseline"},
-        ],
-        "ml_ds_techniques": [
-            {"name": "K-Means + Silhouette + PCA", "tier": "baseline"},
-            {"name": "DBSCAN para detección de grupos atípicos", "tier": "challenger"},
-        ],
-        "validation": "Estabilidad de clusters (Bootstrap)",
-        "metrics": ["Silhouette", "Calinski-Harabasz", "Inertia"],
-    },
-    "clasificacion": {
-        "label": "Clasificación",
-        "target_type": "binary",
-        "business_techniques": [
-            {"name": "Scorecard de riesgo con reglas de negocio", "tier": "baseline"},
-            {"name": "Segmentación binaria por umbrales de KPI", "tier": "baseline"},
-            {"name": "Análisis de cohortes con tasa de conversión", "tier": "baseline"},
-            {"name": "Regresión Logística + SHAP", "tier": "baseline"},
-        ],
-        "ml_ds_techniques": [
-            {"name": "Logistic Regression", "tier": "baseline"},
-            {"name": "Random Forest + SHAP", "tier": "challenger"},
-            {"name": "XGBoost con tuning de hiperparámetros", "tier": "challenger"},
-        ],
-        "validation": "Cross-validation 5-fold + ROC-AUC",
-        "metrics": ["AUC-ROC", "F1", "Precision", "Recall", "Confusion Matrix"],
-    },
-    "regresion": {
-        "label": "Regresión / Predicción Continua",
-        "target_type": "numeric",
-        "business_techniques": [
-            {"name": "Proyección lineal de tendencias", "tier": "baseline"},
-            {"name": "Análisis de sensibilidad con escenarios", "tier": "baseline"},
-            {"name": "Forecast básico por promedio móvil", "tier": "baseline"},
-            {"name": "Regresión Lineal + Ridge/Lasso", "tier": "baseline"},
-        ],
-        "ml_ds_techniques": [
-            {"name": "Linear Regression + Residuals", "tier": "baseline"},
-            {"name": "Ridge / Lasso Regression", "tier": "challenger"},
-            {"name": "Gradient Boosting Regressor", "tier": "challenger"},
-        ],
-        "validation": "Cross-val + Prediction Intervals",
-        "metrics": ["R²", "MAE", "RMSE", "MAPE"],
-    },
-    "serie_temporal": {
-        "label": "Series Temporales",
-        "target_type": "numeric",
-        "business_techniques": [
-            {"name": "Análisis de tendencia y estacionalidad visual", "tier": "baseline"},
-            {"name": "Forecast por promedio móvil ponderado", "tier": "baseline"},
-            {"name": "Comparación interanual (YoY)", "tier": "baseline"},
-            {"name": "STL Decomposition + ARIMA", "tier": "baseline"},
-        ],
-        "ml_ds_techniques": [
-            {"name": "STL Decomposition + ARIMA", "tier": "baseline"},
-            {"name": "Prophet", "tier": "challenger"},
-        ],
-        "validation": "Walk-forward validation + MAPE",
-        "metrics": ["MAPE", "MAE", "RMSE", "Coverage 95%"],
-    },
-    "recomendacion": {
-        "label": "Sistemas de Recomendación",
-        "target_type": "numeric",
-        "business_techniques": [
-            {"name": "Análisis RFM (Recencia, Frecuencia, Monetización)", "tier": "baseline"},
-            {"name": "Segmentación por comportamiento de compra", "tier": "baseline"},
-            {"name": "A/B Testing de estrategias de retención", "tier": "baseline"},
-            {"name": "K-Means RFM", "tier": "baseline"},
-        ],
-        "ml_ds_techniques": [
-            {"name": "Content-Based Filtering (Cosine)", "tier": "baseline"},
-            {"name": "Collaborative Filtering (SVD)", "tier": "challenger"},
-            {"name": "K-Means RFM + Random Forest Feature Importance", "tier": "challenger"},
-        ],
-        "validation": "A/B Test + t-test de Welch",
-        "metrics": ["Precision@K", "Recall@K", "Coverage", "NDCG"],
-    },
-    "nlp": {
-        "label": "Procesamiento de Lenguaje Natural",
-        "target_type": "categorical",
-        "business_techniques": [
-            {"name": "Análisis de sentimiento con VADER/TextBlob", "tier": "baseline"},
-            {"name": "Topic Modeling (LDA) para extracción de temas", "tier": "baseline"},
-            {"name": "TF-IDF para representación e importancia de texto", "tier": "baseline"},
-        ],
-        "ml_ds_techniques": [
-            {"name": "TF-IDF + Sentiment (VADER/TextBlob)", "tier": "baseline"},
-            {"name": "Topic Modeling (LDA) + Word2Vec", "tier": "challenger"},
-        ],
-        "validation": "Kappa inter-rater + Bootstrap",
-        "metrics": ["Accuracy", "F1-macro", "Kappa", "Perplexity"],
-    },
-}
-
-
-# ── Helpers to bridge legacy `list[str]` consumers with the new dict shape.
-def _technique_items(profile: str, family: str) -> list[dict[str, str]]:
-    tech_key = "business_techniques" if profile == "business" else "ml_ds_techniques"
-    return cast(list[dict[str, str]], ALGORITHM_TAXONOMY[family][tech_key])
-
-
-def _technique_names(profile: str, family: str) -> list[str]:
-    return [item["name"] for item in _technique_items(profile, family)]
-
-# Problemas válidos para cada perfil
-BUSINESS_PROBLEM_TYPES = list(ALGORITHM_TAXONOMY.keys())
-ML_DS_PROBLEM_TYPES = list(ALGORITHM_TAXONOMY.keys())
-
-
-# ══════════════════════════════════════════════════════════════════════════════
-# TIER CLASSIFICATION — Issue #230
-# Tier (``baseline`` / ``challenger``) and family (taxonomy key) are now declared
-# per-item inside ``ALGORITHM_TAXONOMY``. ``classify_tier`` is kept as a fallback
-# helper for ad-hoc strings that did not come from the catalog (e.g. legacy
-# ``suggested_techniques`` payloads).
+# ALGORITHM CATALOG — Issue #233 (single source of truth)
+# Replaces the legacy ALGORITHM_TAXONOMY here + ALGORITHM_REGISTRY in graph.py
+# with a single declarative list. 4 families × max 2 algorithms (baseline +
+# optional challenger). Business profile sees only baselines (4 items);
+# ml_ds sees both tiers (8 items).
+#
+# Why so small: the LLM that generates the M3 notebook is more reliable when it
+# reasons over a short, well-known list. Each (family) maps to ONE specialized
+# prompt template in prompts.py via ``prompt_key`` → no notebook is asked to
+# cover heterogeneous techniques.
 # ══════════════════════════════════════════════════════════════════════════════
 
 AlgorithmTier = Literal["baseline", "challenger"]
 
-# Human-readable labels for each family (taxonomy key). Used by the catalog
-# endpoint so the frontend can render section headers.
 FAMILY_LABELS: dict[str, str] = {
-    "clustering": "Clustering",
     "clasificacion": "Clasificación",
     "regresion": "Regresión",
+    "clustering": "Clustering",
     "serie_temporal": "Series Temporales",
-    "recomendacion": "Recomendación",
-    "nlp": "NLP / Texto",
 }
+
+# Per-family metadata used by the suggester prompt and the target-type fallback
+# in ``generate_suggestion``. NOT exposed via the catalog endpoint.
+FAMILY_META: dict[str, dict[str, object]] = {
+    "clasificacion": {
+        "label": "Clasificación",
+        "target_type": "binary",
+        "metrics": ["AUC-ROC", "AUC-PR", "F1", "Precision", "Recall", "Confusion Matrix"],
+        "validation": "Cross-validation 5-fold + AUC-ROC",
+    },
+    "regresion": {
+        "label": "Regresión",
+        "target_type": "numeric",
+        "metrics": ["RMSE", "MAE", "R²"],
+        "validation": "Cross-validation + Residual Analysis",
+    },
+    "clustering": {
+        "label": "Clustering",
+        "target_type": "categorical",
+        "metrics": ["Silhouette", "Davies-Bouldin", "Inertia"],
+        "validation": "Estabilidad de clusters (Bootstrap)",
+    },
+    "serie_temporal": {
+        "label": "Series Temporales",
+        "target_type": "numeric",
+        "metrics": ["MAPE", "sMAPE", "RMSE"],
+        "validation": "Walk-forward + MAPE",
+    },
+}
+
+
+# Each entry carries:
+#   - public fields exposed via /algorithm-catalog: name, family, family_label, tier
+#   - profile_visibility: which profile sees the entry in the selector
+#   - prompt_key + visualization + prerequisite + fragments_hint: server-side
+#     dispatch metadata consumed by graph.py::m3_notebook_generator
+ALGORITHM_CATALOG: list[dict[str, object]] = [
+    # ── Clasificación ───────────────────────────────────────────────────────
+    {
+        "name": "Logistic Regression",
+        "family": "clasificacion",
+        "family_label": FAMILY_LABELS["clasificacion"],
+        "tier": "baseline",
+        "profile_visibility": ["business", "ml_ds"],
+        "prompt_key": "classification",
+        "visualization": "Confusion Matrix + Feature importance (coef_)",
+        "prerequisite": "Features numéricas/categóricas con cardinalidad ≤20 + target binario o multiclase pequeño.",
+        "fragments_hint": ["categoria", "category", "label", "tipo", "clase", "target", "churn"],
+    },
+    {
+        "name": "Random Forest",
+        "family": "clasificacion",
+        "family_label": FAMILY_LABELS["clasificacion"],
+        "tier": "challenger",
+        "profile_visibility": ["ml_ds"],
+        "prompt_key": "classification",
+        "visualization": "Confusion Matrix + Feature importance (feature_importances_)",
+        "prerequisite": "Features numéricas/categóricas con cardinalidad ≤20 + target categórico.",
+        "fragments_hint": ["categoria", "category", "label", "tipo", "clase", "target", "churn"],
+    },
+    # ── Regresión ───────────────────────────────────────────────────────────
+    {
+        "name": "Linear Regression",
+        "family": "regresion",
+        "family_label": FAMILY_LABELS["regresion"],
+        "tier": "baseline",
+        "profile_visibility": ["business", "ml_ds"],
+        "prompt_key": "regression",
+        "visualization": "Scatter real vs predicho con línea 45° + Residuals vs predicho",
+        "prerequisite": "Features numéricas + target numérico continuo finito (no NaN/inf).",
+        "fragments_hint": ["precio", "valor", "monto", "revenue", "ventas", "importe", "score"],
+    },
+    {
+        "name": "Gradient Boosting Regressor",
+        "family": "regresion",
+        "family_label": FAMILY_LABELS["regresion"],
+        "tier": "challenger",
+        "profile_visibility": ["ml_ds"],
+        "prompt_key": "regression",
+        "visualization": "Scatter real vs predicho con línea 45° + Feature importance",
+        "prerequisite": "Features numéricas + target numérico continuo finito.",
+        "fragments_hint": ["precio", "valor", "monto", "revenue", "ventas", "importe", "score"],
+    },
+    # ── Clustering ──────────────────────────────────────────────────────────
+    {
+        "name": "K-Means",
+        "family": "clustering",
+        "family_label": FAMILY_LABELS["clustering"],
+        "tier": "baseline",
+        "profile_visibility": ["business", "ml_ds"],
+        "prompt_key": "clustering",
+        "visualization": "Elbow method (inercia vs k) + scatter 2D PCA por cluster",
+        "prerequisite": "≥2 columnas numéricas escalables (sin target). StandardScaler obligatorio.",
+        "fragments_hint": ["valor", "monto", "cantidad", "score", "edad", "ingreso", "frecuencia"],
+    },
+    {
+        "name": "DBSCAN",
+        "family": "clustering",
+        "family_label": FAMILY_LABELS["clustering"],
+        "tier": "challenger",
+        "profile_visibility": ["ml_ds"],
+        "prompt_key": "clustering",
+        "visualization": "k-distance plot (epsilon) + scatter 2D PCA por cluster",
+        "prerequisite": "≥2 columnas numéricas escalables (sin target). StandardScaler obligatorio.",
+        "fragments_hint": ["valor", "monto", "cantidad", "score", "edad", "ingreso", "frecuencia"],
+    },
+    # ── Series Temporales ───────────────────────────────────────────────────
+    {
+        "name": "ARIMA",
+        "family": "serie_temporal",
+        "family_label": FAMILY_LABELS["serie_temporal"],
+        "tier": "baseline",
+        "profile_visibility": ["business", "ml_ds"],
+        "prompt_key": "timeseries",
+        "visualization": "Forecast vs actual con eje fecha + Residuals vs tiempo",
+        "prerequisite": "Columna fecha parseable + columna numérica objetivo + ≥30 puntos.",
+        "fragments_hint": ["fecha", "date", "timestamp", "periodo", "mes", "dia", "year_month"],
+    },
+    {
+        "name": "Prophet",
+        "family": "serie_temporal",
+        "family_label": FAMILY_LABELS["serie_temporal"],
+        "tier": "challenger",
+        "profile_visibility": ["ml_ds"],
+        "prompt_key": "timeseries",
+        "visualization": "Forecast vs actual con eje fecha + Residuals vs tiempo (fallback ARIMA si Prophet no instalado)",
+        "prerequisite": "Columna fecha parseable + columna numérica objetivo + ≥30 puntos.",
+        "fragments_hint": ["fecha", "date", "timestamp", "periodo", "mes", "dia", "year_month"],
+    },
+]
+
+
+def _validate_catalog_invariants() -> None:
+    """Fail-fast at import time so the catalog never ships violating its contract."""
+    by_family: dict[str, list[dict[str, object]]] = {}
+    for entry in ALGORITHM_CATALOG:
+        by_family.setdefault(cast(str, entry["family"]), []).append(entry)
+    if set(by_family) != set(FAMILY_LABELS):
+        raise RuntimeError(
+            f"Catalog families {sorted(by_family)} != FAMILY_LABELS {sorted(FAMILY_LABELS)}"
+        )
+    for family, entries in by_family.items():
+        if len(entries) > 2:
+            raise RuntimeError(f"Family {family!r} has {len(entries)} entries (max 2)")
+        baselines = [e for e in entries if e["tier"] == "baseline"]
+        if len(baselines) != 1:
+            raise RuntimeError(
+                f"Family {family!r} must have exactly 1 baseline (found {len(baselines)})"
+            )
+        for e in entries:
+            vis = cast(list[str], e["profile_visibility"])
+            if e["tier"] == "baseline" and "business" not in vis:
+                raise RuntimeError(f"Baseline {e['name']!r} must be visible to business profile")
+            if e["tier"] == "challenger" and "business" in vis:
+                raise RuntimeError(
+                    f"Challenger {e['name']!r} must NOT be visible to business profile"
+                )
+
+
+_validate_catalog_invariants()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Family resolution helpers (used by graph.py::m3_notebook_generator)
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Substring → family mapping for legacy / off-catalog names found in historical
+# task_payload rows (jobs created before the Issue #233 catalog reduction).
+# Forward-write paths (intake validator, suggester) reject any name not in the
+# current catalog; this map exists ONLY so the notebook generator can keep
+# republishing old jobs without crashing — the resolution is surfaced as a
+# warning inside the generated notebook.
+_LEGACY_FAMILY_MAP: dict[str, str] = {
+    # tabular classification surrogates
+    "xgboost": "clasificacion",
+    "lightgbm": "clasificacion",
+    "catboost": "clasificacion",
+    "adaboost": "clasificacion",
+    "gradient boosting classifier": "clasificacion",
+    "decision tree": "clasificacion",
+    "svc": "clasificacion",
+    "svm": "clasificacion",
+    "naive bayes": "clasificacion",
+    "shap": "clasificacion",  # "Logistic Regression + SHAP" historical names
+    # tabular regression surrogates
+    "ridge": "regresion",
+    "lasso": "regresion",
+    "elastic net": "regresion",
+    "svr": "regresion",
+    # time series surrogates
+    "stl": "serie_temporal",
+    "lstm": "serie_temporal",
+    "auto_arima": "serie_temporal",
+    "auto-arima": "serie_temporal",
+    # clustering surrogates
+    "hierarchical": "clustering",
+    "agglomerative": "clustering",
+    "rfm": "clustering",
+    "segmentacion": "clustering",
+    "segmentation": "clustering",
+    # NLP / recomendación / grafos / anomalías → fall back to clasificación so the
+    # notebook still gets a runnable template; the warning makes the remap visible.
+    "tfidf": "clasificacion",
+    "tf-idf": "clasificacion",
+    "lda": "clasificacion",
+    "word2vec": "clasificacion",
+    "bert": "clasificacion",
+    "vader": "clasificacion",
+    "textblob": "clasificacion",
+    "topic modeling": "clasificacion",
+    "sentiment": "clasificacion",
+    "collaborative filtering": "clasificacion",
+    "content-based": "clasificacion",
+    "svd": "clasificacion",
+    "matrix factorization": "clasificacion",
+    "isolation forest": "clasificacion",
+    "one-class svm": "clasificacion",
+    "anomaly": "clasificacion",
+    "outlier": "clasificacion",
+    "networkx": "clasificacion",
+    "graph": "clasificacion",
+}
+
+
+def family_of(name: str) -> Optional[str]:
+    """Return the canonical family for a catalog algorithm name, else ``None``."""
+    needle = (name or "").lower().strip()
+    if not needle:
+        return None
+    for entry in ALGORITHM_CATALOG:
+        if cast(str, entry["name"]).lower() == needle:
+            return cast(str, entry["family"])
+    return None
+
+
+def resolve_legacy_family(legacy_name: str) -> Optional[tuple[str, str]]:
+    """Map a legacy/off-catalog algorithm to the closest current family.
+
+    Returns ``(family, warning_msg)`` or ``None`` if no plausible mapping exists.
+    Used ONLY by ``m3_notebook_generator`` for backwards-read of historical jobs.
+    """
+    needle = (legacy_name or "").lower().strip()
+    if not needle:
+        return None
+    # Longest-token-first so "gradient boosting classifier" wins over "gradient".
+    for token in sorted(_LEGACY_FAMILY_MAP.keys(), key=len, reverse=True):
+        if token in needle:
+            family = _LEGACY_FAMILY_MAP[token]
+            return (
+                family,
+                f"Algoritmo legacy '{legacy_name}' tratado como familia "
+                f"'{family}' (catálogo reducido Issue #233).",
+            )
+    return None
+
+
+def get_dispatch_meta(family: str) -> dict[str, object]:
+    """Aggregated per-family dispatch metadata for the M3 notebook prompt.
+
+    Returns a single dict ``{familia, family_label, prompt_key, visualizacion,
+    prerequisito, fragments_hint}``. Both algorithms in a family share the same
+    ``prompt_key`` and use the same prerequisite, so we collapse them.
+    """
+    entries = [e for e in ALGORITHM_CATALOG if e["family"] == family]
+    if not entries:
+        raise KeyError(f"Unknown family: {family!r}")
+    fragments: list[str] = []
+    for e in entries:
+        for f in cast(list[str], e["fragments_hint"]):
+            if f not in fragments:
+                fragments.append(f)
+    return {
+        "familia": family,
+        "family_label": FAMILY_LABELS[family],
+        "prompt_key": cast(str, entries[0]["prompt_key"]),
+        "visualizacion": cast(str, entries[0]["visualization"]),
+        "prerequisito": cast(str, entries[0]["prerequisite"]),
+        "fragments_hint": fragments,
+    }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Suggester / legacy helpers
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Problemas válidos para cada perfil (hoy idénticos: 4 familias canónicas).
+BUSINESS_PROBLEM_TYPES = list(FAMILY_LABELS.keys())
+ML_DS_PROBLEM_TYPES = list(FAMILY_LABELS.keys())
+
+
+def _technique_items(profile: str, family: str) -> list[dict[str, str]]:
+    """Return ``[{name, tier}]`` for a (profile, family) pair — used by the suggester prompt."""
+    out: list[dict[str, str]] = []
+    for e in ALGORITHM_CATALOG:
+        if e["family"] != family:
+            continue
+        if profile not in cast(list[str], e["profile_visibility"]):
+            continue
+        out.append({"name": cast(str, e["name"]), "tier": cast(str, e["tier"])})
+    return out
+
+
+def _technique_names(profile: str, family: str) -> list[str]:
+    return [it["name"] for it in _technique_items(profile, family)]
+
 
 # Substring keywords that mark an unknown (off-catalog) technique as challenger.
 _CHALLENGER_KEYWORDS: tuple[str, ...] = (
-    "random forest",
-    "xgboost",
-    "lightgbm",
-    "catboost",
-    "adaboost",
-    "gradient boosting",
-    "gbm",
-    "lstm",
-    "neural",
-    "redes neuronales",
-    "deep learning",
-    "prophet",
-    "dbscan",
-    "autoencoder",
-    "bert",
-    "embedding",
-    "word2vec",
-    "transformer",
+    "random forest", "xgboost", "lightgbm", "catboost", "adaboost",
+    "gradient boosting", "gbm", "lstm", "neural", "redes neuronales",
+    "deep learning", "prophet", "dbscan", "autoencoder", "bert",
+    "embedding", "word2vec", "transformer",
 )
 
 
 def classify_tier(technique: str) -> AlgorithmTier:
-    """Return ``"challenger"`` if the technique matches any challenger keyword.
-
-    Prefer the declarative ``tier`` field on catalog items over this fallback.
-    """
-    # Prefer declarative tier when the technique is in the catalog.
-    needle = technique.lower().strip()
-    for entry in ALGORITHM_TAXONOMY.values():
-        for tech_key in ("business_techniques", "ml_ds_techniques"):
-            for item in cast(list[dict[str, str]], entry[tech_key]):
-                if item["name"].lower() == needle:
-                    return cast(AlgorithmTier, item["tier"])
-    # Off-catalog fallback — keyword heuristic.
+    """Return the catalog tier for ``technique``, falling back to keyword heuristic."""
+    needle = (technique or "").lower().strip()
+    for entry in ALGORITHM_CATALOG:
+        if cast(str, entry["name"]).lower() == needle:
+            return cast(AlgorithmTier, entry["tier"])
     for kw in _CHALLENGER_KEYWORDS:
         if kw in needle:
             return "challenger"
@@ -211,34 +370,31 @@ def classify_tier(technique: str) -> AlgorithmTier:
 
 @functools.lru_cache(maxsize=8)
 def get_algorithm_catalog(profile: str, case_type: str) -> dict[str, object]:
-    """Return the canonical catalog of algorithms for a (profile, case_type) pair.
+    """Return the canonical algorithm catalog for a (profile, case_type) pair.
 
-    The result is a dict ``{"items": [{"name", "family", "family_label", "tier"}, ...]}``
-    with de-duplicated technique names sourced from ``ALGORITHM_TAXONOMY``.
-    The frontend groups items by ``family`` to render the selector and uses
-    ``tier`` to filter the baseline / challenger dropdowns in contrast mode.
+    Shape: ``{"items": [{"name", "family", "family_label", "tier"}, ...]}``.
+
+    - ``profile=business``: only baseline-tier items (4 algorithms).
+    - ``profile=ml_ds``: full catalog (8 algorithms = 4 families × 2 tiers).
+    - ``case_type=harvard_only``: empty list (no algorithms picked when no EDA).
     """
     if profile not in {"business", "ml_ds"}:
         raise ValueError(f"Invalid profile: {profile!r}")
     if case_type not in {"harvard_only", "harvard_with_eda"}:
         raise ValueError(f"Invalid case_type: {case_type!r}")
+    if case_type == "harvard_only":
+        return {"items": []}
 
-    tech_key = "business_techniques" if profile == "business" else "ml_ds_techniques"
     items: list[dict[str, str]] = []
-    seen_set: set[str] = set()
-    for family, entry in ALGORITHM_TAXONOMY.items():
-        family_label = FAMILY_LABELS.get(family, family)
-        for raw_item in cast(list[dict[str, str]], entry[tech_key]):
-            key = raw_item["name"].lower()
-            if key in seen_set:
-                continue
-            seen_set.add(key)
-            items.append({
-                "name": raw_item["name"],
-                "family": family,
-                "family_label": family_label,
-                "tier": raw_item["tier"],
-            })
+    for entry in ALGORITHM_CATALOG:
+        if profile not in cast(list[str], entry["profile_visibility"]):
+            continue
+        items.append({
+            "name": cast(str, entry["name"]),
+            "family": cast(str, entry["family"]),
+            "family_label": cast(str, entry["family_label"]),
+            "tier": cast(str, entry["tier"]),
+        })
     return {"items": items}
 
 
@@ -248,12 +404,11 @@ def _catalog_lookup(
     name: str,
 ) -> Optional[dict[str, str]]:
     """Return the catalog item matching ``name`` (case-insensitive) or ``None``."""
-    needle = name.lower().strip()
+    needle = (name or "").lower().strip()
     for item in cast(list[dict[str, str]], get_algorithm_catalog(profile, case_type)["items"]):
         if item["name"].lower() == needle:
             return item
     return None
-
 
 
 def _validate_techniques_strict(
@@ -262,17 +417,13 @@ def _validate_techniques_strict(
     case_type: str,
     mode: Literal["single", "contrast"],
 ) -> None:
-    """Strict validator for teacher-submitted algorithm picks (Issue #230).
-
-    Raises ``ValueError`` (with a teacher-friendly message) when the picks do
-    not match the contract for the given mode.
+    """Strict validator for teacher-submitted algorithm picks (Issues #230 / #233).
 
     Contract:
-    - mode="single": exactly 1 technique, must belong to the catalog (any tier).
-    - mode="contrast": exactly 2 techniques where the first is a baseline and
-      the second is a challenger of the catalog for the (profile, case_type),
-      and BOTH must belong to the same family (e.g. ``clasificacion``).
-    - The two contrast techniques must differ.
+    - mode="single": exactly 1 technique, must belong to the catalog visible to
+      ``(profile, case_type)``.
+    - mode="contrast": exactly 2 techniques, [baseline, challenger] of the SAME
+      family, both visible to ``(profile, case_type)``.
     """
     items = cast(list[dict[str, str]], get_algorithm_catalog(profile, case_type)["items"])
     by_name: dict[str, dict[str, str]] = {item["name"].lower(): item for item in items}
@@ -303,7 +454,6 @@ def _validate_techniques_strict(
             f"El primer algoritmo debe ser un baseline del catálogo: {primary_item['name']!r} no lo es."
         )
     if challenger_item["tier"] != "challenger":
-        # Surface a profile-specific hint when the catalog has no challengers at all.
         any_challenger = any(it["tier"] == "challenger" for it in items)
         if not any_challenger:
             raise ValueError(
@@ -372,13 +522,15 @@ class SuggestResponse(BaseModel):
 def _build_taxonomy_context(profile: str) -> str:
     """Genera texto de referencia de la taxonomía para inyectar en el prompt."""
     lines = ["## Catálogo de Tipos de Problema y Técnicas Permitidas\n"]
-    for key, t in ALGORITHM_TAXONOMY.items():
+    for key, meta in FAMILY_META.items():
         items = _technique_items(profile, key)
-        lines.append(f"### {key} — {t['label']}")
-        lines.append(f"  Target: {t['target_type']}")
+        if not items:
+            continue
+        lines.append(f"### {key} — {meta['label']}")
+        lines.append(f"  Target: {meta['target_type']}")
         rendered = ", ".join(f"{it['name']} [{it['tier']}]" for it in items)
         lines.append(f"  Técnicas: {rendered}")
-        lines.append(f"  Métricas: {', '.join(cast(list[str], t['metrics']))}")
+        lines.append(f"  Métricas: {', '.join(cast(list[str], meta['metrics']))}")
         lines.append("")
     return "\n".join(lines)
 
@@ -523,7 +675,7 @@ def _validate_techniques(
     Valida que las técnicas sugeridas por el LLM estén en el catálogo.
     Si alguna no está, la reemplaza por la primera del catálogo.
     """
-    if problem_type not in ALGORITHM_TAXONOMY:
+    if problem_type not in FAMILY_META:
         return techniques[:4]
 
     catalog = _technique_names(profile, problem_type)
@@ -554,12 +706,21 @@ def _validate_problem_type(problem_type: str) -> str:
         "regression": "regresion",
         "time_series": "serie_temporal",
         "temporal": "serie_temporal",
-        "recommendation": "recomendacion",
         "segmentation": "clustering",
         "segmentacion": "clustering",
+        # Issue #233 — NLP / recomendación / grafos / anomalías ya no están en el
+        # catálogo reducido. Si el LLM las propone, las degradamos a la familia
+        # tabular más cercana para que el resto del flujo no rompa.
+        "nlp": "clasificacion",
+        "recommendation": "clasificacion",
+        "recomendacion": "clasificacion",
+        "anomaly": "clasificacion",
+        "anomalias": "clasificacion",
+        "graph": "clasificacion",
+        "grafos": "clasificacion",
     }
     normalized = aliases.get(normalized, normalized)
-    if normalized in ALGORITHM_TAXONOMY:
+    if normalized in FAMILY_META:
         return normalized
     return "clasificacion"  # Default seguro
 
@@ -626,7 +787,7 @@ async def generate_suggestion(req: SuggestRequest) -> SuggestResponse:
         # Derivar del problemType
         resp.targetVariableType = cast(
             str,
-            ALGORITHM_TAXONOMY.get(resp.problemType, {}).get("target_type", "numeric"),
+            FAMILY_META.get(resp.problemType, {}).get("target_type", "numeric"),
         )
 
     # Validate techniques

--- a/backend/tests/test_issue230_algorithm_mode.py
+++ b/backend/tests/test_issue230_algorithm_mode.py
@@ -92,11 +92,57 @@ def test_catalog_ml_ds_excludes_lstm() -> None:
 
 def test_catalog_items_are_grouped_by_family() -> None:
     families = {it["family"] for it in _items("ml_ds")}
-    # All declared families show up at least once for ml_ds.
-    assert {"clustering", "clasificacion", "regresion", "serie_temporal", "recomendacion", "nlp"} <= families
+    # Issue #233 — canonical 4-family taxonomy. nlp/recomendacion deprecated.
+    assert families == {"clasificacion", "regresion", "clustering", "serie_temporal"}
     # family_label is non-empty and human-readable.
     for it in _items("ml_ds"):
         assert it["family_label"] and isinstance(it["family_label"], str)
+
+
+# Issue #233 — 4×2 catalog invariants.
+def test_catalog_has_exactly_4_families() -> None:
+    families = {it["family"] for it in _items("ml_ds")}
+    assert families == {"clasificacion", "regresion", "clustering", "serie_temporal"}
+
+
+def test_catalog_each_family_has_max_2_algorithms() -> None:
+    items = _items("ml_ds")
+    by_family: dict[str, list[dict]] = {}
+    for it in items:
+        by_family.setdefault(it["family"], []).append(it)
+    for fam, members in by_family.items():
+        assert len(members) <= 2, f"familia {fam} excede el cap de 2: {members}"
+
+
+def test_catalog_each_family_has_exactly_one_baseline() -> None:
+    items = _items("ml_ds")
+    by_family: dict[str, list[dict]] = {}
+    for it in items:
+        by_family.setdefault(it["family"], []).append(it)
+    for fam, members in by_family.items():
+        baselines = [m for m in members if m["tier"] == "baseline"]
+        assert len(baselines) == 1, f"familia {fam} debe tener 1 baseline: {members}"
+
+
+def test_catalog_business_only_baselines() -> None:
+    items = _items("business")
+    assert items, "business debe exponer al menos los baselines"
+    for it in items:
+        assert it["tier"] == "baseline", f"business no debe ver challengers: {it}"
+    families = {it["family"] for it in items}
+    assert families == {"clasificacion", "regresion", "clustering", "serie_temporal"}
+
+
+def test_catalog_ml_ds_has_8_algorithms() -> None:
+    # 4 families × 2 tiers (baseline + challenger) = 8 entries for ml_ds.
+    assert len(_items("ml_ds")) == 8
+
+
+def test_catalog_no_legacy_algorithms_exposed() -> None:
+    # Issue #233 — these names were removed from the canonical catalog.
+    forbidden = {"xgboost", "ridge", "lasso", "lstm", "svm", "naive bayes"}
+    names = {it["name"].lower() for it in _items("ml_ds")}
+    assert names.isdisjoint(forbidden), f"algoritmos legacy reaparecieron: {names & forbidden}"
 
 
 def test_catalog_invalid_profile_raises() -> None:

--- a/backend/tests/test_m3_notebook_dispatch.py
+++ b/backend/tests/test_m3_notebook_dispatch.py
@@ -15,6 +15,7 @@ import pytest
 from case_generator.graph import (
     _FAMILY_PROHIBITED_PATTERNS,
     _detect_algorithm_families,
+    _strip_jupytext_for_validation,
     _validate_notebook_family_consistency,
 )
 
@@ -168,3 +169,98 @@ def test_prohibited_patterns_cover_4_canonical_families() -> None:
         "clustering",
         "serie_temporal",
     }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# False-positive defense (post-review fix) — markdown + comments must NOT
+# trigger the validator. The per-family prompts enumerate the forbidden tokens
+# in their "Lista NEGRA" sections, so an obedient LLM will frequently echo
+# those names back as pedagogical text. Treating that as a violation would
+# hard-fail the job in production on a perfectly clean notebook.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_strip_drops_jupytext_markdown_cells() -> None:
+    nb = (
+        "# %% [markdown]\n"
+        "# ### regresion — Linear Regression\n"
+        "# **Concepto:** no usamos roc_auc_score porque es regresión.\n"
+        "\n"
+        "# %%\n"
+        "from sklearn.linear_model import LinearRegression\n"
+    )
+    stripped = _strip_jupytext_for_validation(nb)
+    assert "roc_auc_score" not in stripped
+    assert "LinearRegression" in stripped
+
+
+def test_strip_drops_pure_comment_lines_in_code_cells() -> None:
+    nb = (
+        "# %%\n"
+        "# NOTE: para regresión NO usamos confusion_matrix ni classification_report.\n"
+        "from sklearn.linear_model import LinearRegression\n"
+        "model = LinearRegression()\n"
+    )
+    stripped = _strip_jupytext_for_validation(nb)
+    assert "confusion_matrix" not in stripped
+    assert "classification_report" not in stripped
+    assert "LinearRegression" in stripped
+
+
+def test_strip_drops_inline_trailing_comments() -> None:
+    nb = (
+        "# %%\n"
+        "model = LinearRegression()  # not roc_auc_score, this is regression\n"
+    )
+    stripped = _strip_jupytext_for_validation(nb)
+    assert "roc_auc_score" not in stripped
+    assert "LinearRegression()" in stripped
+
+
+def test_validator_no_false_positive_on_pedagogical_markdown_regression() -> None:
+    """Regression notebook with a markdown lista NEGRA echo must NOT trigger."""
+    nb = (
+        "# %% [markdown]\n"
+        "# ### regresion — Linear Regression\n"
+        "# Recordatorio: para regresión NO usamos `roc_auc_score`, `confusion_matrix`,\n"
+        "# `classification_report`, `auto_arima`, `from prophet import Prophet` ni\n"
+        "# `from sklearn.cluster import KMeans` — esos pertenecen a otras familias.\n"
+        "\n"
+        "# %%\n"
+        "from sklearn.linear_model import LinearRegression\n"
+        "from sklearn.metrics import mean_squared_error, r2_score\n"
+        "model = LinearRegression().fit(X_train, y_train)\n"
+    )
+    assert _validate_notebook_family_consistency("regresion", nb) == []
+
+
+def test_validator_no_false_positive_on_pedagogical_comments_clustering() -> None:
+    """Clustering notebook with `# NO usar train_test_split` comment must pass."""
+    nb = (
+        "# %%\n"
+        "# IMPORTANTE: clustering NO usa train_test_split (no hay etiquetas).\n"
+        "# Tampoco usamos roc_auc_score ni classification_report.\n"
+        "from sklearn.cluster import KMeans\n"
+        "from sklearn.preprocessing import StandardScaler\n"
+        "from sklearn.metrics import silhouette_score\n"
+        "X_scaled = StandardScaler().fit_transform(X)\n"
+        "labels = KMeans(n_clusters=3, random_state=42).fit_predict(X_scaled)\n"
+        "score = silhouette_score(X_scaled, labels)\n"
+    )
+    assert _validate_notebook_family_consistency("clustering", nb) == []
+
+
+def test_validator_still_catches_real_violations_after_filter() -> None:
+    """The filter must not weaken detection: an actual import in code cell is still flagged."""
+    nb = (
+        "# %% [markdown]\n"
+        "# ### regresion — Linear Regression con métricas adicionales\n"
+        "\n"
+        "# %%\n"
+        "from sklearn.linear_model import LinearRegression\n"
+        "from sklearn.metrics import roc_auc_score  # actual import\n"
+        "model = LinearRegression().fit(X_train, y_train)\n"
+        "auc = roc_auc_score(y_test, model.predict(X_test))\n"
+    )
+    violations = _validate_notebook_family_consistency("regresion", nb)
+    assert "roc_auc_score" in violations

--- a/backend/tests/test_m3_notebook_dispatch.py
+++ b/backend/tests/test_m3_notebook_dispatch.py
@@ -1,0 +1,170 @@
+"""Issue #233 — M3 notebook dispatch + family-consistency validator.
+
+Pure-unit tests (no LLM, no DB, no network):
+
+  * `_detect_algorithm_families` returns canonical 4-family keys, falls back
+    to legacy resolver, and uses "unsupported" for unknown names.
+  * `_validate_notebook_family_consistency` flags other-family API tokens
+    only for the active family and returns an empty list on clean input.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from case_generator.graph import (
+    _FAMILY_PROHIBITED_PATTERNS,
+    _detect_algorithm_families,
+    _validate_notebook_family_consistency,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _detect_algorithm_families
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_detect_canonical_classification() -> None:
+    fams = _detect_algorithm_families(["Logistic Regression"])
+    assert "clasificacion" in fams
+
+
+def test_detect_canonical_regression() -> None:
+    fams = _detect_algorithm_families(["Linear Regression"])
+    assert "regresion" in fams
+
+
+def test_detect_canonical_clustering() -> None:
+    fams = _detect_algorithm_families(["K-Means"])
+    assert "clustering" in fams
+
+
+def test_detect_canonical_timeseries() -> None:
+    fams = _detect_algorithm_families(["ARIMA"])
+    assert "serie_temporal" in fams
+
+
+def test_detect_legacy_xgboost_maps_to_classification() -> None:
+    # XGBoost was a legacy challenger for clasificacion_tabular.
+    fams = _detect_algorithm_families(["XGBoost con tuning"])
+    assert "clasificacion" in fams, f"XGBoost debe mapear a clasificacion (legacy), got {fams}"
+
+
+def test_detect_unknown_returns_unsupported_or_empty() -> None:
+    fams = _detect_algorithm_families(["Algoritmo Inventado XYZ"])
+    # Either the function returns "unsupported" or an empty list — both signal
+    # "no canonical family resolved" to the caller.
+    assert "clasificacion" not in fams
+    assert "regresion" not in fams
+    assert "clustering" not in fams
+    assert "serie_temporal" not in fams
+
+
+def test_detect_empty_input_does_not_crash() -> None:
+    fams = _detect_algorithm_families([])
+    assert isinstance(fams, list)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _validate_notebook_family_consistency
+# ──────────────────────────────────────────────────────────────────────────────
+
+CLEAN_CLASSIFICATION_CODE = """
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score, confusion_matrix
+from sklearn.model_selection import train_test_split
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, stratify=y)
+model = LogisticRegression().fit(X_train, y_train)
+auc = roc_auc_score(y_test, model.predict_proba(X_test)[:, 1])
+"""
+
+CLEAN_CLUSTERING_CODE = """
+from sklearn.cluster import KMeans
+from sklearn.preprocessing import StandardScaler
+from sklearn.metrics import silhouette_score
+
+X_scaled = StandardScaler().fit_transform(X)
+labels = KMeans(n_clusters=3, random_state=42).fit_predict(X_scaled)
+score = silhouette_score(X_scaled, labels)
+"""
+
+CLEAN_REGRESSION_CODE = """
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_squared_error, r2_score
+from sklearn.model_selection import train_test_split
+
+X_train, X_test, y_train, y_test = train_test_split(X, y)
+model = LinearRegression().fit(X_train, y_train)
+rmse = mean_squared_error(y_test, model.predict(X_test)) ** 0.5
+"""
+
+CLEAN_TIMESERIES_CODE = """
+from statsmodels.tsa.arima.model import ARIMA
+
+cutoff = int(len(serie) * 0.8)
+train, test = serie.iloc[:cutoff], serie.iloc[cutoff:]
+model = ARIMA(train, order=(1, 1, 1)).fit()
+forecast = model.forecast(steps=len(test))
+"""
+
+
+def test_validator_clean_classification_passes() -> None:
+    assert _validate_notebook_family_consistency("clasificacion", CLEAN_CLASSIFICATION_CODE) == []
+
+
+def test_validator_clean_clustering_passes() -> None:
+    assert _validate_notebook_family_consistency("clustering", CLEAN_CLUSTERING_CODE) == []
+
+
+def test_validator_clean_regression_passes() -> None:
+    assert _validate_notebook_family_consistency("regresion", CLEAN_REGRESSION_CODE) == []
+
+
+def test_validator_clean_timeseries_passes() -> None:
+    assert _validate_notebook_family_consistency("serie_temporal", CLEAN_TIMESERIES_CODE) == []
+
+
+def test_validator_flags_classification_tokens_in_clustering() -> None:
+    # Hallucination: clustering emitting train_test_split / roc_auc_score.
+    bad = """
+from sklearn.cluster import KMeans
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import roc_auc_score
+"""
+    violations = _validate_notebook_family_consistency("clustering", bad)
+    assert "train_test_split(" in violations or "from sklearn.model_selection import train_test_split" in violations
+    assert "roc_auc_score" in violations
+
+
+def test_validator_flags_random_split_in_timeseries() -> None:
+    bad = "from sklearn.model_selection import train_test_split\n"
+    violations = _validate_notebook_family_consistency("serie_temporal", bad)
+    assert any("train_test_split" in v for v in violations)
+
+
+def test_validator_flags_classification_metrics_in_regression() -> None:
+    bad = "from sklearn.metrics import roc_auc_score, confusion_matrix\n"
+    violations = _validate_notebook_family_consistency("regresion", bad)
+    assert "roc_auc_score" in violations
+    assert "confusion_matrix" in violations
+
+
+def test_validator_flags_clustering_tokens_in_classification() -> None:
+    bad = "from sklearn.metrics import silhouette_score\nscore = silhouette_score(X, labels)\n"
+    violations = _validate_notebook_family_consistency("clasificacion", bad)
+    assert "silhouette_score(" in violations
+
+
+def test_validator_unknown_family_returns_empty() -> None:
+    # Defensive: caller should never pass an unknown family, but if it does,
+    # the validator must not crash — empty list signals "no rules to enforce".
+    assert _validate_notebook_family_consistency("nonexistent", "any code") == []
+
+
+def test_prohibited_patterns_cover_4_canonical_families() -> None:
+    assert set(_FAMILY_PROHIBITED_PATTERNS) == {
+        "clasificacion",
+        "regresion",
+        "clustering",
+        "serie_temporal",
+    }

--- a/backend/tests/test_m3_notebook_per_family_prompts.py
+++ b/backend/tests/test_m3_notebook_per_family_prompts.py
@@ -1,0 +1,98 @@
+"""Issue #233 — per-family M3 notebook prompts.
+
+Validates that the four canonical-family prompts (clasificacion / regresion /
+clustering / serie_temporal) each:
+
+  * are exposed via PROMPT_BY_FAMILY with the canonical key
+  * declare a contract-first rule and an explicit lista NEGRA of forbidden
+    other-family API tokens
+  * preserve the atomic-charting contract from Issue #228
+    (Cell 2a metrics-only, Cell 2b/2c plot cells)
+  * accept the shared `.format()` keys without raising KeyError
+
+Cero LLMs, cero red, cero DB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from case_generator.prompts import (
+    M3_NOTEBOOK_ALGO_PROMPT,
+    M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION,
+    M3_NOTEBOOK_ALGO_PROMPT_CLUSTERING,
+    M3_NOTEBOOK_ALGO_PROMPT_REGRESSION,
+    M3_NOTEBOOK_ALGO_PROMPT_TIMESERIES,
+    PROMPT_BY_FAMILY,
+)
+
+
+CANONICAL_FAMILIES = {"clasificacion", "regresion", "clustering", "serie_temporal"}
+
+SHARED_FORMAT_KEYS = {
+    "m3_content": "M3 content",
+    "algoritmos": '["Logistic Regression"]',
+    "familias_meta": "[]",
+    "case_title": "Caso de prueba",
+    "output_language": "es",
+    "dataset_contract_block": "(sin contrato)",
+    "data_gap_warnings_block": "(sin brechas)",
+}
+
+
+def test_prompt_by_family_has_exactly_4_canonical_families() -> None:
+    assert set(PROMPT_BY_FAMILY) == CANONICAL_FAMILIES
+
+
+def test_back_compat_alias_points_to_classification() -> None:
+    assert M3_NOTEBOOK_ALGO_PROMPT is M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION
+
+
+@pytest.mark.parametrize(
+    "family,prompt",
+    [
+        ("clasificacion", M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION),
+        ("regresion", M3_NOTEBOOK_ALGO_PROMPT_REGRESSION),
+        ("clustering", M3_NOTEBOOK_ALGO_PROMPT_CLUSTERING),
+        ("serie_temporal", M3_NOTEBOOK_ALGO_PROMPT_TIMESERIES),
+    ],
+)
+def test_prompt_accepts_shared_format_keys(family: str, prompt: str) -> None:
+    rendered = prompt.format(**SHARED_FORMAT_KEYS)
+    assert rendered, f"prompt {family} renderizó vacío"
+    assert "Caso de prueba" in rendered
+
+
+@pytest.mark.parametrize("family", sorted(CANONICAL_FAMILIES))
+def test_prompt_by_family_returns_correct_prompt(family: str) -> None:
+    prompt = PROMPT_BY_FAMILY[family]
+    assert prompt, f"PROMPT_BY_FAMILY[{family!r}] está vacío"
+
+
+def test_classification_prompt_keeps_atomic_charting() -> None:
+    p = M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION
+    # Issue #228 atomic-charting markers must survive the rename.
+    assert "Defensa extra anti-leakage" in p
+
+
+def test_regression_prompt_declares_blacklist_of_classification_tokens() -> None:
+    p = M3_NOTEBOOK_ALGO_PROMPT_REGRESSION.lower()
+    # Forbidden tokens: regression must NOT mention classification metrics.
+    for token in ("roc_auc_score", "classification_report", "confusion_matrix"):
+        assert token in p, f"regresión debe declarar {token!r} en su lista NEGRA"
+
+
+def test_clustering_prompt_forbids_supervised_tokens() -> None:
+    p = M3_NOTEBOOK_ALGO_PROMPT_CLUSTERING.lower()
+    for token in ("train_test_split", "roc_auc_score", "classification_report"):
+        assert token in p, f"clustering debe declarar {token!r} en su lista NEGRA"
+    # Clustering must require StandardScaler.
+    assert "standardscaler" in p
+
+
+def test_timeseries_prompt_forbids_random_split() -> None:
+    p = M3_NOTEBOOK_ALGO_PROMPT_TIMESERIES.lower()
+    # Time series must NEVER use random train_test_split.
+    assert "train_test_split" in p, "serie_temporal debe declarar train_test_split en lista NEGRA"
+    # Must mention temporal split / último 20%.
+    assert ("último 20" in p) or ("ultimo 20" in p) or ("temporal" in p)

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -65,9 +65,15 @@ export type ModuleId = "m1" | "m2" | "m3" | "m4" | "m5" | "m6";
 // Issue #230 — algorithm selection mode replaces the legacy 5-chip free-text input.
 export type AlgorithmMode = "single" | "contrast";
 export type AlgorithmTier = "baseline" | "challenger";
+// Issue #233 — canonical 4-family taxonomy. Frontend mirrors backend ALGORITHM_CATALOG.
+export type AlgorithmFamily =
+    | "clasificacion"
+    | "regresion"
+    | "clustering"
+    | "serie_temporal";
 export interface AlgorithmCatalogItem {
     name: string;
-    family: string;
+    family: AlgorithmFamily;
     family_label: string;
     tier: AlgorithmTier;
 }


### PR DESCRIPTION
﻿# Issue #233 — M3 Notebook per-family dispatch + canonical 4×2 algorithm catalog

## Summary

Replaces the desync'd dual algorithm registries (`ALGORITHM_TAXONOMY` in `suggest_service.py` + `ALGORITHM_REGISTRY` in `graph.py`) with a single canonical `ALGORITHM_CATALOG` exposing a strict **4 families × 2 tiers** matrix:

| Family            | Baseline                       | Challenger                      |
| ----------------- | ------------------------------ | ------------------------------- |
| `clasificacion`   | Logistic Regression            | Random Forest                   |
| `regresion`       | Linear Regression              | Gradient Boosting Regressor     |
| `clustering`      | K-Means                        | DBSCAN                          |
| `serie_temporal`  | ARIMA                          | Prophet                         |

The M3 notebook generator now dispatches to **one specialized prompt per family** (`PROMPT_BY_FAMILY`) instead of a single monolithic 600+ line prompt that had to cover every ML/DS technique. After the LLM call, a post-LLM family-consistency validator checks the output against per-family forbidden API tokens and **reprompts once** with an explicit forbidden-token list; if the second attempt also violates, the job is failed (`RuntimeError`) — we never ship a notebook with cross-family runtime errors.

Closes #233.

## Why

- The old `ALGORITHM_REGISTRY` in `graph.py` declared 9 keys with `_tabular` suffixes (`clasificacion_tabular`, `regresion_tabular`, `nlp_text_mining`, …) that did not match the 4 canonical family keys exposed by the catalog API. This silently routed prompts through legacy taxonomy that no frontend ever sent.
- The monolithic `M3_NOTEBOOK_ALGO_PROMPT` had to teach the LLM rules for clustering, time-series, classification, and regression simultaneously. Long, multi-purpose prompts are exactly the failure mode the user asked us to harden against — the model would pick wrong APIs (e.g., `train_test_split` in clustering, `roc_auc_score` in regression) and produce non-runnable notebooks.
- For a production deployment to "cientos de personas," we need a contract where each prompt is short, family-specialized, and the output is statically checked.

## Changes (4 bisectable commits)

1. **`feat(case_generator): unify ALGORITHM_CATALOG into 4x2 canonical taxonomy`** — single source of truth in `suggest_service.py`. Adds `family_of()`, `resolve_legacy_family()` (back-compat for XGBoost/Ridge/NLP/etc.), `get_dispatch_meta()`, `FAMILY_LABELS`, `FAMILY_META`. Import-time invariants enforce 4×2 contract. `business` profile exposes baselines only.
2. **`feat(case_generator): per-family M3 notebook prompts + PROMPT_BY_FAMILY`** — splits the monolith into 4 specialized prompts (classification preserves all PR #232 hygiene + Issue #228 atomic charting). Each prompt declares a contract-first allowlist plus an explicit `lista NEGRA` of other-family API tokens. Back-compat alias `M3_NOTEBOOK_ALGO_PROMPT = M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION` preserved.
3. **`feat(case_generator): per-family M3 dispatch + post-LLM consistency validator`** — `m3_notebook_generator` resolves a single family, dispatches to one prompt, then runs `_validate_notebook_family_consistency` against `_FAMILY_PROHIBITED_PATTERNS`; reprompts once on violation, fails the job on second violation. Deletes the 140-line legacy `ALGORITHM_REGISTRY`. Frontend `AlgorithmFamily` Literal narrowed to the 4 canonical values.
4. **`test(case_generator): per-family prompt + dispatch + validator coverage; sync docs`** — 33 new tests across 3 files; AGENTS.md + CLAUDE.md + `case_generator/AGENTS.md` + TODOS.md all synced with the Issue #233 contract.

## Validation

```
uv run --directory backend pytest -q          # 519 passed, 12 skipped
uv run --directory backend mypy src           # clean
npm --prefix frontend run lint                # clean
npm --prefix frontend run test                # 412 passed
npm --prefix frontend run build               # built in 45.00s
```

## Gap Analysis — Risks introduced by longer / specialized prompts

The user explicitly asked for a gap analysis on technical debt, hallucinations, and truncation, since "los prompts al quedar más extensos son más propensos a fallas." Below is what was checked, what was mitigated, and what remains as documented residual risk.

### Verified safe

1. **`.format()` parity across all 4 prompts** — programmatic check confirmed every prompt in `PROMPT_BY_FAMILY` accepts the same shared format keys (`m3_content`, `algoritmos`, `familias_meta`, `case_title`, `output_language`, `dataset_contract_block`, `data_gap_warnings_block`) without `KeyError`. Covered by `test_prompt_accepts_shared_format_keys`.
2. **`{{...}}` escaping** — every literal Python f-string example inside the prompts (e.g. `print(f"⚠️ Error: {{e}}")`) is correctly double-braced so `.format()` does not consume them. Verified by static scan + format() smoke.
3. **No orphan references to deleted symbols** — full repo scan for `ALGORITHM_REGISTRY`, `ALGORITHM_TAXONOMY`, `nlp_text_mining`, `clasificacion_tabular`, `regresion_tabular`. Only matches are intentional comments or legacy-context docstrings.
4. **Validator covers all 4 canonical families** — `_FAMILY_PROHIBITED_PATTERNS` has explicit entries for every key in `PROMPT_BY_FAMILY`, asserted in tests.
5. **Reprompt failure path re-raises** — outer `try` in `m3_notebook_generator` has explicit `except RuntimeError: raise` so a 2nd-attempt validator failure is not silently swallowed by the generic exception handler.
6. **Legacy resolver is deterministic** — `resolve_legacy_family` uses longest-token-first matching so "XGBoost Classifier" maps to `clasificacion`, not `regresion`. Covered by tests.

### Documented residual risks (acceptable trade-offs)

1. **Output-side truncation** — `max_output_tokens=24576`. Per-family dispatch *reduces* this risk vs. the old monolith (which could be asked to emit notebooks for 2 different families simultaneously) but does not eliminate it. M3 notebooks for ml_ds with 2 algorithms in the same family can still approach the limit. Mitigation: the dataset-contract gate caps `m3_content` at ~2000 chars before injection; the per-family prompts are tighter than the monolith. Follow-up suggestion: add observability on `finish_reason == "MAX_TOKENS"` to detect production truncation.
2. **`_FAMILY_PROHIBITED_PATTERNS` uses literal substring matching** — alternative spellings like `metrics.roc_auc_score(` are caught (`roc_auc_score(` substring), but tab-quoted or string-concatenated forms could bypass. Acceptable trade-off vs. false positives that would block legitimate notebooks. Documented in `case_generator/AGENTS.md`.
3. **Back-compat alias `M3_NOTEBOOK_ALGO_PROMPT`** — kept as alias to `_CLASSIFICATION` so legacy imports don't break. Risk: future contributors may import the alias for non-classification work and silently get classification rules. Mitigation: AGENTS.md documents it as back-compat only; new code must use `PROMPT_BY_FAMILY`.
4. **Legacy fallback to `clasificacion`** — when `family_of()` and `resolve_legacy_family()` both miss, the dispatcher falls back to classification and appends a `legacy_warning` to the data-gap block. Risk: this could route a genuinely unsupported family through the wrong prompt. Mitigation: the validator will catch cross-family API usage and either reprompt or fail the job. Follow-up suggestion: add a metric on `legacy_warning` emission to detect catalog drift in production.
5. **Deprecated families (`nlp`, `recomendacion`, `grafos`, `anomalias`, `segmentacion`)** — no longer exposed by the catalog but still resolvable via `resolve_legacy_family` for historical `task_payload` rows. They degrade to `clasificacion`. AGENTS.md forbids reintroduction without an ADR.
6. **Reprompt-once latency cost** — borderline cases incur 2x LLM round-trip latency. Acceptable: the alternative is shipping a broken notebook. Logged at `logger.error` level for production observability.

### Hallucination defense layered

| Layer                  | Caught by                                                                                                  |
| ---------------------- | ---------------------------------------------------------------------------------------------------------- |
| Prompt boundary        | Per-family `lista NEGRA` of forbidden API tokens declared in the prompt itself                             |
| Family selection       | `family_of` → `resolve_legacy_family` → `clasificacion` fallback (deterministic, tested)                  |
| Post-LLM static check  | `_validate_notebook_family_consistency` scans for forbidden tokens in the generated code                   |
| Self-correction        | Reprompt once with explicit forbidden-token list                                                           |
| Hard fail              | `RuntimeError` propagated → job marked failed → no broken notebook reaches the teacher                     |

### Technical debt status

- DRY restored: `ALGORITHM_CATALOG` is the single source of truth. `ALGORITHM_REGISTRY` deleted entirely.
- Frontend types narrowed from `string` to 4-value `Literal` — TS now catches typos at compile time.
- Docs (4 files) synced in same PR per repo policy.
- Future cleanup: deprecate `M3_NOTEBOOK_ALGO_PROMPT` alias once we confirm no external consumers (track in a follow-up issue).

## Test plan

- [x] Backend `pytest -q` green (519 / 12 skipped)
- [x] Backend `mypy src` clean
- [x] Frontend lint clean
- [x] Frontend tests green (412)
- [x] Frontend build green
- [x] Family-coherence enforced at intake (`test_issue230_algorithm_mode.py`)
- [x] Per-family prompt format-key parity (`test_m3_notebook_per_family_prompts.py`)
- [x] Dispatch + validator matrix per family (`test_m3_notebook_dispatch.py`)
- [x] Legacy `_tabular` task_payload backwards-readable (`test_dispatch_resolves_legacy_xgboost`)

## Repo policy

- Branch: `feat/issue-233-m3-per-family-dispatch`
- Default merge mode: **Squash and merge**
- No VERSION/CHANGELOG bumps (per repo convention)
- Touches `backend/src/case_generator/**` (sensitive area) — review with extra care; all changes are functional, not cosmetic.
