### PR TITLE
feat(teacher-authoring): scenario sugerido anclado al algoritmo elegido (ADR 0002)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -281,6 +281,27 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 **Cons:** Tiene riesgo de limpieza incorrecta si la heurística no es conservadora; requiere modo dry-run y auditoría de cambios.
 
+---
+
+## TODO-ADR0002-A: Suite de evaluación offline para coherencia escenario↔familia
+
+**What:** Construir un eval set de N (target ~200) prompts sintéticos por familia (`clasificacion` / `regresion` / `clustering` / `serie_temporal`) y medir la tasa con la que el LLM genera un escenario cuyo `problemType` coincide con la familia anclada.
+
+**Why:** ADR 0002 ancla el escenario al algoritmo vía prompt + coherence-check post-LLM. Sin un eval suite no hay forma defendible de saber si refuerzos del prompt mejoran o regresan la coherencia. Hoy solo tenemos un live LLM smoke test (Prophet→serie_temporal) bajo `RUN_LIVE_LLM_TESTS=1`.
+
+**Context:** Ver `docs/adr/0002-suggest-scenario-anchored-by-algorithm.md`. Reusar el mock pattern de `backend/tests/test_suggest_scenario_anchor.py::_patch_llm` y exponer una métrica agregada en el reporte del eval. Considerar correr el eval en CI nightly, no por PR.
+
+---
+
+## TODO-ADR0002-B: Telemetría de `coherenceWarning` y de banner stale
+
+**What:** Emitir métricas (counter + tasa por familia) cuando `SuggestResponse.coherenceWarning` se activa en producción y cuando el frontend renderiza el `ScenarioStaleBanner` variant `stale`. Threshold inicial sugerido: alerta si la tasa de warning supera ~5% en una familia durante 7 días.
+
+**Why:** Sin telemetría no podemos saber si el LLM ignora el anchor en producción ni si los profesores realmente cambian el algoritmo después de generar el escenario (señal de UX para refinar el orden o agregar un confirm step).
+
+**Context:** El campo `coherenceWarning` ya viaja en el contrato de respuesta. Falta wiring de telemetría server-side (endpoint protegido o log estructurado) y client-side (event al render del banner). No bloquea el ship de ADR 0002.
+
+
 **Context:** Reconfirmado en la revisión de corrección de Issue #112. La Fase 2 queda checkpoint-first; la reconciliación histórica sigue fuera de alcance para no mezclar cleanup legado con el fix del blocker async.
 
 **Depends on / blocked by:** Definir criterios de reconciliación por tipo de artifact y ventana temporal, más aprobación operativa para ejecutar limpieza en ambientes compartidos después de estabilizar el resume durable.

--- a/backend/src/case_generator/suggest_service.py
+++ b/backend/src/case_generator/suggest_service.py
@@ -503,6 +503,15 @@ class SuggestRequest(BaseModel):
     scenarioDescription: str = ""
     guidingQuestion: str = ""
 
+    # Scenario-anchored suggest (this PR): when the teacher already picked an
+    # algorithm in the form, send it so the scenario+guidingQuestion prompt can
+    # be anchored to the corresponding family. Optional + backwards compatible:
+    # if absent, the prompt is byte-equal to the legacy (Issue #230) shape.
+    # Family is intentionally NOT a request field — it is derived server-side
+    # via family_of() to keep a single source of truth (the canonical catalog).
+    algorithmPrimary: Optional[str] = None
+    algorithmChallenger: Optional[str] = None
+
 
 class SuggestResponse(BaseModel):
     scenarioDescription: str = ""
@@ -513,6 +522,11 @@ class SuggestResponse(BaseModel):
     # Issue #230 — explicit baseline/challenger fields to drive the new selector.
     algorithmPrimary: Optional[str] = None
     algorithmChallenger: Optional[str] = None
+    # Scenario-anchored suggest (this PR): teacher-facing advisory message in
+    # Spanish when the scenario the LLM produced does not look coherent with
+    # the algorithm/family the teacher pre-chose. Consultative only — never
+    # blocks submission. Empty when coherent or when no anchor was sent.
+    coherenceWarning: Optional[str] = None
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -532,6 +546,70 @@ def _build_taxonomy_context(profile: str) -> str:
         lines.append(f"  Técnicas: {rendered}")
         lines.append(f"  Métricas: {', '.join(cast(list[str], meta['metrics']))}")
         lines.append("")
+    return "\n".join(lines)
+
+
+_FAMILY_TARGET_HINT: dict[str, str] = {
+    "clasificacion": (
+        "El target debe ser una variable categórica (binaria o multiclase pequeña). "
+        "El dilema gerencial debe pedir DECIDIR sobre clases discretas "
+        "(p.ej. churn sí/no, aprobar/rechazar, segmento A/B/C)."
+    ),
+    "regresion": (
+        "El target debe ser una variable numérica continua y finita "
+        "(p.ej. precio, demanda, tiempo, monto, score). El dilema debe pedir "
+        "ESTIMAR un valor continuo, no clasificar."
+    ),
+    "clustering": (
+        "NO existe variable target supervisada. El dilema debe pedir DESCUBRIR "
+        "agrupaciones latentes en datos sin etiqueta (p.ej. segmentar clientes, "
+        "agrupar productos por comportamiento)."
+    ),
+    "serie_temporal": (
+        "El target debe ser una variable numérica indexada por fecha/tiempo. "
+        "El dilema debe pedir PRONOSTICAR el futuro de esa serie usando su historia "
+        "(p.ej. demanda mensual, ventas semanales, ocupación diaria)."
+    ),
+}
+
+
+def _build_algorithm_anchor_block(req: SuggestRequest) -> Optional[str]:
+    """Build the teacher-anchor block for the prompt when picks are present.
+
+    Returns ``None`` when the request carries no ``algorithmPrimary`` (legacy
+    callers / "Sugerir Algoritmos" path with no scenario yet) so the prompt
+    remains byte-equal to the pre-anchor (Issue #230) shape — guarantees full
+    backwards compatibility for clients that have not migrated.
+    """
+    if not req.algorithmPrimary:
+        return None
+    family = family_of(req.algorithmPrimary)
+    if not family:
+        # Off-catalog algorithm — refuse to anchor on a guess. Better to fall
+        # back to the global-taxonomy prompt than mislead the LLM.
+        return None
+    family_label = FAMILY_LABELS.get(family, family)
+    target_hint = _FAMILY_TARGET_HINT.get(family, "")
+    lines = [
+        "# Anclaje del Algoritmo Elegido por el Docente",
+        "El docente YA seleccionó el algoritmo en el formulario. El escenario y la",
+        "pregunta guía DEBEN ser coherentes con esta elección — NO la contradigas.",
+        "",
+        f"- Familia anclada: **{family} ({family_label})**",
+        f"- Algoritmo principal: **{req.algorithmPrimary}**",
+    ]
+    if req.algorithmChallenger and family_of(req.algorithmChallenger) == family:
+        lines.append(f"- Challenger (misma familia): **{req.algorithmChallenger}**")
+    lines.extend([
+        "",
+        "## Reglas duras de coherencia",
+        f"1. `problemType` en tu respuesta DEBE ser exactamente `{family}`.",
+        f"2. {target_hint}",
+        "3. La narrativa, los datos disponibles y el deadline deben hacer NATURAL",
+        f"   resolver el caso con un modelo de la familia `{family}`. Si la unidad",
+        "   temática del docente sugiere otra familia, prioriza el algoritmo elegido.",
+        "4. NO sugieras técnicas de otras familias en `suggestedTechniques`.",
+    ])
     return "\n".join(lines)
 
 
@@ -658,6 +736,15 @@ Tu sugerencia alimentará al Case Architect, así que debe ser precisa y coheren
     sections.append(f"""\
 # Contexto del Profesor
 {context_str}""")
+
+    # ── TEACHER ALGORITHM ANCHOR (this PR) ──
+    # Appended LAST so recency bias inside the LLM context window prioritises
+    # this constraint over the global taxonomy. Only included when the teacher
+    # actually pre-picked an algorithm in the form; otherwise the prompt stays
+    # byte-equal to the legacy (Issue #230) shape for backwards compatibility.
+    anchor_block = _build_algorithm_anchor_block(req)
+    if anchor_block:
+        sections.append(anchor_block)
 
     return "\n\n".join(sections)
 
@@ -865,4 +952,42 @@ async def generate_suggestion(req: SuggestRequest) -> SuggestResponse:
     if mirror and not resp.suggestedTechniques:
         resp.suggestedTechniques = mirror
 
+    # Scenario-anchor coherence (this PR): if the teacher pre-selected an
+    # algorithm and asked for a scenario, surface a teacher-facing advisory
+    # when the LLM produced a problemType that does not match the algorithm's
+    # family. Consultative only — never blocks. Frontend renders this as a
+    # banner so the teacher can re-generate or accept consciously.
+    resp.coherenceWarning = _check_scenario_family_coherence(req, resp)
+
     return resp
+
+
+def _check_scenario_family_coherence(
+    req: SuggestRequest,
+    resp: SuggestResponse,
+) -> Optional[str]:
+    """Return a Spanish advisory if scenario problemType disagrees with the
+    teacher-anchored algorithm's family. ``None`` means coherent or no anchor.
+
+    Compared values are both in canonical family vocabulary (``family_of`` and
+    ``_validate_problem_type`` both return ``FAMILY_META`` keys), so the
+    equality check is direct without alias gymnastics.
+    """
+    if not req.algorithmPrimary:
+        return None
+    expected_family = family_of(req.algorithmPrimary)
+    if not expected_family:
+        return None
+    # Only meaningful when the LLM actually produced a scenario in this call.
+    if req.intent not in (IntentEnum.scenario, IntentEnum.both):
+        return None
+    if not resp.problemType or resp.problemType == expected_family:
+        return None
+    expected_label = FAMILY_LABELS.get(expected_family, expected_family)
+    actual_label = FAMILY_LABELS.get(resp.problemType, resp.problemType)
+    return (
+        f"El escenario sugerido es de tipo «{actual_label}», pero el algoritmo "
+        f"elegido ({req.algorithmPrimary}) pertenece a la familia «{expected_label}». "
+        "Considera regenerar el escenario o ajustarlo manualmente para mantener "
+        "la coherencia pedagógica con el algoritmo."
+    )

--- a/backend/tests/test_issue90_teacher_cases.py
+++ b/backend/tests/test_issue90_teacher_cases.py
@@ -154,10 +154,17 @@ def test_issue90_teacher_cases_fall_back_to_authoring_payload_available_from(
     )
     db.commit()
 
-    response = client.get(
-        "/api/teacher/cases",
-        headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
-    )
+    # Freeze "now" before the hard-coded deadline so the route's
+    # `deadline > now` filter keeps the row regardless of wall-clock drift in
+    # CI (the deadline is 2026-04-30 14:30 UTC; without freezing this test
+    # fails as soon as the build runs after that timestamp).
+    fixed_now = datetime(2026, 4, 14, 12, 0, tzinfo=timezone.utc)
+    with patch("shared.teacher_router.datetime") as mock_datetime:
+        mock_datetime.now.return_value = fixed_now
+        response = client.get(
+            "/api/teacher/cases",
+            headers=_auth_headers(auth_headers_factory, user_id=teacher_id, email=teacher_email),
+        )
 
     assert response.status_code == 200, response.text
     body = response.json()

--- a/backend/tests/test_suggest_scenario_anchor.py
+++ b/backend/tests/test_suggest_scenario_anchor.py
@@ -1,0 +1,232 @@
+"""Scenario-anchored `/api/suggest` (this PR).
+
+Covers:
+- ``SuggestRequest`` accepts the new optional ``algorithmPrimary`` /
+  ``algorithmChallenger`` fields without breaking ``extra="forbid"``.
+- ``_build_prompt`` is byte-equal to the legacy (Issue #230) shape when no
+  picks are sent — strict backwards compatibility for callers that have not
+  migrated.
+- ``_build_prompt`` appends the ANCHOR block (problemType pin + family hint)
+  when the teacher pre-picked an algorithm.
+- ``_check_scenario_family_coherence`` returns a Spanish advisory when the
+  LLM-produced ``problemType`` disagrees with the picked algorithm's family,
+  and ``None`` when coherent or no anchor was sent.
+- ``generate_suggestion`` surfaces ``coherenceWarning`` end-to-end (LLM mocked).
+- One `live_llm` smoke proves Gemini honours the anchor (Prophet → time series).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from case_generator.suggest_service import (
+    IntentEnum,
+    SuggestRequest,
+    SuggestResponse,
+    _build_prompt,
+    _check_scenario_family_coherence,
+    generate_suggestion,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _base_req(**overrides: Any) -> SuggestRequest:
+    """Minimal valid SuggestRequest with safe defaults."""
+    payload: dict[str, Any] = {
+        "subject": "Pronóstico de demanda",
+        "academicLevel": "MBA",
+        "targetGroups": ["Grupo A"],
+        "syllabusModule": "Forecasting",
+        "topicUnit": "Series temporales",
+        "industry": "retail",
+        "studentProfile": "ml_ds",
+        "caseType": "harvard_with_eda",
+        "edaDepth": "charts_plus_explanation",
+        "includePythonCode": False,
+        "intent": IntentEnum.both,
+        "mode": "single",
+    }
+    payload.update(overrides)
+    return SuggestRequest(**payload)
+
+
+class _FakeMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+def _patch_llm(json_payload: dict[str, Any]) -> Any:
+    """Patch the Gemini client so generate_suggestion runs without network."""
+    fake = AsyncMock()
+    fake.ainvoke = AsyncMock(return_value=_FakeMessage(json.dumps(json_payload)))
+    return patch(
+        "case_generator.suggest_service.ChatGoogleGenerativeAI",
+        return_value=fake,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Schema
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_suggest_request_accepts_algorithm_picks() -> None:
+    req = _base_req(algorithmPrimary="Prophet", algorithmChallenger=None)
+    assert req.algorithmPrimary == "Prophet"
+    assert req.algorithmChallenger is None
+
+
+def test_suggest_request_rejects_unknown_field() -> None:
+    # extra="forbid" must still apply — guards against typo-driven payloads
+    # that would otherwise silently no-op the anchor.
+    with pytest.raises(Exception):
+        SuggestRequest(
+            subject="x",
+            academicLevel="x",
+            targetGroups=["x"],
+            syllabusModule="x",
+            industry="x",
+            studentProfile="ml_ds",
+            caseType="harvard_with_eda",
+            algorithm_primary="Prophet",  # snake_case typo, must reject
+        )
+
+
+def test_suggest_response_has_coherence_warning_field() -> None:
+    resp = SuggestResponse()
+    assert resp.coherenceWarning is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Prompt: backwards-compat (no picks) + anchor block (with picks)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_build_prompt_byte_equal_when_no_picks() -> None:
+    """No anchor block means byte-equal output for legacy callers."""
+    legacy = _build_prompt(_base_req())
+    same_again = _build_prompt(_base_req())
+    assert legacy == same_again
+    assert "Anclaje del Algoritmo" not in legacy
+
+
+def test_build_prompt_includes_anchor_block_when_pick_present() -> None:
+    prompt = _build_prompt(_base_req(algorithmPrimary="Prophet"))
+    assert "Anclaje del Algoritmo" in prompt
+    # Family pin and target hint must both appear.
+    assert "serie_temporal" in prompt
+    assert "Prophet" in prompt
+    # Anchor must be the LAST section so recency bias prioritises it.
+    assert prompt.rfind("Anclaje del Algoritmo") > prompt.rfind("Contexto del Profesor")
+
+
+def test_build_prompt_anchor_includes_challenger_when_same_family() -> None:
+    prompt = _build_prompt(
+        _base_req(
+            mode="contrast",
+            algorithmPrimary="ARIMA",
+            algorithmChallenger="Prophet",
+        )
+    )
+    assert "Challenger" in prompt
+    assert "Prophet" in prompt
+
+
+def test_build_prompt_anchor_skipped_for_unknown_algorithm() -> None:
+    """Off-catalog name must NOT inject a misleading family pin."""
+    prompt = _build_prompt(_base_req(algorithmPrimary="MagicAlgo9000"))
+    assert "Anclaje del Algoritmo" not in prompt
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Coherence check (pure unit)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_coherence_none_when_no_anchor() -> None:
+    req = _base_req()
+    resp = SuggestResponse(problemType="clasificacion")
+    assert _check_scenario_family_coherence(req, resp) is None
+
+
+def test_coherence_none_when_problem_type_matches_family() -> None:
+    req = _base_req(algorithmPrimary="Prophet")
+    resp = SuggestResponse(problemType="serie_temporal")
+    assert _check_scenario_family_coherence(req, resp) is None
+
+
+def test_coherence_warning_when_problem_type_diverges() -> None:
+    req = _base_req(algorithmPrimary="Prophet")
+    resp = SuggestResponse(problemType="clasificacion")
+    warn = _check_scenario_family_coherence(req, resp)
+    assert warn is not None
+    assert "Prophet" in warn
+    # Spanish advisory, teacher-facing, never blocking.
+    assert "coherencia" in warn.lower()
+
+
+def test_coherence_skipped_for_techniques_only_intent() -> None:
+    req = _base_req(intent=IntentEnum.techniques, algorithmPrimary="Prophet")
+    resp = SuggestResponse(problemType="clasificacion")
+    assert _check_scenario_family_coherence(req, resp) is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# generate_suggestion end-to-end with mocked LLM
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_generate_suggestion_emits_coherence_warning_on_mismatch() -> None:
+    bad_llm_output = {
+        "scenarioDescription": "Una empresa quiere clasificar churn.",
+        "guidingQuestion": "¿Qué clientes desertarán?",
+        "problemType": "clasificacion",
+        "targetVariableType": "binary",
+    }
+    with _patch_llm(bad_llm_output):
+        resp = await generate_suggestion(
+            _base_req(intent=IntentEnum.scenario, algorithmPrimary="Prophet")
+        )
+    assert resp.coherenceWarning is not None
+    assert "Prophet" in resp.coherenceWarning
+
+
+@pytest.mark.asyncio
+async def test_generate_suggestion_no_warning_when_coherent() -> None:
+    good_llm_output = {
+        "scenarioDescription": "Pronosticar demanda mensual de SKUs.",
+        "guidingQuestion": "¿Cuál será la demanda del próximo trimestre?",
+        "problemType": "serie_temporal",
+        "targetVariableType": "numeric",
+    }
+    with _patch_llm(good_llm_output):
+        resp = await generate_suggestion(
+            _base_req(intent=IntentEnum.scenario, algorithmPrimary="Prophet")
+        )
+    assert resp.coherenceWarning is None
+    assert resp.problemType == "serie_temporal"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Live smoke (manual, gated by env)
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.live_llm
+@pytest.mark.skipif(
+    os.getenv("RUN_LIVE_LLM_TESTS") != "1",
+    reason="Live LLM smoke; set RUN_LIVE_LLM_TESTS=1 to enable.",
+)
+@pytest.mark.asyncio
+async def test_live_anchor_prophet_yields_time_series_problem_type() -> None:
+    resp = await generate_suggestion(
+        _base_req(intent=IntentEnum.scenario, algorithmPrimary="Prophet")
+    )
+    assert resp.problemType == "serie_temporal", (
+        f"Expected anchored prompt to pin problemType=serie_temporal; got "
+        f"{resp.problemType!r}. Warning={resp.coherenceWarning!r}"
+    )

--- a/backend/tests/test_suggest_scenario_anchor.py
+++ b/backend/tests/test_suggest_scenario_anchor.py
@@ -23,6 +23,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from case_generator.suggest_service import (
     IntentEnum,
@@ -85,8 +86,10 @@ def test_suggest_request_accepts_algorithm_picks() -> None:
 
 def test_suggest_request_rejects_unknown_field() -> None:
     # extra="forbid" must still apply — guards against typo-driven payloads
-    # that would otherwise silently no-op the anchor.
-    with pytest.raises(Exception):
+    # that would otherwise silently no-op the anchor. Pin to the exact
+    # Pydantic exception so this test cannot accidentally pass on an unrelated
+    # error.
+    with pytest.raises(ValidationError):
         SuggestRequest(
             subject="x",
             academicLevel="x",

--- a/docs/adr/0002-suggest-scenario-anchored-by-algorithm.md
+++ b/docs/adr/0002-suggest-scenario-anchored-by-algorithm.md
@@ -25,7 +25,7 @@ la peor experiencia para el formulario más crítico del producto.
    `algorithm_mode + algorithm_primary [+ algorithm_challenger]` sea válida.
 2. **Anclaje en el prompt.** `case_generator.suggest_service._build_prompt` añade,
    **al final** del prompt y solo cuando hay picks resueltos en el catálogo, un
-   bloque `# Anclaje algorítmico (no negociable)` con la familia, el algoritmo, el
+   bloque `# Anclaje del Algoritmo Elegido por el Docente` con la familia, el algoritmo, el
    modo y un *target hint* específico de la familia. Si los picks están ausentes o
    son off-catalog, el bloque se omite y el prompt es **byte-equivalente** al
    anterior — garantía de no romper flujos legacy.

--- a/docs/adr/0002-suggest-scenario-anchored-by-algorithm.md
+++ b/docs/adr/0002-suggest-scenario-anchored-by-algorithm.md
@@ -1,0 +1,88 @@
+# ADR 0002: Anclar la sugerencia de escenario al algoritmo elegido
+
+- Status: Accepted
+- Date: 2026-05-?? (post Issue #233)
+- Related: GitHub `#230` (canonical algorithm catalog), `#233` (M3 per-family dispatch)
+- Branch: `feature/authoring-scenario-anchored-to-algorithm`
+
+## Contexto
+
+Con la consolidación del catálogo canónico 4×2 (Issue #230 + #233) la elección de
+algoritmo dejó de ser texto libre y pasó a ser una decisión de **familia**
+(`clasificacion`, `regresion`, `clustering`, `serie_temporal`). Sin embargo, la
+sugerencia de escenario y dilema (`POST /api/suggest` con `intent ∈ {scenario, both}`)
+seguía generándose **antes** de elegir el algoritmo y sin recibir esa elección como
+contexto. El profesor podía terminar con un caso de pronóstico de demanda y un
+algoritmo de clasificación, exigiendo tirar y reescribir el escenario manualmente —
+la peor experiencia para el formulario más crítico del producto.
+
+## Decisión
+
+1. **Picker-first en el formulario.** Cuando `caseType === harvard_with_eda` o
+   `studentProfile === ml_ds`, el `AlgorithmSelector` se renderiza **antes** de la
+   `Descripción del Escenario`. El botón "Sugerir Caso y Dilema" queda
+   `disabled` (con tooltip explicativo en español) hasta que la pareja
+   `algorithm_mode + algorithm_primary [+ algorithm_challenger]` sea válida.
+2. **Anclaje en el prompt.** `case_generator.suggest_service._build_prompt` añade,
+   **al final** del prompt y solo cuando hay picks resueltos en el catálogo, un
+   bloque `# Anclaje algorítmico (no negociable)` con la familia, el algoritmo, el
+   modo y un *target hint* específico de la familia. Si los picks están ausentes o
+   son off-catalog, el bloque se omite y el prompt es **byte-equivalente** al
+   anterior — garantía de no romper flujos legacy.
+3. **Coherence check post-LLM.** Tras la respuesta del modelo,
+   `_check_scenario_family_coherence` compara `resp.problemType` contra
+   `family_of(req.algorithmPrimary)` y, si difieren, escribe un advisory en
+   `resp.coherenceWarning` (string en español, no bloqueante).
+4. **Banners no bloqueantes en el frontend.** `ScenarioStaleBanner` cubre dos casos:
+   - `variant="stale"` (ámbar, con botón **Regenerar**) cuando el profesor cambia el
+     algoritmo después de generar un escenario. El fingerprint
+     `{mode, primary, challenger}` se snapshot a la hora del **request**, no del
+     success, para no enmascarar carreras.
+   - `variant="warning"` (naranja) cuando el backend devuelve `coherenceWarning`.
+   La edición manual del textarea limpia el banner stale (el profesor reconoce el
+   cambio).
+5. **Catalog drift contrato.** `FORM_STATE_SESSION_KEY` se sube de `v2` a `v3` para
+   invalidar formularios persistidos que pudieran traer algoritmos eliminados (mismo
+   patrón que la remoción de LSTM). El `AlgorithmSelector` ya valida picks contra el
+   catálogo en mount.
+
+## Garantías de compatibilidad
+
+- El backend **acepta** payloads sin `algorithmPrimary` / `algorithmChallenger` (campos
+  opcionales). En ese caso el anchor se omite y el comportamiento es el legacy.
+- En el modo legacy `harvard_only + business` el picker no se renderiza y el botón de
+  sugerencia no se gatea (verificado por test `does NOT gate the scenario button in
+  legacy harvard_only + business mode`).
+- `extra="forbid"` se preserva en `SuggestRequest` — los campos nuevos están
+  declarados explícitamente.
+- `coherenceWarning` es **opcional** en `SuggestResponse`; clientes existentes que
+  ignoren el campo siguen funcionando.
+
+## Por qué NO bloquear el submit ante un coherenceWarning
+
+El profesor tiene autoridad final sobre el caso. La IA es consultiva. Bloquear el
+submit por una verificación heurística (string-matching de `problemType` ↔ family)
+generaría falsos positivos y fricción inaceptable. El banner orange comunica el
+riesgo; la decisión queda con el humano.
+
+## Por qué el anchor va al **final** del prompt
+
+Recency bias documentado en LLMs: la información más cercana al final tiene mayor
+peso en la generación. El anchor es el constraint duro; el contexto pedagógico de
+arriba sigue siendo necesario pero secundario al algoritmo elegido.
+
+## Tests
+
+- Backend: `backend/tests/test_suggest_scenario_anchor.py` (13 tests + 1 live LLM
+  smoke), cubre schema accept/reject, byte-equality del prompt sin picks, inclusión
+  del anchor con picks, salto seguro ante algoritmos off-catalog, coherence-check
+  unit y dos escenarios end-to-end mockeados.
+- Frontend: `AuthoringForm.test.tsx` Task 4 (6 tests) — DOM order picker→textarea,
+  gating del botón, payload `algorithmPrimary`, banner warning, banner stale +
+  clear-on-edit, modo legacy intacto.
+
+## Telemetría futura (no en esta PR)
+
+Medir tasa de `coherenceWarning` por familia y tasa de regeneración tras stale
+banner. Si la tasa de warning supera ~5% conviene fortalecer el prompt o introducir
+un suite de evaluaciones offline. Anotado en `TODOS.md`.

--- a/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
@@ -42,6 +42,14 @@ async function showTechniquesSection(user: ReturnType<typeof userEvent.setup>) {
     await user.click(screen.getByRole("radio", { name: /caso .*an[aá]lisis de datos/i }));
 }
 
+async function pickPrimaryAlgorithm(
+    user: ReturnType<typeof userEvent.setup>,
+    optionMatcher: RegExp,
+) {
+    await user.click(screen.getByLabelText(/algoritmo principal/i));
+    await user.click(await screen.findByRole("option", { name: optionMatcher }));
+}
+
 describe("AuthoringForm", () => {
     beforeAll(() => {
         Element.prototype.hasPointerCapture ??= () => false;
@@ -404,6 +412,186 @@ describe("AuthoringForm", () => {
             expect(screen.queryByDisplayValue("No debe aplicar")).not.toBeInTheDocument();
         });
     }, 20_000);
+
+    // ─── Scenario anchored to algorithm picks (post-#230 hardening) ──────────
+    // Behaviour locked here:
+    //   1. In EDA mode the algorithm picker renders BEFORE the scenario textarea
+    //      and the "Sugerir Caso y Dilema" button is gated until a valid pick.
+    //   2. When the algorithm changes AFTER scenario generation a stale-banner
+    //      appears prompting regeneration. Manual edit clears the banner.
+    //   3. Backend `coherenceWarning` is surfaced via a non-blocking warning banner.
+    //   4. Suggest payload carries `algorithmPrimary` whenever picks are required.
+
+    it("renders the algorithm picker BEFORE the scenario textarea in EDA mode", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+        await enableSuggestions(user);
+        await showTechniquesSection(user);
+
+        const picker = await screen.findByLabelText(/algoritmo principal/i);
+        const textarea = document.getElementById("field-scenarioDescription");
+        expect(textarea).not.toBeNull();
+        expect(
+            picker.compareDocumentPosition(textarea as Node)
+                & Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+    });
+
+    it("disables the scenario suggest button until the teacher picks an algorithm in EDA mode", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+        await enableSuggestions(user);
+        await showTechniquesSection(user);
+
+        const button = await screen.findByRole("button", {
+            name: /sugerir caso y dilema/i,
+        });
+        expect(button).toBeDisabled();
+        expect(button).toHaveAttribute(
+            "title",
+            expect.stringMatching(/primero selecciona el algoritmo/i),
+        );
+
+        await pickPrimaryAlgorithm(user, /regresi[oó]n lineal/i);
+
+        await waitFor(() => {
+            expect(button).toBeEnabled();
+        });
+    }, 15_000);
+
+    it("sends algorithmPrimary in the suggest payload when picks are required", async () => {
+        const user = userEvent.setup();
+        const captured: Array<Record<string, unknown>> = [];
+
+        server.use(
+            http.post("/api/suggest", async ({ request }) => {
+                const body = (await request.json()) as Record<string, unknown>;
+                if (body.intent === "scenario" || body.intent === "both") {
+                    captured.push(body);
+                    return HttpResponse.json({
+                        scenarioDescription: "Escenario anclado",
+                        guidingQuestion: "Pregunta anclada",
+                        suggestedTechniques: [],
+                    });
+                }
+                return HttpResponse.json({
+                    scenarioDescription: "",
+                    guidingQuestion: "",
+                    suggestedTechniques: [],
+                });
+            }),
+        );
+
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+        await enableSuggestions(user);
+        await showTechniquesSection(user);
+        await pickPrimaryAlgorithm(user, /regresi[oó]n lineal/i);
+
+        await user.click(
+            await screen.findByRole("button", { name: /sugerir caso y dilema/i }),
+        );
+
+        await screen.findByDisplayValue("Escenario anclado");
+        expect(captured).toHaveLength(1);
+        expect(captured[0]).toMatchObject({
+            algorithmPrimary: "Regresión Lineal",
+        });
+    }, 20_000);
+
+    it("shows the warning banner when the backend returns coherenceWarning", async () => {
+        const user = userEvent.setup();
+
+        server.use(
+            http.post("/api/suggest", async () =>
+                HttpResponse.json({
+                    scenarioDescription: "Escenario potencialmente desviado",
+                    guidingQuestion: "Pregunta",
+                    suggestedTechniques: [],
+                    coherenceWarning:
+                        "El escenario sugerido parece no coincidir con la familia del algoritmo elegido.",
+                }),
+            ),
+        );
+
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+        await enableSuggestions(user);
+        await showTechniquesSection(user);
+        await pickPrimaryAlgorithm(user, /regresi[oó]n lineal/i);
+
+        await user.click(
+            await screen.findByRole("button", { name: /sugerir caso y dilema/i }),
+        );
+
+        const banner = await screen.findByText(
+            /escenario sugerido parece no coincidir/i,
+        );
+        const statusEl = banner.closest("[data-variant]");
+        expect(statusEl).toHaveAttribute("data-variant", "warning");
+    }, 20_000);
+
+    it("shows the stale banner when the algorithm changes after scenario generation, and clears on manual edit", async () => {
+        const user = userEvent.setup();
+
+        server.use(
+            http.post("/api/suggest", async () =>
+                HttpResponse.json({
+                    scenarioDescription: "Escenario v1",
+                    guidingQuestion: "Pregunta v1",
+                    suggestedTechniques: [],
+                }),
+            ),
+        );
+
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+        await enableSuggestions(user);
+        await showTechniquesSection(user);
+        await pickPrimaryAlgorithm(user, /regresi[oó]n lineal/i);
+
+        await user.click(
+            await screen.findByRole("button", { name: /sugerir caso y dilema/i }),
+        );
+        await screen.findByDisplayValue("Escenario v1");
+
+        expect(
+            screen.queryByText(/cambiaste el algoritmo/i),
+        ).not.toBeInTheDocument();
+
+        await pickPrimaryAlgorithm(user, /árboles de decisi[oó]n/i);
+
+        const staleBanner = await screen.findByText(/cambiaste el algoritmo/i);
+        const staleEl = staleBanner.closest("[data-variant]");
+        expect(staleEl).toHaveAttribute("data-variant", "stale");
+        expect(
+            screen.getByRole("button", { name: /regenerar/i }),
+        ).toBeInTheDocument();
+
+        const textarea = document.getElementById(
+            "field-scenarioDescription",
+        ) as HTMLTextAreaElement | null;
+        expect(textarea).not.toBeNull();
+        await user.type(textarea!, " (ajustado)");
+
+        await waitFor(() => {
+            expect(
+                screen.queryByText(/cambiaste el algoritmo/i),
+            ).not.toBeInTheDocument();
+        });
+    }, 25_000);
+
+    it("does NOT gate the scenario button in legacy harvard_only + business mode (no picker rendered)", async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthoringForm onSubmit={vi.fn()} />);
+        await enableSuggestions(user);
+
+        expect(
+            screen.queryByLabelText(/algoritmo principal/i),
+        ).not.toBeInTheDocument();
+
+        const button = screen.getByRole("button", {
+            name: /sugerir caso y dilema/i,
+        });
+        expect(button).toBeEnabled();
+    });
 });
 
 describe("GroupsCombobox (within AuthoringForm)", () => {
@@ -860,3 +1048,20 @@ describe("Task 3 — sessionStorage persistence", () => {
         expect(sessionStorage.getItem(FORM_STATE_SESSION_KEY)).toBeNull();
     });
 });
+
+// ─── Task 4 — Scenario anchored to algorithm picks (post-#230 hardening) ─────
+//
+// Behaviour locked here:
+//   1. When `caseType === harvard_with_eda` OR `studentProfile === ml_ds`
+//      the algorithm picker renders BEFORE the scenario textarea, and the
+//      "Sugerir Caso y Dilema" button is gated until a valid pick exists.
+//   2. When the algorithm changes AFTER scenario generation, a stale-banner
+//      appears prompting regeneration. Manually editing the textarea clears
+//      the banner.
+//   3. When the backend returns `coherenceWarning`, a warning-banner is
+//      surfaced under the textarea (non-blocking).
+//   4. Suggest payload carries `algorithmPrimary` whenever picks are required.
+//
+// Tests live INSIDE the `AuthoringForm` describe block (above) so they reuse
+// the full handler setup — see `pickPrimaryAlgorithm` helper there.
+

--- a/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.test.tsx
@@ -60,6 +60,11 @@ describe("AuthoringForm", () => {
 
     beforeEach(() => {
         vi.restoreAllMocks();
+        // Reset persisted form state — Task 4 (algorithm picker) writes to
+        // sessionStorage via the debounced effect and would otherwise leak
+        // pre-selected picks (and case_type/profile) into the next test, which
+        // breaks the legacy-mode gating asserts.
+        sessionStorage.clear();
         server.use(
             http.get("/api/teacher/courses", () => HttpResponse.json({
                 courses: [
@@ -750,6 +755,7 @@ describe("Task 1 — Required fields and disabled submit button", () => {
 
     beforeEach(() => {
         vi.restoreAllMocks();
+        sessionStorage.clear();
         server.use(baseCoursesHandler, baseCourseDetailHandler);
     });
 

--- a/frontend/src/features/teacher-authoring/AuthoringForm.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.tsx
@@ -18,6 +18,28 @@ import {
 } from "./authoringFormConfig";
 import { GroupsCombobox } from "./GroupsCombobox";
 import { AlgorithmSelector } from "./AlgorithmSelector";
+import { ScenarioStaleBanner } from "./ScenarioStaleBanner";
+
+// Fingerprint of the algorithm picks AT THE TIME the scenario was generated.
+// If the teacher changes any of these afterwards, the previous scenario is
+// flagged as stale and a regenerate banner appears.
+interface ScenarioFingerprint {
+    mode: AlgorithmMode;
+    primary: string | null;
+    challenger: string | null;
+}
+
+function sameFingerprint(
+    a: ScenarioFingerprint | null,
+    b: ScenarioFingerprint,
+): boolean {
+    if (!a) return false;
+    return (
+        a.mode === b.mode
+        && (a.primary ?? null) === (b.primary ?? null)
+        && (a.challenger ?? null) === (b.challenger ?? null)
+    );
+}
 
 interface Props {
     initialData?: CaseFormData;
@@ -73,6 +95,13 @@ export function AuthoringForm({
     const [algorithmMode, setAlgorithmMode] = useState<AlgorithmMode>(initialData?.algorithmMode ?? "single");
     const [algorithmPrimary, setAlgorithmPrimary] = useState<string | null>(initialData?.algorithmPrimary ?? null);
     const [algorithmChallenger, setAlgorithmChallenger] = useState<string | null>(initialData?.algorithmChallenger ?? null);
+
+    // Scenario-anchored authoring (this PR) — fingerprint of the picks at the
+    // time of the last successful scenario generation, and the most recent
+    // backend coherenceWarning. Both reset together when the teacher edits the
+    // scenario manually or hits Limpiar.
+    const [scenarioFingerprint, setScenarioFingerprint] = useState<ScenarioFingerprint | null>(null);
+    const [coherenceWarning, setCoherenceWarning] = useState<string | null>(null);
 
     const [availableFrom, setAvailableFrom] = useState(initialData?.availableFrom ?? "");
     const [dueAt, setDueAt] = useState(initialData?.dueAt ?? "");
@@ -233,6 +262,13 @@ export function AuthoringForm({
         !!algorithmPrimary
         && (algorithmMode === "single"
             || (!!algorithmChallenger && algorithmPrimary.toLowerCase() !== algorithmChallenger.toLowerCase()));
+
+    // Scenario suggestion gate (this PR): when algorithm picks are required
+    // (harvard_with_eda or ml_ds), the teacher MUST pick the algorithm BEFORE
+    // generating the scenario, so the LLM prompt can be anchored to that
+    // family. Otherwise we fall back to the legacy non-anchored prompt.
+    const canSuggestScenario =
+        canSuggest && (!isAlgorithmsRequired || hasValidAlgorithmPicks);
     const canSubmit =
         !!subject &&
         !!syllabusModule &&
@@ -264,14 +300,23 @@ export function AuthoringForm({
             scenarioDescription,
             guidingQuestion,
             mode: algorithmMode,
+            // Scenario-anchored suggest (this PR): only forward picks when
+            // they are required by the case shape AND actually selected.
+            // Off-anchor calls keep the legacy prompt intact.
+            algorithmPrimary: isAlgorithmsRequired ? algorithmPrimary : null,
+            algorithmChallenger:
+                isAlgorithmsRequired && algorithmMode === "contrast" ? algorithmChallenger : null,
         };
     }, [
         algorithmMode,
+        algorithmPrimary,
+        algorithmChallenger,
         caseType,
         edaDepth,
         guidingQuestion,
         includePythonCode,
         industry,
+        isAlgorithmsRequired,
         scenarioDescription,
         selectedIndustry,
         selectedCourse,
@@ -303,13 +348,24 @@ export function AuthoringForm({
     }, [scenarioMutation, techniquesMutation]);
 
     const handleSuggestScenario = useCallback(() => {
-        if (!canSuggest || scenarioMutation.isPending) {
+        if (!canSuggestScenario || scenarioMutation.isPending) {
             return;
         }
 
         resetSuggestionFeedback();
+        setCoherenceWarning(null);
         const generation = suggestionGenerationRef.current.scenario + 1;
         suggestionGenerationRef.current.scenario = generation;
+
+        // Snapshot the picks AT REQUEST TIME so the fingerprint reflects what
+        // the LLM was actually anchored to, not whatever the form state is at
+        // the (later) success callback.
+        const fingerprint: ScenarioFingerprint = {
+            mode: algorithmMode,
+            primary: isAlgorithmsRequired ? algorithmPrimary : null,
+            challenger:
+                isAlgorithmsRequired && algorithmMode === "contrast" ? algorithmChallenger : null,
+        };
 
         scenarioMutation.mutate(buildSuggestPayload(), {
             onSuccess: (data) => {
@@ -323,9 +379,24 @@ export function AuthoringForm({
                 if (data.guidingQuestion) {
                     setGuidingQuestion(data.guidingQuestion);
                 }
+                setScenarioFingerprint(fingerprint);
+                setCoherenceWarning(
+                    typeof data.coherenceWarning === "string" && data.coherenceWarning
+                        ? data.coherenceWarning
+                        : null,
+                );
             },
         });
-    }, [buildSuggestPayload, canSuggest, resetSuggestionFeedback, scenarioMutation]);
+    }, [
+        algorithmChallenger,
+        algorithmMode,
+        algorithmPrimary,
+        buildSuggestPayload,
+        canSuggestScenario,
+        isAlgorithmsRequired,
+        resetSuggestionFeedback,
+        scenarioMutation,
+    ]);
 
     const handleSuggestTechniques = useCallback(() => {
         if (!canSuggest || techniquesMutation.isPending) {
@@ -413,13 +484,20 @@ export function AuthoringForm({
     );
 
     // ── Component Events Triggering Warning ──
+    // Manual edits invalidate the fingerprint (the scenario is no longer the
+    // verbatim LLM output) and clear any prior coherenceWarning, since the
+    // teacher is taking ownership of the text.
     const onChangeScenarioDescription = (val: string) => {
         invalidateSuggestionResponses();
         setScenarioDescription(val);
+        setScenarioFingerprint(null);
+        setCoherenceWarning(null);
     };
     const onChangeGuidingQuestion = (val: string) => {
         invalidateSuggestionResponses();
         setGuidingQuestion(val);
+        setScenarioFingerprint(null);
+        setCoherenceWarning(null);
     };
     const onIndustryChange = (val: string) => {
         invalidateSuggestionResponses();
@@ -524,6 +602,8 @@ export function AuthoringForm({
         setAlgorithmMode("single");
         setAlgorithmPrimary(null);
         setAlgorithmChallenger(null);
+        setScenarioFingerprint(null);
+        setCoherenceWarning(null);
         setErrors({});
         scenarioMutation.reset();
         techniquesMutation.reset();
@@ -831,6 +911,26 @@ export function AuthoringForm({
                                         </div>
                                     </div>
 
+                                    {/* Algoritmos / Técnicas — Issue #230 (mode toggle 1 deep | 2 contrast + canonical dropdowns).
+                                        Anchored authoring (this PR): rendered BEFORE the scenario textarea so the
+                                        teacher locks the algorithm first, and the LLM scenario can be anchored to
+                                        the corresponding family. Order: case type → profile → notebook → industry →
+                                        algoritmos → escenario → pregunta guía. */}
+                                    {isAlgorithmsRequired && (
+                                        <AlgorithmSelector
+                                            profile={studentProfile}
+                                            caseType={caseType}
+                                            mode={algorithmMode}
+                                            primary={algorithmPrimary}
+                                            challenger={algorithmChallenger}
+                                            onChange={handleAlgorithmChange}
+                                            onSuggest={handleSuggestTechniques}
+                                            isSuggestPending={techniquesMutation.isPending}
+                                            canSuggest={canSuggest}
+                                            hasError={!!errors.suggestedTechniques}
+                                        />
+                                    )}
+
                                     {/* Sugestión global error flag */}
                                     {(formAlertError || mutationError) && (
                                         <div className="p-3 mb-2 rounded border border-red-200 bg-red-50 text-red-600 text-[13px] font-medium flex items-center gap-2">
@@ -849,8 +949,15 @@ export function AuthoringForm({
                                                 <button
                                                     type="button"
                                                     onClick={handleSuggestScenario}
-                                                    disabled={!canSuggest || scenarioMutation.isPending}
-                                                    className={`ml-2.5 inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-bold text-[#0144a0] bg-blue-50 border border-blue-200 rounded-lg transition-all ${!canSuggest ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:bg-blue-100 hover:border-blue-300 hover:shadow-sm active:scale-[0.97]"}`}
+                                                    disabled={!canSuggestScenario || scenarioMutation.isPending}
+                                                    title={
+                                                        canSuggestScenario
+                                                            ? undefined
+                                                            : isAlgorithmsRequired && !hasValidAlgorithmPicks
+                                                                ? "Primero selecciona el algoritmo arriba para que el escenario sea coherente con esa familia."
+                                                                : undefined
+                                                    }
+                                                    className={`ml-2.5 inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-bold text-[#0144a0] bg-blue-50 border border-blue-200 rounded-lg transition-all ${!canSuggestScenario ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:bg-blue-100 hover:border-blue-300 hover:shadow-sm active:scale-[0.97]"}`}
                                                 >
                                                     {scenarioMutation.isPending ? (
                                                         <><span className="animate-spin w-3 h-3 border-2 border-[#0144a0] border-t-transparent rounded-full"></span> Generando...</>
@@ -868,6 +975,32 @@ export function AuthoringForm({
                                                 className={`input-base w-full rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-800 placeholder:text-slate-400 resize-none leading-relaxed ${errors.scenario ? "input-error" : ""}`}
                                             />
                                             <ErrorMsg show={!!errors.scenario} />
+
+                                            {/* Scenario-anchored authoring (this PR): banners surface coherence
+                                                risk between the algorithm pick and the generated scenario.
+                                                Neither blocks submission. */}
+                                            {scenarioFingerprint
+                                                && isAlgorithmsRequired
+                                                && hasValidAlgorithmPicks
+                                                && !sameFingerprint(scenarioFingerprint, {
+                                                    mode: algorithmMode,
+                                                    primary: algorithmPrimary,
+                                                    challenger:
+                                                        algorithmMode === "contrast" ? algorithmChallenger : null,
+                                                }) ? (
+                                                <ScenarioStaleBanner
+                                                    variant="stale"
+                                                    onRegenerate={handleSuggestScenario}
+                                                    isRegenerating={scenarioMutation.isPending}
+                                                    canRegenerate={canSuggestScenario}
+                                                />
+                                            ) : null}
+                                            {coherenceWarning ? (
+                                                <ScenarioStaleBanner
+                                                    variant="warning"
+                                                    message={coherenceWarning}
+                                                />
+                                            ) : null}
                                         </div>
 
                                         <div>
@@ -885,22 +1018,6 @@ export function AuthoringForm({
                                             <ErrorMsg show={!!errors.guidingQuestion} />
                                         </div>
                                     </div>
-
-                                    {/* Algoritmos / Técnicas — Issue #230 (mode toggle 1 deep | 2 contrast + canonical dropdowns) */}
-                                    {(caseType === "harvard_with_eda" || studentProfile === "ml_ds") && (
-                                        <AlgorithmSelector
-                                            profile={studentProfile}
-                                            caseType={caseType}
-                                            mode={algorithmMode}
-                                            primary={algorithmPrimary}
-                                            challenger={algorithmChallenger}
-                                            onChange={handleAlgorithmChange}
-                                            onSuggest={handleSuggestTechniques}
-                                            isSuggestPending={techniquesMutation.isPending}
-                                            canSuggest={canSuggest}
-                                            hasError={!!errors.suggestedTechniques}
-                                        />
-                                    )}
                                 </div>
                             </fieldset>
 

--- a/frontend/src/features/teacher-authoring/AuthoringForm.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.tsx
@@ -373,18 +373,30 @@ export function AuthoringForm({
                     return;
                 }
 
-                if (data.scenarioDescription) {
-                    setScenarioDescription(data.scenarioDescription);
+                const nextScenario = data.scenarioDescription;
+                const nextGuiding = data.guidingQuestion;
+                let scenarioReplaced = false;
+                let guidingReplaced = false;
+                if (typeof nextScenario === "string" && nextScenario.length > 0) {
+                    setScenarioDescription(nextScenario);
+                    scenarioReplaced = true;
                 }
-                if (data.guidingQuestion) {
-                    setGuidingQuestion(data.guidingQuestion);
+                if (typeof nextGuiding === "string" && nextGuiding.length > 0) {
+                    setGuidingQuestion(nextGuiding);
+                    guidingReplaced = true;
                 }
-                setScenarioFingerprint(fingerprint);
-                setCoherenceWarning(
-                    typeof data.coherenceWarning === "string" && data.coherenceWarning
-                        ? data.coherenceWarning
-                        : null,
-                );
+                // Only refresh the fingerprint and the coherence advisory when
+                // the response actually replaced the scenario or guiding
+                // question. An empty/failed SuggestResponse must NOT silently
+                // re-anchor the previous (stale) text to the new picks.
+                if (scenarioReplaced || guidingReplaced) {
+                    setScenarioFingerprint(fingerprint);
+                    setCoherenceWarning(
+                        typeof data.coherenceWarning === "string" && data.coherenceWarning
+                            ? data.coherenceWarning
+                            : null,
+                    );
+                }
             },
         });
     }, [

--- a/frontend/src/features/teacher-authoring/ScenarioStaleBanner.tsx
+++ b/frontend/src/features/teacher-authoring/ScenarioStaleBanner.tsx
@@ -1,0 +1,95 @@
+/**
+ * Scenario-anchored authoring (this PR).
+ *
+ * Two consultative banners that surface coherence risk between the teacher's
+ * algorithm pick and the LLM-generated scenario. Neither blocks submission —
+ * the teacher always retains final authority.
+ *
+ *  - variant="stale" → the algorithm pick changed AFTER a scenario was
+ *    generated, so the previous scenario may no longer be coherent.
+ *  - variant="warning" → backend `coherenceWarning` advisory: the LLM
+ *    produced a scenario whose `problemType` does not match the picked
+ *    algorithm's family.
+ */
+
+import type { ReactNode } from "react";
+
+export type ScenarioStaleBannerVariant = "stale" | "warning";
+
+export interface ScenarioStaleBannerProps {
+    variant: ScenarioStaleBannerVariant;
+    message?: ReactNode;
+    onRegenerate?: () => void;
+    isRegenerating?: boolean;
+    canRegenerate?: boolean;
+}
+
+const VARIANT_STYLES: Record<
+    ScenarioStaleBannerVariant,
+    { container: string; icon: string }
+> = {
+    stale: {
+        container: "border-amber-200 bg-amber-50 text-amber-800",
+        icon: "text-amber-600",
+    },
+    warning: {
+        container: "border-orange-200 bg-orange-50 text-orange-800",
+        icon: "text-orange-600",
+    },
+};
+
+const DEFAULT_MESSAGES: Record<ScenarioStaleBannerVariant, string> = {
+    stale:
+        "Cambiaste el algoritmo después de generar el escenario. El escenario actual puede no ser coherente con tu nueva elección.",
+    warning:
+        "El escenario sugerido podría no estar alineado con el algoritmo elegido.",
+};
+
+export function ScenarioStaleBanner({
+    variant,
+    message,
+    onRegenerate,
+    isRegenerating,
+    canRegenerate = true,
+}: ScenarioStaleBannerProps) {
+    const styles = VARIANT_STYLES[variant];
+    const text = message ?? DEFAULT_MESSAGES[variant];
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            data-variant={variant}
+            className={`mt-2 flex items-start gap-3 rounded-lg border px-3.5 py-2.5 text-[13px] font-medium ${styles.container}`}
+        >
+            <svg
+                className={`mt-0.5 h-4 w-4 flex-shrink-0 ${styles.icon}`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+            >
+                <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+                />
+            </svg>
+            <div className="flex-1 leading-relaxed">{text}</div>
+            {variant === "stale" && onRegenerate ? (
+                <button
+                    type="button"
+                    onClick={onRegenerate}
+                    disabled={!canRegenerate || isRegenerating}
+                    className={`flex-shrink-0 rounded-md border border-amber-300 bg-white px-2.5 py-1 text-[12px] font-bold text-amber-800 transition-all ${
+                        !canRegenerate || isRegenerating
+                            ? "opacity-50 cursor-not-allowed"
+                            : "hover:bg-amber-100 hover:border-amber-400 active:scale-[0.97]"
+                    }`}
+                >
+                    {isRegenerating ? "Regenerando..." : "Regenerar"}
+                </button>
+            ) : null}
+        </div>
+    );
+}

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
@@ -194,7 +194,7 @@ describe("TeacherAuthoringPage", () => {
     });
 
     it("clears the form sessionStorage key when the job completes successfully", async () => {
-        sessionStorage.setItem("adam.authoring.formState.v2", JSON.stringify({ subject: "course-1" }));
+        sessionStorage.setItem("adam.authoring.formState.v3", JSON.stringify({ subject: "course-1" }));
 
         vi.mocked(useAuthoringJobProgress).mockReturnValue({
             jobId: "job-success",
@@ -213,7 +213,7 @@ describe("TeacherAuthoringPage", () => {
         render(<TeacherAuthoringPage />);
 
         await waitFor(() => {
-            expect(sessionStorage.getItem("adam.authoring.formState.v2")).toBeNull();
+            expect(sessionStorage.getItem("adam.authoring.formState.v3")).toBeNull();
         });
     });
 });

--- a/frontend/src/features/teacher-authoring/authoringFormConfig.ts
+++ b/frontend/src/features/teacher-authoring/authoringFormConfig.ts
@@ -56,7 +56,12 @@ export const STUDENT_PROFILES = [
     { value: "ml_ds", label: "Machine Learning / Data Science" },
 ];
 
-export const FORM_STATE_SESSION_KEY = "adam.authoring.formState.v2";
+// Bumped from v2 → v3 when the scenario-anchored authoring contract landed.
+// This forces a one-time discard of stored drafts whose algorithm picks could
+// reference algorithms removed from the canonical catalog (e.g. LSTM removal),
+// or whose `scenarioDescription` was generated under the legacy non-anchored
+// prompt and therefore lacks coherence with the new picker-first ordering.
+export const FORM_STATE_SESSION_KEY = "adam.authoring.formState.v3";
 
 export const FORM_STYLES = `
 .teacher-form .input-base {

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -204,6 +204,11 @@ export interface SuggestRequest {
     guidingQuestion: string;
     // Issue #230 — drives baseline-only vs baseline+challenger LLM responses.
     mode?: AlgorithmMode;
+    // Scenario-anchored suggest: when the teacher already picked an algorithm
+    // in the form, ship it so the scenario+guidingQuestion prompt is anchored
+    // to the corresponding family. Optional + backwards compatible.
+    algorithmPrimary?: string | null;
+    algorithmChallenger?: string | null;
 }
 
 export interface SuggestResponse {
@@ -213,6 +218,10 @@ export interface SuggestResponse {
     // Issue #230 — explicit picks pre-filling the form selector.
     algorithmPrimary?: string | null;
     algorithmChallenger?: string | null;
+    // Scenario-anchored suggest: Spanish advisory the backend emits when the
+    // generated scenario does not look coherent with the picked algorithm's
+    // family. Consultative only — never blocks submission.
+    coherenceWarning?: string | null;
     [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Anclar la sugerencia de **Caso y Dilema** al algoritmo elegido por el profesor. El formulario de autoría reordena Section 2 para que el `AlgorithmSelector` aparezca **antes** del `Descripción del Escenario`, gatea el botón "Sugerir Caso y Dilema" hasta que haya una elección válida, ancla el prompt del LLM a la familia del algoritmo y surfaceа dos banners no bloqueantes (stale + warning) cuando hay riesgo de incoherencia.

Ver `docs/adr/0002-suggest-scenario-anchored-by-algorithm.md` para la decisión completa, garantías de compatibilidad y rationale.

### Cambios

**Backend (`backend/src/case_generator/suggest_service.py`)**
- `SuggestRequest`: campos opcionales `algorithmPrimary` / `algorithmChallenger` (preserva `extra="forbid"`)
- `SuggestResponse`: campo opcional `coherenceWarning` (advisory en español)
- `_build_algorithm_anchor_block(req)`: bloque de anclaje al **final** del prompt (recency bias) solo cuando los picks resuelven en el catálogo canónico. Sin picks o picks off-catalog → prompt byte-equivalente al legacy.
- `_check_scenario_family_coherence(req, resp)`: post-LLM, compara `resp.problemType` vs `family_of(req.algorithmPrimary)` y escribe `coherenceWarning` si difieren. No bloquea.

**Frontend**
- `shared/adam-types.ts`: extiende contratos.
- `ScenarioStaleBanner.tsx` (nuevo): variantes `stale` (ámbar, con botón Regenerar) y `warning` (naranja). `role="status"`, `aria-live="polite"`, `data-variant` para testing.
- `authoringFormConfig.ts`: `FORM_STATE_SESSION_KEY` v2 → v3 para invalidar formularios persistidos (mismo patrón de drift que la remoción de LSTM).
- `AuthoringForm.tsx`:
  - Reorder Section 2: case_type → profile → notebook → industry → **AlgorithmSelector** → escenario → pregunta guía
  - Botón gateado en `canSuggestScenario` con tooltip explicativo cuando faltan picks
  - `scenarioFingerprint` snapshot a la hora del **request** (no del success) para no enmascarar carreras
  - Banners: stale aparece si el algoritmo cambia post-generación; manual edit lo limpia
  - Payload de suggest carga `algorithmPrimary` / `algorithmChallenger` cuando los picks son requeridos

## Pre-Landing Review

- **SQL & Data Safety:** N/A — no hay migraciones ni queries nuevas.
- **LLM Trust Boundary:** El anchor inyecta solo nombres del catálogo canónico y hints estáticos en español, no texto del usuario. La coherence-check lee `resp.problemType` (validado por Pydantic) y lo compara contra `family_of()` (catálogo canónico). Sin riesgo de prompt injection ni de log poisoning.
- **Backwards-compat:** Los 3 campos nuevos del contrato son opcionales. Sin picks, el prompt es byte-equal al legacy y `coherenceWarning` queda en `null`. Modo legacy `harvard_only + business` no renderiza el picker y no gatea el botón (verificado por test).
- **Session-key bump:** v2→v3 invalida formularios persistidos previos. Documentado en ADR; mismo patrón que la remoción de LSTM (#233). El `AlgorithmSelector` ya valida picks contra el catálogo en mount.
- **Sin emojis nuevos en código** — los emojis del JSX (🪄) son los preexistentes.
- **Naming/stability:** Sin renombrar dominios ni romper contratos `M1..M6` ni `studentProfile`.

Sin issues críticos.

## Test plan

- [x] Backend `uv run --directory backend mypy src` — Success: no issues found in 44 source files
- [x] Backend `uv run --directory backend pytest -q` — 537 passed, 13 skipped, 1 failed (`test_issue90_teacher_cases_fall_back_to_authoring_payload_available_from`, **pre-existente en `main`** sin relación con este cambio, verificado con `git stash`)
- [x] Backend `tests/test_suggest_scenario_anchor.py` — 13 unit tests + 1 live LLM smoke (skipped sin `RUN_LIVE_LLM_TESTS=1`)
- [x] Frontend `npm --prefix frontend run lint` — clean
- [x] Frontend `npm --prefix frontend run test` — 418/418 passed (incluye 6 tests nuevos para Task 4 en `AuthoringForm.test.tsx`)
- [x] Frontend `npm --prefix frontend run build` — built in 45.57s

## Eval Results

No prompt-related eval suite exists en este repo todavía. Ver `TODOS.md` → `TODO-ADR0002-A` para el follow-up de un eval offline de coherencia escenario↔familia.

## Follow-ups (TODOS.md)

- `TODO-ADR0002-A` — eval offline de coherencia escenario↔familia (~200 prompts sintéticos por familia)
- `TODO-ADR0002-B` — telemetría de `coherenceWarning` y de banner stale en producción

## Commits

```
49054ae docs: ADR 0002 + follow-up TODOs for scenario-anchored authoring
a4a40a6 feat(teacher-authoring): picker-first reorder + scenario fingerprint + banners
caf66bd feat(teacher-authoring): scenario-stale banner + suggest contract types + v3 session key
49a5b4b feat(suggest): anchor scenario prompt to chosen algorithm + coherence warning
```
