### PR TITLE
feat(case-generator): harden M3 classification notebook with Harvard pedagogical contract (#236)

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -3024,6 +3024,45 @@ _FAMILY_PROHIBITED_PATTERNS: dict[str, tuple[str, ...]] = {
 }
 
 
+# Issue #236 — Required-token validator for the Harvard ml_ds quality bar.
+#
+# Unlike `_FAMILY_PROHIBITED_PATTERNS` (which rejects cross-family API leakage),
+# this map enumerates pedagogical artefacts the notebook MUST contain. Today it
+# is populated only for ``clasificacion`` because the v1 quality push targets
+# Logistic Regression vs Random Forest. Other families return ``()`` from the
+# ``.get(family, ())`` lookup, so they remain bit-identical to the pre-#236
+# behaviour (no FALTANTE entries can be raised against them).
+#
+# Two kinds of tokens live here:
+#   * Section sentinels (``# === SECTION:<id> ===``) — force the LLM to emit
+#     the 6 mandatory pedagogical sections in a parser-friendly shape.
+#   * Canonical sklearn API tokens (``DummyClassifier``, ``StratifiedKFold``,
+#     ``ColumnTransformer``, ``cross_val_score``, ``roc_curve(``,
+#     ``precision_recall_curve(``) — guarantee the sections do real work.
+#
+# IMPORTANT: required-token scanning runs against the RAW notebook text (not
+# the comment-stripped variant used for prohibited tokens). Sentinels are
+# Python ``#`` comments and would otherwise be erased by
+# ``_strip_jupytext_for_validation``. Real API tokens also legitimately appear
+# in markdown pedagogical preambles, and that should count as ``present``.
+_FAMILY_REQUIRED_PATTERNS: dict[str, tuple[str, ...]] = {
+    "clasificacion": (
+        "# === SECTION:dummy_baseline ===",
+        "# === SECTION:pipeline_lr ===",
+        "# === SECTION:pipeline_rf ===",
+        "# === SECTION:cv_scores ===",
+        "# === SECTION:roc_pr_curves ===",
+        "# === SECTION:comparison_table ===",
+        "DummyClassifier",
+        "ColumnTransformer",
+        "StratifiedKFold",
+        "cross_val_score",
+        "roc_curve(",
+        "precision_recall_curve(",
+    ),
+}
+
+
 def _strip_jupytext_for_validation(notebook_text: str) -> str:
     """Return only the executable Python from a Jupytext Percent notebook.
 
@@ -3070,21 +3109,47 @@ def _strip_jupytext_for_validation(notebook_text: str) -> str:
 
 
 def _validate_notebook_family_consistency(family: str, code: str) -> list[str]:
-    """Return a list of prohibited tokens found in executable code for ``family``.
+    """Return notebook violations for ``family`` (prohibited + required tokens).
 
-    Strips Jupytext markdown cells and code-comment lines first, then runs a
-    substring scan against ``_FAMILY_PROHIBITED_PATTERNS[family]``. This avoids
-    flagging the prompt's own ``Lista NEGRA`` echoes that the LLM may legitimately
-    include as documentation.
+    Two independent checks are combined into a single flat list of strings so
+    that the existing reprompt-once-then-fail policy in ``m3_notebook_generator``
+    keeps a single integration point.
 
-    Empty list = pass. Non-empty = the LLM strayed; caller should reprompt
-    once and fail-job if the second attempt also contains forbidden tokens.
+    Result format
+    -------------
+    * Prohibited tokens (cross-family API leakage) are returned as **bare
+      strings** matching the pattern (e.g. ``"silhouette_score("``). This
+      preserves backwards compatibility with the Issue #233 unit tests and the
+      reprompt block which references the prompt's ``Lista NEGRA`` section.
+    * Required tokens missing from the notebook (Issue #236, classification
+      Harvard ml_ds quality bar) are returned with a ``"FALTANTE: "`` prefix.
+      The reprompt block can split on this prefix to build a corrective
+      instruction that explicitly lists the missing artefacts.
+
+    Empty list = pass. Non-empty = the LLM strayed; caller reprompts once and
+    fails the job if the second attempt still has any entry.
+
+    Scoping rules (anti false-positive)
+    -----------------------------------
+    * Prohibited scan runs on the **stripped** code (markdown + ``#`` comments
+      removed) so the prompt's own ``Lista NEGRA`` echoes don't trip it.
+    * Required scan runs on the **raw** code because section sentinels are
+      themselves ``#``-prefixed lines and would otherwise be erased by the
+      strip pass; legitimate appearance of a required identifier in a
+      markdown pedagogical preamble also counts as "present".
     """
-    patterns = _FAMILY_PROHIBITED_PATTERNS.get(family, ())
-    if not patterns:
-        return []
-    scannable = _strip_jupytext_for_validation(code)
-    return [p for p in patterns if p in scannable]
+    violations: list[str] = []
+
+    prohibited = _FAMILY_PROHIBITED_PATTERNS.get(family, ())
+    if prohibited:
+        scannable = _strip_jupytext_for_validation(code)
+        violations.extend(p for p in prohibited if p in scannable)
+
+    required = _FAMILY_REQUIRED_PATTERNS.get(family, ())
+    if required:
+        violations.extend(f"FALTANTE: {token}" for token in required if token not in code)
+
+    return violations
 
 
 def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
@@ -3244,37 +3309,54 @@ def m3_notebook_generator(state: ADAMState, config: RunnableConfig) -> dict:
             algo_section = sanitize_markdown(_extract_text(response))
             print(f"[m3_notebook_generator] Sección módulos LLM (1ª pasada): {len(algo_section)} chars")
 
-            # Issue #233 — post-LLM family-consistency check + reprompt-once.
+            # Issue #233 + #236 — post-LLM family-consistency check + reprompt-once.
+            # Violations come pre-tagged: bare strings = prohibited cross-family
+            # tokens (don't echo back to avoid amplification); ``"FALTANTE: ..."``
+            # = required Harvard-quality artefacts missing (DO echo so the LLM
+            # has a precise fixing target).
             violations = _validate_notebook_family_consistency(family, algo_section)
             if violations:
+                missing = [v.removeprefix("FALTANTE: ") for v in violations if v.startswith("FALTANTE: ")]
+                prohibited_hits = [v for v in violations if not v.startswith("FALTANTE: ")]
                 print(
                     f"[m3_notebook_generator] Violación de familia detectada (familia={family}, "
-                    f"tokens={violations}). Reprompt explícito (1/1)."
+                    f"prohibited={prohibited_hits}, faltantes={missing}). Reprompt explícito (1/1)."
                 )
-                # Belt-and-suspenders against reprompt amplification: we do NOT
-                # echo the offending token strings in the corrective message
-                # (the LLM might politely repeat them in its acknowledgement,
-                # which would re-trip the validator and fail the job). Instead
-                # we reference the prompt's own ``Lista NEGRA`` section.
-                reprompt = (
-                    prompt
-                    + "\n\n# CORRECCIÓN OBLIGATORIA\n"
-                    + f"# Tu salida anterior emitió código ejecutable de OTRAS familias prohibidas para '{family}'.\n"
-                    + "# Releé la sección 'Lista NEGRA' del prompt y reescribe la salida COMPLETA\n"
-                    + "# usando EXCLUSIVAMENTE la API estable declarada para esta familia.\n"
-                    + "# Los nombres prohibidos pueden aparecer en celdas markdown como advertencia pedagógica,\n"
-                    + "# pero NUNCA como import, call site, ni dentro de un string ejecutable."
-                )
+                corrective_blocks: list[str] = ["\n\n# CORRECCIÓN OBLIGATORIA"]
+                if prohibited_hits:
+                    # Belt-and-suspenders against reprompt amplification: we do
+                    # NOT echo the offending prohibited tokens (the LLM might
+                    # politely repeat them and re-trip the validator). Refer
+                    # the model to the prompt's own ``Lista NEGRA`` section.
+                    corrective_blocks.append(
+                        f"# Tu salida anterior emitió código ejecutable de OTRAS familias prohibidas para '{family}'.\n"
+                        "# Releé la sección 'Lista NEGRA' del prompt y reescribe la salida COMPLETA\n"
+                        "# usando EXCLUSIVAMENTE la API estable declarada para esta familia.\n"
+                        "# Los nombres prohibidos pueden aparecer en celdas markdown como advertencia pedagógica,\n"
+                        "# pero NUNCA como import, call site, ni dentro de un string ejecutable."
+                    )
+                if missing:
+                    # For FALTANTE we DO echo: the LLM needs to know exactly
+                    # what to add. Sentinels are emitted verbatim.
+                    bullet_list = "\n".join(f"#   - {tok}" for tok in missing)
+                    corrective_blocks.append(
+                        "# Tu salida anterior NO incluyó artefactos pedagógicos OBLIGATORIOS\n"
+                        f"# para la familia '{family}'. Reescribe la salida COMPLETA asegurándote\n"
+                        "# de que aparezcan literalmente (sentinelas como comentario Python al inicio\n"
+                        "# de la celda correspondiente; identificadores como import o call real):\n"
+                        f"{bullet_list}"
+                    )
+                reprompt = prompt + "\n".join(corrective_blocks)
                 response2 = llm.invoke(reprompt)
                 algo_section = sanitize_markdown(_extract_text(response2))
                 violations2 = _validate_notebook_family_consistency(family, algo_section)
                 if violations2:
                     logger.error(
-                        "[m3_notebook_generator] Reprompt falló — familia=%s tokens=%s",
+                        "[m3_notebook_generator] Reprompt falló — familia=%s violations=%s",
                         family, violations2,
                     )
                     raise RuntimeError(
-                        f"M3 notebook generator emitió código de otras familias para "
+                        f"M3 notebook generator no satisfizo la familia "
                         f"'{family}' incluso tras un reprompt: {violations2}. "
                         f"Job marcado como fallido para evitar shipping de notebook roto."
                     )

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -3040,26 +3040,55 @@ _FAMILY_PROHIBITED_PATTERNS: dict[str, tuple[str, ...]] = {
 #     ``ColumnTransformer``, ``cross_val_score``, ``roc_curve(``,
 #     ``precision_recall_curve(``) — guarantee the sections do real work.
 #
-# IMPORTANT: required-token scanning runs against the RAW notebook text (not
-# the comment-stripped variant used for prohibited tokens). Sentinels are
-# Python ``#`` comments and would otherwise be erased by
-# ``_strip_jupytext_for_validation``. Real API tokens also legitimately appear
-# in markdown pedagogical preambles, and that should count as ``present``.
-_FAMILY_REQUIRED_PATTERNS: dict[str, tuple[str, ...]] = {
+# Required tokens split in two buckets so each is checked against the right
+# corpus (PR #244 review):
+#
+#   * ``_FAMILY_REQUIRED_SENTINELS`` — section-marker comments
+#     (``# === SECTION:<id> ===``). These are Python ``#`` comments and would
+#     be erased by ``_strip_jupytext_for_validation``, so we MUST scan them
+#     against the RAW notebook text.
+#   * ``_FAMILY_REQUIRED_APIS`` — canonical sklearn API tokens
+#     (``DummyClassifier``, ``StratifiedKFold``, ``ColumnTransformer``,
+#     ``cross_val_score``, ``roc_curve(``, ``precision_recall_curve(``).
+#     These MUST be scanned against the STRIPPED text so the LLM cannot
+#     satisfy the validator by merely mentioning the identifier inside a
+#     markdown preamble or a Python comment — they have to appear in
+#     executable code (call site or import) for the section to do real work.
+#
+# Both maps remain populated only for ``clasificacion`` (Issue #236 v1 scope).
+# Other families return ``()`` from the ``.get`` lookup and remain
+# bit-identical to pre-#236 behaviour (no FALTANTE entries can ever fire).
+_FAMILY_REQUIRED_SENTINELS: dict[str, tuple[str, ...]] = {
     "clasificacion": (
         "# === SECTION:dummy_baseline ===",
         "# === SECTION:pipeline_lr ===",
         "# === SECTION:pipeline_rf ===",
         "# === SECTION:cv_scores ===",
-        "# === SECTION:roc_pr_curves ===",
+        "# === SECTION:roc_curves ===",
+        "# === SECTION:pr_curves ===",
         "# === SECTION:comparison_table ===",
+    ),
+}
+
+_FAMILY_REQUIRED_APIS: dict[str, tuple[str, ...]] = {
+    "clasificacion": (
         "DummyClassifier",
         "ColumnTransformer",
         "StratifiedKFold",
         "cross_val_score",
         "roc_curve(",
         "precision_recall_curve(",
+        "train_test_split(",
     ),
+}
+
+# Back-compat alias: external callers and Issue #233 unit tests may still
+# reference the legacy combined map. Keep it as a derived view so future code
+# can migrate to the explicit pair without an import break.
+_FAMILY_REQUIRED_PATTERNS: dict[str, tuple[str, ...]] = {
+    family: _FAMILY_REQUIRED_SENTINELS.get(family, ())
+    + _FAMILY_REQUIRED_APIS.get(family, ())
+    for family in set(_FAMILY_REQUIRED_SENTINELS) | set(_FAMILY_REQUIRED_APIS)
 }
 
 
@@ -3129,25 +3158,31 @@ def _validate_notebook_family_consistency(family: str, code: str) -> list[str]:
     Empty list = pass. Non-empty = the LLM strayed; caller reprompts once and
     fails the job if the second attempt still has any entry.
 
-    Scoping rules (anti false-positive)
-    -----------------------------------
+    Scoping rules (anti false-positive AND anti false-negative — PR #244)
+    ---------------------------------------------------------------------
     * Prohibited scan runs on the **stripped** code (markdown + ``#`` comments
       removed) so the prompt's own ``Lista NEGRA`` echoes don't trip it.
-    * Required scan runs on the **raw** code because section sentinels are
-      themselves ``#``-prefixed lines and would otherwise be erased by the
-      strip pass; legitimate appearance of a required identifier in a
-      markdown pedagogical preamble also counts as "present".
+    * Required **sentinels** scan runs on the **raw** code because they ARE
+      ``#``-prefixed lines that the strip pass would erase. The contract says
+      they must appear as the first line of their cell.
+    * Required **APIs** scan runs on the **stripped** code so the LLM cannot
+      cheat by mentioning ``DummyClassifier`` only inside a markdown
+      pedagogical preamble or a ``# Comentario`` line. They have to appear in
+      executable code (call site or import) for the section to do real work.
     """
     violations: list[str] = []
 
+    scannable = _strip_jupytext_for_validation(code)
+
     prohibited = _FAMILY_PROHIBITED_PATTERNS.get(family, ())
     if prohibited:
-        scannable = _strip_jupytext_for_validation(code)
         violations.extend(p for p in prohibited if p in scannable)
 
-    required = _FAMILY_REQUIRED_PATTERNS.get(family, ())
-    if required:
-        violations.extend(f"FALTANTE: {token}" for token in required if token not in code)
+    sentinels = _FAMILY_REQUIRED_SENTINELS.get(family, ())
+    violations.extend(f"FALTANTE: {token}" for token in sentinels if token not in code)
+
+    apis = _FAMILY_REQUIRED_APIS.get(family, ())
+    violations.extend(f"FALTANTE: {token}" for token in apis if token not in scannable)
 
     return violations
 

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -2342,6 +2342,37 @@ L. **Atomic Cell Charting (Issue #228 — un gráfico por celda)**: cada celda d
      consecutivos). NUNCA mezcles SHAP con cualquier otra cosa.
    - Cada celda de visualización debe terminar con `plt.tight_layout(); plt.show()`.
 
+M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO (Issue #236).**
+   Antes del bloque per-algoritmo, emite la **Sección 3.0.5** descrita más
+   abajo en "Estructura OBLIGATORIA". Esa sección contiene SEIS celdas con
+   sentinelas contractuales que el validador post-LLM verifica:
+     - `# === SECTION:dummy_baseline ===`     → DummyClassifier (most_frequent + stratified)
+     - `# === SECTION:pipeline_lr ===`        → Pipeline(ColumnTransformer + LogisticRegression)
+     - `# === SECTION:pipeline_rf ===`        → Pipeline(ColumnTransformer + RandomForestClassifier)
+     - `# === SECTION:cv_scores ===`          → StratifiedKFold(5) + cross_val_score (fallback cv=3 si la minoritaria es escasa)
+     - `# === SECTION:roc_pr_curves ===`      → curvas ROC y PR (LR vs RF) ploteadas
+     - `# === SECTION:comparison_table ===`   → tabla pd.DataFrame final con las 7 columnas
+   Reglas:
+   * Las sentinelas se emiten LITERALMENTE como primera línea de su celda
+     `# %%` (comentario Python). Si una sentinela falta, el job falla en
+     reprompt-once.
+   * El bloque comparativo es CASE-WIDE (no per-algoritmo): se emite una sola
+     vez con LR y RF juntos. El bloque per-algoritmo posterior queda para
+     interpretación profunda (importancias, narrativa de negocio).
+   * `ColumnTransformer` debe combinar `StandardScaler` para numéricas y
+     `OneHotEncoder(handle_unknown="ignore")` para categóricas (≤20
+     cardinalidad). Reusa la lista `feature_cols` de la REGLA K-bis y
+     particiónala por dtype antes del Pipeline. NUNCA pre-codifiques con
+     `pd.get_dummies` antes del split en este bloque (el ColumnTransformer
+     vive dentro del Pipeline para que el CV no filtre estadísticos).
+   * Las curvas ROC y PR van en celdas DEDICADAS (REGLA L), una `plt.figure`
+     y un `plt.show` por curva. Trazan LR y RF en el mismo eje para
+     comparación visual directa, con leyenda y AUC en el título.
+   * La tabla comparativa final es un `pd.DataFrame` con columnas exactas
+     `["model", "auc_roc_cv_mean", "auc_roc_cv_std", "f1_macro", "recall_minority", "training_time_s", "interpretability_note"]`,
+     una fila por modelo (Dummy + LR + RF), renderizada con `display(...)` o
+     `print(comparison.to_markdown(index=False))`.
+
 # Estructura OBLIGATORIA
 
 ## Sección 3.0 — EDA Express (UNA sola vez, antes del primer algoritmo).
@@ -2379,6 +2410,232 @@ try:
         print(f"  {{c}}: {{n}} outliers")
 except Exception as e:
     print(f"⚠️ EDA Express falló: {{e}}")
+
+## Sección 3.0.5 — Bloque comparativo Harvard ml_ds (REGLA M, Issue #236)
+## Emite EXACTAMENTE las 6 celdas de código siguientes, EN ORDEN, con su
+## sentinela como primera línea (comentario Python). Cada sentinela es
+## contractual — el validador post-LLM rechaza el notebook y reprompt si falta.
+## Este bloque es CASE-WIDE (una sola vez, para Logistic Regression vs
+## Random Forest juntos). El bloque per-algoritmo posterior queda para
+## interpretación profunda. Si por algún motivo el target NO es binario tras
+## resolver el contrato, emite igual las celdas pero imprimiendo
+## `print("Bloque comparativo omitido: target no binario")` dentro de cada
+## try y mantén las sentinelas (no rompas el contrato del validador).
+
+# %% [markdown]
+# ### 3.0.5 — Bloque comparativo Harvard
+# Comparamos siempre contra el baseline trivial (Dummy), entrenamos Logistic
+# Regression y Random Forest dentro de Pipelines reproducibles, validamos con
+# CV estratificada de 5 folds, ploteamos curvas ROC y PR, y consolidamos en
+# una tabla comparativa final.
+
+# %% [markdown]
+# #### 3.0.5.1 Baseline trivial (DummyClassifier)
+# Sin baseline, una AUC de 0.7 no significa nada. Comparamos siempre contra
+# la estrategia más tonta posible: predecir la clase mayoritaria.
+
+# %%
+# === SECTION:dummy_baseline ===
+try:
+    from sklearn.dummy import DummyClassifier
+    from sklearn.model_selection import train_test_split as _tts_dummy
+    from sklearn.metrics import f1_score as _f1_dummy
+
+    # Reusa target_col, X (post higiene K-bis) y y; si el target NO es binario,
+    # documenta y salta los modelos pero mantén la celda visible.
+    if target_col is not None and y.nunique() == 2:
+        X_tr_d, X_te_d, y_tr_d, y_te_d = _tts_dummy(
+            X, y, test_size=0.2, random_state=42,
+            stratify=y if y.value_counts().min() >= 2 else None,
+        )
+        dummy_mf = DummyClassifier(strategy="most_frequent", random_state=42).fit(X_tr_d, y_tr_d)
+        dummy_st = DummyClassifier(strategy="stratified",     random_state=42).fit(X_tr_d, y_tr_d)
+        print("Dummy most_frequent → F1 macro:", _f1_dummy(y_te_d, dummy_mf.predict(X_te_d), average="macro", zero_division=0))
+        print("Dummy stratified    → F1 macro:", _f1_dummy(y_te_d, dummy_st.predict(X_te_d), average="macro", zero_division=0))
+        print("Distribución y_train:", y_tr_d.value_counts(normalize=True).round(3).to_dict())
+    else:
+        print("Bloque comparativo omitido: target no binario")
+except Exception as e:
+    print(f"⚠️ Dummy baseline falló: {{e}}")
+
+# %% [markdown]
+# #### 3.0.5.2 Pipeline reproducible — Logistic Regression
+# `ColumnTransformer` aplica `StandardScaler` a numéricas y `OneHotEncoder`
+# a categóricas dentro del Pipeline, así el CV no filtra estadísticos del fold
+# de validación al de entrenamiento.
+
+# %%
+# === SECTION:pipeline_lr ===
+try:
+    from sklearn.pipeline import Pipeline
+    from sklearn.compose import ColumnTransformer
+    from sklearn.preprocessing import StandardScaler, OneHotEncoder
+    from sklearn.linear_model import LogisticRegression
+
+    # Particiona feature_cols por dtype reusando la lista resultante de la
+    # REGLA K-bis (NO uses pd.get_dummies en este bloque).
+    _num_feats = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
+    _cat_feats = [c for c in feature_cols if c not in _num_feats]
+    preprocess_lr = ColumnTransformer(
+        transformers=[
+            ("num", StandardScaler(), _num_feats),
+            ("cat", OneHotEncoder(handle_unknown="ignore"), _cat_feats),
+        ],
+        remainder="drop",
+    )
+    pipe_lr = Pipeline(steps=[
+        ("preprocess", preprocess_lr),
+        ("clf", LogisticRegression(max_iter=1000, class_weight="balanced", random_state=42)),
+    ])
+    pipe_lr.fit(df[feature_cols], y)
+    print("Pipeline LR ajustado:", pipe_lr.named_steps["clf"])
+except Exception as e:
+    print(f"⚠️ Pipeline LR falló: {{e}}")
+
+# %% [markdown]
+# #### 3.0.5.3 Pipeline reproducible — Random Forest
+
+# %%
+# === SECTION:pipeline_rf ===
+try:
+    from sklearn.pipeline import Pipeline as _PipelineRF
+    from sklearn.compose import ColumnTransformer as _CTRF
+    from sklearn.preprocessing import StandardScaler as _StdRF, OneHotEncoder as _OheRF
+    from sklearn.ensemble import RandomForestClassifier
+
+    _num_feats_rf = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
+    _cat_feats_rf = [c for c in feature_cols if c not in _num_feats_rf]
+    preprocess_rf = _CTRF(
+        transformers=[
+            ("num", _StdRF(), _num_feats_rf),
+            ("cat", _OheRF(handle_unknown="ignore"), _cat_feats_rf),
+        ],
+        remainder="drop",
+    )
+    pipe_rf = _PipelineRF(steps=[
+        ("preprocess", preprocess_rf),
+        ("clf", RandomForestClassifier(n_estimators=200, class_weight="balanced", random_state=42)),
+    ])
+    pipe_rf.fit(df[feature_cols], y)
+    print("Pipeline RF ajustado:", pipe_rf.named_steps["clf"])
+except Exception as e:
+    print(f"⚠️ Pipeline RF falló: {{e}}")
+
+# %% [markdown]
+# #### 3.0.5.4 Validación cruzada estratificada (5 folds)
+# `StratifiedKFold` preserva la prevalencia en cada fold. Si la minoritaria
+# tiene <5 ejemplos por fold posible, hacemos fallback a `cv=3`.
+
+# %%
+# === SECTION:cv_scores ===
+try:
+    from sklearn.model_selection import StratifiedKFold, cross_val_score
+
+    _min_class = int(y.value_counts().min()) if y is not None and len(y) else 0
+    n_splits_cv = 5 if _min_class >= 5 else (3 if _min_class >= 3 else 2)
+    cv_kfold = StratifiedKFold(n_splits=n_splits_cv, shuffle=True, random_state=42)
+    cv_lr = cross_val_score(pipe_lr, df[feature_cols], y, cv=cv_kfold, scoring="roc_auc")
+    cv_rf = cross_val_score(pipe_rf, df[feature_cols], y, cv=cv_kfold, scoring="roc_auc")
+    print(f"AUC-ROC CV (n_splits={{n_splits_cv}}) — LR: {{cv_lr.mean():.3f}} ± {{cv_lr.std():.3f}}")
+    print(f"AUC-ROC CV (n_splits={{n_splits_cv}}) — RF: {{cv_rf.mean():.3f}} ± {{cv_rf.std():.3f}}")
+except Exception as e:
+    print(f"⚠️ CV scores fallaron: {{e}}")
+    cv_lr, cv_rf = None, None
+
+# %% [markdown]
+# #### 3.0.5.5 Curvas ROC y PR — LR vs RF
+# Una sola figura para ROC, una sola figura para PR (REGLA L atomic charting).
+# Trazamos LR y RF en el mismo eje para comparación visual directa.
+
+# %%
+# === SECTION:roc_pr_curves ===
+try:
+    from sklearn.metrics import roc_curve, precision_recall_curve, auc as _auc_pr, roc_auc_score, average_precision_score
+
+    # Hold-out limpio para curvas (no reusamos splits del CV).
+    _Xtr, _Xte, _ytr, _yte = train_test_split(
+        df[feature_cols], y, test_size=0.2, random_state=42,
+        stratify=y if y is not None and y.nunique() == 2 and y.value_counts().min() >= 2 else None,
+    )
+    pipe_lr.fit(_Xtr, _ytr); pipe_rf.fit(_Xtr, _ytr)
+    _proba_lr = pipe_lr.predict_proba(_Xte)[:, 1]
+    _proba_rf = pipe_rf.predict_proba(_Xte)[:, 1]
+    _pos = pipe_lr.named_steps["clf"].classes_[1]
+    _y_bin = (_yte.reset_index(drop=True) == _pos).astype(int)
+
+    fpr_lr, tpr_lr, _ = roc_curve(_y_bin, _proba_lr)
+    fpr_rf, tpr_rf, _ = roc_curve(_y_bin, _proba_rf)
+    plt.figure(figsize=(7, 6))
+    plt.plot(fpr_lr, tpr_lr, label=f"LR (AUC={{roc_auc_score(_y_bin, _proba_lr):.3f}})")
+    plt.plot(fpr_rf, tpr_rf, label=f"RF (AUC={{roc_auc_score(_y_bin, _proba_rf):.3f}})")
+    plt.plot([0, 1], [0, 1], "k--", alpha=0.4)
+    plt.xlabel("False Positive Rate"); plt.ylabel("True Positive Rate")
+    plt.title("Curvas ROC — LR vs RF"); plt.legend(loc="lower right")
+    plt.tight_layout(); plt.show()
+except Exception as e:
+    print(f"⚠️ Curvas ROC fallaron: {{e}}")
+
+# %%
+try:
+    prec_lr, rec_lr, _ = precision_recall_curve(_y_bin, _proba_lr)
+    prec_rf, rec_rf, _ = precision_recall_curve(_y_bin, _proba_rf)
+    plt.figure(figsize=(7, 6))
+    plt.plot(rec_lr, prec_lr, label=f"LR (AP={{average_precision_score(_y_bin, _proba_lr):.3f}})")
+    plt.plot(rec_rf, prec_rf, label=f"RF (AP={{average_precision_score(_y_bin, _proba_rf):.3f}})")
+    plt.xlabel("Recall"); plt.ylabel("Precision")
+    plt.title("Curvas Precision-Recall — LR vs RF"); plt.legend(loc="lower left")
+    plt.tight_layout(); plt.show()
+except Exception as e:
+    print(f"⚠️ Curvas PR fallaron: {{e}}")
+
+# %% [markdown]
+# #### 3.0.5.6 Tabla comparativa final
+# Consolida AUC CV (media y std), F1 macro, recall de la clase minoritaria,
+# tiempo de entrenamiento e interpretabilidad cualitativa.
+
+# %%
+# === SECTION:comparison_table ===
+try:
+    import time as _time_cmp
+    from sklearn.metrics import f1_score as _f1_cmp, recall_score as _rec_cmp
+
+    def _train_and_score(pipe, name):
+        t0 = _time_cmp.perf_counter()
+        pipe.fit(_Xtr, _ytr)
+        elapsed = _time_cmp.perf_counter() - t0
+        y_hat = pipe.predict(_Xte)
+        minority = y.value_counts().idxmin() if y is not None and y.nunique() == 2 else None
+        rec_min = _rec_cmp(_yte, y_hat, labels=[minority], average="macro", zero_division=0) if minority is not None else float("nan")
+        return {{
+            "model": name,
+            "auc_roc_cv_mean": float(cv_lr.mean()) if name == "LogisticRegression" and cv_lr is not None else (float(cv_rf.mean()) if name == "RandomForest" and cv_rf is not None else float("nan")),
+            "auc_roc_cv_std":  float(cv_lr.std())  if name == "LogisticRegression" and cv_lr is not None else (float(cv_rf.std())  if name == "RandomForest" and cv_rf is not None else float("nan")),
+            "f1_macro": float(_f1_cmp(_yte, y_hat, average="macro", zero_division=0)),
+            "recall_minority": float(rec_min),
+            "training_time_s": round(elapsed, 4),
+            "interpretability_note": (
+                "alta — coeficientes interpretables como log-odds" if name == "LogisticRegression"
+                else "media — feature_importances_, requiere permutation importance para causalidad"
+            ),
+        }}
+
+    rows_cmp = [
+        {{"model": "DummyClassifier(most_frequent)", "auc_roc_cv_mean": 0.5, "auc_roc_cv_std": 0.0,
+          "f1_macro": float("nan"), "recall_minority": 0.0, "training_time_s": 0.0,
+          "interpretability_note": "baseline trivial — sin aprendizaje"}},
+        _train_and_score(pipe_lr, "LogisticRegression"),
+        _train_and_score(pipe_rf, "RandomForest"),
+    ]
+    comparison = pd.DataFrame(rows_cmp, columns=[
+        "model", "auc_roc_cv_mean", "auc_roc_cv_std", "f1_macro",
+        "recall_minority", "training_time_s", "interpretability_note",
+    ])
+    try:
+        print(comparison.to_markdown(index=False))
+    except Exception:
+        print(comparison.to_string(index=False))
+except Exception as e:
+    print(f"⚠️ Tabla comparativa falló: {{e}}")
 
 ## Para CADA familia en {familias_meta}, y para CADA algoritmo dentro del campo
 ## "algoritmos" de esa familia, emite las siguientes celdas EN ORDEN (no

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -2344,14 +2344,15 @@ L. **Atomic Cell Charting (Issue #228 — un gráfico por celda)**: cada celda d
 
 M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO (Issue #236).**
    Antes del bloque per-algoritmo, emite la **Sección 3.0.5** descrita más
-   abajo en "Estructura OBLIGATORIA". Esa sección contiene SEIS celdas con
+   abajo en "Estructura OBLIGATORIA". Esa sección contiene SIETE celdas con
    sentinelas contractuales que el validador post-LLM verifica:
-     - `# === SECTION:dummy_baseline ===`     → DummyClassifier (most_frequent + stratified)
+     - `# === SECTION:dummy_baseline ===`     → bootstrap (target_col, y, feature_cols, X_raw, is_binary) + DummyClassifier (most_frequent + stratified)
      - `# === SECTION:pipeline_lr ===`        → Pipeline(ColumnTransformer + LogisticRegression)
      - `# === SECTION:pipeline_rf ===`        → Pipeline(ColumnTransformer + RandomForestClassifier)
      - `# === SECTION:cv_scores ===`          → StratifiedKFold(5) + cross_val_score (fallback cv=3 si la minoritaria es escasa)
-     - `# === SECTION:roc_pr_curves ===`      → curvas ROC y PR (LR vs RF) ploteadas
-     - `# === SECTION:comparison_table ===`   → tabla pd.DataFrame final con las 7 columnas
+     - `# === SECTION:roc_curves ===`         → hold-out propio + curva ROC (LR vs RF) en una sola figura
+     - `# === SECTION:pr_curves ===`          → curva Precision-Recall (LR vs RF) en una sola figura, reusando el hold-out
+     - `# === SECTION:comparison_table ===`   → tabla pd.DataFrame final con las 7 columnas, hold-out reconstruido localmente
    Reglas:
    * Las sentinelas se emiten LITERALMENTE como primera línea de su celda
      `# %%` (comentario Python). Si una sentinela falta, el job falla en
@@ -2359,15 +2360,29 @@ M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO (Issue #236).**
    * El bloque comparativo es CASE-WIDE (no per-algoritmo): se emite una sola
      vez con LR y RF juntos. El bloque per-algoritmo posterior queda para
      interpretación profunda (importancias, narrativa de negocio).
+   * **Auto-contención (PR #244 review)**: la celda `dummy_baseline` resuelve
+     `target_col`, deriva `y`, calcula `feature_cols` con la receta K-bis,
+     construye `X_raw = df[feature_cols]`, y fija `is_binary = (target_col is
+     not None) and (y.nunique() == 2)`. Las celdas siguientes NO pueden
+     asumir variables del bloque per-algoritmo (que se ejecuta DESPUÉS); usan
+     `feature_cols`, `y`, `X_raw` e `is_binary` definidos aquí.
+   * **Guarda binaria consistente**: cada celda inicia con
+     `if not is_binary: print("Bloque comparativo omitido: target no
+     binario")` antes del trabajo real, dentro de su `try`. Esto garantiza
+     que un dataset multiclase NO produzca cascada de NameError ni mensajes
+     de error inútiles — solo el aviso pedagógico unificado.
    * `ColumnTransformer` debe combinar `StandardScaler` para numéricas y
      `OneHotEncoder(handle_unknown="ignore")` para categóricas (≤20
-     cardinalidad). Reusa la lista `feature_cols` de la REGLA K-bis y
-     particiónala por dtype antes del Pipeline. NUNCA pre-codifiques con
-     `pd.get_dummies` antes del split en este bloque (el ColumnTransformer
-     vive dentro del Pipeline para que el CV no filtre estadísticos).
-   * Las curvas ROC y PR van en celdas DEDICADAS (REGLA L), una `plt.figure`
-     y un `plt.show` por curva. Trazan LR y RF en el mismo eje para
-     comparación visual directa, con leyenda y AUC en el título.
+     cardinalidad). Particiona `feature_cols` por dtype antes del Pipeline.
+     NUNCA pre-codifiques con `pd.get_dummies` antes del split en este
+     bloque (el ColumnTransformer vive dentro del Pipeline para que el CV
+     no filtre estadísticos).
+   * `roc_curves` IMPORTA explícitamente `train_test_split` y construye su
+     propio hold-out estratificado (`_Xtr/_Xte/_ytr/_yte`). `pr_curves` y
+     `comparison_table` NO pueden depender de variables de celdas previas:
+     cada una reconstruye el hold-out localmente con la misma semilla
+     (`random_state=42`) para garantizar aislamiento (Regla 6) y
+     reproducibilidad.
    * La tabla comparativa final es un `pd.DataFrame` con columnas exactas
      `["model", "auc_roc_cv_mean", "auc_roc_cv_std", "f1_macro", "recall_minority", "training_time_s", "interpretability_note"]`,
      una fila por modelo (Dummy + LR + RF), renderizada con `display(...)` o
@@ -2412,50 +2427,91 @@ except Exception as e:
     print(f"⚠️ EDA Express falló: {{e}}")
 
 ## Sección 3.0.5 — Bloque comparativo Harvard ml_ds (REGLA M, Issue #236)
-## Emite EXACTAMENTE las 6 celdas de código siguientes, EN ORDEN, con su
+## Emite EXACTAMENTE las 7 celdas de código siguientes, EN ORDEN, con su
 ## sentinela como primera línea (comentario Python). Cada sentinela es
 ## contractual — el validador post-LLM rechaza el notebook y reprompt si falta.
 ## Este bloque es CASE-WIDE (una sola vez, para Logistic Regression vs
 ## Random Forest juntos). El bloque per-algoritmo posterior queda para
-## interpretación profunda. Si por algún motivo el target NO es binario tras
-## resolver el contrato, emite igual las celdas pero imprimiendo
-## `print("Bloque comparativo omitido: target no binario")` dentro de cada
-## try y mantén las sentinelas (no rompas el contrato del validador).
+## interpretación profunda.
+##
+## AUTO-CONTENCIÓN (PR #244 review): la primera celda (`dummy_baseline`)
+## DEBE bootstrappar `target_col`, `y`, `feature_cols`, `X_raw` e
+## `is_binary` a partir de `df` directamente. Las celdas siguientes NO
+## pueden asumir variables del bloque per-algoritmo (que se ejecuta
+## DESPUÉS de esta sección). Cada celda subsiguiente arranca con la
+## guarda `if not is_binary: print("Bloque comparativo omitido: target
+## no binario")` antes del trabajo real, dentro de su `try` aislado.
 
 # %% [markdown]
 # ### 3.0.5 — Bloque comparativo Harvard
 # Comparamos siempre contra el baseline trivial (Dummy), entrenamos Logistic
 # Regression y Random Forest dentro de Pipelines reproducibles, validamos con
-# CV estratificada de 5 folds, ploteamos curvas ROC y PR, y consolidamos en
-# una tabla comparativa final.
+# CV estratificada de 5 folds, ploteamos curvas ROC y PR (en celdas
+# separadas), y consolidamos en una tabla comparativa final.
 
 # %% [markdown]
-# #### 3.0.5.1 Baseline trivial (DummyClassifier)
+# #### 3.0.5.1 Baseline trivial (DummyClassifier) + bootstrap de variables
 # Sin baseline, una AUC de 0.7 no significa nada. Comparamos siempre contra
-# la estrategia más tonta posible: predecir la clase mayoritaria.
+# la estrategia más tonta posible: predecir la clase mayoritaria. Esta celda
+# además resuelve `target_col`, `y`, `feature_cols`, `X_raw` e `is_binary`
+# que reutilizan las 6 celdas siguientes.
 
 # %%
 # === SECTION:dummy_baseline ===
 try:
     from sklearn.dummy import DummyClassifier
-    from sklearn.model_selection import train_test_split as _tts_dummy
+    from sklearn.model_selection import train_test_split
     from sklearn.metrics import f1_score as _f1_dummy
 
-    # Reusa target_col, X (post higiene K-bis) y y; si el target NO es binario,
-    # documenta y salta los modelos pero mantén la celda visible.
-    if target_col is not None and y.nunique() == 2:
-        X_tr_d, X_te_d, y_tr_d, y_te_d = _tts_dummy(
-            X, y, test_size=0.2, random_state=42,
+    # 1) Resolver target_col vía alias-first (label_aliases → churn_aliases →
+    #    último categórico). Independiente del bloque per-algoritmo posterior.
+    target_col = find_first_matching_column(df.columns, label_aliases) or \
+                 find_first_matching_column(df.columns, churn_aliases)
+    if target_col is None:
+        _cat_cols_boot = df.select_dtypes(include=["object", "category"]).columns.tolist()
+        target_col = _cat_cols_boot[-1] if _cat_cols_boot else None
+
+    # 2) Construir feature_cols con la receta K-bis (sin target, sin IDs, sin
+    #    constantes, sin >50%% nulos). NO usamos pd.get_dummies aquí —
+    #    el ColumnTransformer del Pipeline se encarga del encoding sin fuga.
+    _num_cols_boot = df.select_dtypes(include=np.number).columns.tolist()
+    _cat_cols_boot = [c for c in df.select_dtypes(include=["object", "category"]).columns
+                      if df[c].nunique(dropna=True) <= 20]
+    _candidates_boot = [c for c in (_num_cols_boot + _cat_cols_boot) if c != target_col]
+    _n_boot = len(df)
+    feature_cols = [
+        c for c in _candidates_boot
+        if df[c].nunique(dropna=True) < _n_boot
+        and "id" not in normalize_colname(c).split("_")
+        and df[c].nunique(dropna=True) > 1
+        and df[c].isna().mean() <= 0.5
+    ]
+
+    # 3) Derivar y, X_raw, is_binary. is_binary gobierna las 6 celdas siguientes.
+    y = df[target_col] if target_col is not None else None
+    X_raw = df[feature_cols] if feature_cols else None
+    is_binary = bool(target_col is not None and y is not None and y.nunique(dropna=True) == 2)
+
+    if is_binary:
+        X_tr_d, X_te_d, y_tr_d, y_te_d = train_test_split(
+            X_raw, y, test_size=0.2, random_state=42,
             stratify=y if y.value_counts().min() >= 2 else None,
         )
-        dummy_mf = DummyClassifier(strategy="most_frequent", random_state=42).fit(X_tr_d, y_tr_d)
-        dummy_st = DummyClassifier(strategy="stratified",     random_state=42).fit(X_tr_d, y_tr_d)
-        print("Dummy most_frequent → F1 macro:", _f1_dummy(y_te_d, dummy_mf.predict(X_te_d), average="macro", zero_division=0))
-        print("Dummy stratified    → F1 macro:", _f1_dummy(y_te_d, dummy_st.predict(X_te_d), average="macro", zero_division=0))
+        # DummyClassifier necesita features numéricas/binarias ⇒ get_dummies SOLO
+        # para esta celda (no contaminamos el pipeline real, que vive aparte).
+        _Xtr_dummy = pd.get_dummies(X_tr_d, drop_first=True, dummy_na=False)
+        _Xte_dummy = pd.get_dummies(X_te_d, drop_first=True, dummy_na=False).reindex(columns=_Xtr_dummy.columns, fill_value=0)
+        dummy_mf = DummyClassifier(strategy="most_frequent", random_state=42).fit(_Xtr_dummy, y_tr_d)
+        dummy_st = DummyClassifier(strategy="stratified",     random_state=42).fit(_Xtr_dummy, y_tr_d)
+        print("Dummy most_frequent → F1 macro:", _f1_dummy(y_te_d, dummy_mf.predict(_Xte_dummy), average="macro", zero_division=0))
+        print("Dummy stratified    → F1 macro:", _f1_dummy(y_te_d, dummy_st.predict(_Xte_dummy), average="macro", zero_division=0))
         print("Distribución y_train:", y_tr_d.value_counts(normalize=True).round(3).to_dict())
     else:
         print("Bloque comparativo omitido: target no binario")
 except Exception as e:
+    # Failsafe: si el bootstrap falla, garantiza que las celdas siguientes
+    # encuentren is_binary=False y emitan el aviso pedagógico estándar.
+    is_binary = False
     print(f"⚠️ Dummy baseline falló: {{e}}")
 
 # %% [markdown]
@@ -2467,28 +2523,29 @@ except Exception as e:
 # %%
 # === SECTION:pipeline_lr ===
 try:
-    from sklearn.pipeline import Pipeline
-    from sklearn.compose import ColumnTransformer
-    from sklearn.preprocessing import StandardScaler, OneHotEncoder
-    from sklearn.linear_model import LogisticRegression
+    if not is_binary:
+        print("Bloque comparativo omitido: target no binario")
+    else:
+        from sklearn.pipeline import Pipeline
+        from sklearn.compose import ColumnTransformer
+        from sklearn.preprocessing import StandardScaler, OneHotEncoder
+        from sklearn.linear_model import LogisticRegression
 
-    # Particiona feature_cols por dtype reusando la lista resultante de la
-    # REGLA K-bis (NO uses pd.get_dummies en este bloque).
-    _num_feats = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
-    _cat_feats = [c for c in feature_cols if c not in _num_feats]
-    preprocess_lr = ColumnTransformer(
-        transformers=[
-            ("num", StandardScaler(), _num_feats),
-            ("cat", OneHotEncoder(handle_unknown="ignore"), _cat_feats),
-        ],
-        remainder="drop",
-    )
-    pipe_lr = Pipeline(steps=[
-        ("preprocess", preprocess_lr),
-        ("clf", LogisticRegression(max_iter=1000, class_weight="balanced", random_state=42)),
-    ])
-    pipe_lr.fit(df[feature_cols], y)
-    print("Pipeline LR ajustado:", pipe_lr.named_steps["clf"])
+        _num_feats = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
+        _cat_feats = [c for c in feature_cols if c not in _num_feats]
+        preprocess_lr = ColumnTransformer(
+            transformers=[
+                ("num", StandardScaler(), _num_feats),
+                ("cat", OneHotEncoder(handle_unknown="ignore"), _cat_feats),
+            ],
+            remainder="drop",
+        )
+        pipe_lr = Pipeline(steps=[
+            ("preprocess", preprocess_lr),
+            ("clf", LogisticRegression(max_iter=1000, class_weight="balanced", random_state=42)),
+        ])
+        pipe_lr.fit(X_raw, y)
+        print("Pipeline LR ajustado:", pipe_lr.named_steps["clf"])
 except Exception as e:
     print(f"⚠️ Pipeline LR falló: {{e}}")
 
@@ -2498,26 +2555,29 @@ except Exception as e:
 # %%
 # === SECTION:pipeline_rf ===
 try:
-    from sklearn.pipeline import Pipeline as _PipelineRF
-    from sklearn.compose import ColumnTransformer as _CTRF
-    from sklearn.preprocessing import StandardScaler as _StdRF, OneHotEncoder as _OheRF
-    from sklearn.ensemble import RandomForestClassifier
+    if not is_binary:
+        print("Bloque comparativo omitido: target no binario")
+    else:
+        from sklearn.pipeline import Pipeline as _PipelineRF
+        from sklearn.compose import ColumnTransformer as _CTRF
+        from sklearn.preprocessing import StandardScaler as _StdRF, OneHotEncoder as _OheRF
+        from sklearn.ensemble import RandomForestClassifier
 
-    _num_feats_rf = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
-    _cat_feats_rf = [c for c in feature_cols if c not in _num_feats_rf]
-    preprocess_rf = _CTRF(
-        transformers=[
-            ("num", _StdRF(), _num_feats_rf),
-            ("cat", _OheRF(handle_unknown="ignore"), _cat_feats_rf),
-        ],
-        remainder="drop",
-    )
-    pipe_rf = _PipelineRF(steps=[
-        ("preprocess", preprocess_rf),
-        ("clf", RandomForestClassifier(n_estimators=200, class_weight="balanced", random_state=42)),
-    ])
-    pipe_rf.fit(df[feature_cols], y)
-    print("Pipeline RF ajustado:", pipe_rf.named_steps["clf"])
+        _num_feats_rf = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
+        _cat_feats_rf = [c for c in feature_cols if c not in _num_feats_rf]
+        preprocess_rf = _CTRF(
+            transformers=[
+                ("num", _StdRF(), _num_feats_rf),
+                ("cat", _OheRF(handle_unknown="ignore"), _cat_feats_rf),
+            ],
+            remainder="drop",
+        )
+        pipe_rf = _PipelineRF(steps=[
+            ("preprocess", preprocess_rf),
+            ("clf", RandomForestClassifier(n_estimators=200, class_weight="balanced", random_state=42)),
+        ])
+        pipe_rf.fit(X_raw, y)
+        print("Pipeline RF ajustado:", pipe_rf.named_steps["clf"])
 except Exception as e:
     print(f"⚠️ Pipeline RF falló: {{e}}")
 
@@ -2528,112 +2588,151 @@ except Exception as e:
 
 # %%
 # === SECTION:cv_scores ===
+cv_lr, cv_rf = None, None
 try:
-    from sklearn.model_selection import StratifiedKFold, cross_val_score
+    if not is_binary:
+        print("Bloque comparativo omitido: target no binario")
+    else:
+        from sklearn.model_selection import StratifiedKFold, cross_val_score
 
-    _min_class = int(y.value_counts().min()) if y is not None and len(y) else 0
-    n_splits_cv = 5 if _min_class >= 5 else (3 if _min_class >= 3 else 2)
-    cv_kfold = StratifiedKFold(n_splits=n_splits_cv, shuffle=True, random_state=42)
-    cv_lr = cross_val_score(pipe_lr, df[feature_cols], y, cv=cv_kfold, scoring="roc_auc")
-    cv_rf = cross_val_score(pipe_rf, df[feature_cols], y, cv=cv_kfold, scoring="roc_auc")
-    print(f"AUC-ROC CV (n_splits={{n_splits_cv}}) — LR: {{cv_lr.mean():.3f}} ± {{cv_lr.std():.3f}}")
-    print(f"AUC-ROC CV (n_splits={{n_splits_cv}}) — RF: {{cv_rf.mean():.3f}} ± {{cv_rf.std():.3f}}")
+        _min_class = int(y.value_counts().min()) if y is not None and len(y) else 0
+        n_splits_cv = 5 if _min_class >= 5 else (3 if _min_class >= 3 else 2)
+        cv_kfold = StratifiedKFold(n_splits=n_splits_cv, shuffle=True, random_state=42)
+        cv_lr = cross_val_score(pipe_lr, X_raw, y, cv=cv_kfold, scoring="roc_auc")
+        cv_rf = cross_val_score(pipe_rf, X_raw, y, cv=cv_kfold, scoring="roc_auc")
+        print(f"AUC-ROC CV (n_splits={{n_splits_cv}}) — LR: {{cv_lr.mean():.3f}} ± {{cv_lr.std():.3f}}")
+        print(f"AUC-ROC CV (n_splits={{n_splits_cv}}) — RF: {{cv_rf.mean():.3f}} ± {{cv_rf.std():.3f}}")
 except Exception as e:
     print(f"⚠️ CV scores fallaron: {{e}}")
-    cv_lr, cv_rf = None, None
 
 # %% [markdown]
-# #### 3.0.5.5 Curvas ROC y PR — LR vs RF
-# Una sola figura para ROC, una sola figura para PR (REGLA L atomic charting).
-# Trazamos LR y RF en el mismo eje para comparación visual directa.
+# #### 3.0.5.5 Curva ROC — LR vs RF
+# Una sola figura, una sola `plt.show()` (REGLA L atomic charting). El
+# hold-out se construye localmente con `train_test_split` (semilla 42) para
+# que la celda sea aislada (Regla 6).
 
 # %%
-# === SECTION:roc_pr_curves ===
+# === SECTION:roc_curves ===
 try:
-    from sklearn.metrics import roc_curve, precision_recall_curve, auc as _auc_pr, roc_auc_score, average_precision_score
+    if not is_binary:
+        print("Bloque comparativo omitido: target no binario")
+    else:
+        from sklearn.model_selection import train_test_split
+        from sklearn.metrics import roc_curve, roc_auc_score
 
-    # Hold-out limpio para curvas (no reusamos splits del CV).
-    _Xtr, _Xte, _ytr, _yte = train_test_split(
-        df[feature_cols], y, test_size=0.2, random_state=42,
-        stratify=y if y is not None and y.nunique() == 2 and y.value_counts().min() >= 2 else None,
-    )
-    pipe_lr.fit(_Xtr, _ytr); pipe_rf.fit(_Xtr, _ytr)
-    _proba_lr = pipe_lr.predict_proba(_Xte)[:, 1]
-    _proba_rf = pipe_rf.predict_proba(_Xte)[:, 1]
-    _pos = pipe_lr.named_steps["clf"].classes_[1]
-    _y_bin = (_yte.reset_index(drop=True) == _pos).astype(int)
+        _Xtr_roc, _Xte_roc, _ytr_roc, _yte_roc = train_test_split(
+            X_raw, y, test_size=0.2, random_state=42,
+            stratify=y if y.value_counts().min() >= 2 else None,
+        )
+        pipe_lr.fit(_Xtr_roc, _ytr_roc); pipe_rf.fit(_Xtr_roc, _ytr_roc)
+        _proba_lr_roc = pipe_lr.predict_proba(_Xte_roc)[:, 1]
+        _proba_rf_roc = pipe_rf.predict_proba(_Xte_roc)[:, 1]
+        _pos_roc = pipe_lr.named_steps["clf"].classes_[1]
+        _y_bin_roc = (_yte_roc.reset_index(drop=True) == _pos_roc).astype(int)
 
-    fpr_lr, tpr_lr, _ = roc_curve(_y_bin, _proba_lr)
-    fpr_rf, tpr_rf, _ = roc_curve(_y_bin, _proba_rf)
-    plt.figure(figsize=(7, 6))
-    plt.plot(fpr_lr, tpr_lr, label=f"LR (AUC={{roc_auc_score(_y_bin, _proba_lr):.3f}})")
-    plt.plot(fpr_rf, tpr_rf, label=f"RF (AUC={{roc_auc_score(_y_bin, _proba_rf):.3f}})")
-    plt.plot([0, 1], [0, 1], "k--", alpha=0.4)
-    plt.xlabel("False Positive Rate"); plt.ylabel("True Positive Rate")
-    plt.title("Curvas ROC — LR vs RF"); plt.legend(loc="lower right")
-    plt.tight_layout(); plt.show()
+        fpr_lr, tpr_lr, _ = roc_curve(_y_bin_roc, _proba_lr_roc)
+        fpr_rf, tpr_rf, _ = roc_curve(_y_bin_roc, _proba_rf_roc)
+        plt.figure(figsize=(7, 6))
+        plt.plot(fpr_lr, tpr_lr, label=f"LR (AUC={{roc_auc_score(_y_bin_roc, _proba_lr_roc):.3f}})")
+        plt.plot(fpr_rf, tpr_rf, label=f"RF (AUC={{roc_auc_score(_y_bin_roc, _proba_rf_roc):.3f}})")
+        plt.plot([0, 1], [0, 1], "k--", alpha=0.4)
+        plt.xlabel("False Positive Rate"); plt.ylabel("True Positive Rate")
+        plt.title("Curvas ROC — LR vs RF"); plt.legend(loc="lower right")
+        plt.tight_layout(); plt.show()
 except Exception as e:
     print(f"⚠️ Curvas ROC fallaron: {{e}}")
 
+# %% [markdown]
+# #### 3.0.5.6 Curva Precision-Recall — LR vs RF
+# Celda dedicada (REGLA L). Reconstruye el hold-out localmente para no
+# depender del estado de la celda anterior (Regla 6 — try/except aislado).
+
 # %%
+# === SECTION:pr_curves ===
 try:
-    prec_lr, rec_lr, _ = precision_recall_curve(_y_bin, _proba_lr)
-    prec_rf, rec_rf, _ = precision_recall_curve(_y_bin, _proba_rf)
-    plt.figure(figsize=(7, 6))
-    plt.plot(rec_lr, prec_lr, label=f"LR (AP={{average_precision_score(_y_bin, _proba_lr):.3f}})")
-    plt.plot(rec_rf, prec_rf, label=f"RF (AP={{average_precision_score(_y_bin, _proba_rf):.3f}})")
-    plt.xlabel("Recall"); plt.ylabel("Precision")
-    plt.title("Curvas Precision-Recall — LR vs RF"); plt.legend(loc="lower left")
-    plt.tight_layout(); plt.show()
+    if not is_binary:
+        print("Bloque comparativo omitido: target no binario")
+    else:
+        from sklearn.model_selection import train_test_split
+        from sklearn.metrics import precision_recall_curve, average_precision_score
+
+        _Xtr_pr, _Xte_pr, _ytr_pr, _yte_pr = train_test_split(
+            X_raw, y, test_size=0.2, random_state=42,
+            stratify=y if y.value_counts().min() >= 2 else None,
+        )
+        pipe_lr.fit(_Xtr_pr, _ytr_pr); pipe_rf.fit(_Xtr_pr, _ytr_pr)
+        _proba_lr_pr = pipe_lr.predict_proba(_Xte_pr)[:, 1]
+        _proba_rf_pr = pipe_rf.predict_proba(_Xte_pr)[:, 1]
+        _pos_pr = pipe_lr.named_steps["clf"].classes_[1]
+        _y_bin_pr = (_yte_pr.reset_index(drop=True) == _pos_pr).astype(int)
+
+        prec_lr, rec_lr, _ = precision_recall_curve(_y_bin_pr, _proba_lr_pr)
+        prec_rf, rec_rf, _ = precision_recall_curve(_y_bin_pr, _proba_rf_pr)
+        plt.figure(figsize=(7, 6))
+        plt.plot(rec_lr, prec_lr, label=f"LR (AP={{average_precision_score(_y_bin_pr, _proba_lr_pr):.3f}})")
+        plt.plot(rec_rf, prec_rf, label=f"RF (AP={{average_precision_score(_y_bin_pr, _proba_rf_pr):.3f}})")
+        plt.xlabel("Recall"); plt.ylabel("Precision")
+        plt.title("Curvas Precision-Recall — LR vs RF"); plt.legend(loc="lower left")
+        plt.tight_layout(); plt.show()
 except Exception as e:
     print(f"⚠️ Curvas PR fallaron: {{e}}")
 
 # %% [markdown]
-# #### 3.0.5.6 Tabla comparativa final
+# #### 3.0.5.7 Tabla comparativa final
 # Consolida AUC CV (media y std), F1 macro, recall de la clase minoritaria,
-# tiempo de entrenamiento e interpretabilidad cualitativa.
+# tiempo de entrenamiento e interpretabilidad cualitativa. Reconstruye el
+# hold-out localmente para no depender del estado de las curvas (Regla 6).
 
 # %%
 # === SECTION:comparison_table ===
 try:
-    import time as _time_cmp
-    from sklearn.metrics import f1_score as _f1_cmp, recall_score as _rec_cmp
+    if not is_binary:
+        print("Bloque comparativo omitido: target no binario")
+    else:
+        import time as _time_cmp
+        from sklearn.model_selection import train_test_split
+        from sklearn.metrics import f1_score as _f1_cmp, recall_score as _rec_cmp
 
-    def _train_and_score(pipe, name):
-        t0 = _time_cmp.perf_counter()
-        pipe.fit(_Xtr, _ytr)
-        elapsed = _time_cmp.perf_counter() - t0
-        y_hat = pipe.predict(_Xte)
-        minority = y.value_counts().idxmin() if y is not None and y.nunique() == 2 else None
-        rec_min = _rec_cmp(_yte, y_hat, labels=[minority], average="macro", zero_division=0) if minority is not None else float("nan")
-        return {{
-            "model": name,
-            "auc_roc_cv_mean": float(cv_lr.mean()) if name == "LogisticRegression" and cv_lr is not None else (float(cv_rf.mean()) if name == "RandomForest" and cv_rf is not None else float("nan")),
-            "auc_roc_cv_std":  float(cv_lr.std())  if name == "LogisticRegression" and cv_lr is not None else (float(cv_rf.std())  if name == "RandomForest" and cv_rf is not None else float("nan")),
-            "f1_macro": float(_f1_cmp(_yte, y_hat, average="macro", zero_division=0)),
-            "recall_minority": float(rec_min),
-            "training_time_s": round(elapsed, 4),
-            "interpretability_note": (
-                "alta — coeficientes interpretables como log-odds" if name == "LogisticRegression"
-                else "media — feature_importances_, requiere permutation importance para causalidad"
-            ),
-        }}
+        _Xtr_cmp, _Xte_cmp, _ytr_cmp, _yte_cmp = train_test_split(
+            X_raw, y, test_size=0.2, random_state=42,
+            stratify=y if y.value_counts().min() >= 2 else None,
+        )
 
-    rows_cmp = [
-        {{"model": "DummyClassifier(most_frequent)", "auc_roc_cv_mean": 0.5, "auc_roc_cv_std": 0.0,
-          "f1_macro": float("nan"), "recall_minority": 0.0, "training_time_s": 0.0,
-          "interpretability_note": "baseline trivial — sin aprendizaje"}},
-        _train_and_score(pipe_lr, "LogisticRegression"),
-        _train_and_score(pipe_rf, "RandomForest"),
-    ]
-    comparison = pd.DataFrame(rows_cmp, columns=[
-        "model", "auc_roc_cv_mean", "auc_roc_cv_std", "f1_macro",
-        "recall_minority", "training_time_s", "interpretability_note",
-    ])
-    try:
-        print(comparison.to_markdown(index=False))
-    except Exception:
-        print(comparison.to_string(index=False))
+        def _train_and_score(pipe, name):
+            t0 = _time_cmp.perf_counter()
+            pipe.fit(_Xtr_cmp, _ytr_cmp)
+            elapsed = _time_cmp.perf_counter() - t0
+            y_hat = pipe.predict(_Xte_cmp)
+            minority = y.value_counts().idxmin() if y is not None and y.nunique() == 2 else None
+            rec_min = _rec_cmp(_yte_cmp, y_hat, labels=[minority], average="macro", zero_division=0) if minority is not None else float("nan")
+            return {{
+                "model": name,
+                "auc_roc_cv_mean": float(cv_lr.mean()) if name == "LogisticRegression" and cv_lr is not None else (float(cv_rf.mean()) if name == "RandomForest" and cv_rf is not None else float("nan")),
+                "auc_roc_cv_std":  float(cv_lr.std())  if name == "LogisticRegression" and cv_lr is not None else (float(cv_rf.std())  if name == "RandomForest" and cv_rf is not None else float("nan")),
+                "f1_macro": float(_f1_cmp(_yte_cmp, y_hat, average="macro", zero_division=0)),
+                "recall_minority": float(rec_min),
+                "training_time_s": round(elapsed, 4),
+                "interpretability_note": (
+                    "alta — coeficientes interpretables como log-odds" if name == "LogisticRegression"
+                    else "media — feature_importances_, requiere permutation importance para causalidad"
+                ),
+            }}
+
+        rows_cmp = [
+            {{"model": "DummyClassifier(most_frequent)", "auc_roc_cv_mean": 0.5, "auc_roc_cv_std": 0.0,
+              "f1_macro": float("nan"), "recall_minority": 0.0, "training_time_s": 0.0,
+              "interpretability_note": "baseline trivial — sin aprendizaje"}},
+            _train_and_score(pipe_lr, "LogisticRegression"),
+            _train_and_score(pipe_rf, "RandomForest"),
+        ]
+        comparison = pd.DataFrame(rows_cmp, columns=[
+            "model", "auc_roc_cv_mean", "auc_roc_cv_std", "f1_macro",
+            "recall_minority", "training_time_s", "interpretability_note",
+        ])
+        try:
+            print(comparison.to_markdown(index=False))
+        except Exception:
+            print(comparison.to_string(index=False))
 except Exception as e:
     print(f"⚠️ Tabla comparativa falló: {{e}}")
 

--- a/backend/tests/test_m3_notebook_classification_hygiene.py
+++ b/backend/tests/test_m3_notebook_classification_hygiene.py
@@ -9,11 +9,22 @@ matriz de confusión 1x1) by enforcing five rules in the prompt:
   4. Higiene de feature_cols (drop IDs/constantes, one-hot categóricas)
   5. UndefinedMetricWarning ya no se silencia globalmente
 
+Issue #236 — Harvard ml_ds quality bar adds:
+
+  6. Bloque comparativo obligatorio (DummyClassifier + Pipelines + StratifiedKFold
+     + curvas ROC/PR + tabla comparativa final) con sentinelas contractuales.
+  7. ``_FAMILY_REQUIRED_PATTERNS`` + extensión del validador a ``FALTANTE: <token>``
+     sin afectar otras familias.
+
 Cero LLMs, cero red, cero DB.
 """
 
 from __future__ import annotations
 
+from case_generator.graph import (
+    _FAMILY_REQUIRED_PATTERNS,
+    _validate_notebook_family_consistency,
+)
 from case_generator.prompts import (
     M3_NOTEBOOK_ALGO_PROMPT,
     M3_NOTEBOOK_BASE_TEMPLATE,
@@ -117,3 +128,112 @@ def test_prompt_still_renders_with_existing_substitution_vars() -> None:
     assert "LogisticRegression" in rendered
     # 3) Sigue siendo un prompt sustancial (sanidad gruesa, no fragil a refactor).
     assert len(rendered) > 1000
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Issue #236 — Harvard ml_ds quality bar (sentinelas + required-token validator)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_REQUIRED_SENTINELS = (
+    "# === SECTION:dummy_baseline ===",
+    "# === SECTION:pipeline_lr ===",
+    "# === SECTION:pipeline_rf ===",
+    "# === SECTION:cv_scores ===",
+    "# === SECTION:roc_pr_curves ===",
+    "# === SECTION:comparison_table ===",
+)
+
+_REQUIRED_API_TOKENS = (
+    "DummyClassifier",
+    "ColumnTransformer",
+    "StandardScaler",
+    "OneHotEncoder",
+    "StratifiedKFold",
+    "cross_val_score",
+    "roc_curve(",
+    "precision_recall_curve(",
+)
+
+
+def test_prompt_emits_six_mandatory_sentinels_for_classification() -> None:
+    """Las 6 sentinelas son contractuales: el validador rechaza el notebook
+    si falta cualquiera. El prompt DEBE instruir al LLM a emitirlas."""
+    for sentinel in _REQUIRED_SENTINELS:
+        assert sentinel in M3_NOTEBOOK_ALGO_PROMPT, f"falta sentinela {sentinel!r}"
+
+
+def test_prompt_mandates_dummy_pipeline_cv_curves_and_table() -> None:
+    """Las 6 mejoras pedagógicas Harvard ml_ds están explicitadas en el prompt."""
+    for token in _REQUIRED_API_TOKENS:
+        assert token in M3_NOTEBOOK_ALGO_PROMPT, f"falta API token {token!r}"
+    # Tabla comparativa final con columnas exactas.
+    for col in (
+        "auc_roc_cv_mean",
+        "auc_roc_cv_std",
+        "f1_macro",
+        "recall_minority",
+        "training_time_s",
+        "interpretability_note",
+    ):
+        assert col in M3_NOTEBOOK_ALGO_PROMPT, f"falta columna comparison_table {col!r}"
+
+
+def test_prompt_has_dedicated_harvard_quality_section() -> None:
+    """El bloque comparativo vive en una sección case-wide explícita."""
+    assert "Sección 3.0.5" in M3_NOTEBOOK_ALGO_PROMPT
+    assert "PEDAGOGÍA HARVARD" in M3_NOTEBOOK_ALGO_PROMPT
+
+
+def test_required_patterns_only_populated_for_classification() -> None:
+    """Issue #236 se enfoca en clasificación. Otras familias NO deben aparecer
+    en el mapa (devolverán () por .get y mantendrán bit-identicidad pre-#236)."""
+    assert set(_FAMILY_REQUIRED_PATTERNS) == {"clasificacion"}
+
+
+def test_validator_flags_missing_required_tokens_with_faltante_prefix() -> None:
+    """Notebook de clasificación SIN ningún token Harvard → todas las
+    sentinelas + APIs salen como FALTANTE: <token>."""
+    bad = "from sklearn.linear_model import LogisticRegression\nmodel = LogisticRegression()\n"
+    violations = _validate_notebook_family_consistency("clasificacion", bad)
+    # Cada token requerido aparece UNA vez con prefijo FALTANTE.
+    for sentinel in _REQUIRED_SENTINELS:
+        assert f"FALTANTE: {sentinel}" in violations, f"falta marca FALTANTE de {sentinel!r}"
+    assert "FALTANTE: DummyClassifier" in violations
+    assert "FALTANTE: StratifiedKFold" in violations
+    assert "FALTANTE: roc_curve(" in violations
+    assert "FALTANTE: precision_recall_curve(" in violations
+
+
+def test_validator_passes_when_all_required_present() -> None:
+    """Notebook con sentinelas + APIs + sin tokens prohibidos → []. """
+    code = "\n".join(_REQUIRED_SENTINELS) + "\n" + (
+        "from sklearn.dummy import DummyClassifier\n"
+        "from sklearn.compose import ColumnTransformer\n"
+        "from sklearn.preprocessing import StandardScaler, OneHotEncoder\n"
+        "from sklearn.model_selection import StratifiedKFold, cross_val_score\n"
+        "from sklearn.metrics import roc_curve, precision_recall_curve\n"
+        "model = DummyClassifier(strategy='most_frequent')\n"
+        "fpr, tpr, _ = roc_curve(y, scores)\n"
+        "prec, rec, _ = precision_recall_curve(y, scores)\n"
+    )
+    assert _validate_notebook_family_consistency("clasificacion", code) == []
+
+
+def test_validator_does_not_enforce_classification_tokens_on_other_families() -> None:
+    """No-regresión crítica: regresión / clustering / serie_temporal NUNCA
+    reciben FALTANTE: ... aunque omitan los tokens de clasificación."""
+    minimal_code = "from sklearn.linear_model import LinearRegression\n"
+    for family in ("regresion", "clustering", "serie_temporal"):
+        violations = _validate_notebook_family_consistency(family, minimal_code)
+        assert all(not v.startswith("FALTANTE:") for v in violations), (
+            f"familia {family!r} no debe recibir FALTANTE: ... — got {violations!r}"
+        )
+
+
+def test_prohibited_violations_remain_bare_strings_for_back_compat() -> None:
+    """Los tokens prohibidos siguen retornándose SIN prefijo (compat con
+    los unit tests de Issue #233 que hacen `assert token in violations`)."""
+    bad = "from sklearn.cluster import KMeans\nlabels = KMeans().fit_predict(X)\n"
+    violations = _validate_notebook_family_consistency("clasificacion", bad)
+    # El token prohibido viene SIN prefijo FALTANTE.
+    assert "from sklearn.cluster import" in violations

--- a/backend/tests/test_m3_notebook_classification_hygiene.py
+++ b/backend/tests/test_m3_notebook_classification_hygiene.py
@@ -22,7 +22,9 @@ Cero LLMs, cero red, cero DB.
 from __future__ import annotations
 
 from case_generator.graph import (
+    _FAMILY_REQUIRED_APIS,
     _FAMILY_REQUIRED_PATTERNS,
+    _FAMILY_REQUIRED_SENTINELS,
     _validate_notebook_family_consistency,
 )
 from case_generator.prompts import (
@@ -134,12 +136,15 @@ def test_prompt_still_renders_with_existing_substitution_vars() -> None:
 # Issue #236 — Harvard ml_ds quality bar (sentinelas + required-token validator)
 # ──────────────────────────────────────────────────────────────────────────────
 
+# PR #244 review: contract is now 7 sentinels (ROC and PR split into separate
+# cells per Rule L atomic-charting + Rule 6 cell isolation).
 _REQUIRED_SENTINELS = (
     "# === SECTION:dummy_baseline ===",
     "# === SECTION:pipeline_lr ===",
     "# === SECTION:pipeline_rf ===",
     "# === SECTION:cv_scores ===",
-    "# === SECTION:roc_pr_curves ===",
+    "# === SECTION:roc_curves ===",
+    "# === SECTION:pr_curves ===",
     "# === SECTION:comparison_table ===",
 )
 
@@ -152,14 +157,20 @@ _REQUIRED_API_TOKENS = (
     "cross_val_score",
     "roc_curve(",
     "precision_recall_curve(",
+    "train_test_split(",
 )
 
 
-def test_prompt_emits_six_mandatory_sentinels_for_classification() -> None:
-    """Las 6 sentinelas son contractuales: el validador rechaza el notebook
-    si falta cualquiera. El prompt DEBE instruir al LLM a emitirlas."""
+def test_prompt_emits_seven_mandatory_sentinels_for_classification() -> None:
+    """Las 7 sentinelas son contractuales: el validador rechaza el notebook
+    si falta cualquiera. El prompt DEBE instruir al LLM a emitirlas.
+    PR #244 review: ROC y PR ahora viven en celdas separadas (Regla L +
+    Regla 6). El antiguo ``roc_pr_curves`` ya NO debe aparecer."""
     for sentinel in _REQUIRED_SENTINELS:
         assert sentinel in M3_NOTEBOOK_ALGO_PROMPT, f"falta sentinela {sentinel!r}"
+    assert "# === SECTION:roc_pr_curves ===" not in M3_NOTEBOOK_ALGO_PROMPT, (
+        "sentinela legacy roc_pr_curves debe estar eliminada"
+    )
 
 
 def test_prompt_mandates_dummy_pipeline_cv_curves_and_table() -> None:
@@ -186,8 +197,16 @@ def test_prompt_has_dedicated_harvard_quality_section() -> None:
 
 def test_required_patterns_only_populated_for_classification() -> None:
     """Issue #236 se enfoca en clasificación. Otras familias NO deben aparecer
-    en el mapa (devolverán () por .get y mantendrán bit-identicidad pre-#236)."""
+    en el mapa (devolverán () por .get y mantendrán bit-identicidad pre-#236).
+    PR #244 review: el mapa ahora se desglosa en sentinels + apis (compat
+    alias mantenido para los tests legacy de Issue #233)."""
     assert set(_FAMILY_REQUIRED_PATTERNS) == {"clasificacion"}
+    assert set(_FAMILY_REQUIRED_SENTINELS) == {"clasificacion"}
+    assert set(_FAMILY_REQUIRED_APIS) == {"clasificacion"}
+    # El alias combinado debe ser superset de cada bucket por familia.
+    combined = set(_FAMILY_REQUIRED_PATTERNS["clasificacion"])
+    assert set(_FAMILY_REQUIRED_SENTINELS["clasificacion"]).issubset(combined)
+    assert set(_FAMILY_REQUIRED_APIS["clasificacion"]).issubset(combined)
 
 
 def test_validator_flags_missing_required_tokens_with_faltante_prefix() -> None:
@@ -210,13 +229,37 @@ def test_validator_passes_when_all_required_present() -> None:
         "from sklearn.dummy import DummyClassifier\n"
         "from sklearn.compose import ColumnTransformer\n"
         "from sklearn.preprocessing import StandardScaler, OneHotEncoder\n"
-        "from sklearn.model_selection import StratifiedKFold, cross_val_score\n"
+        "from sklearn.model_selection import StratifiedKFold, cross_val_score, train_test_split\n"
         "from sklearn.metrics import roc_curve, precision_recall_curve\n"
         "model = DummyClassifier(strategy='most_frequent')\n"
+        "X_tr, X_te, y_tr, y_te = train_test_split(X, y, random_state=42)\n"
         "fpr, tpr, _ = roc_curve(y, scores)\n"
         "prec, rec, _ = precision_recall_curve(y, scores)\n"
     )
     assert _validate_notebook_family_consistency("clasificacion", code) == []
+
+
+def test_validator_rejects_required_apis_only_present_in_comments() -> None:
+    """PR #244 review: required APIs deben buscarse contra el código
+    EJECUTABLE (post-strip). Si un LLM intenta satisfacer el validador
+    poniendo ``DummyClassifier`` solo en un comentario o markdown, debe
+    seguir saliendo FALTANTE: DummyClassifier."""
+    cheating = "\n".join(_REQUIRED_SENTINELS) + "\n" + (
+        "# DummyClassifier StratifiedKFold cross_val_score ColumnTransformer\n"
+        "# roc_curve( precision_recall_curve( train_test_split(\n"
+        "x = 1\n"
+    )
+    violations = _validate_notebook_family_consistency("clasificacion", cheating)
+    # Sentinelas (que SON comentarios) sí pasan; APIs (que viven solo en
+    # comentarios) NO deben pasar.
+    assert "FALTANTE: DummyClassifier" in violations
+    assert "FALTANTE: StratifiedKFold" in violations
+    assert "FALTANTE: roc_curve(" in violations
+    assert "FALTANTE: precision_recall_curve(" in violations
+    assert "FALTANTE: train_test_split(" in violations
+    # Y las sentinelas SÍ están presentes (no aparecen en violations).
+    for sentinel in _REQUIRED_SENTINELS:
+        assert f"FALTANTE: {sentinel}" not in violations
 
 
 def test_validator_does_not_enforce_classification_tokens_on_other_families() -> None:

--- a/backend/tests/test_m3_notebook_dispatch.py
+++ b/backend/tests/test_m3_notebook_dispatch.py
@@ -74,7 +74,8 @@ CLEAN_CLASSIFICATION_CODE = """
 # === SECTION:pipeline_lr ===
 # === SECTION:pipeline_rf ===
 # === SECTION:cv_scores ===
-# === SECTION:roc_pr_curves ===
+# === SECTION:roc_curves ===
+# === SECTION:pr_curves ===
 # === SECTION:comparison_table ===
 from sklearn.dummy import DummyClassifier
 from sklearn.compose import ColumnTransformer

--- a/backend/tests/test_m3_notebook_dispatch.py
+++ b/backend/tests/test_m3_notebook_dispatch.py
@@ -70,13 +70,23 @@ def test_detect_empty_input_does_not_crash() -> None:
 # ──────────────────────────────────────────────────────────────────────────────
 
 CLEAN_CLASSIFICATION_CODE = """
+# === SECTION:dummy_baseline ===
+# === SECTION:pipeline_lr ===
+# === SECTION:pipeline_rf ===
+# === SECTION:cv_scores ===
+# === SECTION:roc_pr_curves ===
+# === SECTION:comparison_table ===
+from sklearn.dummy import DummyClassifier
+from sklearn.compose import ColumnTransformer
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import roc_auc_score, confusion_matrix
-from sklearn.model_selection import train_test_split
+from sklearn.metrics import roc_auc_score, confusion_matrix, roc_curve, precision_recall_curve
+from sklearn.model_selection import StratifiedKFold, cross_val_score, train_test_split
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, stratify=y)
 model = LogisticRegression().fit(X_train, y_train)
 auc = roc_auc_score(y_test, model.predict_proba(X_test)[:, 1])
+fpr, tpr, _ = roc_curve(y_test, model.predict_proba(X_test)[:, 1])
+prec, rec, _ = precision_recall_curve(y_test, model.predict_proba(X_test)[:, 1])
 """
 
 CLEAN_CLUSTERING_CODE = """

--- a/backend/tests/test_m3_notebook_per_family_prompts.py
+++ b/backend/tests/test_m3_notebook_per_family_prompts.py
@@ -56,6 +56,7 @@ def test_back_compat_alias_points_to_classification() -> None:
         ("clustering", M3_NOTEBOOK_ALGO_PROMPT_CLUSTERING),
         ("serie_temporal", M3_NOTEBOOK_ALGO_PROMPT_TIMESERIES),
     ],
+    ids=["clasificacion", "regresion", "clustering", "serie_temporal"],
 )
 def test_prompt_accepts_shared_format_keys(family: str, prompt: str) -> None:
     rendered = prompt.format(**SHARED_FORMAT_KEYS)


### PR DESCRIPTION
Closes #236.

Adds a case-wide comparative block (**Sección 3.0.5**) to the classification M3 prompt and enforces it via contractual sentinels validated post-LLM. v1 of a 7-part roadmap (#237 … #243).

> **Update (2026-04-30, follow-up commit `6a1d025`)** — addresses 7 production-blocker findings from the PR review. The contract now uses **7 sentinels** (ROC and PR split per Rule L), the section is **fully self-contained** (no NameErrors at runtime), and the validator scopes sentinels vs APIs separately. Details in the **Follow-up — production-readiness fixes** section at the bottom of this body. The original v1 description below is preserved with corrections inline so reviewers can trace the diff.

## What changes

### `backend/src/case_generator/prompts.py`
Append **Rule M (PEDAGOGÍA HARVARD ml_ds)** plus a literal Sección 3.0.5 template emitting **seven** cells in order, each opened by a contractual sentinel comment:

| Sentinel | Contents |
|---|---|
| `# === SECTION:dummy_baseline ===` | **Bootstrap** of `target_col`, `y`, `feature_cols`, `X_raw`, `is_binary` (alias-first + K-bis hygiene) **+** `DummyClassifier` (`most_frequent` + `stratified`) — anti-trivial-AUC |
| `# === SECTION:pipeline_lr ===` | `Pipeline(ColumnTransformer + LogisticRegression(class_weight="balanced"))` |
| `# === SECTION:pipeline_rf ===` | `Pipeline(ColumnTransformer + RandomForestClassifier(class_weight="balanced"))` |
| `# === SECTION:cv_scores ===` | `StratifiedKFold(5)` + `cross_val_score`, fallback `cv=3` if minority is sparse |
| `# === SECTION:roc_curves ===` | One figure for ROC (Rule L atomic charting), LR vs RF on same axes; **imports `train_test_split` explicitly**, builds local hold-out |
| `# === SECTION:pr_curves ===` | One figure for Precision-Recall (Rule L), LR vs RF on same axes; rebuilds hold-out locally (Rule 6 cell isolation) |
| `# === SECTION:comparison_table ===` | `pd.DataFrame` with the 7 columns (`model`, `auc_roc_cv_mean`, `auc_roc_cv_std`, `f1_macro`, `recall_minority`, `training_time_s`, `interpretability_note`); rebuilds hold-out locally |

`ColumnTransformer` combines `StandardScaler` (numeric) with `OneHotEncoder(handle_unknown="ignore")` (categoric ≤20 cardinality) **inside the Pipeline** so CV does not leak fold statistics. Other family prompts (`REGRESSION`, `CLUSTERING`, `TIMESERIES`) and the base notebook template are untouched.

Every cell after `dummy_baseline` opens with `if not is_binary: print("Bloque comparativo omitido: target no binario")` so multiclass / regression targets emit a unified pedagogical message instead of cascading exception traces.

### `backend/src/case_generator/graph.py`
Extend `_validate_notebook_family_consistency` with **two scoped maps** (only populated for `"clasificacion"`):

- `_FAMILY_REQUIRED_SENTINELS` — section-marker comments (7 entries). Scanned against the **raw** notebook text because `# === SECTION:* ===` lines would be erased by `_strip_jupytext_for_validation`.
- `_FAMILY_REQUIRED_APIS` — canonical sklearn API tokens (`DummyClassifier`, `ColumnTransformer`, `StratifiedKFold`, `cross_val_score`, `roc_curve(`, `precision_recall_curve(`, `train_test_split(`). Scanned against the **stripped** code so the LLM cannot satisfy the validator by mentioning identifiers only inside markdown / `#` comments.

Findings format:

- **Prohibited cross-family tokens**: returned as **bare strings** (kept this way for back-compat with Issue #233 unit tests that do `assert token in violations`). Not echoed back to the LLM in the reprompt to avoid amplification.
- **Missing required sentinels / APIs**: returned with the `FALTANTE: ` prefix. **DO** echoed back to the LLM in the reprompt so it has a precise fixing target.

The legacy combined `_FAMILY_REQUIRED_PATTERNS` map is preserved as a derived view over `_FAMILY_REQUIRED_SENTINELS ∪ _FAMILY_REQUIRED_APIS` so no external imports break.

The reprompt-once block in `m3_notebook_generator` splits violations into two corrective messages so the second LLM attempt sees both classes of error separately.

### Tests
- `backend/tests/test_m3_notebook_classification_hygiene.py` — Issue #236 + PR #244-review assertions: presence of the **7 sentinels** and required APIs in the prompt; validator returns `FALTANTE` prefix for missing sentinels/APIs; validator returns `[]` when sentinels + APIs are present; **anti-cheat**: APIs present only in comments / markdown still trip `FALTANTE`; required-token check is **scoped to `"clasificacion"` only** (regresion / clustering / serie_temporal stay bit-identical pre-#236); prohibited tokens still return bare strings (Issue #233 back-compat).
- `backend/tests/test_m3_notebook_dispatch.py` — `CLEAN_CLASSIFICATION_CODE` updated to the 7-sentinel contract.
- `backend/tests/test_m3_notebook_per_family_prompts.py` — `ids=` on the shared-format-keys parametrize prevents the now-larger classification prompt from overflowing the Windows 32767-char env-var limit.

## Validation

```
uv run --directory backend pytest -q   → 547 passed, 13 skipped in 37.98s
uv run --directory backend mypy src    → Success: no issues found in 44 source files
```

## Risk surface

- **Prompt + validator change.** `graph.py` topology, other family prompts, base notebook template, and student-facing contracts are untouched.
- **Validator change is additive**: prohibited findings still appear as bare token strings (back-compat with Issue #233 unit tests). `FALTANTE` is a clearly-prefixed return path. The new sentinel/API split tightens the contract without changing the public function signature.
- **Required-token maps are keyed only by `"clasificacion"`**; `.get(family, ())` falls back to empty for other families, so the regression / clustering / serie_temporal dispatch paths produce identical violation lists to pre-#236.
- **Section 3.0.5 is now self-contained**: it bootstraps `target_col` / `y` / `feature_cols` / `X_raw` / `is_binary` from `df` directly, so the per-algorithm K-bis block that runs **after** it can no longer cause NameErrors in this section. Each cell is independently re-runnable.

---

## Follow-up — production-readiness fixes (commit `6a1d025`)

A critical PR review surfaced **7 production-blocker findings** in the original v1 commit. All seven were validated as real bugs (no false positives) and fixed in this single follow-up commit. Quick reference of what changed and why:

| # | Finding | Root cause | Fix |
|---|---|---|---|
| 1 | PR body claimed `PROHIBIDO:` prefix on prohibited findings, but code returned bare strings. | Doc/code drift — the bare-string format is intentional Issue #233 back-compat. | PR body corrected to document the actual (intentional) bare-string format. |
| 2 | Contract said "EXACTAMENTE 6 celdas" but the prompt emitted 7 (the PR-curves cell had no sentinel). | The original `# === SECTION:roc_pr_curves ===` sentinel covered only the ROC cell; the PR cell was un-marked. | Split into `# === SECTION:roc_curves ===` + `# === SECTION:pr_curves ===`. Contract is now **7 sentinels**, asserted by tests. |
| 3 | The ROC/PR cell used `train_test_split` without importing it → silent `except` swallow → curves never plotted. | Missing import inside the `try` block. | Each curve cell now imports `train_test_split` explicitly. |
| 4 | **CRITICAL** — Sección 3.0.5 referenced `X`, `y`, `feature_cols` BEFORE the per-algorithm K-bis block defined them. Every cell except `dummy_baseline` NameError'd at runtime. | Cross-section variable dependency: 3.0.5 emitted *before* the per-algorithm block. The entire section was dead code at runtime. | `dummy_baseline` cell now bootstraps `target_col` / `y` / `feature_cols` / `X_raw` / `is_binary` itself (alias-first target detection + K-bis hygiene recipe). Section 3.0.5 is now fully self-contained. |
| 5 | Non-binary guard inconsistent — only `dummy_baseline` checked `is_binary`; the other 5 cells produced cascading exception traces on multiclass / regression targets. | Guard not propagated. | `is_binary` flag computed in `dummy_baseline`; every subsequent cell starts with `if not is_binary: print("Bloque comparativo omitido: target no binario")` inside its isolated `try`. |
| 6 | Required-token validator scanned against RAW code → an LLM could satisfy `DummyClassifier` by mentioning it only in a markdown preamble. | Single scan corpus for both sentinels and APIs. | Split into `_FAMILY_REQUIRED_SENTINELS` (raw scan — sentinels ARE comments) and `_FAMILY_REQUIRED_APIS` (stripped scan — must appear in EXECUTABLE code). New anti-cheat test codifies this. |
| 7 | `comparison_table` depended on `_Xtr` / `_Xte` from the prior `roc_pr_curves` cell → cascading NameError if curves cell failed. | Cross-cell variable coupling violated Rule 6 (per-cell try/except isolation). | `comparison_table` and `pr_curves` each rebuild their own hold-out locally with `random_state=42`. Cells are now independently re-runnable. |

**Test delta**: 546 → 547 passed (+1 anti-cheat test for "required API only in comment" scenario). mypy clean. Every fix is covered by an explicit assertion.

## Roadmap (parallelizable follow-ups)

This PR ships **v1** of #236. The remaining slices are tracked as independent issues so other agents/devs can pick them up:

- #237 CHARTS — richer per-family charts and ATOMIC violations
- #238 COST  — token/cost-aware prompt slicing
- #239 EXEC  — execution sandbox + auto-rerun on validator FALTANTE / prohibited findings
- #240 TUNE  — hyperparameter narrative & RandomSearch baseline
- #241 DATA  — dataset contract assertions in M3
- #242 PEDA  — narrative voice and learning-objective tagging
- #243 NARR  — auto-generated executive summary cell

---

Per repo policy: **squash-merge** when CI is green.
