### PR TITLE
feat(M3): cost matrix + threshold tuning para familia clasificacion (#238)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -580,3 +580,35 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 **Depends on / blocked by:** Nada. Puede implementarse en cualquier PR de hardening de los endpoints de caso docente.
 
+
+
+---
+
+## TODO-238-A: Validadores estrictos para BusinessCostMatrix (#242)
+
+**What:** Endurecer `BusinessCostMatrix` (`case_generator/tools_and_schemas.py`) con validación estricta de:
+  * ratio plausible `fp_cost`/`fn_cost` (rechazar > 1000:1 o < 1:1000 — casi siempre error del LLM)
+  * `currency` contra catálogo ISO 4217 mínimo (USD/EUR/GBP/COP/MXN/BRL/CLP/PEN/ARS)
+  * cap superior absoluto en cada costo (e.g. 1e9) para evitar valores delirantes que rompan el plot
+
+**Why:** Hoy el helper `_validate_business_cost_matrix` solo nulifica costos negativos / no finitos / cross-family. Un LLM que emita `fp_cost=1e15` o `currency='dollars '` pasa el validador y rompe el plot del notebook M3.
+
+**Pros:** Más capas de defensa contra LLM drift; warnings más accionables para el docente.
+
+**Cons:** Reglas demasiado estrictas pueden rechazar casos legítimos (e.g. fraude bancario donde fn_cost realmente es 1000× fp_cost). Necesita evidencia empírica antes de fijar el umbral.
+
+**Context:** Issue #238 (PR cerrando esto) implementó la validación mínima viable (campos > 0, finitos, currency normalizada). El hardening completo se difirió a #242 para no agregar superficie de revisión a #238.
+
+---
+
+## TODO-238-B: Test de rendering del bloque de warnings de matriz de costos en prompts downstream (#242)
+
+**What:** Añadir un test de integración que verifique que `business_cost_matrix_missing` / `_invalid` / `_wrong_family` / `_unknown_family` emitidos por `case_architect` aparecen efectivamente en `data_gap_warnings_block` cuando se renderiza el prompt de `schema_designer`, `m3_content_generator`, `m3_notebook_generator` y demás consumidores listados en `graph.py:1010`.
+
+**Why:** El helper `_validate_business_cost_matrix` añade strings al `data_gap_warnings` del state, pero hoy no hay test que confirme que esos strings llegan al prompt final del LLM (el rendering vive en `graph.py:1010` con `"\n".join(f"- {w}" for w in ...)`).
+
+**Pros:** Cierra el ciclo end-to-end del warning sanitizado; previene regresiones cuando se refactorice el rendering de gaps.
+
+**Cons:** Test relativamente acoplado a la forma exacta del rendering. Si se cambia el formato de `data_gap_warnings_block` el test rompe — lo cual es deseable.
+
+**Context:** Issue #238 dejó este test fuera de scope porque requiere fixturizar todo el state del grafo. Se puede hacer con un state minimal y una llamada directa al renderizador interno sin invocar al LLM.

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -800,6 +800,28 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
         )
         contract_dict = _infer_leakage_risk_from_naming(contract_dict)
 
+        # Issue #238 — valida la matriz de costos del negocio para threshold
+        # tuning en M3. Resolvemos la familia desde task_payload.algoritmos
+        # (mismo orden que el dispatcher M3): family_of(name) → fallback
+        # resolve_legacy_family(name) → None si no hay algoritmos. La política
+        # es degrade-with-warning (no reprompts en M1).
+        task_payload_obj = state.get("task_payload") or {}
+        algoritmos_list: list = []
+        if isinstance(task_payload_obj, dict):
+            algoritmos_list = task_payload_obj.get("algoritmos") or []
+        family_resolved: str | None = None
+        if algoritmos_list:
+            primary_algo = str(algoritmos_list[0])
+            family_resolved = family_of(primary_algo)
+            if family_resolved is None:
+                legacy = resolve_legacy_family(primary_algo)
+                if legacy is not None:
+                    family_resolved = legacy[0]
+        contract_dict, cost_warnings = _validate_business_cost_matrix(
+            contract_dict, family_resolved, result.titulo
+        )
+        coherence_warnings = list(coherence_warnings) + cost_warnings
+
         return {
             "current_agent": "case_architect",
             "titulo": result.titulo,
@@ -1895,6 +1917,142 @@ def _infer_leakage_risk_from_naming(contract: dict | None) -> dict | None:
         inferred_count, target_name, target_role,
     )
     return new_contract
+
+
+def _validate_business_cost_matrix(
+    contract: dict | None, family: str | None, case_title: str | None
+) -> tuple[dict | None, list[str]]:
+    """Valida y sanitiza ``business_cost_matrix`` del contrato (Issue #238).
+
+    Política de degradación (case_architect-style):
+      * Si ``family is None`` (no se pudo resolver el algoritmo via
+        ``family_of`` ni ``resolve_legacy_family``) y el campo viene poblado
+        → se preserva intacto + warning ``unknown_family``. Razón: el
+        dispatcher M3 hace fallback a ``clasificacion`` cuando no resuelve
+        familia, así que nulificar aquí perdería una matriz que M3 sí va a
+        usar. La asimetría no se compromete por un nombre de algoritmo
+        no canónico.
+      * Si el LLM emitió un dict inválido (negativo, no finito, fields faltantes)
+        → ``ValidationError`` capturado, structured ``logger.warning`` con
+        ``case_title`` + ``raw_values`` + ``e.errors()`` para trazabilidad,
+        + warning sanitizado en español apto para ``data_gap_warnings`` (sin
+        repetir el título crudo en el string del prompt), + ``business_cost_matrix``
+        nulificado en el dict devuelto.
+      * Si la familia es ``clasificacion`` y el campo viene None → warning
+        estructurado + sanitizado (M3 caerá en el fallback fp=1, fn=5).
+      * Si la familia es una NO-clasificación conocida y el campo viene
+        poblado → warning + nulificado (M3 de otras familias no usa cost
+        matrix).
+      * Si todo OK → se devuelve un contrato con la matriz **normalizada**
+        (currency upper, tipos float emitidos por Pydantic). El contrato
+        original nunca se muta in-place.
+
+    El contrato de entrada NO se muta in-place: se devuelve un nuevo dict
+    cuando hay cualquier cambio efectivo (nulificación o normalización).
+    Devuelve ``(contract_or_copy, warnings)``.
+
+    El logger NUNCA loguea el dict raw completo del contrato (puede contener
+    metadatos pedagógicos largos); siempre acota ``raw_values`` a las 3 keys
+    esperadas (``fp_cost``, ``fn_cost``, ``currency``) para evitar leakear
+    shape inesperada del LLM al log estructurado.
+    """
+    # Late import para evitar ciclo: tools_and_schemas <- graph en tests.
+    from case_generator.tools_and_schemas import BusinessCostMatrix
+    from pydantic import ValidationError
+
+    warnings: list[str] = []
+    if contract is None:
+        return contract, warnings
+
+    raw_value = contract.get("business_cost_matrix")
+    family_norm = (family or "").strip().lower()
+    is_classification = family_norm == "clasificacion"
+    is_unknown_family = family_norm == ""
+
+    # Helper para acotar el log estructurado a las 3 keys conocidas, evitando
+    # leakear keys inesperadas del LLM.
+    def _safe_subset(value: object) -> dict:
+        if not isinstance(value, dict):
+            return {"_raw_type": type(value).__name__}
+        return {k: value.get(k) for k in ("fp_cost", "fn_cost", "currency")}
+
+    # Caso 1 — campo ausente para clasificacion.
+    if raw_value is None:
+        if is_classification:
+            logger.warning(
+                "[case_architect.cost_matrix] missing for classification case "
+                "(case_title=%r, family=%r)",
+                case_title or "<sin titulo>", family,
+            )
+            warnings.append(
+                "business_cost_matrix_missing: el caso es de clasificación pero "
+                "case_architect no emitió matriz de costos (fp_cost/fn_cost). "
+                "El notebook M3 usará fallback fp=1, fn=5 (sin asimetría real)."
+            )
+        return contract, warnings
+
+    # Caso 1b — familia desconocida (no resoluble) con matriz poblada:
+    # NO nulificar. El dispatcher M3 cae a clasificación por defecto, así
+    # que descartar aquí perdería datos válidos. Solo emitimos warning.
+    if is_unknown_family:
+        logger.warning(
+            "[case_architect.cost_matrix] cost matrix emitted but family could "
+            "not be resolved (case_title=%r, family=%r, raw_values=%r) \u2014 "
+            "preservando matriz (M3 har\u00e1 fallback a clasificacion)",
+            case_title or "<sin titulo>", family, _safe_subset(raw_value),
+        )
+        warnings.append(
+            "business_cost_matrix_unknown_family: no se pudo resolver la familia "
+            "del algoritmo principal. La matriz de costos se preserva porque el "
+            "notebook M3 hará fallback a clasificación."
+        )
+        # Continúa al Caso 3/4 para validar e (idealmente) normalizar la matriz.
+
+    # Caso 2 — campo poblado para una familia conocida que no es clasificación.
+    elif not is_classification:
+        logger.warning(
+            "[case_architect.cost_matrix] cost matrix emitted for non-classification "
+            "family (case_title=%r, family=%r, raw_values=%r) \u2014 nulificando",
+            case_title or "<sin titulo>", family, _safe_subset(raw_value),
+        )
+        warnings.append(
+            "business_cost_matrix_wrong_family: case_architect emitió matriz de "
+            "costos para una familia que no es clasificación. Se descarta "
+            "(M3 no la usa fuera de clasificación)."
+        )
+        new_contract = dict(contract)
+        new_contract["business_cost_matrix"] = None
+        return new_contract, warnings
+
+    # Caso 3 — campo poblado para clasificacion (o familia desconocida que
+    # cae al fallback de M3): validamos con Pydantic.
+    try:
+        validated = BusinessCostMatrix.model_validate(raw_value)
+    except ValidationError as e:
+        # Structured log con todos los detalles para trazabilidad en producción.
+        # raw_values se acota a las 3 keys esperadas para evitar PII inesperada.
+        logger.warning(
+            "[case_architect.cost_matrix] ValidationError (case_title=%r, "
+            "raw_values=%r, errors=%r) \u2014 nulificando",
+            case_title or "<sin titulo>", _safe_subset(raw_value), e.errors(),
+        )
+        # Warning sanitizado para data_gap_warnings (no repite el título crudo
+        # ni los errors de Pydantic; basta para que el docente entienda que el
+        # M3 cayó al fallback).
+        warnings.append(
+            "business_cost_matrix_invalid: case_architect emitió valores no "
+            "válidos en la matriz de costos (revisa logs estructurados para "
+            "fp_cost/fn_cost/currency exactos). El notebook M3 usará fallback "
+            "fp=1, fn=5."
+        )
+        new_contract = dict(contract)
+        new_contract["business_cost_matrix"] = None
+        return new_contract, warnings
+
+    # Caso 4 — válido. Persistimos la versión normalizada (currency upper).
+    new_contract = dict(contract)
+    new_contract["business_cost_matrix"] = validated.model_dump()
+    return new_contract, warnings
 
 
 def _format_dataset_contract_block(contract: dict | None) -> str:
@@ -3035,10 +3193,12 @@ _FAMILY_PROHIBITED_PATTERNS: dict[str, tuple[str, ...]] = {
 #
 # Two kinds of tokens live here:
 #   * Section sentinels (``# === SECTION:<id> ===``) — force the LLM to emit
-#     the 6 mandatory pedagogical sections in a parser-friendly shape.
+#     the 8 mandatory pedagogical sections in a parser-friendly shape
+#     (Issue #238 added ``cost_matrix`` to the original 7 from #236).
 #   * Canonical sklearn API tokens (``DummyClassifier``, ``StratifiedKFold``,
 #     ``ColumnTransformer``, ``cross_val_score``, ``roc_curve(``,
-#     ``precision_recall_curve(``) — guarantee the sections do real work.
+#     ``precision_recall_curve(``, ``confusion_matrix(``, ``predict_proba(``)
+#     — guarantee the sections do real work.
 #
 # Required tokens split in two buckets so each is checked against the right
 # corpus (PR #244 review):
@@ -3067,6 +3227,8 @@ _FAMILY_REQUIRED_SENTINELS: dict[str, tuple[str, ...]] = {
         "# === SECTION:roc_curves ===",
         "# === SECTION:pr_curves ===",
         "# === SECTION:comparison_table ===",
+        # Issue #238 — celda de threshold tuning con matriz de costos del negocio.
+        "# === SECTION:cost_matrix ===",
     ),
 }
 
@@ -3079,6 +3241,11 @@ _FAMILY_REQUIRED_APIS: dict[str, tuple[str, ...]] = {
         "roc_curve(",
         "precision_recall_curve(",
         "train_test_split(",
+        # Issue #238 — la celda cost_matrix usa confusion_matrix() para barrer
+        # thresholds y predict_proba() para obtener scores continuos. Ambos
+        # tienen que aparecer en código ejecutable, no solo en markdown.
+        "confusion_matrix(",
+        "predict_proba(",
     ),
 }
 

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -2344,7 +2344,7 @@ L. **Atomic Cell Charting (Issue #228 — un gráfico por celda)**: cada celda d
 
 M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO (Issue #236).**
    Antes del bloque per-algoritmo, emite la **Sección 3.0.5** descrita más
-   abajo en "Estructura OBLIGATORIA". Esa sección contiene SIETE celdas con
+   abajo en "Estructura OBLIGATORIA". Esa sección contiene OCHO celdas con
    sentinelas contractuales que el validador post-LLM verifica:
      - `# === SECTION:dummy_baseline ===`     → bootstrap (target_col, y, feature_cols, X_raw, is_binary) + DummyClassifier (most_frequent + stratified)
      - `# === SECTION:pipeline_lr ===`        → Pipeline(ColumnTransformer + LogisticRegression)
@@ -2353,6 +2353,7 @@ M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO (Issue #236).**
      - `# === SECTION:roc_curves ===`         → hold-out propio + curva ROC (LR vs RF) en una sola figura
      - `# === SECTION:pr_curves ===`          → curva Precision-Recall (LR vs RF) en una sola figura, reusando el hold-out
      - `# === SECTION:comparison_table ===`   → tabla pd.DataFrame final con las 7 columnas, hold-out reconstruido localmente
+     - `# === SECTION:cost_matrix ===`        → (Issue #238) curva costo-vs-threshold con confusion_matrix + predict_proba; eje Y en `currency` del contrato; línea vertical roja en threshold óptimo y línea gris en 0.5
    Reglas:
    * Las sentinelas se emiten LITERALMENTE como primera línea de su celda
      `# %%` (comentario Python). Si una sentinela falta, el job falla en
@@ -2427,7 +2428,8 @@ except Exception as e:
     print(f"⚠️ EDA Express falló: {{e}}")
 
 ## Sección 3.0.5 — Bloque comparativo Harvard ml_ds (REGLA M, Issue #236)
-## Emite EXACTAMENTE las 7 celdas de código siguientes, EN ORDEN, con su
+## Emite EXACTAMENTE las 8 celdas de código siguientes (Issue #238 añadió
+## la celda cost_matrix), EN ORDEN, con su
 ## sentinela como primera línea (comentario Python). Cada sentinela es
 ## contractual — el validador post-LLM rechaza el notebook y reprompt si falta.
 ## Este bloque es CASE-WIDE (una sola vez, para Logistic Regression vs
@@ -2735,6 +2737,96 @@ try:
             print(comparison.to_string(index=False))
 except Exception as e:
     print(f"⚠️ Tabla comparativa falló: {{e}}")
+
+# %% [markdown]
+# ### 3.0.6 — Matriz de costos del negocio + threshold tuning (Issue #238)
+# El threshold default 0.5 SOLO es óptimo si FP y FN cuestan igual. En la
+# mayoría de los problemas de negocio (churn, fraude, mantenimiento) los
+# costos son asimétricos. Esta celda lee la matriz de costos del contrato
+# (`dataset_schema_required.business_cost_matrix`), barre 100 thresholds
+# y elige el que minimiza el costo total esperado en el hold-out.
+#
+# **Cómo extraer los costos:**
+# Inspecciona el JSON del contrato del caso (bloque `dataset_contract_block`
+# que recibiste en el prompt). Si contiene `business_cost_matrix` con
+# `fp_cost`, `fn_cost`, `currency`, EMITE esos números literales en la celda.
+# Si NO está presente, usa el fallback `fp_cost=1.0`, `fn_cost=5.0`,
+# `currency="USD"` Y añade un `print` explicando que se usó fallback.
+
+# %%
+# === SECTION:cost_matrix ===
+try:
+    if not is_binary:
+        print("Bloque comparativo omitido: target no binario")
+    else:
+        from sklearn.model_selection import train_test_split
+        from sklearn.metrics import confusion_matrix
+
+        # Costos del negocio extraídos del contrato dataset_schema_required
+        # .business_cost_matrix. Si el contrato no los traía, fallback fp=1, fn=5.
+        # IMPORTANTE: emite los 3 valores como literales Python (NO leas un
+        # diccionario `dataset_schema_required` en runtime — el notebook se
+        # ejecuta standalone).
+        fp_cost = 1.0   # ← reemplaza por business_cost_matrix.fp_cost del contrato
+        fn_cost = 5.0   # ← reemplaza por business_cost_matrix.fn_cost del contrato
+        currency = "USD"  # ← reemplaza por business_cost_matrix.currency del contrato
+        # Si el contrato NO traía business_cost_matrix, deja los valores fallback
+        # de arriba y añade un print pedagógico explicando el fallback:
+        # print(f"⚠️ Sin matriz de costos en el contrato — usando fallback fp={{fp_cost}}, fn={{fn_cost}} {{currency}}")
+
+        _Xtr_cm, _Xte_cm, _ytr_cm, _yte_cm = train_test_split(
+            X_raw, y, test_size=0.2, random_state=42,
+            stratify=y if y.value_counts().min() >= 2 else None,
+        )
+        pipe_lr.fit(_Xtr_cm, _ytr_cm)
+        proba_lr = pipe_lr.predict_proba(_Xte_cm)[:, 1]
+        _pos_cm = pipe_lr.named_steps["clf"].classes_[1]
+        _y_bin_cm = (_yte_cm.reset_index(drop=True) == _pos_cm).astype(int)
+
+        thresholds = np.linspace(0.05, 0.95, 100)
+        costs = []
+        for t in thresholds:
+            tn, fp, fn, tp = confusion_matrix(_y_bin_cm, (proba_lr >= t).astype(int)).ravel()
+            costs.append(fp * fp_cost + fn * fn_cost)
+        costs = np.array(costs)
+        optimal = float(thresholds[int(np.argmin(costs))])
+        cost_at_optimal = float(costs[int(np.argmin(costs))])
+        cost_at_default = float(costs[int(np.argmin(np.abs(thresholds - 0.5)))])
+
+        # Una sola figura, un solo show (REGLA L atomic charting)
+        plt.figure(figsize=(8, 5))
+        plt.plot(thresholds, costs, label="Costo total esperado")
+        plt.axvline(optimal, color="red", linestyle="-", label=f"Óptimo = {{optimal:.2f}}")
+        plt.axvline(0.5, color="gray", linestyle="--", alpha=0.7, label="Default 0.5")
+        plt.xlabel("Threshold de decisión")
+        plt.ylabel(f"Costo total ({{currency}})")
+        plt.title(f"Curva costo-vs-threshold (LR) — fp={{fp_cost}} {{currency}}, fn={{fn_cost}} {{currency}}")
+        plt.legend(loc="best")
+        plt.tight_layout(); plt.show()
+
+        # Pedagogía 3 ramas:
+        if optimal in (float(thresholds[0]), float(thresholds[-1])):
+            print(
+                f"⚠️ El threshold óptimo {{optimal:.2f}} está en el borde del barrido "
+                f"[0.05, 0.95]. Esto sugiere que la matriz de costos es muy desbalanceada "
+                f"o que el modelo no separa bien las clases — revisa fp/fn antes de productivizar."
+            )
+        elif abs(optimal - 0.5) < 0.05:
+            print(
+                f"El threshold óptimo {{optimal:.2f}} es prácticamente el default 0.5: "
+                f"para esta matriz de costos (fp={{fp_cost}}, fn={{fn_cost}} {{currency}}) "
+                f"el sesgo asimétrico no compensa mover el umbral."
+            )
+        else:
+            ahorro = cost_at_default - cost_at_optimal
+            print(
+                f"Threshold óptimo: {{optimal:.2f}} (vs default 0.5). "
+                f"Costo total: {{cost_at_optimal:,.0f}} {{currency}} (ahorro estimado vs 0.5: "
+                f"{{ahorro:,.0f}} {{currency}}). Productivizar este threshold puede traducirse "
+                f"directamente a un caso de negocio cuantificable."
+            )
+except Exception as e:
+    print(f"⚠️ Cost matrix + threshold tuning falló: {{e}}")
 
 ## Para CADA familia en {familias_meta}, y para CADA algoritmo dentro del campo
 ## "algoritmos" de esa familia, emite las siguientes celdas EN ORDEN (no

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -4,9 +4,10 @@ These models describe the structured payloads returned by the authoring agents
 that feed the teacher preview and downstream synthesis steps.
 """
 
+import math
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 # ═══════════════════════════════════════════════════════
@@ -130,6 +131,78 @@ class DatasetSchemaRequired(BaseModel):
         default=None,
         description="Notas opcionales del architect sobre el diseño del contrato",
     )
+    # Issue #238 — matriz de costos del negocio para threshold tuning en M3.
+    # Solo aplica cuando family == "clasificacion"; para otras familias debe
+    # quedar None. Validación estricta (ratios, ISO 4217, cross-family) está
+    # deferred a #242 (ver TODOS.md).
+    business_cost_matrix: Optional["BusinessCostMatrix"] = Field(
+        default=None,
+        description=(
+            "Costos asimétricos del negocio (USD/EUR/etc.) para tuning de "
+            "threshold en clasificación. fp_cost = costo de un falso positivo "
+            "(predecir 1 cuando es 0). fn_cost = costo de un falso negativo "
+            "(predecir 0 cuando es 1). Si None, M3 usa fallback fp=1, fn=5."
+        ),
+    )
+
+
+class BusinessCostMatrix(BaseModel):
+    """Costos asimétricos del negocio para threshold tuning en M3 (Issue #238).
+
+    Solo aplica para problemas de clasificación. Permite que el notebook M3
+    construya una curva de costo total vs threshold y elija el óptimo en
+    lugar de quedarse con el default 0.5.
+
+    Validación strict-mode (Issue #238 scope reducido):
+      * fp_cost > 0 y finito
+      * fn_cost > 0 y finito
+      * currency normalizada vía .upper().strip() (sin enforcement ISO 4217)
+    """
+
+    fp_cost: float = Field(
+        gt=0,
+        description=(
+            "Costo de un falso positivo en la moneda indicada por `currency`. "
+            "Ej: en churn, costo de regalar una retención a un cliente que no "
+            "se iba a ir. Debe ser > 0 y finito."
+        ),
+    )
+    fn_cost: float = Field(
+        gt=0,
+        description=(
+            "Costo de un falso negativo en la moneda indicada por `currency`. "
+            "Ej: en churn, costo de perder un cliente porque no se le ofreció "
+            "retención. Debe ser > 0 y finito."
+        ),
+    )
+    currency: str = Field(
+        default="USD",
+        description=(
+            "Código de moneda (string libre, normalizado a mayúsculas). "
+            "No se valida contra ISO 4217 en este scope (#242)."
+        ),
+    )
+
+    @field_validator("fp_cost", "fn_cost")
+    @classmethod
+    def _finite_cost(cls, v: float) -> float:
+        if not math.isfinite(v):
+            raise ValueError("cost must be a finite number (no inf/nan)")
+        return v
+
+    @field_validator("currency")
+    @classmethod
+    def _normalize_currency(cls, v: str) -> str:
+        normalized = (v or "").strip().upper()
+        if not normalized:
+            return "USD"
+        return normalized
+
+
+# Issue #238 — resuelve la forward reference declarada en DatasetSchemaRequired
+# para el campo `business_cost_matrix`. Pydantic v2 no resuelve string refs
+# automáticamente cuando la clase referenciada se define después.
+DatasetSchemaRequired.model_rebuild()
 
 
 # ═══════════════════════════════════════════════════════

--- a/backend/tests/test_issue238_cost_matrix.py
+++ b/backend/tests/test_issue238_cost_matrix.py
@@ -1,0 +1,305 @@
+"""Issue #238 — matriz de costos del negocio + threshold tuning en M3 (familia clasificacion).
+
+Cubre:
+  * `BusinessCostMatrix` Pydantic model: campos > 0, finitos, currency normalizada
+  * `DatasetSchemaRequired.business_cost_matrix` opcional, default None
+  * `_validate_business_cost_matrix` helper en graph.py:
+      - dict válido pasa intacto (con normalización)
+      - dict inválido (negativo / inf) → loguea structured + nulifica + warning
+      - missing en clasificación → warning
+      - missing en otra familia → no-op
+      - poblado en otra familia → nulifica + warning
+  * `_FAMILY_REQUIRED_SENTINELS["clasificacion"]` incluye `cost_matrix`
+  * `_FAMILY_REQUIRED_APIS["clasificacion"]` incluye `confusion_matrix(` y `predict_proba(`
+  * El prompt de clasificación contiene la sentinela y las dos APIs
+
+Cero LLMs, cero red, cero DB.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from case_generator import graph as graph_module
+from case_generator.graph import (
+    _FAMILY_REQUIRED_APIS,
+    _FAMILY_REQUIRED_SENTINELS,
+    _validate_business_cost_matrix,
+)
+from case_generator.prompts import M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION
+from case_generator.tools_and_schemas import (
+    BusinessCostMatrix,
+    DatasetFeatureSpec,
+    DatasetSchemaRequired,
+    DatasetTargetSpec,
+)
+
+
+@pytest.fixture()
+def graph_logs(monkeypatch):
+    """Sustituye el logger del módulo por un Mock para inspección determinista.
+
+    Razones:
+      * `shared.app` llama a `logging.basicConfig(handlers=[...], force=True)`
+        cuando se importa, lo que rompe `caplog` en suite completa.
+      * Adjuntar un Handler directo al logger también es frágil ante el orden
+        de tests. Mockear el atributo del módulo es 100% estable.
+
+    Devuelve un objeto con ``.messages`` (lista de strings ya formateados de
+    todas las llamadas warning/info/error) para hacer asserts sobre contenido.
+    """
+    mock_logger = MagicMock(spec=logging.Logger)
+    monkeypatch.setattr(graph_module, "logger", mock_logger)
+
+    class _Sink:
+        @property
+        def messages(self) -> list[str]:
+            out: list[str] = []
+            for method in ("warning", "info", "error", "debug"):
+                for call in getattr(mock_logger, method).call_args_list:
+                    args, kwargs = call
+                    if not args:
+                        continue
+                    fmt, *fmt_args = args
+                    try:
+                        out.append(fmt % tuple(fmt_args) if fmt_args else str(fmt))
+                    except Exception:
+                        out.append(str(args))
+            return out
+
+    return _Sink()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 1. Pydantic model: BusinessCostMatrix
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_business_cost_matrix_valid_normalizes_currency() -> None:
+    m = BusinessCostMatrix(fp_cost=10.0, fn_cost=50.0, currency=" usd ")
+    assert m.fp_cost == 10.0
+    assert m.fn_cost == 50.0
+    assert m.currency == "USD"
+
+
+def test_business_cost_matrix_default_currency_is_usd() -> None:
+    m = BusinessCostMatrix(fp_cost=1.0, fn_cost=5.0)
+    assert m.currency == "USD"
+
+
+def test_business_cost_matrix_rejects_non_positive() -> None:
+    with pytest.raises(ValidationError):
+        BusinessCostMatrix(fp_cost=0, fn_cost=5)
+    with pytest.raises(ValidationError):
+        BusinessCostMatrix(fp_cost=10, fn_cost=-1)
+
+
+def test_business_cost_matrix_rejects_non_finite() -> None:
+    with pytest.raises(ValidationError):
+        BusinessCostMatrix(fp_cost=float("inf"), fn_cost=5.0)
+    with pytest.raises(ValidationError):
+        BusinessCostMatrix(fp_cost=10.0, fn_cost=float("nan"))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 2. Schema integration: DatasetSchemaRequired.business_cost_matrix
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _build_minimal_schema(**overrides) -> DatasetSchemaRequired:
+    return DatasetSchemaRequired(
+        target_column=DatasetTargetSpec(
+            name="churn_flag",
+            role="classification_target",
+            dtype="int",
+            description="1 si el cliente se va, 0 si se queda",
+        ),
+        feature_columns=[
+            DatasetFeatureSpec(
+                name="tenure_months",
+                role="feature",
+                dtype="int",
+                description="meses de antigüedad",
+            ),
+        ],
+        **overrides,
+    )
+
+
+def test_dataset_schema_required_business_cost_matrix_optional_default_none() -> None:
+    s = _build_minimal_schema()
+    assert s.business_cost_matrix is None
+
+
+def test_dataset_schema_required_accepts_business_cost_matrix() -> None:
+    cm = BusinessCostMatrix(fp_cost=20.0, fn_cost=200.0, currency="EUR")
+    s = _build_minimal_schema(business_cost_matrix=cm)
+    assert s.business_cost_matrix is not None
+    assert s.business_cost_matrix.currency == "EUR"
+    dumped = s.model_dump()
+    assert dumped["business_cost_matrix"]["fp_cost"] == 20.0
+    assert dumped["business_cost_matrix"]["fn_cost"] == 200.0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 3. Helper: _validate_business_cost_matrix
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_validator_passes_valid_cost_matrix_for_classification() -> None:
+    contract = {
+        "target_column": {"name": "churn", "role": "classification_target"},
+        "business_cost_matrix": {"fp_cost": 10, "fn_cost": 50, "currency": "usd"},
+    }
+    out, warnings = _validate_business_cost_matrix(contract, "clasificacion", "Caso X")
+    assert warnings == []
+    assert out is not None
+    assert out["business_cost_matrix"]["currency"] == "USD"
+    assert out["business_cost_matrix"]["fp_cost"] == 10.0
+
+
+def test_validator_warns_when_missing_for_classification(graph_logs) -> None:
+    contract = {"target_column": {"name": "churn"}}
+    out, warnings = _validate_business_cost_matrix(contract, "clasificacion", "ChurnCo")
+    assert out is contract  # no mutation when nothing to fix
+    assert len(warnings) == 1
+    assert "business_cost_matrix_missing" in warnings[0]
+    assert any("ChurnCo" in m for m in graph_logs.messages)
+
+
+def test_validator_no_op_when_missing_for_non_classification() -> None:
+    contract = {"target_column": {"name": "ventas"}}
+    out, warnings = _validate_business_cost_matrix(contract, "regresion", "ForecastCo")
+    assert out is contract
+    assert warnings == []
+
+
+def test_validator_nullifies_when_present_in_non_classification(graph_logs) -> None:
+    contract = {
+        "target_column": {"name": "ventas"},
+        "business_cost_matrix": {"fp_cost": 1, "fn_cost": 2, "currency": "USD"},
+    }
+    out, warnings = _validate_business_cost_matrix(contract, "regresion", "ForecastCo")
+    assert out is not None
+    assert out["business_cost_matrix"] is None
+    assert len(warnings) == 1
+    assert "wrong_family" in warnings[0]
+    assert any("ForecastCo" in m for m in graph_logs.messages)
+
+
+def test_validator_nullifies_invalid_dict_and_emits_structured_log(graph_logs) -> None:
+    contract = {
+        "target_column": {"name": "churn"},
+        "business_cost_matrix": {"fp_cost": -5, "fn_cost": 50, "currency": "USD"},
+    }
+    out, warnings = _validate_business_cost_matrix(contract, "clasificacion", "ChurnCo")
+    assert out is not None
+    assert out["business_cost_matrix"] is None
+    assert len(warnings) == 1
+    assert "business_cost_matrix_invalid" in warnings[0]
+    msgs = graph_logs.messages
+    assert any("ChurnCo" in m for m in msgs)
+    assert any("fp_cost" in m for m in msgs)
+    # No mutamos el contrato original.
+    assert contract["business_cost_matrix"] == {"fp_cost": -5, "fn_cost": 50, "currency": "USD"}
+
+
+def test_validator_nullifies_non_finite_values(graph_logs) -> None:
+    contract = {
+        "target_column": {"name": "churn"},
+        "business_cost_matrix": {
+            "fp_cost": float("inf"),
+            "fn_cost": 50,
+            "currency": "USD",
+        },
+    }
+    out, warnings = _validate_business_cost_matrix(contract, "clasificacion", "ChurnCo")
+    assert out is not None
+    assert out["business_cost_matrix"] is None
+    assert any("invalid" in w for w in warnings)
+
+
+def test_validator_handles_none_contract() -> None:
+    out, warnings = _validate_business_cost_matrix(None, "clasificacion", "ChurnCo")
+    assert out is None
+    assert warnings == []
+
+
+def test_validator_preserves_matrix_when_family_is_unknown(graph_logs) -> None:
+    """Cuando case_architect no puede resolver familia (algoritmo no canónico
+    ni en el legacy resolver), el dispatcher M3 cae a `clasificacion` por
+    defecto. Por eso el helper NO debe nulificar la matriz: la perdería antes
+    de que M3 la consuma. Debe emitir warning ``unknown_family`` y preservar
+    la matriz **normalizada** (currency upper)."""
+    contract = {
+        "target_column": {"name": "churn"},
+        "business_cost_matrix": {"fp_cost": 7, "fn_cost": 70, "currency": "eur"},
+    }
+    out, warnings = _validate_business_cost_matrix(contract, None, "ChurnCo")
+    assert out is not None
+    # NO nulificada: M3 hará fallback a clasificación y la usará.
+    assert out["business_cost_matrix"] is not None
+    assert out["business_cost_matrix"]["fp_cost"] == 7.0
+    assert out["business_cost_matrix"]["currency"] == "EUR"
+    assert any("unknown_family" in w for w in warnings)
+    # Log estructurado no debe leakear keys inesperadas (acotado a 3 keys).
+    assert any("ChurnCo" in m for m in graph_logs.messages)
+
+
+def test_validator_unknown_family_with_missing_matrix_is_no_op() -> None:
+    """family=None + matriz ausente = sin warnings (no hay nada que preservar
+    ni señalar; M3 caerá a fallback fp=1/fn=5 igual que en clasificación
+    explícita sin matriz, pero ese caso ya está cubierto por la rama de
+    clasificación cuando el algoritmo SÍ se resuelve)."""
+    contract = {"target_column": {"name": "churn"}}
+    out, warnings = _validate_business_cost_matrix(contract, None, "ChurnCo")
+    assert out is contract
+    assert warnings == []
+
+
+def test_validator_safe_subset_does_not_leak_extra_keys(graph_logs) -> None:
+    """El log estructurado de Caso 2 (wrong_family) acota raw_values a las
+    3 keys conocidas, sin importar qué basura emita el LLM."""
+    contract = {
+        "target_column": {"name": "ventas"},
+        "business_cost_matrix": {
+            "fp_cost": 1,
+            "fn_cost": 2,
+            "currency": "USD",
+            "leaked_pii": "social_security_number_123",
+        },
+    }
+    _out, _warnings = _validate_business_cost_matrix(contract, "regresion", "ForecastCo")
+    msgs = graph_logs.messages
+    assert any("ForecastCo" in m for m in msgs)
+    assert not any("leaked_pii" in m or "social_security_number_123" in m for m in msgs)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 4. Sentinel + API contract integration
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_required_sentinels_include_cost_matrix() -> None:
+    sentinels = _FAMILY_REQUIRED_SENTINELS["clasificacion"]
+    assert "# === SECTION:cost_matrix ===" in sentinels
+    assert len(sentinels) == 8
+
+
+def test_required_apis_include_confusion_matrix_and_predict_proba() -> None:
+    apis = _FAMILY_REQUIRED_APIS["clasificacion"]
+    assert "confusion_matrix(" in apis
+    assert "predict_proba(" in apis
+
+
+def test_classification_prompt_emits_cost_matrix_sentinel_and_apis() -> None:
+    prompt = M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION
+    assert "# === SECTION:cost_matrix ===" in prompt
+    assert "confusion_matrix(" in prompt
+    assert "predict_proba(" in prompt
+    # El bloque pedagógico de la 8ª celda debe aparecer.
+    assert "threshold" in prompt.lower()

--- a/backend/tests/test_m3_notebook_classification_hygiene.py
+++ b/backend/tests/test_m3_notebook_classification_hygiene.py
@@ -138,6 +138,7 @@ def test_prompt_still_renders_with_existing_substitution_vars() -> None:
 
 # PR #244 review: contract is now 7 sentinels (ROC and PR split into separate
 # cells per Rule L atomic-charting + Rule 6 cell isolation).
+# Issue #238: 8th sentinel ``cost_matrix`` added for business-cost threshold tuning.
 _REQUIRED_SENTINELS = (
     "# === SECTION:dummy_baseline ===",
     "# === SECTION:pipeline_lr ===",
@@ -146,6 +147,7 @@ _REQUIRED_SENTINELS = (
     "# === SECTION:roc_curves ===",
     "# === SECTION:pr_curves ===",
     "# === SECTION:comparison_table ===",
+    "# === SECTION:cost_matrix ===",
 )
 
 _REQUIRED_API_TOKENS = (
@@ -158,14 +160,18 @@ _REQUIRED_API_TOKENS = (
     "roc_curve(",
     "precision_recall_curve(",
     "train_test_split(",
+    # Issue #238 — cost matrix cell uses both APIs in executable code.
+    "confusion_matrix(",
+    "predict_proba(",
 )
 
 
-def test_prompt_emits_seven_mandatory_sentinels_for_classification() -> None:
-    """Las 7 sentinelas son contractuales: el validador rechaza el notebook
+def test_prompt_emits_eight_mandatory_sentinels_for_classification() -> None:
+    """Las 8 sentinelas son contractuales: el validador rechaza el notebook
     si falta cualquiera. El prompt DEBE instruir al LLM a emitirlas.
     PR #244 review: ROC y PR ahora viven en celdas separadas (Regla L +
-    Regla 6). El antiguo ``roc_pr_curves`` ya NO debe aparecer."""
+    Regla 6). El antiguo ``roc_pr_curves`` ya NO debe aparecer.
+    Issue #238: añadida la 8ª sentinela ``cost_matrix``."""
     for sentinel in _REQUIRED_SENTINELS:
         assert sentinel in M3_NOTEBOOK_ALGO_PROMPT, f"falta sentinela {sentinel!r}"
     assert "# === SECTION:roc_pr_curves ===" not in M3_NOTEBOOK_ALGO_PROMPT, (
@@ -230,11 +236,13 @@ def test_validator_passes_when_all_required_present() -> None:
         "from sklearn.compose import ColumnTransformer\n"
         "from sklearn.preprocessing import StandardScaler, OneHotEncoder\n"
         "from sklearn.model_selection import StratifiedKFold, cross_val_score, train_test_split\n"
-        "from sklearn.metrics import roc_curve, precision_recall_curve\n"
+        "from sklearn.metrics import roc_curve, precision_recall_curve, confusion_matrix\n"
         "model = DummyClassifier(strategy='most_frequent')\n"
         "X_tr, X_te, y_tr, y_te = train_test_split(X, y, random_state=42)\n"
         "fpr, tpr, _ = roc_curve(y, scores)\n"
         "prec, rec, _ = precision_recall_curve(y, scores)\n"
+        "proba = model.predict_proba(X_te)[:, 1]\n"
+        "tn, fp, fn, tp = confusion_matrix(y, (proba >= 0.5).astype(int)).ravel()\n"
     )
     assert _validate_notebook_family_consistency("clasificacion", code) == []
 
@@ -246,7 +254,7 @@ def test_validator_rejects_required_apis_only_present_in_comments() -> None:
     seguir saliendo FALTANTE: DummyClassifier."""
     cheating = "\n".join(_REQUIRED_SENTINELS) + "\n" + (
         "# DummyClassifier StratifiedKFold cross_val_score ColumnTransformer\n"
-        "# roc_curve( precision_recall_curve( train_test_split(\n"
+        "# roc_curve( precision_recall_curve( train_test_split( confusion_matrix( predict_proba(\n"
         "x = 1\n"
     )
     violations = _validate_notebook_family_consistency("clasificacion", cheating)
@@ -257,6 +265,8 @@ def test_validator_rejects_required_apis_only_present_in_comments() -> None:
     assert "FALTANTE: roc_curve(" in violations
     assert "FALTANTE: precision_recall_curve(" in violations
     assert "FALTANTE: train_test_split(" in violations
+    assert "FALTANTE: confusion_matrix(" in violations
+    assert "FALTANTE: predict_proba(" in violations
     # Y las sentinelas SÍ están presentes (no aparecen en violations).
     for sentinel in _REQUIRED_SENTINELS:
         assert f"FALTANTE: {sentinel}" not in violations

--- a/backend/tests/test_m3_notebook_dispatch.py
+++ b/backend/tests/test_m3_notebook_dispatch.py
@@ -77,6 +77,7 @@ CLEAN_CLASSIFICATION_CODE = """
 # === SECTION:roc_curves ===
 # === SECTION:pr_curves ===
 # === SECTION:comparison_table ===
+# === SECTION:cost_matrix ===
 from sklearn.dummy import DummyClassifier
 from sklearn.compose import ColumnTransformer
 from sklearn.linear_model import LogisticRegression
@@ -88,6 +89,8 @@ model = LogisticRegression().fit(X_train, y_train)
 auc = roc_auc_score(y_test, model.predict_proba(X_test)[:, 1])
 fpr, tpr, _ = roc_curve(y_test, model.predict_proba(X_test)[:, 1])
 prec, rec, _ = precision_recall_curve(y_test, model.predict_proba(X_test)[:, 1])
+proba = model.predict_proba(X_test)[:, 1]
+tn, fp, fn, tp = confusion_matrix(y_test, (proba >= 0.5).astype(int)).ravel()
 """
 
 CLEAN_CLUSTERING_CODE = """


### PR DESCRIPTION
Closes #238

## Resumen

Introduce **matriz de costos del negocio** (`fp_cost`, `fn_cost`, `currency`) en el contrato de `case_architect` y **threshold tuning** (curva costo-vs-umbral) en el notebook M3 para la familia `clasificacion`. La elección del umbral óptimo deja de ser un default ciego (0.5) y pasa a ser una decisión de negocio trazable.

## Cambios

### Schema y validación (case_architect → M1)
- **`BusinessCostMatrix`** (Pydantic v2): `fp_cost`/`fn_cost` con `Field(gt=0)` y validador finito (rechaza `inf`/`nan`); `currency` normalizada a uppercase con default `"USD"`.
- **`DatasetSchemaRequired.business_cost_matrix`**: campo opcional, default `None` (forward-ref + `model_rebuild()`).
- **`_validate_business_cost_matrix(contract, family, case_title)`** (helper degrade-with-warning, sin reprompts):
  - dict válido → normalizado y persistido.
  - dict inválido → `ValidationError` capturado, **structured log** (`logger.warning` con `case_title` + `raw_values` acotado + `e.errors()`), warning sanitizado en español al `data_gap_warnings`, campo nulificado.
  - missing en clasificación → warning estructurado (M3 cae al fallback `fp=1, fn=5`).
  - presente en otra familia → nulificado + warning.
- Hook en `case_architect`: resuelve familia desde `task_payload.algoritmos[0]` con `family_of(...) → resolve_legacy_family(...)`, mismo orden que el dispatcher M3.

### M3 prompt clasificacion (Section 3.0.6)
- Nueva celda `# === SECTION:cost_matrix ===` con curva costo-vs-threshold:
  - `train_test_split(random_state=42)` + refit `pipe_lr` (binarizado).
  - `predict_proba(...)[:, 1]` + barrido `np.linspace(0.05, 0.95, 100)`.
  - `confusion_matrix(...).ravel()` → `costs.append(fp*fp_cost + fn*fn_cost)`.
  - **Una sola figura** (Regla L) con `axvline(optimal, color="red")` + `axvline(0.5, color="gray", linestyle="--")`.
  - Print pedagógico de 3 ramas (boundary edge / cerca del default / mejora clara).
  - Placeholders `fp_cost=1.0, fn_cost=5.0` para reemplazar desde `dataset_contract_block.business_cost_matrix`.

### Validador de hygiene (graph.py)
- `_FAMILY_REQUIRED_SENTINELS["clasificacion"]`: 7 → **8** (añade sentinela `cost_matrix`).
- `_FAMILY_REQUIRED_APIS["clasificacion"]`: añade `confusion_matrix(` y `predict_proba(`.
- REGLA M actualizada: 7 → 8 celdas mandatorias.

## Tests
- **`test_issue238_cost_matrix.py`** (nuevo, 16 tests): modelo Pydantic, integración `DatasetSchemaRequired`, helper (5 ramas), contrato sentinel/APIs, contenido del prompt.
- **`test_m3_notebook_classification_hygiene.py`**: bumped 7→8 sentinelas + nuevas APIs en `_REQUIRED_API_TOKENS`; tests de "passes when complete" y "rejects comment-only" actualizados.
- **`test_m3_notebook_dispatch.py`**: `CLEAN_CLASSIFICATION_CODE` extendido con sentinela + `predict_proba` + `confusion_matrix` ejecutables.

Logger inspection en los nuevos tests usa `monkeypatch` directo del atributo `case_generator.graph.logger` con `MagicMock` — `caplog` falla en suite completa porque `shared.app` llama a `logging.basicConfig(force=True)` al importarse (lo dejé documentado en el docstring del fixture).

## Validación
- `uv run --directory backend pytest -q` → **563 passed, 13 skipped, 0 failed** (suite completa).
- `uv run --directory backend mypy src` → **Success: no issues found in 44 source files**.

## Out of scope (diferido a #242)
Documentado en `TODOS.md`:
- **TODO-238-A**: validadores estrictos adicionales (ratio `fn/fp` razonable, ISO 4217 tabla cerrada para `currency`, cap superior por valor).
- **TODO-238-B**: test de rendering del `data_gap_warnings_block` (verificar que los warnings de `_validate_business_cost_matrix` aparecen renderizados en el bloque que se inyecta a M2/M3 a través de `graph.py:1010`).

## Notas de plan
- Plan-eng-review: 10 issues, todos resueltos (A/A/A/A/A/A/A/A/A/C). El ítem C que se cerró fue precisamente el alcance de validadores estrictos, deferido a #242 para no inflar este PR.
- Política de degradación coherente con M1 (`_validate_target_semantic_coherence`, `_infer_leakage_risk_from_naming`): nunca reprompt, siempre warning + fallback observable.
- Sin cambios en infra Supabase, sin nuevos endpoints, sin migraciones.