### PR TITLE
Harden M3 notebook metrics and M4 grounding

### DIFF
--- a/backend/langgraph.json
+++ b/backend/langgraph.json
@@ -3,10 +3,10 @@
     "."
   ],
   "graphs": {
-    "agent": "./src/case_generator/graph.py:graph"
+    "agent": "case_generator.graph:get_graph"
   },
   "http": {
-    "app": "./src/shared/app.py:app"
+    "app": "shared.app:app"
   },
   "env": ".env"
 }

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -205,6 +205,9 @@ _rate_limiter = InMemoryRateLimiter(
     max_bucket_size=20,  # Burst de hasta 20 llamadas acumuladas
 )
 
+_M5_MODEL = "gemini-3.1-pro-preview"
+_M5_MAX_OUTPUT_TOKENS = 32768
+
 
 # ─── LLM Factory ────────────────────────────────────────
 
@@ -345,53 +348,26 @@ def _get_chart_llm(
     return primary.with_fallbacks([fallback])
 
 
-def _get_m5_llm(
-    model: str,
-    temperature: float = 0.5,
-    thinking_level: str = "medium",
-):
-    """LLM Pro para m5_questions_generator — preguntas de Junta Directiva.
+def _get_m5_llm(temperature: float = 0.5):
+    """Dedicated Pro chain for all Module 5 generation nodes.
 
-    Usa architect_model (Pro) porque M5 es la evaluación final integrativa:
-    3 preguntas × solucion_esperada 250-300 palabras + JSON = ~3000-4000 tokens.
-    Con thinking_level="medium" el modelo consume ~2-4K tokens de reasoning
-    adicionales — el mismo bug silencioso de _get_chart_llm aplica aquí.
-    Fix: 16384 tokens de output garantizan que las 3 solucion_esperada se completen.
-
-    Cadena de 3 fallbacks para resiliencia ante spikes 503:
-    1. gemini-3.1-pro-preview  (thinking="medium" — calidad máxima)
-    2. gemini-3-flash-preview   (thinking="minimal" — misma familia, menor costo)
-    3. gemini-2.5-flash         (sin thinking — infraestructura distinta/estable)
-    El 3er nivel cubre spikes que afectan toda la familia gemini-3-preview.
+    M5 is the final synthesis surface: content must reconcile M1-M4 evidence,
+    narrative grounding, and the decision matrix, while questions produce long
+    board-level expected answers. Keep both nodes on Gemini Pro and fall back to
+    the same model with lower reasoning so transient reasoning-budget failures
+    do not degrade the pedagogical contract to Flash.
     """
-    primary = ChatGoogleGenerativeAI(
-        model=model,
+    common_kwargs = dict(
+        model=_M5_MODEL,
         temperature=temperature,
-        thinking_level=thinking_level,
         max_retries=2,
-        max_output_tokens=16384,
+        max_output_tokens=_M5_MAX_OUTPUT_TOKENS,
         api_key=os.getenv("GEMINI_API_KEY"),
         rate_limiter=_rate_limiter,
     )
-    fallback_flash = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
-        temperature=temperature,
-        thinking_level="minimal",
-        max_output_tokens=16384,
-        max_retries=2,
-        api_key=os.getenv("GEMINI_API_KEY"),
-        rate_limiter=_rate_limiter,
-    )
-    # Nivel 3 — generación anterior estable; no soporta thinking_level.
-    fallback_stable = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
-        temperature=temperature,
-        max_output_tokens=16384,
-        max_retries=2,
-        api_key=os.getenv("GEMINI_API_KEY"),
-        rate_limiter=_rate_limiter,
-    )
-    return primary.with_fallbacks([fallback_flash, fallback_stable])
+    primary = ChatGoogleGenerativeAI(thinking_level="medium", **common_kwargs)
+    pro_fallback_low = ChatGoogleGenerativeAI(thinking_level="low", **common_kwargs)
+    return primary.with_fallbacks([pro_fallback_low])
 
 
 # ─── Utilidades ─────────────────────────────────────────
@@ -3157,11 +3133,9 @@ def m5_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
     Corre DESPUÉS de synthesis_phase1_sync — necesita m5_content del state.
     """
     try:
-        cfg = Configuration.from_runnable_config(config)
         # temperature=0.5: balance entre creatividad en enunciados y consistencia estructural
-        # Usa architect_model (Pro) + 16384 tokens — M5 es evaluación final integrativa.
-        # Con thinking_level="medium" el budget de 8192 se truncaba silenciosamente.
-        llm = _get_m5_llm(cfg.architect_model, temperature=0.5)
+        # Usa Gemini Pro medium + fallback Pro low: M5 es evaluación final integrativa.
+        llm = _get_m5_llm(temperature=0.5)
 
         # Filtrar preguntas complejas de M1 (bloom Level 2/3) como historial de referencia.
         # Prioridad: synthesis → evaluation → analysis. Máx 3 para no saturar el contexto.
@@ -4593,8 +4567,7 @@ def m5_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
     y son filtradas por frontend_output_adapter antes de llegar al estudiante.
     """
     try:
-        cfg = Configuration.from_runnable_config(config)
-        llm = _get_writer_llm(cfg.writer_model, temperature=0.6, thinking_level="medium")
+        llm = _get_m5_llm(temperature=0.6)
 
         context = _build_base_context(state)
         context.update({

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -110,6 +110,7 @@ from case_generator.suggest_service import (
 from case_generator.narrative_grounding import (
     NARRATIVE_GROUNDING_WARNING,
     build_computed_metrics_block,
+    contextualize_grounding_violations,
     has_metric_anchors,
     validate_narrative_grounding,
 )
@@ -284,6 +285,29 @@ def _get_architect_llm(
         rate_limiter=_rate_limiter,
     )
     return primary.with_fallbacks([pro_fallback_medium, flash_fallback])
+
+
+def _get_m4_llm(temperature: float = 0.5):
+    """High-reasoning Pro chain for M4 narrative impact analysis.
+
+    M4 has to translate notebook/model evidence into executive ROI, risk, and
+    deployment language. Keep it on Gemini Pro but do not reuse the architect
+    helper because M4 should not receive Code Execution tools.
+    """
+    common_kwargs = dict(
+        model="gemini-3.1-pro-preview",
+        temperature=temperature,
+        max_retries=2,
+        max_output_tokens=24576,
+        api_key=os.getenv("GEMINI_API_KEY"),
+        rate_limiter=_rate_limiter,
+    )
+    primary = ChatGoogleGenerativeAI(thinking_level="high", **common_kwargs)
+    pro_fallback_medium = ChatGoogleGenerativeAI(
+        thinking_level="medium",
+        **common_kwargs,
+    )
+    return primary.with_fallbacks([pro_fallback_medium])
 
 
 def _get_chart_llm(
@@ -3521,7 +3545,8 @@ def _invoke_narrative_with_grounding(
     if not violations:
         return prose
 
-    bullet_list = "\n".join(f"- {violation}" for violation in violations)
+    contextualized_violations = contextualize_grounding_violations(prose, violations)
+    bullet_list = "\n".join(f"- {violation}" for violation in contextualized_violations)
     print(
         f"[{node_name}] Violaciones narrative grounding detectadas: "
         f"{violations}. Reprompt explícito (1/1)."
@@ -4409,8 +4434,7 @@ def m4_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
     Si no hay M2/M3, el prompt usa fallback basado en Exhibits del M1.
     """
     try:
-        cfg = Configuration.from_runnable_config(config)
-        llm = _get_writer_llm(cfg.writer_model, temperature=0.5, thinking_level="medium")
+        llm = _get_m4_llm(temperature=0.5)
 
         context = _build_base_context(state)
         context.update({

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -118,6 +118,7 @@ from case_generator.m3_notebook_execution import (
     M3NotebookExecutionError,
     execute_m3_notebook,
     format_execution_failure_for_prompt,
+    is_m3_quality_warning_blocking,
 )
 from case_generator.tools_and_schemas import (
     CaseArchitectOutput,
@@ -3538,14 +3539,15 @@ def _invoke_narrative_with_grounding(
     prose = sanitize_markdown(_extract_text(response2))
     violations2 = validate_narrative_grounding(prose, metrics_block)
     if violations2:
+        contextualized_violations2 = contextualize_grounding_violations(prose, violations2)
         logger.error(
             "[%s] Reprompt narrative grounding falló — violations=%s",
             node_name,
-            violations2,
+            contextualized_violations2,
         )
         raise RuntimeError(
             f"{node_name} narrative grounding falló incluso tras un reprompt: "
-            f"{violations2}. Job marcado como fallido para evitar narrativa "
+            f"{contextualized_violations2}. Job marcado como fallido para evitar narrativa "
             "con números o citas no ancladas."
         )
     print(f"[{node_name}] Reprompt narrative grounding OK")
@@ -4356,6 +4358,12 @@ def m3_notebook_executor(state: ADAMState, config: RunnableConfig) -> dict:
                 notebook_code=notebook_code,
                 dataset_rows=cast(list[dict[str, Any]], dataset_rows),
             )
+            if is_m3_quality_warning_blocking(result.quality_warning, result.metrics_summary):
+                raise M3NotebookExecutionError(
+                    "M3 notebook quality gate failed.",
+                    diagnostics=result.quality_warning,
+                    kind="quality_gate",
+                )
             logger.info(
                 "[m3_notebook_executor] attempt=%s success warning=%s",
                 attempt,
@@ -4681,9 +4689,7 @@ def _artifact_cached_output_for_node(node_name: str, state: ADAMState) -> dict[s
 
 def _checkpoint_has_node_output(node_name: str, state: ADAMState) -> bool:
     if node_name == "m3_notebook_executor":
-        return _is_resumable_state_value(
-            state.get("m3_metrics_summary")
-        ) or _is_resumable_state_value(state.get("m3_quality_warning"))
+        return _is_resumable_state_value(state.get("m3_metrics_summary"))
 
     required_keys = _RESUME_NODE_REQUIRED_OUTPUTS.get(node_name, ())
     if not required_keys:

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -26,12 +26,13 @@ Total nodos LLM por path:
 Modelos:
   architect_model (Pro): case_architect, schema_designer
   m3 (Pro chain) : m3_content_generator (ml_ds), m3_notebook_generator
-  writer_model (Flash): m3_content_generator (business), demás nodos LLM
+    m4/m5 (Pro chain): m4_content_generator, m5_content_generator, m5_questions_generator
+    writer_model (Flash): m3_content_generator (business), demás nodos LLM y fallback operativo M4/M5
   chart_llm (Flash, 16K tokens): chart generators (M2, M3, M4)
   Cadenas de fallback (depende del nodo, no es global):
     - _get_writer_llm  / _get_chart_llm    : primary -> gemini-2.5-flash
     - _get_architect_llm                   : Pro-high -> Pro-medium -> gemini-3-flash-preview
-    - _get_m5_llm                          : Pro -> gemini-3-flash-preview -> gemini-2.5-flash
+        - _get_m4_llm / _get_m5_llm            : Pro -> Pro-low/medium -> writer_model -> gemini-2.5-flash
     - schema_designer (M2 inline)          : Pro-medium -> Pro-low -> gemini-3-flash-preview
     - m3_content_generator (ml_ds inline)  : Pro-medium -> Pro-low -> gemini-3-flash-preview
     - m3_notebook_generator/executor       : Pro-medium -> Pro-low -> gemini-3-flash-preview
@@ -291,15 +292,20 @@ def _get_architect_llm(
     return primary.with_fallbacks([pro_fallback_medium, flash_fallback])
 
 
-def _get_m4_llm(temperature: float = 0.5):
+def _get_m4_llm(
+    model: str = "gemini-3.1-pro-preview",
+    fallback_model: str = "gemini-3-flash-preview",
+    temperature: float = 0.5,
+):
     """High-reasoning Pro chain for M4 narrative impact analysis.
 
     M4 has to translate notebook/model evidence into executive ROI, risk, and
-    deployment language. Keep it on Gemini Pro but do not reuse the architect
-    helper because M4 should not receive Code Execution tools.
+    deployment language. Prefer Gemini Pro, but keep Configuration-driven
+    fallback escape hatches for preview-model outages and rollouts. Do not reuse
+    the architect helper because M4 should not receive Code Execution tools.
     """
     common_kwargs = dict(
-        model="gemini-3.1-pro-preview",
+        model=model,
         temperature=temperature,
         max_retries=2,
         max_output_tokens=24576,
@@ -311,7 +317,23 @@ def _get_m4_llm(temperature: float = 0.5):
         thinking_level="medium",
         **common_kwargs,
     )
-    return primary.with_fallbacks([pro_fallback_medium])
+    writer_fallback = ChatGoogleGenerativeAI(
+        model=fallback_model,
+        temperature=temperature,
+        max_retries=2,
+        max_output_tokens=24576,
+        api_key=os.getenv("GEMINI_API_KEY"),
+        rate_limiter=_rate_limiter,
+    )
+    stable_fallback = ChatGoogleGenerativeAI(
+        model="gemini-2.5-flash",
+        temperature=temperature,
+        max_retries=2,
+        max_output_tokens=24576,
+        api_key=os.getenv("GEMINI_API_KEY"),
+        rate_limiter=_rate_limiter,
+    )
+    return primary.with_fallbacks([pro_fallback_medium, writer_fallback, stable_fallback])
 
 
 def _get_chart_llm(
@@ -349,17 +371,21 @@ def _get_chart_llm(
     return primary.with_fallbacks([fallback])
 
 
-def _get_m5_llm(temperature: float = 0.5):
+def _get_m5_llm(
+    model: str = _M5_MODEL,
+    fallback_model: str = "gemini-3-flash-preview",
+    temperature: float = 0.5,
+):
     """Dedicated Pro chain for all Module 5 generation nodes.
 
     M5 is the final synthesis surface: content must reconcile M1-M4 evidence,
     narrative grounding, and the decision matrix, while questions produce long
-    board-level expected answers. Keep both nodes on Gemini Pro and fall back to
-    the same model with lower reasoning so transient reasoning-budget failures
-    do not degrade the pedagogical contract to Flash.
+    board-level expected answers. Prefer Gemini Pro and first fall back to the
+    same model with lower reasoning; then use configured writer/stable Flash
+    fallbacks so operations can route around preview-model incidents.
     """
     common_kwargs = dict(
-        model=_M5_MODEL,
+        model=model,
         temperature=temperature,
         max_retries=2,
         max_output_tokens=_M5_MAX_OUTPUT_TOKENS,
@@ -368,7 +394,23 @@ def _get_m5_llm(temperature: float = 0.5):
     )
     primary = ChatGoogleGenerativeAI(thinking_level="medium", **common_kwargs)
     pro_fallback_low = ChatGoogleGenerativeAI(thinking_level="low", **common_kwargs)
-    return primary.with_fallbacks([pro_fallback_low])
+    writer_fallback = ChatGoogleGenerativeAI(
+        model=fallback_model,
+        temperature=temperature,
+        max_retries=2,
+        max_output_tokens=_M5_MAX_OUTPUT_TOKENS,
+        api_key=os.getenv("GEMINI_API_KEY"),
+        rate_limiter=_rate_limiter,
+    )
+    stable_fallback = ChatGoogleGenerativeAI(
+        model="gemini-2.5-flash",
+        temperature=temperature,
+        max_retries=2,
+        max_output_tokens=_M5_MAX_OUTPUT_TOKENS,
+        api_key=os.getenv("GEMINI_API_KEY"),
+        rate_limiter=_rate_limiter,
+    )
+    return primary.with_fallbacks([pro_fallback_low, writer_fallback, stable_fallback])
 
 
 # ─── Utilidades ─────────────────────────────────────────
@@ -3134,9 +3176,10 @@ def m5_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
     Corre DESPUÉS de synthesis_phase1_sync — necesita m5_content del state.
     """
     try:
+        cfg = Configuration.from_runnable_config(config)
         # temperature=0.5: balance entre creatividad en enunciados y consistencia estructural
         # Usa Gemini Pro medium + fallback Pro low: M5 es evaluación final integrativa.
-        llm = _get_m5_llm(temperature=0.5)
+        llm = _get_m5_llm(cfg.architect_model, cfg.writer_model, temperature=0.5)
 
         # Filtrar preguntas complejas de M1 (bloom Level 2/3) como historial de referencia.
         # Prioridad: synthesis → evaluation → analysis. Máx 3 para no saturar el contexto.
@@ -4416,7 +4459,8 @@ def m4_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
     Si no hay M2/M3, el prompt usa fallback basado en Exhibits del M1.
     """
     try:
-        llm = _get_m4_llm(temperature=0.5)
+        cfg = Configuration.from_runnable_config(config)
+        llm = _get_m4_llm(cfg.architect_model, cfg.writer_model, temperature=0.5)
 
         context = _build_base_context(state)
         context.update({
@@ -4575,7 +4619,8 @@ def m5_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
     y son filtradas por frontend_output_adapter antes de llegar al estudiante.
     """
     try:
-        llm = _get_m5_llm(temperature=0.6)
+        cfg = Configuration.from_runnable_config(config)
+        llm = _get_m5_llm(cfg.architect_model, cfg.writer_model, temperature=0.6)
 
         context = _build_base_context(state)
         context.update({

--- a/backend/src/case_generator/m3_notebook_execution.py
+++ b/backend/src/case_generator/m3_notebook_execution.py
@@ -466,7 +466,7 @@ def build_m3_quality_warning(
     metrics_summary: dict[str, Any] | None,
     marker_warning: str | None = None,
 ) -> str | None:
-    """Return the non-blocking quality warning for executed classification notebooks."""
+    """Return the quality warning for executed classification notebooks."""
 
     if marker_warning:
         return marker_warning
@@ -477,6 +477,35 @@ def build_m3_quality_warning(
     if best_auc < 0.55 or best_auc > 0.99:
         return f"m3_quality_auc_out_of_range: best AUC {best_auc:.4f} outside [0.55, 0.99]"
     return None
+
+
+def _metrics_declares_intentional_modeling_skip(metrics_summary: dict[str, Any] | None) -> bool:
+    if not metrics_summary:
+        return False
+    status = metrics_summary.get("modeling_status")
+    if not isinstance(status, str):
+        return False
+    return status in {
+        "skipped_degenerate_target",
+        "skipped_non_binary_target",
+        "skipped_no_features",
+    }
+
+
+def is_m3_quality_warning_blocking(
+    quality_warning: str | None,
+    metrics_summary: dict[str, Any] | None,
+) -> bool:
+    """Return whether a quality warning should trigger correction/fail-closed."""
+
+    if not quality_warning:
+        return False
+    warning_kind = quality_warning.split(":", 1)[0]
+    if warning_kind in {"m3_quality_marker_missing", "m3_quality_marker_invalid"}:
+        return True
+    if warning_kind == "m3_quality_auc_missing":
+        return not _metrics_declares_intentional_modeling_skip(metrics_summary)
+    return False
 
 
 def _read_output_notebook_text(output_path: Path) -> str:

--- a/backend/src/case_generator/narrative_grounding.py
+++ b/backend/src/case_generator/narrative_grounding.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import math
 import re
+import unicodedata
 from collections.abc import Mapping, Sequence
 from numbers import Real
 from typing import Any
@@ -43,7 +44,7 @@ _ADJACENT_MODEL_METRIC_NUMBER_RE = re.compile(
 # so business figures ("ROI 35% y AUC 72%") in the same sentence as a model
 # metric are not transitively flagged as unanchored.
 _CLAUSE_BOUNDARY_RE = re.compile(
-    r"[.,;:\n\u2014\u2013]|\s+(?:y|o|and|or)\s+",
+    r"[.,;:\n|\u2014\u2013]|\s+(?:y|o|and|or)\s+",
     flags=re.IGNORECASE,
 )
 _DATE_RANGE_RE = re.compile(r"\b(?:19|20)\d{2}\s*[-–]\s*(?:19|20)\d{2}\b")
@@ -115,15 +116,17 @@ def validate_narrative_grounding(prose: str, metrics_block: str) -> list[str]:
     structural markers only (markdown heading numbers, module/section labels,
     parenthetical citation years, non-metric date ranges like ``2019-2023``, and
     fixed writing-rule phrases such as ``4 párrafos``). Business figures from
-    M2/Exhibits/M4 are allowed; only numeric claims near model performance or
-    interpretability terms must be anchored to ``metrics_block``.
+    M2/Exhibits/M4 and the M5 decision-matrix ``KPI esperado`` column are
+    allowed; only numeric claims near model performance or interpretability
+    terms must be anchored to ``metrics_block``.
     """
     if _FALLBACK_MARKER in metrics_block:
         return []
 
     violations = [f"CITA: {match.group(0)}" for match in _CITATION_RE.finditer(prose)]
     anchors = _extract_anchor_numbers(metrics_block)
-    numeric_prose = _strip_structural_numbers_for_numeric_anchoring(prose)
+    numeric_prose = _strip_m5_decision_matrix_kpi_cells(prose)
+    numeric_prose = _strip_structural_numbers_for_numeric_anchoring(numeric_prose)
     for raw_number, found in _iter_model_metric_numbers(numeric_prose):
         if not any(_within_tolerance(found, anchor) for anchor in anchors):
             violations.append(f"UNANCHORED: {raw_number}")
@@ -294,8 +297,8 @@ def _is_model_metric_number(prose: str, match: re.Match[str]) -> bool:
     """Return True when the matched number sits in the same clause as a model-metric keyword.
 
     A clause is bounded by sentence punctuation (``.``, ``;``, ``:``, em/en
-    dashes, newline), commas, and Spanish/English list connectors (``y``,
-    ``o``, ``and``, ``or``). Restricting the keyword search to the clause
+    dashes, newline, Markdown table pipes), commas, and Spanish/English list
+    connectors (``y``, ``o``, ``and``, ``or``). Restricting the keyword search to the clause
     around the number prevents false UNANCHORED violations when the same
     sentence mixes a legitimate model metric ("AUC 72%") with business figures
     ("ROI 35%"), a pattern that occurs in M4 ml_ds Harvard prose.
@@ -323,6 +326,75 @@ def _strip_structural_numbers_for_numeric_anchoring(prose: str) -> str:
     cleaned = _SECTION_REF_RE.sub(" ", cleaned)
     cleaned = _PARAGRAPH_RULE_RE.sub(" ", cleaned)
     return cleaned
+
+
+def _strip_m5_decision_matrix_kpi_cells(prose: str) -> str:
+    lines: list[str] = []
+    kpi_index: int | None = None
+    inside_m5_matrix = False
+    for line in prose.splitlines():
+        cells = _split_markdown_table_row(line)
+        if not cells:
+            inside_m5_matrix = False
+            kpi_index = None
+            lines.append(line)
+            continue
+
+        normalized_cells = [_normalize_table_cell(cell) for cell in cells]
+        if _is_m5_decision_matrix_header(normalized_cells):
+            inside_m5_matrix = True
+            kpi_index = normalized_cells.index("kpi esperado")
+            lines.append(line)
+            continue
+
+        if inside_m5_matrix and _is_markdown_separator_row(cells):
+            lines.append(line)
+            continue
+
+        if inside_m5_matrix and kpi_index is not None and len(cells) > kpi_index:
+            cells[kpi_index] = "KPI_ESPERADO_NEGOCIO"
+            lines.append("| " + " | ".join(cells) + " |")
+            continue
+
+        inside_m5_matrix = False
+        kpi_index = None
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _split_markdown_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if not stripped or "|" not in stripped:
+        return []
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def _is_markdown_separator_row(cells: list[str]) -> bool:
+    if not cells:
+        return False
+    return all(re.fullmatch(r":?-{3,}:?", cell.replace(" ", "")) for cell in cells)
+
+
+def _normalize_table_cell(cell: str) -> str:
+    compact = " ".join(cell.lower().split())
+    return "".join(
+        char
+        for char in unicodedata.normalize("NFKD", compact)
+        if not unicodedata.combining(char)
+    )
+
+
+def _is_m5_decision_matrix_header(normalized_cells: list[str]) -> bool:
+    return (
+        "accion" in normalized_cells
+        and "kpi esperado" in normalized_cells
+        and "riesgo" in normalized_cells
+        and "modelo soporte" in normalized_cells
+    )
 
 
 def _format_float(value: float) -> str:

--- a/backend/src/case_generator/narrative_grounding.py
+++ b/backend/src/case_generator/narrative_grounding.py
@@ -23,7 +23,7 @@ NARRATIVE_GROUNDING_WARNING = (
 _FALLBACK_MARKER = "M3_METRICS_SUMMARY_AUSENTE"
 _NUMBER_RE = re.compile(r"(?<![A-Za-z_])([+-]?\d+(?:[.,]\d+)?)\s*%?")
 _CITATION_RE = re.compile(
-    r"(?i)(según\s+(?:el\s+)?estudio|paper|et\s+al\.|\(\d{4}\))"
+    r"(?i)(seg[uú]n\s+(?:el\s+|un\s+|una\s+)?estudios?|et\s+al\.|\(\d{4}\))"
 )
 _MODEL_METRIC_CONTEXT_RE = re.compile(
     r"(?i)"
@@ -134,14 +134,15 @@ def validate_narrative_grounding(prose: str, metrics_block: str) -> list[str]:
 
 
 def contextualize_grounding_violations(prose: str, violations: list[str]) -> list[str]:
-    """Attach prior-output fragments to UNANCHORED violations for reprompts."""
+    """Attach prior-output fragments to grounding violations for reprompts."""
     contextualized: list[str] = []
     for violation in violations:
         raw_number = _extract_unanchored_raw_number(violation)
-        if raw_number is None:
-            contextualized.append(violation)
-            continue
-        fragment = _find_fragment_containing_number(prose, raw_number)
+        fragment = (
+            _find_fragment_containing_number(prose, raw_number)
+            if raw_number is not None
+            else _find_fragment_containing_citation(prose, violation)
+        )
         if fragment is None:
             contextualized.append(violation)
             continue
@@ -255,16 +256,38 @@ def _extract_unanchored_raw_number(violation: str) -> str | None:
     return raw_number or None
 
 
+def _extract_citation_raw_text(violation: str) -> str | None:
+    prefix = "CITA: "
+    if not violation.startswith(prefix):
+        return None
+    raw_text = violation[len(prefix):].strip()
+    return raw_text or None
+
+
+def _find_fragment_containing_citation(prose: str, violation: str) -> str | None:
+    raw_text = _extract_citation_raw_text(violation)
+    if raw_text is None:
+        return None
+    match = re.search(re.escape(raw_text), prose, flags=re.IGNORECASE)
+    if match is None:
+        return None
+    return _fragment_for_match(prose, match.start(), match.end())
+
+
 def _find_fragment_containing_number(prose: str, raw_number: str) -> str | None:
     match = _find_number_match(prose, raw_number)
     if match is None:
         return None
-    start, end = _sentence_bounds(prose, match.start(), match.end())
+    return _fragment_for_match(prose, match.start(), match.end())
+
+
+def _fragment_for_match(prose: str, match_start: int, match_end: int) -> str | None:
+    start, end = _sentence_bounds(prose, match_start, match_end)
     fragment = " ".join(prose[start:end].strip().split())
     if len(fragment) <= 240:
         return fragment
-    window_start = max(start, match.start() - 90)
-    window_end = min(end, match.end() + 90)
+    window_start = max(start, match_start - 90)
+    window_end = min(end, match_end + 90)
     compact = " ".join(prose[window_start:window_end].strip().split())
     return f"...{compact}..." if compact else None
 

--- a/backend/src/case_generator/narrative_grounding.py
+++ b/backend/src/case_generator/narrative_grounding.py
@@ -23,7 +23,9 @@ NARRATIVE_GROUNDING_WARNING = (
 _FALLBACK_MARKER = "M3_METRICS_SUMMARY_AUSENTE"
 _NUMBER_RE = re.compile(r"(?<![A-Za-z_])([+-]?\d+(?:[.,]\d+)?)\s*%?")
 _CITATION_RE = re.compile(
-    r"(?i)(seg[uú]n\s+(?:el\s+|un\s+|una\s+)?estudios?|et\s+al\.|\(\d{4}\))"
+    r"(?i)(seg[uú]n\s+(?:el\s+|un\s+|una\s+)?(?:estudios?|papers?)|"
+    r"papers?\s+(?:recientes?|extern[oa]s?|acad[eé]micos?|cient[ií]ficos?|de\s+[\wÁÉÍÓÚÑáéíóúñ.-]+)|"
+    r"et\s+al\.|\(\d{4}\))"
 )
 _MODEL_METRIC_CONTEXT_RE = re.compile(
     r"(?i)"
@@ -65,6 +67,18 @@ _MODELING_SKIPPED_STATUSES = {
     "skipped_degenerate_target",
     "skipped_non_binary_target",
     "skipped_no_features",
+}
+_M5_DECISION_MATRIX_HEADER_ALIASES = {
+    "accion": "accion",
+    "accion ejecutiva": "accion",
+    "accion recomendada": "accion",
+    "kpi esperado": "kpi esperado",
+    "indicador esperado": "kpi esperado",
+    "riesgo": "riesgo",
+    "riesgo principal": "riesgo",
+    "modelo soporte": "modelo soporte",
+    "modelo de soporte": "modelo soporte",
+    "soporte modelo": "modelo soporte",
 }
 
 
@@ -334,14 +348,11 @@ def _fragment_for_match(prose: str, match_start: int, match_end: int) -> str | N
 
 
 def _find_number_match(prose: str, raw_number: str) -> re.Match[str] | None:
-    escaped = re.escape(raw_number)
-    integer_number = raw_number.split(".", 1)[0]
-    candidates = [escaped]
-    if "." in raw_number:
-        candidates.append(re.escape(raw_number.replace(".", ",")))
-    if integer_number != raw_number:
-        candidates.append(re.escape(integer_number))
-    pattern = r"(?<!\d)(?:" + "|".join(dict.fromkeys(candidates)) + r")\s*%?"
+    normalized = raw_number.replace(",", ".")
+    candidates = [re.escape(normalized)]
+    if "." in normalized:
+        candidates.append(re.escape(normalized.replace(".", ",")))
+    pattern = r"(?<![\d.,])(?:" + "|".join(dict.fromkeys(candidates)) + r")\s*%?(?![\d.,])"
     return re.search(pattern, prose)
 
 
@@ -410,7 +421,7 @@ def _strip_m5_decision_matrix_kpi_cells(prose: str) -> str:
             lines.append(line)
             continue
 
-        normalized_cells = [_normalize_table_cell(cell) for cell in cells]
+        normalized_cells = [_normalize_m5_decision_matrix_header_cell(cell) for cell in cells]
         if _is_m5_decision_matrix_header(normalized_cells):
             inside_m5_matrix = True
             kpi_index = normalized_cells.index("kpi esperado")
@@ -456,6 +467,11 @@ def _normalize_table_cell(cell: str) -> str:
         for char in unicodedata.normalize("NFKD", compact)
         if not unicodedata.combining(char)
     )
+
+
+def _normalize_m5_decision_matrix_header_cell(cell: str) -> str:
+    normalized = _normalize_table_cell(cell)
+    return _M5_DECISION_MATRIX_HEADER_ALIASES.get(normalized, normalized)
 
 
 def _is_m5_decision_matrix_header(normalized_cells: list[str]) -> bool:

--- a/backend/src/case_generator/narrative_grounding.py
+++ b/backend/src/case_generator/narrative_grounding.py
@@ -31,6 +31,9 @@ _MODEL_METRIC_CONTEXT_RE = re.compile(
     r"especificidad|prevalencia|prevalence|baseline|dummy|coeficiente|coefficient|"
     r"importancia|importance|feature|variable|shap|permutation)\b"
 )
+_SKIPPED_ZERO_PLACEHOLDER_CONTEXT_RE = re.compile(
+    r"(?i)\b(auc|roc|f1|accuracy|exactitud|precision|precisión|recall|sensibilidad|especificidad)\b"
+)
 _ADJACENT_MODEL_METRIC_NUMBER_RE = re.compile(
     r"(?i)"
     r"(?<![A-Za-z_])"
@@ -58,6 +61,11 @@ _PARAGRAPH_RULE_RE = re.compile(
     r"\b(?:regla\s+de\s+los\s+)?\d+\s+p[aá]rrafos\b",
     flags=re.IGNORECASE,
 )
+_MODELING_SKIPPED_STATUSES = {
+    "skipped_degenerate_target",
+    "skipped_non_binary_target",
+    "skipped_no_features",
+}
 
 
 def build_computed_metrics_block(metrics_summary: dict | None) -> str:
@@ -125,9 +133,16 @@ def validate_narrative_grounding(prose: str, metrics_block: str) -> list[str]:
 
     violations = [f"CITA: {match.group(0)}" for match in _CITATION_RE.finditer(prose)]
     anchors = _extract_anchor_numbers(metrics_block)
+    modeling_was_skipped = _metrics_block_declares_modeling_skipped(metrics_block)
     numeric_prose = _strip_m5_decision_matrix_kpi_cells(prose)
     numeric_prose = _strip_structural_numbers_for_numeric_anchoring(numeric_prose)
-    for raw_number, found in _iter_model_metric_numbers(numeric_prose):
+    for raw_number, found, allows_skipped_zero_placeholder in _iter_model_metric_numbers(numeric_prose):
+        if (
+            modeling_was_skipped
+            and allows_skipped_zero_placeholder
+            and math.isclose(found, 0.0, abs_tol=1e-12)
+        ):
+            continue
         if not any(_within_tolerance(found, anchor) for anchor in anchors):
             violations.append(f"UNANCHORED: {raw_number}")
     return violations
@@ -210,6 +225,8 @@ def _extract_anchor_numbers(metrics_block: str) -> list[float]:
         if ":" not in line:
             continue
         value = line.split(":", 1)[1]
+        if not re.match(r"\s*[+-]?\d", value):
+            continue
         for match in _NUMBER_RE.finditer(value):
             anchors.append(float(match.group(1).replace(",", ".")))
     return anchors
@@ -222,14 +239,29 @@ def has_metric_anchors(metrics_block: str) -> bool:
     return bool(_extract_anchor_numbers(metrics_block))
 
 
-def _iter_model_metric_numbers(prose: str) -> list[tuple[str, float]]:
-    matches: list[tuple[int, str, float]] = []
+def _metrics_block_declares_modeling_skipped(metrics_block: str) -> bool:
+    for line in metrics_block.splitlines():
+        key, separator, value = line.partition(":")
+        if separator != ":" or key.strip().lower() != "modeling_status":
+            continue
+        return value.strip().lower() in _MODELING_SKIPPED_STATUSES
+    return False
+
+
+def _iter_model_metric_numbers(prose: str) -> list[tuple[str, float, bool]]:
+    matches: list[tuple[int, str, float, bool]] = []
     consumed_spans: list[tuple[int, int]] = []
 
     for match in _ADJACENT_MODEL_METRIC_NUMBER_RE.finditer(prose):
         raw_number = match.group("value").replace(",", ".")
         value_span = match.span("value")
-        matches.append((value_span[0], raw_number, float(raw_number)))
+        segment = match.group(0)
+        matches.append((
+            value_span[0],
+            raw_number,
+            float(raw_number),
+            _allows_skipped_zero_placeholder(segment),
+        ))
         consumed_spans.append(value_span)
 
     for match in _NUMBER_RE.finditer(prose):
@@ -239,9 +271,18 @@ def _iter_model_metric_numbers(prose: str) -> list[tuple[str, float]]:
         if not _is_model_metric_number(prose, match):
             continue
         raw_number = match.group(1).replace(",", ".")
-        matches.append((value_span[0], raw_number, float(raw_number)))
+        segment = _model_metric_clause(prose, value_span[0], value_span[1])
+        matches.append((
+            value_span[0],
+            raw_number,
+            float(raw_number),
+            _allows_skipped_zero_placeholder(segment),
+        ))
 
-    return [(raw_number, found) for _start, raw_number, found in sorted(matches)]
+    return [
+        (raw_number, found, allows_skipped_zero_placeholder)
+        for _start, raw_number, found, allows_skipped_zero_placeholder in sorted(matches)
+    ]
 
 
 def _spans_overlap(left: tuple[int, int], right: tuple[int, int]) -> bool:
@@ -326,15 +367,21 @@ def _is_model_metric_number(prose: str, match: re.Match[str]) -> bool:
     sentence mixes a legitimate model metric ("AUC 72%") with business figures
     ("ROI 35%"), a pattern that occurs in M4 ml_ds Harvard prose.
     """
-    start = match.start()
-    end = match.end()
+    segment = _model_metric_clause(prose, match.start(), match.end())
+    return bool(_MODEL_METRIC_CONTEXT_RE.search(segment))
+
+
+def _model_metric_clause(prose: str, start: int, end: int) -> str:
     seg_start = 0
     for boundary in _CLAUSE_BOUNDARY_RE.finditer(prose, 0, start):
         seg_start = boundary.end()
     forward = _CLAUSE_BOUNDARY_RE.search(prose, end)
     seg_end = forward.start() if forward else len(prose)
-    segment = prose[seg_start:seg_end]
-    return bool(_MODEL_METRIC_CONTEXT_RE.search(segment))
+    return prose[seg_start:seg_end]
+
+
+def _allows_skipped_zero_placeholder(segment: str) -> bool:
+    return bool(_SKIPPED_ZERO_PLACEHOLDER_CONTEXT_RE.search(segment))
 
 
 def _strip_structural_numbers_for_numeric_anchoring(prose: str) -> str:

--- a/backend/src/case_generator/narrative_grounding.py
+++ b/backend/src/case_generator/narrative_grounding.py
@@ -130,6 +130,22 @@ def validate_narrative_grounding(prose: str, metrics_block: str) -> list[str]:
     return violations
 
 
+def contextualize_grounding_violations(prose: str, violations: list[str]) -> list[str]:
+    """Attach prior-output fragments to UNANCHORED violations for reprompts."""
+    contextualized: list[str] = []
+    for violation in violations:
+        raw_number = _extract_unanchored_raw_number(violation)
+        if raw_number is None:
+            contextualized.append(violation)
+            continue
+        fragment = _find_fragment_containing_number(prose, raw_number)
+        if fragment is None:
+            contextualized.append(violation)
+            continue
+        contextualized.append(f'{violation} -> "{fragment}"')
+    return contextualized
+
+
 def _within_tolerance(found: float, anchor: float) -> bool:
     """Return True when ``found`` is close enough to ``anchor``.
 
@@ -226,6 +242,52 @@ def _iter_model_metric_numbers(prose: str) -> list[tuple[str, float]]:
 
 def _spans_overlap(left: tuple[int, int], right: tuple[int, int]) -> bool:
     return left[0] < right[1] and right[0] < left[1]
+
+
+def _extract_unanchored_raw_number(violation: str) -> str | None:
+    prefix = "UNANCHORED: "
+    if not violation.startswith(prefix):
+        return None
+    raw_number = violation[len(prefix):].strip()
+    return raw_number or None
+
+
+def _find_fragment_containing_number(prose: str, raw_number: str) -> str | None:
+    match = _find_number_match(prose, raw_number)
+    if match is None:
+        return None
+    start, end = _sentence_bounds(prose, match.start(), match.end())
+    fragment = " ".join(prose[start:end].strip().split())
+    if len(fragment) <= 240:
+        return fragment
+    window_start = max(start, match.start() - 90)
+    window_end = min(end, match.end() + 90)
+    compact = " ".join(prose[window_start:window_end].strip().split())
+    return f"...{compact}..." if compact else None
+
+
+def _find_number_match(prose: str, raw_number: str) -> re.Match[str] | None:
+    escaped = re.escape(raw_number)
+    integer_number = raw_number.split(".", 1)[0]
+    candidates = [escaped]
+    if "." in raw_number:
+        candidates.append(re.escape(raw_number.replace(".", ",")))
+    if integer_number != raw_number:
+        candidates.append(re.escape(integer_number))
+    pattern = r"(?<!\d)(?:" + "|".join(dict.fromkeys(candidates)) + r")\s*%?"
+    return re.search(pattern, prose)
+
+
+def _sentence_bounds(prose: str, start: int, end: int) -> tuple[int, int]:
+    left_candidates = [prose.rfind(boundary, 0, start) for boundary in ".!?\n"]
+    left = max(left_candidates)
+    seg_start = 0 if left == -1 else left + 1
+    right_positions = [
+        position for boundary in ".!?\n"
+        if (position := prose.find(boundary, end)) != -1
+    ]
+    seg_end = min(right_positions) + 1 if right_positions else len(prose)
+    return seg_start, seg_end
 
 
 def _is_model_metric_number(prose: str, match: re.Match[str]) -> bool:

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -1626,7 +1626,7 @@ defendiendo tu postura con evidencia de los módulos M1–M4.
 2. **Aplicación al caso:** Conecta el concepto con los datos y hallazgos específicos del caso.
 3. **Implicación ejecutiva:** Argumenta cómo este análisis define la decisión de la Junta.
 4. **Marco académico:** Relaciona tu postura con un framework reconocido
-   (Porter, Kahneman, Prahalad, Kotter u otro marco sólido — sin citar papers inventados).
+    (Porter, Kahneman, Prahalad, Kotter u otro marco sólido — sin citar fuentes externas inventadas).
 
 *Las preguntas aparecerán a continuación en el sistema.*
 
@@ -1663,7 +1663,7 @@ _NARRATIVE_GROUNDING_CLASSIFICATION_BLOCK = """\
 {computed_metrics_block}
 
 # Prohibición literal de grounding narrativo
-NUNCA cites estudios externos, papers, autores ni estadísticas de industria. Razona EXCLUSIVAMENTE sobre `{{computed_metrics_block}}` y el contexto del caso. Si una métrica de rendimiento o interpretabilidad del modelo (AUC, F1, precisión, recall, prevalencia, coeficiente, importancia, etc.) no está en `{{computed_metrics_block}}`, NO la escribas. Los números de negocio deben venir de M2, Exhibits o M4.
+NUNCA cites estudios externos, autores, referencias académicas fabricadas ni estadísticas de industria. Razona EXCLUSIVAMENTE sobre `{{computed_metrics_block}}` y el contexto del caso. Si una métrica de rendimiento o interpretabilidad del modelo (AUC, F1, precisión, recall, prevalencia, coeficiente, importancia, etc.) no está en `{{computed_metrics_block}}`, NO la escribas. Los números de negocio deben venir de M2, Exhibits o M4.
 """
 
 _M3_CLASSIFICATION_COHERENCE_BLOCK = """\
@@ -1789,7 +1789,7 @@ Párrafo 3 — Implicación ejecutiva (70-90 palabras): argumenta cómo este an�
 Párrafo 4 — Marco académico (40-60 palabras): relaciona la postura con un framework reconocido.
   REGLA ANTI-ALUCINACIÓN: citar SOLO frameworks ampliamente reconocidos (Porter, Kahneman,
   Prahalad, Kotter, Christensen, Osterwalder). Formato: "Según [Marco/Autor] ([concepto])..."
-  PROHIBIDO inventar títulos de papers, años específicos o autores desconocidos.
+  PROHIBIDO inventar títulos de fuentes externas, años específicos o autores desconocidos.
 
 # How You Work (Workflow)
 1. **Lee el contexto completo:** m5_content (informe de resolución), hallazgos M3/M4.
@@ -1807,7 +1807,7 @@ Párrafo 4 — Marco académico (40-60 palabras): relaciona la postura con un fr
 - EXACTAMENTE 3 preguntas — ni más, ni menos.
 - P2 DEBE usar el `{main_risk_from_m3_m4}` inyectado — es el push-back específico del caso.
 - P3 DEBE usar `{implementation_timeframe}` para un marco temporal realista.
-- solucion_esperada: NUNCA menciones papers inventados. Solo frameworks reconocidos sin año.
+- solucion_esperada: NUNCA menciones fuentes externas inventadas. Solo frameworks reconocidos sin año.
 - **Idioma de salida: {output_language}**
 
 # Perfil del estudiante: {student_profile}

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -2561,17 +2561,23 @@ M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO (Issue #236).**
      not None) and (y.nunique() == 2)`. Las celdas siguientes NO pueden
      asumir variables del bloque per-algoritmo (que se ejecuta DESPUÉS); usan
      `feature_cols`, `y`, `X_raw` e `is_binary` definidos aquí.
-   * **Guarda binaria consistente**: cada celda inicia con
-     `if not is_binary: print("Bloque comparativo omitido: target no
-     binario")` antes del trabajo real, dentro de su `try`. Esto garantiza
-     que un dataset multiclase NO produzca cascada de NameError ni mensajes
-     de error inútiles — solo el aviso pedagógico unificado.
-   * `ColumnTransformer` debe combinar `StandardScaler` para numéricas y
-     `OneHotEncoder(handle_unknown="ignore")` para categóricas (≤20
+   * **Guarda binaria consistente**: `dummy_baseline` fija `is_binary` y
+     `can_model_binary`. `is_binary` solo confirma 2 clases; `can_model_binary`
+     exige además `min_class >= 2` y `feature_cols` no vacío. Cada celda inicia
+     con `if not is_binary or not can_model_binary: ...` antes del trabajo real,
+     dentro de su `try`. Esto evita cascadas de fit sobre targets raros como
+     199/1, donde cualquier AUC o gráfico sería engañoso.
+   * `ColumnTransformer` debe combinar `SimpleImputer(strategy="median")` +
+     `StandardScaler` para numéricas y `SimpleImputer(strategy="most_frequent")`
+     + `OneHotEncoder(handle_unknown="ignore")` para categóricas (≤20
      cardinalidad). Particiona `feature_cols` por dtype antes del Pipeline.
-     NUNCA pre-codifiques con `pd.get_dummies` antes del split en este
-     bloque (el ColumnTransformer vive dentro del Pipeline para que el CV
-     no filtre estadísticos).
+     NUNCA pre-codifiques con `pd.get_dummies` antes del split en este bloque
+     (el ColumnTransformer vive dentro del Pipeline para que CV/hold-out no
+     filtren estadísticos).
+   * Las celdas Issue #240 (`tuning_lr`, `tuning_rf`, `interp_lr`, `interp_rf`)
+     deben entrenar y explicar modelos Pipeline con el MISMO preprocesamiento
+     robusto. PROHIBIDO usar `StandardScaler` o `RandomForestClassifier` directo
+     sobre `X_train` crudo porque puede contener strings y NaN.
    * `roc_curves` IMPORTA explícitamente `train_test_split` y construye su
      propio hold-out estratificado (`_Xtr/_Xte/_ytr/_yte`). `pr_curves` y
      `comparison_table` NO pueden depender de variables de celdas previas:
@@ -2635,8 +2641,8 @@ except Exception as e:
 ## `is_binary` a partir de `df` directamente. Las celdas siguientes NO
 ## pueden asumir variables del bloque per-algoritmo (que se ejecuta
 ## DESPUÉS de esta sección). Cada celda subsiguiente arranca con la
-## guarda `if not is_binary: print("Bloque comparativo omitido: target
-## no binario")` antes del trabajo real, dentro de su `try` aislado.
+## guarda `if not is_binary or not can_model_binary: print(...)` antes del
+## trabajo real, dentro de su `try` aislado.
 
 # %% [markdown]
 # ### 3.0.5 — Bloque comparativo Harvard
@@ -2683,12 +2689,27 @@ try:
         and df[c].isna().mean() <= 0.5
     ]
 
-    # 3) Derivar y, X_raw, is_binary. is_binary gobierna las 6 celdas siguientes.
+    # 3) Derivar y, X_raw, is_binary y can_model_binary. is_binary confirma
+    #    2 clases; can_model_binary exige soporte mínimo para train/test/CV.
     y = df[target_col] if target_col is not None else None
     X_raw = df[feature_cols] if feature_cols else None
     is_binary = bool(target_col is not None and y is not None and y.nunique(dropna=True) == 2)
+    _class_counts_boot = y.value_counts(dropna=True) if y is not None else pd.Series(dtype=int)
+    _min_class_boot = int(_class_counts_boot.min()) if len(_class_counts_boot) else 0
+    modeling_status = "ready"
+    modeling_skip_reason = ""
+    can_model_binary = bool(is_binary and X_raw is not None and len(feature_cols) > 0 and _min_class_boot >= 2)
+    if not is_binary:
+        modeling_status = "skipped_non_binary_target"
+        modeling_skip_reason = "target no binario o ausente"
+    elif X_raw is None or not feature_cols:
+        modeling_status = "skipped_no_features"
+        modeling_skip_reason = "sin features útiles tras higiene"
+    elif _min_class_boot < 2:
+        modeling_status = "skipped_degenerate_target"
+        modeling_skip_reason = f"clase minoritaria con solo {{_min_class_boot}} fila(s)"
 
-    if is_binary:
+    if can_model_binary:
         X_tr_d, X_te_d, y_tr_d, y_te_d = train_test_split(
             X_raw, y, test_size=0.2, random_state=42,
             stratify=y if y.value_counts().min() >= 2 else None,
@@ -2703,11 +2724,14 @@ try:
         print("Dummy stratified    → F1 macro:", _f1_dummy(y_te_d, dummy_st.predict(_Xte_dummy), average="macro", zero_division=0))
         print("Distribución y_train:", y_tr_d.value_counts(normalize=True).round(3).to_dict())
     else:
-        print("Bloque comparativo omitido: target no binario")
+        print(f"Bloque comparativo omitido: {{modeling_skip_reason}}")
 except Exception as e:
     # Failsafe: si el bootstrap falla, garantiza que las celdas siguientes
     # encuentren is_binary=False y emitan el aviso pedagógico estándar.
     is_binary = False
+    can_model_binary = False
+    modeling_status = "skipped_bootstrap_error"
+    modeling_skip_reason = str(e)[:200]
     print(f"⚠️ Dummy baseline falló: {{e}}")
 
 # %% [markdown]
@@ -2718,30 +2742,40 @@ except Exception as e:
 
 # %%
 # === SECTION:pipeline_lr ===
+pipe_lr = None
 try:
-    if not is_binary:
-        print("Bloque comparativo omitido: target no binario")
-    else:
-        from sklearn.pipeline import Pipeline
-        from sklearn.compose import ColumnTransformer
-        from sklearn.preprocessing import StandardScaler, OneHotEncoder
-        from sklearn.linear_model import LogisticRegression
+  if not is_binary or not can_model_binary:
+    print(f"Bloque comparativo omitido: {{modeling_skip_reason}}")
+  else:
+    from sklearn.pipeline import Pipeline
+    from sklearn.compose import ColumnTransformer
+    from sklearn.preprocessing import StandardScaler, OneHotEncoder
+    from sklearn.impute import SimpleImputer
+    from sklearn.linear_model import LogisticRegression
 
-        _num_feats = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
-        _cat_feats = [c for c in feature_cols if c not in _num_feats]
-        preprocess_lr = ColumnTransformer(
-            transformers=[
-                ("num", StandardScaler(), _num_feats),
-                ("cat", OneHotEncoder(handle_unknown="ignore"), _cat_feats),
-            ],
-            remainder="drop",
-        )
-        pipe_lr = Pipeline(steps=[
-            ("preprocess", preprocess_lr),
-            ("clf", LogisticRegression(max_iter=1000, class_weight="balanced", random_state=42)),
-        ])
-        pipe_lr.fit(X_raw, y)
-        print("Pipeline LR ajustado:", pipe_lr.named_steps["clf"])
+    _num_feats = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
+    _cat_feats = [c for c in feature_cols if c not in _num_feats]
+    _num_pipe_lr = Pipeline(steps=[
+      ("imputer", SimpleImputer(strategy="median")),
+      ("scaler", StandardScaler()),
+    ])
+    _cat_pipe_lr = Pipeline(steps=[
+      ("imputer", SimpleImputer(strategy="most_frequent")),
+      ("onehot", OneHotEncoder(handle_unknown="ignore")),
+    ])
+    preprocess_lr = ColumnTransformer(
+      transformers=[
+        ("num", _num_pipe_lr, _num_feats),
+        ("cat", _cat_pipe_lr, _cat_feats),
+      ],
+      remainder="drop",
+    )
+    pipe_lr = Pipeline(steps=[
+      ("preprocess", preprocess_lr),
+      ("clf", LogisticRegression(max_iter=1000, class_weight="balanced", random_state=42)),
+    ])
+    pipe_lr.fit(X_raw, y)
+    print("Pipeline LR ajustado:", pipe_lr.named_steps["clf"])
 except Exception as e:
     print(f"⚠️ Pipeline LR falló: {{e}}")
 
@@ -2750,30 +2784,40 @@ except Exception as e:
 
 # %%
 # === SECTION:pipeline_rf ===
+pipe_rf = None
 try:
-    if not is_binary:
-        print("Bloque comparativo omitido: target no binario")
-    else:
-        from sklearn.pipeline import Pipeline as _PipelineRF
-        from sklearn.compose import ColumnTransformer as _CTRF
-        from sklearn.preprocessing import StandardScaler as _StdRF, OneHotEncoder as _OheRF
-        from sklearn.ensemble import RandomForestClassifier
+  if not is_binary or not can_model_binary:
+    print(f"Bloque comparativo omitido: {{modeling_skip_reason}}")
+  else:
+    from sklearn.pipeline import Pipeline as _PipelineRF
+    from sklearn.compose import ColumnTransformer as _CTRF
+    from sklearn.preprocessing import StandardScaler as _StdRF, OneHotEncoder as _OheRF
+    from sklearn.impute import SimpleImputer as _SimpleImputerRF
+    from sklearn.ensemble import RandomForestClassifier
 
-        _num_feats_rf = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
-        _cat_feats_rf = [c for c in feature_cols if c not in _num_feats_rf]
-        preprocess_rf = _CTRF(
-            transformers=[
-                ("num", _StdRF(), _num_feats_rf),
-                ("cat", _OheRF(handle_unknown="ignore"), _cat_feats_rf),
-            ],
-            remainder="drop",
-        )
-        pipe_rf = _PipelineRF(steps=[
-            ("preprocess", preprocess_rf),
-            ("clf", RandomForestClassifier(n_estimators=200, class_weight="balanced", random_state=42)),
-        ])
-        pipe_rf.fit(X_raw, y)
-        print("Pipeline RF ajustado:", pipe_rf.named_steps["clf"])
+    _num_feats_rf = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
+    _cat_feats_rf = [c for c in feature_cols if c not in _num_feats_rf]
+    _num_pipe_rf = _PipelineRF(steps=[
+      ("imputer", _SimpleImputerRF(strategy="median")),
+      ("scaler", _StdRF()),
+    ])
+    _cat_pipe_rf = _PipelineRF(steps=[
+      ("imputer", _SimpleImputerRF(strategy="most_frequent")),
+      ("onehot", _OheRF(handle_unknown="ignore")),
+    ])
+    preprocess_rf = _CTRF(
+      transformers=[
+        ("num", _num_pipe_rf, _num_feats_rf),
+        ("cat", _cat_pipe_rf, _cat_feats_rf),
+      ],
+      remainder="drop",
+    )
+    pipe_rf = _PipelineRF(steps=[
+      ("preprocess", preprocess_rf),
+      ("clf", RandomForestClassifier(n_estimators=200, class_weight="balanced", random_state=42, n_jobs=1)),
+    ])
+    pipe_rf.fit(X_raw, y)
+    print("Pipeline RF ajustado:", pipe_rf.named_steps["clf"])
 except Exception as e:
     print(f"⚠️ Pipeline RF falló: {{e}}")
 
@@ -2786,9 +2830,9 @@ except Exception as e:
 # === SECTION:cv_scores ===
 cv_lr, cv_rf = None, None
 try:
-    if not is_binary:
-        print("Bloque comparativo omitido: target no binario")
-    else:
+  if not is_binary or not can_model_binary:
+    print(f"Bloque comparativo omitido: {{modeling_skip_reason}}")
+  else:
         from sklearn.model_selection import StratifiedKFold, cross_val_score
 
         _min_class = int(y.value_counts().min()) if y is not None and len(y) else 0
@@ -2810,9 +2854,9 @@ except Exception as e:
 # %%
 # === SECTION:roc_curves ===
 try:
-    if not is_binary:
-        print("Bloque comparativo omitido: target no binario")
-    else:
+  if not is_binary or not can_model_binary:
+    print(f"Bloque comparativo omitido: {{modeling_skip_reason}}")
+  else:
         from sklearn.model_selection import train_test_split
         from sklearn.metrics import roc_curve, roc_auc_score
 
@@ -2846,9 +2890,9 @@ except Exception as e:
 # %%
 # === SECTION:pr_curves ===
 try:
-    if not is_binary:
-        print("Bloque comparativo omitido: target no binario")
-    else:
+  if not is_binary or not can_model_binary:
+    print(f"Bloque comparativo omitido: {{modeling_skip_reason}}")
+  else:
         from sklearn.model_selection import train_test_split
         from sklearn.metrics import precision_recall_curve, average_precision_score
 
@@ -2882,9 +2926,9 @@ except Exception as e:
 # %%
 # === SECTION:comparison_table ===
 try:
-    if not is_binary:
-        print("Bloque comparativo omitido: target no binario")
-    else:
+  if not is_binary or not can_model_binary:
+    print(f"Bloque comparativo omitido: {{modeling_skip_reason}}")
+  else:
         import time as _time_cmp
         from sklearn.model_selection import train_test_split
         from sklearn.metrics import f1_score as _f1_cmp, recall_score as _rec_cmp
@@ -2950,9 +2994,9 @@ except Exception as e:
 # %%
 # === SECTION:cost_matrix ===
 try:
-    if not is_binary:
-        print("Bloque comparativo omitido: target no binario")
-    else:
+  if not is_binary or not can_model_binary:
+    print(f"Bloque comparativo omitido: {{modeling_skip_reason}}")
+  else:
         from sklearn.model_selection import train_test_split
         from sklearn.metrics import confusion_matrix
 
@@ -3044,64 +3088,77 @@ except Exception as e:
 # %%
 # === SECTION:tuning_lr ===
 try:
-    import numpy as np
-    import pandas as pd
-    from sklearn.linear_model import LogisticRegression
-    from sklearn.model_selection import GridSearchCV, StratifiedKFold, train_test_split
-    from sklearn.preprocessing import StandardScaler
-    from sklearn.pipeline import Pipeline
+  import numpy as np
+  import pandas as pd
+  from sklearn.compose import ColumnTransformer
+  from sklearn.impute import SimpleImputer
+  from sklearn.linear_model import LogisticRegression
+  from sklearn.model_selection import GridSearchCV, StratifiedKFold, train_test_split
+  from sklearn.pipeline import Pipeline
+  from sklearn.preprocessing import StandardScaler, OneHotEncoder
 
-    if not is_binary:
-        print("Tuning LR omitido: target no es binario.")
+  if not is_binary or not can_model_binary:
+    print(f"Tuning LR omitido: {{modeling_skip_reason}}")
+  else:
+    try:
+      X_train
+      y_train
+    except NameError:
+      X_train, X_test, y_train, y_test = train_test_split(
+        X_raw, y, test_size=0.2, random_state=42,
+        stratify=y if y.value_counts().min() >= 2 else None,
+      )
+    _num_feats_tune_lr = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
+    _cat_feats_tune_lr = [c for c in feature_cols if c not in _num_feats_tune_lr]
+    preprocess_tune_lr = ColumnTransformer(
+      transformers=[
+        ("num", Pipeline([
+          ("imputer", SimpleImputer(strategy="median")),
+          ("scaler", StandardScaler()),
+        ]), _num_feats_tune_lr),
+        ("cat", Pipeline([
+          ("imputer", SimpleImputer(strategy="most_frequent")),
+          ("onehot", OneHotEncoder(handle_unknown="ignore")),
+        ]), _cat_feats_tune_lr),
+      ],
+      remainder="drop",
+    )
+    n_train = len(X_train)
+    if n_train > 5000:
+      print(
+        f"⚠️ Modo rápido: dataset con {{n_train}} filas (> 5000) — "
+        f"se omite GridSearchCV y se entrena LogisticRegression con "
+        f"defaults (C=1.0, class_weight='balanced')."
+      )
+      best_lr = Pipeline([
+        ("preprocess", preprocess_tune_lr),
+        ("clf", LogisticRegression(C=1.0, class_weight="balanced",
+                       max_iter=2000, random_state=42)),
+      ])
+      best_lr.fit(X_train, y_train)
+      best_lr_params = {{"clf__C": 1.0, "note": "skipped tuning (n>5000)"}}
+      best_lr_score = float("nan")
     else:
-        # Self-bootstrap (Rule 6): recrear splits si no existen.
-        try:
-            X_train
-            y_train
-        except NameError:
-            X_train, X_test, y_train, y_test = train_test_split(
-                X_raw, y, test_size=0.2, random_state=42,
-                stratify=y if y.value_counts().min() >= 2 else None,
-            )
-        n_train = len(X_train)
-        # Cascada de mayor a menor — orden importa para que las ramas
-        # reducidas sean alcanzables (>5000 ⊂ >2000).
-        if n_train > 5000:
-            print(
-                f"⚠️ Modo rápido: dataset con {{n_train}} filas (> 5000) — "
-                f"se omite GridSearchCV y se entrena LogisticRegression con "
-                f"defaults (C=1.0, class_weight='balanced'). Razonamiento: "
-                f"el barrido 4 valores × 5 folds excedería el budget exec-time."
-            )
-            best_lr = Pipeline([
-                ("scaler", StandardScaler(with_mean=False)),
-                ("clf", LogisticRegression(C=1.0, class_weight="balanced",
-                                           max_iter=2000, random_state=42)),
-            ])
-            best_lr.fit(X_train, y_train)
-            best_lr_params = {{"C": 1.0, "note": "skipped tuning (n>5000)"}}
-            best_lr_score = float("nan")
-        else:
-            cv_splits = 3 if n_train > 2000 else 5
-            base_pipe_lr = Pipeline([
-                ("scaler", StandardScaler(with_mean=False)),
-                ("clf", LogisticRegression(class_weight="balanced",
-                                           max_iter=2000, random_state=42)),
-            ])
-            grid_lr = {{"clf__C": [0.01, 0.1, 1, 10]}}
-            cv_lr = StratifiedKFold(n_splits=cv_splits, shuffle=True, random_state=42)
-            search_lr = GridSearchCV(
-                base_pipe_lr, grid_lr, cv=cv_lr,
-                scoring="roc_auc", n_jobs=1, refit=True,
-            )
-            search_lr.fit(X_train, y_train)
-            best_lr = search_lr.best_estimator_
-            best_lr_params = dict(search_lr.best_params_)
-            best_lr_score = float(search_lr.best_score_)
-            print(
-                f"Best LR params: {{best_lr_params}} | "
-                f"best CV ROC-AUC: {{best_lr_score:.4f}}"
-            )
+      cv_splits = 3 if n_train > 2000 else 5
+      base_pipe_lr = Pipeline([
+        ("preprocess", preprocess_tune_lr),
+        ("clf", LogisticRegression(class_weight="balanced",
+                       max_iter=2000, random_state=42)),
+      ])
+      grid_lr = {{"clf__C": [0.01, 0.1, 1, 10]}}
+      cv_lr = StratifiedKFold(n_splits=cv_splits, shuffle=True, random_state=42)
+      search_lr = GridSearchCV(
+        base_pipe_lr, grid_lr, cv=cv_lr,
+        scoring="roc_auc", n_jobs=1, refit=True,
+      )
+      search_lr.fit(X_train, y_train)
+      best_lr = search_lr.best_estimator_
+      best_lr_params = dict(search_lr.best_params_)
+      best_lr_score = float(search_lr.best_score_)
+      print(
+        f"Best LR params: {{best_lr_params}} | "
+        f"best CV ROC-AUC: {{best_lr_score:.4f}}"
+      )
 except Exception as e:
     print(f"⚠️ Tuning LR falló: {{e}}")
 
@@ -3119,63 +3176,89 @@ except Exception as e:
 # %%
 # === SECTION:tuning_rf ===
 try:
-    import numpy as np
-    from sklearn.ensemble import RandomForestClassifier
-    from sklearn.model_selection import RandomizedSearchCV, StratifiedKFold, train_test_split
+  import numpy as np
+  from sklearn.compose import ColumnTransformer
+  from sklearn.ensemble import RandomForestClassifier
+  from sklearn.impute import SimpleImputer
+  from sklearn.model_selection import RandomizedSearchCV, StratifiedKFold, train_test_split
+  from sklearn.pipeline import Pipeline
+  from sklearn.preprocessing import StandardScaler, OneHotEncoder
 
-    if not is_binary:
-        print("Tuning RF omitido: target no es binario.")
+  if not is_binary or not can_model_binary:
+    print(f"Tuning RF omitido: {{modeling_skip_reason}}")
+  else:
+    try:
+      X_train
+      y_train
+    except NameError:
+      X_train, X_test, y_train, y_test = train_test_split(
+        X_raw, y, test_size=0.2, random_state=42,
+        stratify=y if y.value_counts().min() >= 2 else None,
+      )
+    _num_feats_tune_rf = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
+    _cat_feats_tune_rf = [c for c in feature_cols if c not in _num_feats_tune_rf]
+    preprocess_tune_rf = ColumnTransformer(
+      transformers=[
+        ("num", Pipeline([
+          ("imputer", SimpleImputer(strategy="median")),
+          ("scaler", StandardScaler()),
+        ]), _num_feats_tune_rf),
+        ("cat", Pipeline([
+          ("imputer", SimpleImputer(strategy="most_frequent")),
+          ("onehot", OneHotEncoder(handle_unknown="ignore")),
+        ]), _cat_feats_tune_rf),
+      ],
+      remainder="drop",
+    )
+    n_train = len(X_train)
+    if n_train > 5000:
+      print(
+        f"⚠️ Modo rápido: dataset con {{n_train}} filas (> 5000) — "
+        f"se omite RandomizedSearchCV y se entrena RandomForest con "
+        f"defaults (n_estimators=200, class_weight='balanced')."
+      )
+      best_rf = Pipeline([
+        ("preprocess", preprocess_tune_rf),
+        ("clf", RandomForestClassifier(
+          n_estimators=200, class_weight="balanced",
+          random_state=42, n_jobs=1,
+        )),
+      ])
+      best_rf.fit(X_train, y_train)
+      best_rf_params = {{"clf__n_estimators": 200, "note": "skipped tuning (n>5000)"}}
+      best_rf_score = float("nan")
     else:
-        try:
-            X_train
-            y_train
-        except NameError:
-            X_train, X_test, y_train, y_test = train_test_split(
-                X_raw, y, test_size=0.2, random_state=42,
-                stratify=y if y.value_counts().min() >= 2 else None,
-            )
-        n_train = len(X_train)
-        # Cascada de mayor a menor — orden importa para alcanzabilidad.
-        if n_train > 5000:
-            print(
-                f"⚠️ Modo rápido: dataset con {{n_train}} filas (> 5000) — "
-                f"se omite RandomizedSearchCV y se entrena RandomForest con "
-                f"defaults (n_estimators=200, class_weight='balanced')."
-            )
-            best_rf = RandomForestClassifier(
-                n_estimators=200, class_weight="balanced",
-                random_state=42, n_jobs=1,
-            )
-            best_rf.fit(X_train, y_train)
-            best_rf_params = {{"note": "skipped tuning (n>5000)"}}
-            best_rf_score = float("nan")
-        else:
-            n_iter_rf = 5 if n_train > 2000 else 10
-            cv_splits_rf = 3 if n_train > 2000 else 5
-            param_dist_rf = {{
-                "max_depth": [None, 5, 10, 20],
-                "min_samples_leaf": [1, 5, 20],
-                "n_estimators": [100, 200],
-            }}
-            search_rf = RandomizedSearchCV(
-                RandomForestClassifier(class_weight="balanced",
-                                       random_state=42, n_jobs=1),
-                param_distributions=param_dist_rf,
-                n_iter=n_iter_rf,
-                cv=cv_splits_rf,
-                scoring="roc_auc",
-                random_state=42,
-                n_jobs=1,
-                refit=True,
-            )
-            search_rf.fit(X_train, y_train)
-            best_rf = search_rf.best_estimator_
-            best_rf_params = dict(search_rf.best_params_)
-            best_rf_score = float(search_rf.best_score_)
-            print(
-                f"Best RF params: {{best_rf_params}} | "
-                f"best CV ROC-AUC: {{best_rf_score:.4f}}"
-            )
+      n_iter_rf = 5 if n_train > 2000 else 10
+      cv_splits_rf = 3 if n_train > 2000 else 5
+      param_dist_rf = {{
+        "clf__max_depth": [None, 5, 10, 20],
+        "clf__min_samples_leaf": [1, 5, 20],
+        "clf__n_estimators": [100, 200],
+      }}
+      base_pipe_rf = Pipeline([
+        ("preprocess", preprocess_tune_rf),
+        ("clf", RandomForestClassifier(class_weight="balanced",
+                         random_state=42, n_jobs=1)),
+      ])
+      cv_rf_search = StratifiedKFold(n_splits=cv_splits_rf, shuffle=True, random_state=42)
+      search_rf = RandomizedSearchCV(
+        base_pipe_rf,
+        param_distributions=param_dist_rf,
+        n_iter=n_iter_rf,
+        cv=cv_rf_search,
+        scoring="roc_auc",
+        random_state=42,
+        n_jobs=1,
+        refit=True,
+      )
+      search_rf.fit(X_train, y_train)
+      best_rf = search_rf.best_estimator_
+      best_rf_params = dict(search_rf.best_params_)
+      best_rf_score = float(search_rf.best_score_)
+      print(
+        f"Best RF params: {{best_rf_params}} | "
+        f"best CV ROC-AUC: {{best_rf_score:.4f}}"
+      )
 except Exception as e:
     print(f"⚠️ Tuning RF falló: {{e}}")
 
@@ -3196,13 +3279,15 @@ try:
     import numpy as np
     import pandas as pd
     import matplotlib.pyplot as plt
+    from sklearn.compose import ColumnTransformer
+    from sklearn.impute import SimpleImputer
     from sklearn.linear_model import LogisticRegression, LinearRegression
     from sklearn.model_selection import train_test_split
-    from sklearn.preprocessing import StandardScaler
     from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler, OneHotEncoder
 
-    if not is_binary:
-        print("Interpretabilidad LR omitida: target no es binario.")
+    if not is_binary or not can_model_binary:
+        print(f"Interpretabilidad LR omitida: {{modeling_skip_reason}}")
     else:
         try:
             X_train
@@ -3215,8 +3300,23 @@ try:
         try:
             best_lr
         except NameError:
+            _num_feats_interp_lr = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
+            _cat_feats_interp_lr = [c for c in feature_cols if c not in _num_feats_interp_lr]
+            preprocess_interp_lr = ColumnTransformer(
+                transformers=[
+                    ("num", Pipeline([
+                        ("imputer", SimpleImputer(strategy="median")),
+                        ("scaler", StandardScaler()),
+                    ]), _num_feats_interp_lr),
+                    ("cat", Pipeline([
+                        ("imputer", SimpleImputer(strategy="most_frequent")),
+                        ("onehot", OneHotEncoder(handle_unknown="ignore")),
+                    ]), _cat_feats_interp_lr),
+                ],
+                remainder="drop",
+            )
             best_lr = Pipeline([
-                ("scaler", StandardScaler(with_mean=False)),
+                ("preprocess", preprocess_interp_lr),
                 ("clf", LogisticRegression(C=1.0, class_weight="balanced",
                                            max_iter=2000, random_state=42)),
             ])
@@ -3228,11 +3328,13 @@ try:
         if not hasattr(clf_lr, "coef_"):
             print("⚠️ best_lr no expone coef_ — saltando odds ratios.")
         else:
-            feature_names_lr = (
-                list(X_train.columns) if hasattr(X_train, "columns")
-                else [f"f{{i}}" for i in range(clf_lr.coef_.shape[1])]
-            )
+            try:
+                feature_names_lr = list(best_lr.named_steps["preprocess"].get_feature_names_out())
+            except Exception:
+                feature_names_lr = [f"f{{i}}" for i in range(clf_lr.coef_.shape[1])]
             odds_ratios = np.exp(clf_lr.coef_.ravel())
+            if len(feature_names_lr) != len(odds_ratios):
+                feature_names_lr = [f"f{{i}}" for i in range(len(odds_ratios))]
             or_df = pd.DataFrame(
                 {{"feature": feature_names_lr, "odds_ratio": odds_ratios}}
             ).sort_values("odds_ratio", ascending=False)
@@ -3246,7 +3348,11 @@ try:
             top_idx_or = [feature_names_lr.index(f) for f in top_features_or]
             boot_or = np.empty((B_boot, len(top_idx_or)))
             n_boot = len(X_train)
-            X_arr = X_train.values if hasattr(X_train, "values") else np.asarray(X_train)
+            if hasattr(best_lr, "named_steps") and "preprocess" in best_lr.named_steps:
+                X_encoded = best_lr.named_steps["preprocess"].transform(X_train)
+            else:
+                X_encoded = X_train.values if hasattr(X_train, "values") else np.asarray(X_train)
+            X_arr = X_encoded
             y_arr = y_train.values if hasattr(y_train, "values") else np.asarray(y_train)
             for b in range(B_boot):
                 idx_b = rng_or.integers(0, n_boot, size=n_boot)
@@ -3269,34 +3375,28 @@ try:
             print(ci_df.to_string(index=False))
 
             # 3) VIF manual 1/(1-R²) — fallback sin statsmodels.
-            #    Para cada feature numérica, regresar todas las demás contra ella.
-            #    VIF >= 5 sugiere colinealidad; >= 10 problema serio.
-            if hasattr(X_train, "columns"):
-                numeric_cols_vif = [
-                    c for c in feature_names_lr
-                    if pd.api.types.is_numeric_dtype(X_train[c])
-                ]
-            else:
-                numeric_cols_vif = list(feature_names_lr)
+            numeric_cols_vif = list(X_train.select_dtypes(include=np.number).columns) if hasattr(X_train, "select_dtypes") else []
             vif_rows = []
-            for col in numeric_cols_vif[:15]:  # cap para budget exec-time
+            if len(numeric_cols_vif) < 2:
+              print("\\nVIF omitido: se requieren al menos 2 features numéricas.")
+            else:
+              X_vif = X_train[numeric_cols_vif].copy()
+              X_vif = X_vif.replace([np.inf, -np.inf], np.nan)
+              X_vif = X_vif.fillna(X_vif.median(numeric_only=True)).dropna(axis=1)
+              numeric_cols_vif = list(X_vif.columns)
+              for col in numeric_cols_vif[:15]:
                 others = [c for c in numeric_cols_vif if c != col]
                 if not others:
-                    continue
+                  continue
                 try:
-                    if hasattr(X_train, "columns"):
-                        Xj = X_train[others].values
-                        yj = X_train[col].values
-                    else:
-                        j_idx = numeric_cols_vif.index(col)
-                        Xj = np.delete(X_arr, j_idx, axis=1)
-                        yj = X_arr[:, j_idx]
-                    lin_vif = LinearRegression()
-                    lin_vif.fit(Xj, yj)
-                    r2 = float(lin_vif.score(Xj, yj))
-                    vif_val = float("inf") if r2 >= 0.999 else 1.0 / (1.0 - r2)
+                  Xj = X_vif[others].values
+                  yj = X_vif[col].values
+                  lin_vif = LinearRegression()
+                  lin_vif.fit(Xj, yj)
+                  r2 = float(lin_vif.score(Xj, yj))
+                  vif_val = float("inf") if r2 >= 0.999 else 1.0 / (1.0 - r2)
                 except Exception:
-                    vif_val = float("nan")
+                  vif_val = float("nan")
                 vif_rows.append({{"feature": col, "VIF": vif_val}})
             if vif_rows:
                 vif_df = pd.DataFrame(vif_rows).sort_values("VIF", ascending=False)
@@ -3328,11 +3428,15 @@ try:
     import pandas as pd
     import matplotlib.pyplot as plt
     from sklearn.ensemble import RandomForestClassifier
+    from sklearn.compose import ColumnTransformer
+    from sklearn.impute import SimpleImputer
     from sklearn.inspection import permutation_importance, PartialDependenceDisplay
     from sklearn.model_selection import train_test_split
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler, OneHotEncoder
 
-    if not is_binary:
-        print("Interpretabilidad RF omitida: target no es binario.")
+    if not is_binary or not can_model_binary:
+      print(f"Interpretabilidad RF omitida: {{modeling_skip_reason}}")
     else:
         try:
             X_train
@@ -3345,10 +3449,28 @@ try:
         try:
             best_rf
         except NameError:
-            best_rf = RandomForestClassifier(
+            _num_feats_interp_rf = [c for c in feature_cols if c in df.select_dtypes(include=np.number).columns]
+            _cat_feats_interp_rf = [c for c in feature_cols if c not in _num_feats_interp_rf]
+            preprocess_interp_rf = ColumnTransformer(
+              transformers=[
+                ("num", Pipeline([
+                  ("imputer", SimpleImputer(strategy="median")),
+                  ("scaler", StandardScaler()),
+                ]), _num_feats_interp_rf),
+                ("cat", Pipeline([
+                  ("imputer", SimpleImputer(strategy="most_frequent")),
+                  ("onehot", OneHotEncoder(handle_unknown="ignore")),
+                ]), _cat_feats_interp_rf),
+              ],
+              remainder="drop",
+            )
+            best_rf = Pipeline([
+              ("preprocess", preprocess_interp_rf),
+              ("clf", RandomForestClassifier(
                 n_estimators=200, class_weight="balanced",
                 random_state=42, n_jobs=1,
-            )
+              )),
+            ])
             best_rf.fit(X_train, y_train)
             print("⚠️ best_rf no encontrado en el kernel — fallback a RandomForest default.")
 
@@ -3420,6 +3542,17 @@ def _adam_metric_float(value):
 
 _metrics_summary = {{}}
 try:
+  try:
+    _adam_modeling_status = modeling_status
+  except NameError:
+    _adam_modeling_status = None
+  if isinstance(_adam_modeling_status, str) and _adam_modeling_status != "ready":
+    _metrics_summary["modeling_status"] = _adam_modeling_status
+    try:
+      _metrics_summary["modeling_skip_reason"] = str(modeling_skip_reason)[:300]
+    except Exception:
+      pass
+
   try:
     _adam_y = y
   except NameError:
@@ -3509,6 +3642,10 @@ print("ADAM_M3_METRICS_SUMMARY_JSON=" + _json_m3_metrics.dumps(_metrics_summary,
 ## Celda 2a — Entrenamiento + Métricas (código, SIN plots) [una por algoritmo]
 # %%
 try:
+    # Inicializa SIEMPRE el modelo antes de cualquier branch. Si usas nombres
+    # especializados, escribe `model_lr = None` / `model_rf = None` antes de
+    # preguntar `if model_lr is not None` o `if model_rf is not None`.
+    model = None
     # 1. INTENTO PRIMARIO: Buscar por alias semántico usando helpers del base template
     #    col = find_first_matching_column(df.columns, <alias_list>)
     # 2. INTENTO SECUNDARIO — FALLBACK HEURÍSTICO OBLIGATORIO si el paso 1 falla:
@@ -3534,6 +3671,9 @@ try:
     # 7. NO emitas plots en esta celda — la visualización va en 2b/2c/2d.
     # 8. Asigna `model`, `X`, `X_test`, `y_test`, `y_pred` a nombres reutilizables
     #    para que las celdas 2b/2c/2d puedan referirse a ellos sin re-entrenar.
+    # 9. Nunca hagas branch contra una variable de modelo no asignada en todos
+    #    los caminos. Patrón permitido:
+    #    `model_lr = None` → resolver datos → si todo es válido, entrenar y asignar.
     pass
 except Exception as e:
     print(f"⚠️ Error: {{e}}")

--- a/backend/tests/test_issue239_m3_notebook_executor.py
+++ b/backend/tests/test_issue239_m3_notebook_executor.py
@@ -25,6 +25,7 @@ from case_generator.m3_notebook_execution import (
     execute_m3_notebook,
     extract_metrics_summary_from_text,
     format_execution_failure_for_prompt,
+    is_m3_quality_warning_blocking,
     scrub_notebook_for_safe_execution,
 )
 from case_generator.prompts import M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION
@@ -390,13 +391,32 @@ def test_graph_executor_fails_closed_without_dataset() -> None:
         graph_module.m3_notebook_executor(_executor_state(doc7_dataset=[]), {})
 
 
-def test_resume_skip_treats_quality_warning_as_executor_completion() -> None:
+def test_resume_skip_requires_metrics_summary_not_quality_warning_only() -> None:
     state = {
         "m3_metrics_summary": None,
         "m3_quality_warning": "m3_quality_marker_missing: notebook executed without marker",
     }
 
-    assert graph_module._checkpoint_has_node_output("m3_notebook_executor", state)
+    assert not graph_module._checkpoint_has_node_output("m3_notebook_executor", state)
+
+
+def test_quality_warning_blocking_policy_allows_intentional_skip() -> None:
+    assert is_m3_quality_warning_blocking(
+        "m3_quality_marker_missing: notebook executed without marker",
+        None,
+    )
+    assert is_m3_quality_warning_blocking(
+        "m3_quality_auc_missing: notebook executed but no parseable AUC was emitted",
+        {"prevalence": 0.5},
+    )
+    assert not is_m3_quality_warning_blocking(
+        "m3_quality_auc_missing: notebook executed but no parseable AUC was emitted",
+        {"modeling_status": "skipped_degenerate_target", "prevalence": 0.005},
+    )
+    assert not is_m3_quality_warning_blocking(
+        "m3_quality_auc_out_of_range: best AUC 0.9950 outside [0.55, 0.99]",
+        {"auc_rf": 0.995},
+    )
 
 
 def test_graph_executor_reprompts_once_after_crash(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -423,6 +443,37 @@ def test_graph_executor_reprompts_once_after_crash(monkeypatch: pytest.MonkeyPat
     assert result["m3_notebook_code"] == "corrected notebook"
     assert result["m3_metrics_summary"] == _GOOD_METRICS
     assert result["current_agent"] == "m3_notebook_executor"
+
+
+def test_graph_executor_reprompts_once_after_missing_auc_quality_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"execute": 0, "generate": 0}
+
+    def fake_execute(**kwargs: Any) -> M3NotebookExecutionResult:
+        calls["execute"] += 1
+        if calls["execute"] == 1:
+            return M3NotebookExecutionResult(
+                {"prevalence": 0.5},
+                "m3_quality_auc_missing: notebook executed but no parseable AUC was emitted",
+            )
+        assert kwargs["notebook_code"] == "corrected notebook"
+        return M3NotebookExecutionResult(_GOOD_METRICS, None)
+
+    def fake_generate(*_args: Any, **kwargs: Any) -> tuple[str, str]:
+        calls["generate"] += 1
+        assert "quality_gate" in kwargs["execution_correction"]
+        assert "m3_quality_auc_missing" in kwargs["execution_correction"]
+        return "corrected notebook", "clasificacion"
+
+    monkeypatch.setattr(graph_module, "execute_m3_notebook", fake_execute)
+    monkeypatch.setattr(graph_module, "_generate_m3_notebook_code", fake_generate)
+
+    result = graph_module.m3_notebook_executor(_executor_state(), {})
+
+    assert calls == {"execute": 2, "generate": 1}
+    assert result["m3_notebook_code"] == "corrected notebook"
+    assert result["m3_metrics_summary"] == _GOOD_METRICS
 
 
 def test_graph_executor_unsafe_globals_reprompt_names_safe_replacement(

--- a/backend/tests/test_issue240_classification_tuning_interpretability.py
+++ b/backend/tests/test_issue240_classification_tuning_interpretability.py
@@ -119,6 +119,49 @@ def test_prompt_declares_is_binary_guard_in_each_new_cell() -> None:
         )
 
 
+def test_prompt_adds_imputation_to_classification_pipelines() -> None:
+    """NaNs en features reales no deben romper LR/RF ni tuning/interp."""
+    p = M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION
+    assert "SimpleImputer" in p
+    assert 'SimpleImputer(strategy="median")' in p
+    assert 'SimpleImputer(strategy="most_frequent")' in p
+    assert 'OneHotEncoder(handle_unknown="ignore")' in p
+
+
+def test_prompt_uses_can_model_binary_for_rare_class_guard() -> None:
+    """Targets 199/1 deben omitirse explícitamente, no intentar AUC falsa."""
+    p = M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION
+    assert "can_model_binary" in p
+    assert "_min_class_boot >= 2" in p
+    assert "skipped_degenerate_target" in p
+    assert "modeling_status" in p
+
+
+def test_prompt_tuning_uses_preprocess_pipelines_not_raw_mixed_x() -> None:
+    """Tuning debe operar sobre Pipeline(preprocess, clf), no sobre strings/NaNs crudos."""
+    p = M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION
+    tuning_lr_idx = p.index("# === SECTION:tuning_lr ===")
+    tuning_rf_idx = p.index("# === SECTION:tuning_rf ===")
+    interp_lr_idx = p.index("# === SECTION:interp_lr ===")
+    tuning_lr_cell = p[tuning_lr_idx:tuning_rf_idx]
+    tuning_rf_cell = p[tuning_rf_idx:interp_lr_idx]
+
+    assert '("preprocess", preprocess_tune_lr)' in tuning_lr_cell
+    assert '("preprocess", preprocess_tune_rf)' in tuning_rf_cell
+    assert 'grid_lr = {{"clf__C": [0.01, 0.1, 1, 10]}}' in tuning_lr_cell
+    assert '"clf__max_depth"' in tuning_rf_cell
+    assert '"clf__min_samples_leaf"' in tuning_rf_cell
+    assert '"clf__n_estimators"' in tuning_rf_cell
+
+
+def test_prompt_initializes_algorithm_model_names_before_branching() -> None:
+    """Per-algorithm generated cells must not branch on undefined model_lr/model_rf."""
+    p = M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION
+    assert "model_lr = None" in p
+    assert "model_rf = None" in p
+    assert "Nunca hagas branch contra una variable de modelo no asignada" in p
+
+
 def test_prompt_uses_vif_manual_fallback_not_statsmodels() -> None:
     """VIF: fallback manual `1/(1-R²)` con LinearRegression de sklearn.
     NO añadir statsmodels como dep (D1, decisión documentada en #240)."""

--- a/backend/tests/test_issue243_narrative_grounding.py
+++ b/backend/tests/test_issue243_narrative_grounding.py
@@ -151,6 +151,22 @@ def test_contextualizes_decimal_comma_and_adjacent_metric_numbers() -> None:
     ]
 
 
+def test_contextualizes_decimal_without_falling_back_to_unrelated_integer() -> None:
+    prose = (
+        "El segmento 0 quedó como referencia histórica. "
+        "En validación, el F1 fue 0,87 fuera del bloque computado."
+    )
+
+    contextualized = contextualize_grounding_violations(
+        prose,
+        ["UNANCHORED: 0.87"],
+    )
+
+    assert contextualized == [
+        'UNANCHORED: 0.87 -> "En validación, el F1 fue 0,87 fuera del bloque computado."'
+    ]
+
+
 def test_contextualization_preserves_violation_when_fragment_is_missing() -> None:
     contextualized = contextualize_grounding_violations(
         "El modelo se describe sin el número conflictivo.",
@@ -290,6 +306,27 @@ def test_validator_isolates_m5_decision_matrix_business_kpis_by_cell() -> None:
     assert "UNANCHORED: 87" in violations
 
 
+def test_validator_isolates_m5_decision_matrix_business_kpis_with_header_aliases() -> None:
+    block = build_computed_metrics_block({"auc_lr": 0.7234})
+    prose = """
+| acción recomendada | indicador esperado | riesgo principal | modelo de soporte |
+|---|---|---|---|
+| Piloto controlado | Reducir fuga 10% | Sesgo operativo | LR baseline |
+| Umbral ejecutivo | Ahorrar 22.50% del presupuesto | Falsos negativos | RF challenger |
+""".strip()
+
+    assert validate_narrative_grounding(prose, block) == []
+
+    violations = validate_narrative_grounding(
+        "| acción recomendada | indicador esperado | riesgo principal | modelo de soporte |\n"
+        "|---|---|---|---|\n"
+        "| Piloto | Control operativo | AUC 87% | LR baseline |",
+        block,
+    )
+
+    assert "UNANCHORED: 87" in violations
+
+
 def test_validator_accepts_number_within_tolerance() -> None:
     block = build_computed_metrics_block({"auc_lr": 0.7234})
 
@@ -332,6 +369,19 @@ def test_validator_flags_citation_patterns() -> None:
     assert any("et al." in v.lower() for v in citation_violations)
     assert any("(2023)" in v for v in citation_violations)
     assert all(not v.startswith("UNANCHORED: 2023") for v in violations)
+
+
+def test_validator_flags_external_paper_citation_patterns() -> None:
+    block = build_computed_metrics_block(SUMMARY)
+
+    violations = validate_narrative_grounding(
+        "Según un paper reciente, el mercado confirma la tesis. Un paper de Gartner refuerza el plan.",
+        block,
+    )
+
+    citation_violations = [v for v in violations if v.startswith("CITA: ")]
+    assert any("según un paper" in v.lower() for v in citation_violations)
+    assert any("paper de gartner" in v.lower() for v in citation_violations)
 
 
 def test_validator_allows_standalone_paper_and_negative_no_citation_phrases() -> None:
@@ -461,7 +511,7 @@ def test_reprompt_once_then_runtime_error_on_repeat_violation(monkeypatch: pytes
     monkeypatch.setattr(
         graph_module.Configuration,
         "from_runnable_config",
-        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+        MagicMock(return_value=SimpleNamespace(architect_model="fake-pro", writer_model="fake")),
     )
 
     with pytest.raises(RuntimeError, match="narrative grounding") as exc_info:
@@ -482,7 +532,7 @@ def test_reprompt_includes_unanchored_prior_output_fragment(monkeypatch: pytest.
     monkeypatch.setattr(
         graph_module.Configuration,
         "from_runnable_config",
-        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+        MagicMock(return_value=SimpleNamespace(architect_model="fake-pro", writer_model="fake")),
     )
 
     update = graph_module.m4_content_generator(_base_state(), config={})
@@ -508,15 +558,19 @@ def test_get_m4_llm_uses_pro_high_with_pro_medium_fallback(
 
     monkeypatch.setattr(graph_module, "ChatGoogleGenerativeAI", _FakeGemini)
 
-    result = graph_module._get_m4_llm()
+    result = graph_module._get_m4_llm("pro-override", "writer-override")
 
-    assert len(constructed) == 2
-    assert result[0].kwargs["model"] == "gemini-3.1-pro-preview"
+    assert len(constructed) == 4
+    assert result[0].kwargs["model"] == "pro-override"
     assert result[0].kwargs["thinking_level"] == "high"
     assert result[0].kwargs["max_output_tokens"] == 24576
-    assert constructed[1]["model"] == "gemini-3.1-pro-preview"
+    assert constructed[1]["model"] == "pro-override"
     assert constructed[1]["thinking_level"] == "medium"
     assert constructed[1]["max_output_tokens"] == 24576
+    assert constructed[2]["model"] == "writer-override"
+    assert constructed[2]["max_output_tokens"] == 24576
+    assert constructed[3]["model"] == "gemini-2.5-flash"
+    assert constructed[3]["max_output_tokens"] == 24576
 
 
 def test_get_m5_llm_uses_pro_medium_with_pro_low_fallback(
@@ -534,15 +588,53 @@ def test_get_m5_llm_uses_pro_medium_with_pro_low_fallback(
 
     monkeypatch.setattr(graph_module, "ChatGoogleGenerativeAI", _FakeGemini)
 
-    result = graph_module._get_m5_llm()
+    result = graph_module._get_m5_llm("pro-override", "writer-override")
 
-    assert len(constructed) == 2
-    assert result[0].kwargs["model"] == "gemini-3.1-pro-preview"
+    assert len(constructed) == 4
+    assert result[0].kwargs["model"] == "pro-override"
     assert result[0].kwargs["thinking_level"] == "medium"
     assert result[0].kwargs["max_output_tokens"] == 32768
-    assert constructed[1]["model"] == "gemini-3.1-pro-preview"
+    assert constructed[1]["model"] == "pro-override"
     assert constructed[1]["thinking_level"] == "low"
     assert constructed[1]["max_output_tokens"] == 32768
+    assert constructed[2]["model"] == "writer-override"
+    assert constructed[2]["max_output_tokens"] == 32768
+    assert constructed[3]["model"] == "gemini-2.5-flash"
+    assert constructed[3]["max_output_tokens"] == 32768
+
+
+def test_m4_content_uses_configurable_pro_llm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_llm = _FakeLLM(["El AUC fue 72% y se mantiene dentro del bloque computado."])
+    factory_kwargs: list[dict] = []
+
+    def _fake_get_m4_llm(model: str, fallback_model: str, **kwargs: object) -> _FakeLLM:
+        factory_kwargs.append({"model": model, "fallback_model": fallback_model, **kwargs})
+        return fake_llm
+
+    monkeypatch.setattr(graph_module, "_get_m4_llm", _fake_get_m4_llm)
+    monkeypatch.setattr(
+        graph_module.Configuration,
+        "from_runnable_config",
+        MagicMock(
+            return_value=SimpleNamespace(
+                architect_model="pro-override",
+                writer_model="writer-override",
+            )
+        ),
+    )
+
+    update = graph_module.m4_content_generator(_base_state(), config={})
+
+    assert update["m4_content"] == "El AUC fue 72% y se mantiene dentro del bloque computado."
+    assert factory_kwargs == [
+        {
+            "model": "pro-override",
+            "fallback_model": "writer-override",
+            "temperature": 0.5,
+        }
+    ]
 
 
 def test_m5_content_uses_dedicated_pro_llm_and_accepts_matrix_business_kpis(
@@ -563,8 +655,8 @@ El AUC fue 72% y sostiene una lectura prudente para Junta Directiva.
     fake_llm = _FakeLLM([m5_output])
     factory_kwargs: list[dict] = []
 
-    def _fake_get_m5_llm(**kwargs: object) -> _FakeLLM:
-        factory_kwargs.append(kwargs)
+    def _fake_get_m5_llm(model: str, fallback_model: str, **kwargs: object) -> _FakeLLM:
+        factory_kwargs.append({"model": model, "fallback_model": fallback_model, **kwargs})
         return fake_llm
 
     monkeypatch.setattr(graph_module, "_get_m5_llm", _fake_get_m5_llm)
@@ -572,7 +664,13 @@ El AUC fue 72% y sostiene una lectura prudente para Junta Directiva.
     update = graph_module.m5_content_generator(_base_state(), config={})
 
     assert update["m5_content"] == m5_output
-    assert factory_kwargs == [{"temperature": 0.6}]
+    assert factory_kwargs == [
+        {
+            "model": "gemini-3.1-pro-preview",
+            "fallback_model": "gemini-3-flash-preview",
+            "temperature": 0.6,
+        }
+    ]
     assert len(fake_llm.prompts) == 1
 
 
@@ -582,7 +680,7 @@ def test_grounding_disabled_when_summary_absent(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(
         graph_module.Configuration,
         "from_runnable_config",
-        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+        MagicMock(return_value=SimpleNamespace(architect_model="fake-pro", writer_model="fake")),
     )
 
     update = graph_module.m4_content_generator(_base_state(metrics_summary=None), config={})
@@ -600,7 +698,7 @@ def test_grounding_disabled_when_summary_has_no_numeric_anchors(
     monkeypatch.setattr(
         graph_module.Configuration,
         "from_runnable_config",
-        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+        MagicMock(return_value=SimpleNamespace(architect_model="fake-pro", writer_model="fake")),
     )
 
     update = graph_module.m4_content_generator(_base_state(metrics_summary={}), config={})
@@ -622,7 +720,7 @@ def test_m4_allows_zero_metric_placeholders_when_m3_modeling_was_skipped(
     monkeypatch.setattr(
         graph_module.Configuration,
         "from_runnable_config",
-        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+        MagicMock(return_value=SimpleNamespace(architect_model="fake-pro", writer_model="fake")),
     )
 
     update = graph_module.m4_content_generator(
@@ -651,7 +749,7 @@ def test_m4_still_reprompts_positive_metric_when_m3_modeling_was_skipped(
     monkeypatch.setattr(
         graph_module.Configuration,
         "from_runnable_config",
-        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+        MagicMock(return_value=SimpleNamespace(architect_model="fake-pro", writer_model="fake")),
     )
 
     update = graph_module.m4_content_generator(
@@ -718,7 +816,7 @@ def test_m4_graph_reaches_sync_after_contextualized_reprompt(
     monkeypatch.setattr(
         graph_module.Configuration,
         "from_runnable_config",
-        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+        MagicMock(return_value=SimpleNamespace(architect_model="fake-pro", writer_model="fake")),
     )
 
     final_state = graph_module.m4_graph.invoke(_base_state(), config={"configurable": {}})

--- a/backend/tests/test_issue243_narrative_grounding.py
+++ b/backend/tests/test_issue243_narrative_grounding.py
@@ -361,6 +361,53 @@ def test_validator_strips_date_ranges_but_keeps_percentages() -> None:
     )
 
 
+def test_validator_allows_zero_metric_placeholder_when_modeling_was_skipped() -> None:
+    block = build_computed_metrics_block(
+        {
+            "modeling_status": "skipped_degenerate_target",
+            "modeling_skip_reason": "clase minoritaria con solo 1 fila",
+            "prevalence": 0.005,
+        }
+    )
+
+    assert validate_narrative_grounding(
+        "El notebook no reportó AUC: 0 ni F1: 0 porque no era válido entrenar.",
+        block,
+    ) == []
+    assert "UNANCHORED: 0" in validate_narrative_grounding(
+        "El notebook sí calculó la prevalencia, pero la prevalencia fue 0%.",
+        block,
+    )
+    assert "UNANCHORED: 87" in validate_narrative_grounding(
+        "El notebook no entrenó modelo, pero AUC 87% sería una mejora clara.",
+        block,
+    )
+
+
+def test_validator_does_not_treat_textual_skip_reason_digits_as_anchors() -> None:
+    block = build_computed_metrics_block(
+        {
+            "modeling_status": "skipped_degenerate_target",
+            "modeling_skip_reason": "clase minoritaria con solo 1 fila",
+            "prevalence": 0.005,
+        }
+    )
+
+    assert "UNANCHORED: 1" in validate_narrative_grounding(
+        "El AUC 1 sería perfecto, pero no está anclado.",
+        block,
+    )
+
+
+def test_validator_still_flags_zero_metric_when_modeling_was_not_skipped() -> None:
+    block = build_computed_metrics_block({"auc_lr": 0.7234})
+
+    assert "UNANCHORED: 0" in validate_narrative_grounding(
+        "El AUC fue 0 tras el ajuste.",
+        block,
+    )
+
+
 def test_prompts_inject_computed_metrics_block_only_for_classification() -> None:
     rendered = M4_PROMPT_CLASSIFICATION.format(
         contexto_m1="M1",
@@ -417,9 +464,10 @@ def test_reprompt_once_then_runtime_error_on_repeat_violation(monkeypatch: pytes
         MagicMock(return_value=SimpleNamespace(writer_model="fake")),
     )
 
-    with pytest.raises(RuntimeError, match="narrative grounding"):
+    with pytest.raises(RuntimeError, match="narrative grounding") as exc_info:
         graph_module.m4_content_generator(_base_state(), config={})
 
+    assert "Pérez et al. confirma el mismo resultado." in str(exc_info.value)
     assert len(fake_llm.prompts) == 2
     assert "- CITA:" in fake_llm.prompts[1]
     assert "Según el estudio, el modelo funcionó." in fake_llm.prompts[1]
@@ -560,6 +608,66 @@ def test_grounding_disabled_when_summary_has_no_numeric_anchors(
     assert update["m4_content"] == "El AUC fue 87%."
     assert update["narrative_grounding_warning"] == NARRATIVE_GROUNDING_WARNING
     assert len(fake_llm.prompts) == 1
+
+
+def test_m4_allows_zero_metric_placeholders_when_m3_modeling_was_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    m4_output = (
+        "El notebook no reportó AUC: 0 ni F1: 0 porque la clase minoritaria "
+        "no tenía soporte suficiente. La prevalencia computada fue 0.5%."
+    )
+    fake_llm = _FakeLLM([m4_output])
+    monkeypatch.setattr(graph_module, "_get_m4_llm", lambda *args, **kwargs: fake_llm)
+    monkeypatch.setattr(
+        graph_module.Configuration,
+        "from_runnable_config",
+        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+    )
+
+    update = graph_module.m4_content_generator(
+        _base_state(
+            metrics_summary={
+                "modeling_status": "skipped_degenerate_target",
+                "modeling_skip_reason": "clase minoritaria con solo 1 fila",
+                "prevalence": 0.005,
+            }
+        ),
+        config={},
+    )
+
+    assert update["m4_content"] == m4_output
+    assert len(fake_llm.prompts) == 1
+
+
+def test_m4_still_reprompts_positive_metric_when_m3_modeling_was_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_llm = _FakeLLM([
+        "El notebook no entrenó modelo, pero AUC 87% sería una mejora clara.",
+        "El notebook no reportó AUC: 0 porque no era válido entrenar.",
+    ])
+    monkeypatch.setattr(graph_module, "_get_m4_llm", lambda *args, **kwargs: fake_llm)
+    monkeypatch.setattr(
+        graph_module.Configuration,
+        "from_runnable_config",
+        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+    )
+
+    update = graph_module.m4_content_generator(
+        _base_state(
+            metrics_summary={
+                "modeling_status": "skipped_degenerate_target",
+                "modeling_skip_reason": "clase minoritaria con solo 1 fila",
+                "prevalence": 0.005,
+            }
+        ),
+        config={},
+    )
+
+    assert update["m4_content"] == "El notebook no reportó AUC: 0 porque no era válido entrenar."
+    assert len(fake_llm.prompts) == 2
+    assert "UNANCHORED: 87" in fake_llm.prompts[1]
 
 
 def test_m4_graph_reaches_sync_after_contextualized_reprompt(

--- a/backend/tests/test_issue243_narrative_grounding.py
+++ b/backend/tests/test_issue243_narrative_grounding.py
@@ -29,6 +29,7 @@ from case_generator.prompts import (
     M5_CONTENT_GENERATOR_PROMPT,
     M5_PROMPT_BY_FAMILY,
     M5_PROMPT_CLASSIFICATION,
+    M5_QUESTIONS_GENERATOR_PROMPT,
 )
 
 
@@ -157,6 +158,23 @@ def test_contextualization_preserves_violation_when_fragment_is_missing() -> Non
     )
 
     assert contextualized == ["UNANCHORED: 70", "CITA: paper"]
+
+
+def test_contextualizes_citation_with_prior_output_fragment() -> None:
+    prose = (
+        "La recomendación se apoya en evidencia del caso. "
+        "Según el estudio, el marco externo confirma la decisión. "
+        "La Junta debe deliberar con datos propios."
+    )
+
+    contextualized = contextualize_grounding_violations(
+        prose,
+        ["CITA: Según el estudio"],
+    )
+
+    assert contextualized == [
+        'CITA: Según el estudio -> "Según el estudio, el marco externo confirma la decisión."'
+    ]
 
 
 def test_validator_allows_business_numbers_from_case_context() -> None:
@@ -303,16 +321,31 @@ def test_validator_flags_citation_patterns() -> None:
     block = build_computed_metrics_block(SUMMARY)
 
     violations = validate_narrative_grounding(
-        "Según el estudio, la mejora coincide con Pérez et al. (2023).",
+        "Según el estudio, Segun estudio adicional, la mejora coincide con Pérez et al. (2023).",
         block,
     )
 
     citation_violations = [v for v in violations if v.startswith("CITA: ")]
-    assert len(citation_violations) == 3
+    assert len(citation_violations) == 4
     assert any("según el estudio" in v.lower() for v in citation_violations)
+    assert any("segun estudio" in v.lower() for v in citation_violations)
     assert any("et al." in v.lower() for v in citation_violations)
     assert any("(2023)" in v for v in citation_violations)
     assert all(not v.startswith("UNANCHORED: 2023") for v in violations)
+
+
+def test_validator_allows_standalone_paper_and_negative_no_citation_phrases() -> None:
+    block = build_computed_metrics_block(SUMMARY)
+
+    allowed_samples = [
+        "El comité redacta un position paper interno sin usar fuentes externas.",
+        "El estudiante debe responder sin citar papers inventados.",
+        "Marco académico: sin citar fuentes externas inventadas.",
+        "NUNCA cites estudios externos, autores ni referencias académicas fabricadas.",
+    ]
+
+    for sample in allowed_samples:
+        assert validate_narrative_grounding(sample, block) == []
 
 
 def test_validator_strips_date_ranges_but_keeps_percentages() -> None:
@@ -344,7 +377,8 @@ def test_prompts_inject_computed_metrics_block_only_for_classification() -> None
     )
 
     literal_rule = (
-        "NUNCA cites estudios externos, papers, autores ni estadísticas de industria. "
+        "NUNCA cites estudios externos, autores, referencias académicas fabricadas "
+        "ni estadísticas de industria. "
         "Razona EXCLUSIVAMENTE sobre `{computed_metrics_block}` y el contexto del caso. "
         "Si una métrica de rendimiento o interpretabilidad del modelo (AUC, F1, "
         "precisión, recall, prevalencia, coeficiente, importancia, etc.) no está "
@@ -359,6 +393,8 @@ def test_prompts_inject_computed_metrics_block_only_for_classification() -> None
         assert "computed_metrics_block" in prompt
     assert literal_rule in rendered
     assert "auc_lr: 0.7234" in rendered
+    assert "paper" not in M5_PROMPT_CLASSIFICATION.lower()
+    assert "paper" not in M5_QUESTIONS_GENERATOR_PROMPT.lower()
 
     for family in ("regresion", "clustering", "serie_temporal"):
         assert M3_CONTENT_PROMPT_BY_FAMILY[family] is M3_EXPERIMENT_PROMPT
@@ -386,6 +422,7 @@ def test_reprompt_once_then_runtime_error_on_repeat_violation(monkeypatch: pytes
 
     assert len(fake_llm.prompts) == 2
     assert "- CITA:" in fake_llm.prompts[1]
+    assert "Según el estudio, el modelo funcionó." in fake_llm.prompts[1]
 
 
 def test_reprompt_includes_unanchored_prior_output_fragment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_issue243_narrative_grounding.py
+++ b/backend/tests/test_issue243_narrative_grounding.py
@@ -16,6 +16,7 @@ import case_generator.graph as graph_module
 from case_generator.narrative_grounding import (
     NARRATIVE_GROUNDING_WARNING,
     build_computed_metrics_block,
+    contextualize_grounding_violations,
     validate_narrative_grounding,
 )
 from case_generator.prompts import (
@@ -59,6 +60,19 @@ class _FakeLLM:
         if not self._outputs:
             raise AssertionError("Fake LLM invoked more times than expected")
         return _FakeResponse(self._outputs.pop(0))
+
+
+class _FakeStructuredLLM:
+    def __init__(self, output: object) -> None:
+        self.output = output
+        self.prompts: list[str] = []
+
+    def with_structured_output(self, _schema: object) -> "_FakeStructuredLLM":
+        return self
+
+    def invoke(self, prompt: str) -> object:
+        self.prompts.append(prompt)
+        return self.output
 
 
 def _base_state(*, metrics_summary: dict | None = SUMMARY) -> dict:
@@ -106,6 +120,43 @@ def test_validator_flags_unanchored_number() -> None:
     violations = validate_narrative_grounding("El modelo logró 87% de AUC.", block)
 
     assert "UNANCHORED: 87" in violations
+
+
+def test_contextualizes_unanchored_percent_with_prior_output_fragment() -> None:
+    prose = (
+        "El modelo conserva una base estable. "
+        "En producción, la tasa de rechazo del 70% supera el umbral operativo. "
+        "La decisión requiere monitoreo."
+    )
+
+    contextualized = contextualize_grounding_violations(prose, ["UNANCHORED: 70"])
+
+    assert contextualized == [
+        'UNANCHORED: 70 -> "En producción, la tasa de rechazo del 70% supera el umbral operativo."'
+    ]
+
+
+def test_contextualizes_decimal_comma_and_adjacent_metric_numbers() -> None:
+    prose = "El F1 fue 0,87 en validación. AUC95% quedó fuera del bloque computado."
+
+    contextualized = contextualize_grounding_violations(
+        prose,
+        ["UNANCHORED: 0.87", "UNANCHORED: 95"],
+    )
+
+    assert contextualized == [
+        'UNANCHORED: 0.87 -> "El F1 fue 0,87 en validación."',
+        'UNANCHORED: 95 -> "AUC95% quedó fuera del bloque computado."',
+    ]
+
+
+def test_contextualization_preserves_violation_when_fragment_is_missing() -> None:
+    contextualized = contextualize_grounding_violations(
+        "El modelo se describe sin el número conflictivo.",
+        ["UNANCHORED: 70", "CITA: paper"],
+    )
+
+    assert contextualized == ["UNANCHORED: 70", "CITA: paper"]
 
 
 def test_validator_allows_business_numbers_from_case_context() -> None:
@@ -301,7 +352,7 @@ def test_reprompt_once_then_runtime_error_on_repeat_violation(monkeypatch: pytes
         "Según el estudio, el modelo funcionó.",
         "Pérez et al. confirma el mismo resultado.",
     ])
-    monkeypatch.setattr(graph_module, "_get_writer_llm", lambda *args, **kwargs: fake_llm)
+    monkeypatch.setattr(graph_module, "_get_m4_llm", lambda *args, **kwargs: fake_llm)
     monkeypatch.setattr(
         graph_module.Configuration,
         "from_runnable_config",
@@ -315,9 +366,55 @@ def test_reprompt_once_then_runtime_error_on_repeat_violation(monkeypatch: pytes
     assert "- CITA:" in fake_llm.prompts[1]
 
 
+def test_reprompt_includes_unanchored_prior_output_fragment(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_llm = _FakeLLM([
+        "La tasa de rechazo del 70% asociada al AUC supera el umbral operativo.",
+        "El AUC fue 72% y se mantiene dentro del bloque computado.",
+    ])
+    monkeypatch.setattr(graph_module, "_get_m4_llm", lambda *args, **kwargs: fake_llm)
+    monkeypatch.setattr(
+        graph_module.Configuration,
+        "from_runnable_config",
+        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+    )
+
+    update = graph_module.m4_content_generator(_base_state(), config={})
+
+    assert update["m4_content"] == "El AUC fue 72% y se mantiene dentro del bloque computado."
+    assert len(fake_llm.prompts) == 2
+    assert "UNANCHORED: 70" in fake_llm.prompts[1]
+    assert "La tasa de rechazo del 70% asociada al AUC supera el umbral operativo." in fake_llm.prompts[1]
+
+
+def test_get_m4_llm_uses_pro_high_with_pro_medium_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed: list[dict] = []
+
+    class _FakeGemini:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+            constructed.append(kwargs)
+
+        def with_fallbacks(self, fallbacks: list[object]) -> tuple["_FakeGemini", list[object]]:
+            return self, fallbacks
+
+    monkeypatch.setattr(graph_module, "ChatGoogleGenerativeAI", _FakeGemini)
+
+    result = graph_module._get_m4_llm()
+
+    assert len(constructed) == 2
+    assert result[0].kwargs["model"] == "gemini-3.1-pro-preview"
+    assert result[0].kwargs["thinking_level"] == "high"
+    assert result[0].kwargs["max_output_tokens"] == 24576
+    assert constructed[1]["model"] == "gemini-3.1-pro-preview"
+    assert constructed[1]["thinking_level"] == "medium"
+    assert constructed[1]["max_output_tokens"] == 24576
+
+
 def test_grounding_disabled_when_summary_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_llm = _FakeLLM(["Según el estudio, el modelo logró 87%."])
-    monkeypatch.setattr(graph_module, "_get_writer_llm", lambda *args, **kwargs: fake_llm)
+    monkeypatch.setattr(graph_module, "_get_m4_llm", lambda *args, **kwargs: fake_llm)
     monkeypatch.setattr(
         graph_module.Configuration,
         "from_runnable_config",
@@ -335,7 +432,7 @@ def test_grounding_disabled_when_summary_has_no_numeric_anchors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_llm = _FakeLLM(["El AUC fue 87%."])
-    monkeypatch.setattr(graph_module, "_get_writer_llm", lambda *args, **kwargs: fake_llm)
+    monkeypatch.setattr(graph_module, "_get_m4_llm", lambda *args, **kwargs: fake_llm)
     monkeypatch.setattr(
         graph_module.Configuration,
         "from_runnable_config",
@@ -347,6 +444,67 @@ def test_grounding_disabled_when_summary_has_no_numeric_anchors(
     assert update["m4_content"] == "El AUC fue 87%."
     assert update["narrative_grounding_warning"] == NARRATIVE_GROUNDING_WARNING
     assert len(fake_llm.prompts) == 1
+
+
+def test_m4_graph_reaches_sync_after_contextualized_reprompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content_llm = _FakeLLM([
+        "La tasa de rechazo del 70% asociada al AUC supera el umbral operativo.",
+        "El AUC fue 72% y se mantiene anclado al notebook ejecutado.",
+    ])
+    questions_llm = _FakeStructuredLLM(
+        SimpleNamespace(
+            preguntas=[
+                SimpleNamespace(
+                    model_dump=lambda: {
+                        "numero": 1,
+                        "titulo": "Impacto",
+                        "enunciado": "Compare A/B/C con métricas de M4.",
+                        "solucion_esperada": "Debe elegir con evidencia.",
+                        "bloom_level": "analysis",
+                        "m4_section_ref": "4.2",
+                    }
+                )
+            ]
+        )
+    )
+    chart_llm = _FakeStructuredLLM(
+        SimpleNamespace(
+            charts=[
+                SimpleNamespace(
+                    model_dump=lambda: {
+                        "id": "m4_chart_01",
+                        "title": "ROI",
+                        "subtitle": "Comparativo",
+                        "library": "plotly",
+                        "chart_type": "bar",
+                        "traces": [],
+                        "layout": {},
+                        "source": "Análisis Financiero — case_issue_243",
+                        "notes": "Mock",
+                    }
+                )
+            ]
+        )
+    )
+    monkeypatch.setattr(graph_module, "_get_m4_llm", lambda *args, **kwargs: content_llm)
+    monkeypatch.setattr(graph_module, "_get_writer_llm", lambda *args, **kwargs: questions_llm)
+    monkeypatch.setattr(graph_module, "_get_chart_llm", lambda *args, **kwargs: chart_llm)
+    monkeypatch.setattr(
+        graph_module.Configuration,
+        "from_runnable_config",
+        MagicMock(return_value=SimpleNamespace(writer_model="fake")),
+    )
+
+    final_state = graph_module.m4_graph.invoke(_base_state(), config={"configurable": {}})
+
+    assert final_state["m4_content"] == "El AUC fue 72% y se mantiene anclado al notebook ejecutado."
+    assert final_state["m4_questions"]
+    assert final_state["m4_charts"]
+    assert final_state["current_agent"] in {"m4_questions_generator", "m4_chart_generator"}
+    assert "UNANCHORED: 70" in content_llm.prompts[1]
+    assert "La tasa de rechazo del 70% asociada al AUC supera el umbral operativo." in content_llm.prompts[1]
 
 
 def test_select_narrative_prompt_falls_back_to_clasificacion_for_unresolved_algo() -> None:

--- a/backend/tests/test_issue243_narrative_grounding.py
+++ b/backend/tests/test_issue243_narrative_grounding.py
@@ -250,6 +250,28 @@ def test_validator_isolates_business_number_in_mixed_clause() -> None:
     assert not any("UNANCHORED: 35" == v for v in bad_violations)
 
 
+def test_validator_isolates_m5_decision_matrix_business_kpis_by_cell() -> None:
+    block = build_computed_metrics_block({"auc_lr": 0.7234})
+    prose = """
+| acción | KPI esperado | riesgo | modelo soporte |
+|---|---|---|---|
+| Piloto controlado | Reducir fuga 10% | Sesgo operativo | LR baseline |
+| Umbral ejecutivo | Ahorrar 22.50% del presupuesto | Falsos negativos | RF challenger |
+| Monitoreo mensual | Mantener prevalencia comercial 15.4% | Drift | evidencia M2/M4 |
+""".strip()
+
+    assert validate_narrative_grounding(prose, block) == []
+
+    violations = validate_narrative_grounding(
+        "| acción | KPI esperado | riesgo | modelo soporte |\n"
+        "|---|---|---|---|\n"
+        "| Piloto | Control operativo | AUC 87% | LR baseline |",
+        block,
+    )
+
+    assert "UNANCHORED: 87" in violations
+
+
 def test_validator_accepts_number_within_tolerance() -> None:
     block = build_computed_metrics_block({"auc_lr": 0.7234})
 
@@ -410,6 +432,63 @@ def test_get_m4_llm_uses_pro_high_with_pro_medium_fallback(
     assert constructed[1]["model"] == "gemini-3.1-pro-preview"
     assert constructed[1]["thinking_level"] == "medium"
     assert constructed[1]["max_output_tokens"] == 24576
+
+
+def test_get_m5_llm_uses_pro_medium_with_pro_low_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed: list[dict] = []
+
+    class _FakeGemini:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+            constructed.append(kwargs)
+
+        def with_fallbacks(self, fallbacks: list[object]) -> tuple["_FakeGemini", list[object]]:
+            return self, fallbacks
+
+    monkeypatch.setattr(graph_module, "ChatGoogleGenerativeAI", _FakeGemini)
+
+    result = graph_module._get_m5_llm()
+
+    assert len(constructed) == 2
+    assert result[0].kwargs["model"] == "gemini-3.1-pro-preview"
+    assert result[0].kwargs["thinking_level"] == "medium"
+    assert result[0].kwargs["max_output_tokens"] == 32768
+    assert constructed[1]["model"] == "gemini-3.1-pro-preview"
+    assert constructed[1]["thinking_level"] == "low"
+    assert constructed[1]["max_output_tokens"] == 32768
+
+
+def test_m5_content_uses_dedicated_pro_llm_and_accepts_matrix_business_kpis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    m5_output = """
+### Informe de Resolución
+
+El AUC fue 72% y sostiene una lectura prudente para Junta Directiva.
+
+| acción | KPI esperado | riesgo | modelo soporte |
+|---|---|---|---|
+| Piloto controlado | Reducir fuga 10% | Sesgo operativo | LR baseline |
+| Umbral ejecutivo | Ahorrar 22.50% del presupuesto | Falsos negativos | RF challenger |
+| Monitoreo mensual | Mantener prevalencia comercial 15.4% | Drift | evidencia M2/M4 |
+| Comité de revisión | Reducir escalamiento 8% | Fatiga operativa | matriz de costos |
+""".strip()
+    fake_llm = _FakeLLM([m5_output])
+    factory_kwargs: list[dict] = []
+
+    def _fake_get_m5_llm(**kwargs: object) -> _FakeLLM:
+        factory_kwargs.append(kwargs)
+        return fake_llm
+
+    monkeypatch.setattr(graph_module, "_get_m5_llm", _fake_get_m5_llm)
+
+    update = graph_module.m5_content_generator(_base_state(), config={})
+
+    assert update["m5_content"] == m5_output
+    assert factory_kwargs == [{"temperature": 0.6}]
+    assert len(fake_llm.prompts) == 1
 
 
 def test_grounding_disabled_when_summary_absent(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Harden generated M3 classification notebooks for deployment-scale edge cases: NaN-safe preprocessing with `SimpleImputer`, pipeline-based LR/RF tuning and interpretation, rare-target `can_model_binary` guards, and explicit `modeling_status` / `modeling_skip_reason` metadata.
- Make the M3 notebook executor fail closed when the metrics marker/AUC contract is missing, while allowing intentional skip summaries for degenerate/non-binary/no-feature datasets.
- Fix M4 narrative grounding for intentional M3 modeling skips so zero placeholders like `AUC: 0` / `F1: 0` do not fail `UNANCHORED: 0`, while invented positive metrics such as `AUC 87%` still reprompt/fail closed.
- Add `contextualize_grounding_violations(...)` so `UNANCHORED` correction reprompts include the exact prior-output sentence/fragment containing the unanchored number.
- Harden citation and metric-grounding validation after pre-landing review: catch external `paper` / `papers` citation patterns, keep decimal contextualization exact instead of falling back to bare integers, and align M5 decision-matrix KPI stripping with the same header aliases accepted by graph validation.
- Keep M4 and M5 on Gemini Pro by default, but restore operational escape hatches through `Configuration`: `architect_model` drives the Pro primary/fallback chain, `writer_model` is the configured fallback, and `gemini-2.5-flash` remains the final stable fallback.
- Fix M5 narrative-grounding false positives by treating Markdown table pipes as clause boundaries and protecting the M5 decision-matrix `KPI esperado` column as business KPI context, while still flagging model metrics in non-KPI cells.
- Fix LangGraph Studio local dev entrypoints by loading `shared.app:app` and `case_generator.graph:get_graph` via module imports instead of stale file-path targets.

## Pre-Landing Review Follow-Up

Five external review comments were triaged against the live PR diff:

- Valid and fixed: citation regex missing external `paper` / `papers` forms.
- Valid and fixed: `_find_number_match()` could contextualize a decimal violation with an unrelated bare integer.
- Valid and fixed: M5 KPI-cell stripping did not honor graph-level header aliases such as `indicador esperado` and `modelo de soporte`.
- Valid and fixed: `_get_m4_llm()` had become hardcoded to `gemini-3.1-pro-preview` and ignored model override/fallback controls.
- Valid and fixed: `_get_m5_llm()` had become hardcoded to the preview model for both primary and fallback paths.

A read-only second pass over the full diff found no remaining blockers.

## Validation

Latest backend validation after review fixes:

- `git diff --check` -> clean
- `uv run --directory backend pytest tests/test_issue243_narrative_grounding.py -q` -> 40 passed
- `uv run --directory backend pytest tests/test_issue239_m3_notebook_executor.py tests/test_issue240_classification_tuning_interpretability.py tests/test_issue243_narrative_grounding.py -q` -> 106 passed
- `uv run --directory backend mypy src` -> Success: no issues found in 48 source files
- `uv run --directory backend pytest -q` -> 711 passed, 13 skipped, 1 warning
- VS Code Problems check on touched backend/test files -> no errors found

Earlier full PR gate before the backend-only review follow-up:

- `npm --prefix frontend run lint` -> passed
- `npm --prefix frontend run test` -> 60 passed, 426 tests passed
- `npm --prefix frontend run build` -> passed, Vite production build completed

## Notes

- A first full backend run during the prior ship pass had one transient failure in `test_tiny_real_runner_smoke_loads_base_plotting_stack`. The test passed in isolation immediately after, and later full backend reruns passed.
- Prompt-related files changed, but this repository currently has no executable `test/evals` or eval runner, so there was no LLM eval suite to run.
- Repo policy: no root `VERSION` / `CHANGELOG.md` files are used here, so no release-file churn was introduced.
- GitHub secret scanning is not enabled for this repository. The diff was reviewed and contains no literal secrets.