### PR TITLE
Fix M4 grounding success condition prompt

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -4,6 +4,22 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
+## TODO-243-A: Excepción estrecha para umbrales prospectivos en grounding narrativo
+
+**What:** Evaluar si `validate_narrative_grounding` debe permitir números técnicos dentro de contextos explícitamente prospectivos, como "Condición mínima de éxito", "target futuro" o recomendaciones de monitoreo, sin tratarlos como métricas ejecutadas del notebook.
+
+**Why:** El hotfix de M4 evita pedir umbrales numéricos aspiracionales en el prompt, pero a largo plazo podría ser pedagógicamente útil permitir cortes futuros controlados (por ejemplo, un umbral de deploy) sin fallar la generación del caso.
+
+**Pros:** Permitiría recomendaciones de producción más específicas cuando el equipo quiera umbrales técnicos explícitos; reduce dependencia de que el LLM siempre reformule en lenguaje cualitativo.
+
+**Cons:** Una excepción amplia podría ocultar métricas de modelo inventadas y debilitar el guardrail de Issue #243. Requiere regex/contexto muy estrecho y pruebas negativas fuertes para que `El AUC fue 87%` siga fallando si no está anclado.
+
+**Context:** El fallo de producción vino de M4 `ml_ds + clasificacion`: el prompt pedía una condición mínima de éxito y Gemini emitió `AUC de 0.70`; el validador lo rechazó como `UNANCHORED` porque no estaba en `m3_metrics_summary`. La corrección inmediata cambió el prompt para pedir una condición cualitativa o anclada, dejando intacto el validador.
+
+**Depends on / blocked by:** Telemetría de M4 después del hotfix y plan-eng-review dedicado si se decide relajar el validador.
+
+---
+
 ## TODO-239-A: Two-pass M3-content grounding con métricas ejecutadas
 
 **What:** Evaluar un rediseño two-pass donde M3-content pueda recibir métricas ejecutadas del notebook, no solo M4/M5.

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -1372,7 +1372,10 @@ KPIs base obligatorios (en formato tabla Markdown):
 | ROI del modelo | X% |
 | Payback estimado | X meses |
 | Riesgo principal de producción | concept drift / sesgo / disponibilidad datos |
-Condición mínima de éxito: umbral de métrica técnica que debe mantenerse en producción.
+Condición mínima de éxito: criterio operativo cualitativo o anclado al desempeño técnico
+ya observado en M3 (estabilidad, monitoreo, retraining o rollback). No inventes umbrales
+numéricos futuros de AUC/F1/recall/precisión; si necesitas un número técnico, reutiliza
+únicamente una métrica ya reportada en M3.
 
 # Context
 Narrativa M1: {contexto_m1}

--- a/backend/tests/test_issue243_narrative_grounding.py
+++ b/backend/tests/test_issue243_narrative_grounding.py
@@ -490,6 +490,8 @@ def test_prompts_inject_computed_metrics_block_only_for_classification() -> None
         assert "computed_metrics_block" in prompt
     assert literal_rule in rendered
     assert "auc_lr: 0.7234" in rendered
+    assert "umbral de métrica técnica que debe mantenerse" not in rendered
+    assert "No inventes umbrales\nnuméricos futuros de AUC/F1/recall/precisión" in rendered
     assert "paper" not in M5_PROMPT_CLASSIFICATION.lower()
     assert "paper" not in M5_QUESTIONS_GENERATOR_PROMPT.lower()
 
@@ -500,6 +502,55 @@ def test_prompts_inject_computed_metrics_block_only_for_classification() -> None
         assert "computed_metrics_block" not in M3_CONTENT_PROMPT_BY_FAMILY[family]
         assert "computed_metrics_block" not in M4_PROMPT_BY_FAMILY[family]
         assert "computed_metrics_block" not in M5_PROMPT_BY_FAMILY[family]
+
+
+def test_m4_accepts_qualitative_minimum_success_condition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    m4_output = (
+        "Condición mínima de éxito: mantener estabilidad del desempeño observado en M3 "
+        "con monitoreo continuo, retraining planificado y rollback si aparece degradación."
+    )
+    fake_llm = _FakeLLM([m4_output])
+    monkeypatch.setattr(graph_module, "_get_m4_llm", lambda *args, **kwargs: fake_llm)
+    monkeypatch.setattr(
+        graph_module.Configuration,
+        "from_runnable_config",
+        MagicMock(return_value=SimpleNamespace(architect_model="fake-pro", writer_model="fake")),
+    )
+
+    update = graph_module.m4_content_generator(_base_state(), config={})
+
+    assert update["m4_content"] == m4_output
+    assert len(fake_llm.prompts) == 1
+
+
+def test_m4_reprompts_aspirational_numeric_threshold_from_prior_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bad_output = (
+        "Condición mínima de éxito futuro: ningún modelo predictivo deberá pasar a "
+        "producción hasta que un baseline interpretable supere consistentemente un AUC de 0.70 "
+        "con datos en tiempo real."
+    )
+    fixed_output = (
+        "Condición mínima de éxito: sostener el desempeño observado en M3 con monitoreo "
+        "continuo y rollback si hay degradación."
+    )
+    fake_llm = _FakeLLM([bad_output, fixed_output])
+    monkeypatch.setattr(graph_module, "_get_m4_llm", lambda *args, **kwargs: fake_llm)
+    monkeypatch.setattr(
+        graph_module.Configuration,
+        "from_runnable_config",
+        MagicMock(return_value=SimpleNamespace(architect_model="fake-pro", writer_model="fake")),
+    )
+
+    update = graph_module.m4_content_generator(_base_state(), config={})
+
+    assert update["m4_content"] == fixed_output
+    assert len(fake_llm.prompts) == 2
+    assert "UNANCHORED: 0.70" in fake_llm.prompts[1]
+    assert bad_output in fake_llm.prompts[1]
 
 
 def test_reprompt_once_then_runtime_error_on_repeat_violation(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Update the M4 `ml_ds` deployment recommendation prompt so the minimum success condition is qualitative or anchored to already observed M3 performance instead of asking for a fresh numeric technical threshold.
- Add Issue #243 regression coverage for the production-shaped `AUC de 0.70` unanchored threshold path and for qualitative success conditions that should pass without reprompt.
- Add `TODO-243-A` to track the deferred validator-exception option for explicitly prospective thresholds.

## Why
The classification grounding validator correctly rejects model metric numbers that are not anchored in `m3_metrics_summary`. M4 was also asking the LLM for a future technical threshold, which encouraged invented aspirational values such as `AUC de 0.70`; if the reprompt repeated that number, the authoring job failed. This patch resolves the prompt/validator contract mismatch without weakening the validator.

## Tests
- `uv run --directory backend pytest tests/test_issue243_narrative_grounding.py -q` (`42 passed`)
- `uv run --directory backend pytest tests/test_issue239_m3_notebook_executor.py tests/test_issue243_narrative_grounding.py -q` (`88 passed`)

## Notes
- Remote GitHub secret scanning could not run because GitHub Advanced Security is not enabled for the repository.
- This intentionally does not add a prospective-threshold validator exception in the hotfix; that path is captured in `TODO-243-A` for a separate review.