### PR TITLE
Make M5 final question a decision memo

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -4,6 +4,38 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
+## TODO-M5-A: Evaluar contrato dedicado `m5Memo` para memorándum final
+
+**What:** Evaluar si M5 debe evolucionar desde el contrato compatible actual `m5Questions[0]` / `m5QuestionsSolutions[0]` hacia un artefacto explícito `m5Memo` con UI y grading propios.
+
+**Why:** El cambio actual mantiene el contrato de preguntas para minimizar riesgo de despliegue y compatibilidad con casos históricos. Si el memorándum final se vuelve una experiencia de evaluación distinta, un contrato dedicado podría expresar mejor el dominio.
+
+**Pros:** Permitiría una UI de memo más rica, validaciones semánticas específicas y un flujo de calificación diseñado para documentos ejecutivos largos en vez de tarjetas de pregunta.
+
+**Cons:** Requiere migración o compatibilidad dual, tocar backend output adapters, sanitización, student runtime, teacher submission detail y frontend preview. Aumenta la superficie de QA.
+
+**Context:** La implementación de M5 memo en este PR conserva `m5_questions` como lista de longitud 1 porque `frontend_output_adapter`, sanitizers, student/teacher reads y `renderPreguntas` ya soportan ese shape. Empezar por `m5_questions_generator`, `frontend_output_adapter`, `M5ExecutiveReport` y los fallbacks de teacher submission detail.
+
+**Depends on / blocked by:** Decisión de producto de que el memo final necesita UI/grading distinto al flujo actual de preguntas. No bloquea el rollout de M5 como una sola consigna tipo memo.
+
+---
+
+## TODO-M5-B: Suite eval/golden para calidad del memorándum M5
+
+**What:** Diseñar una suite de evaluación para el prompt de M5 memo en casos `business`, `ml_ds + clasificacion` y al menos un caso sin M2/M3 ejecutado.
+
+**Why:** Los tests determinísticos protegen schema, copy y no filtrado de soluciones, pero no juzgan si el memorándum generado toma una decisión fuerte, usa evidencia real, responde al riesgo principal y mantiene calidad pedagógica.
+
+**Pros:** Daría una señal de calidad antes de futuros cambios de prompt; ayudaría a comparar baselines y evitar regresiones sutiles de coherencia ejecutiva.
+
+**Cons:** Requiere fixtures, criterios de scoring y mantenimiento de baselines. Si usa live LLM, añade costo, latencia y potencial flakiness.
+
+**Context:** El prompt M5 ahora pide una consigna única de memorándum y una `solucion_esperada` modelo con decisión, evidencia, riesgo, implementación y criterio académico. La suite debería verificar que no invente cifras, no reintroduzca rúbricas ni términos que disparen falsos positivos conocidos del grounding narrativo.
+
+**Depends on / blocked by:** Definir harness de eval/golden estable y confirmar si la suite será puramente fixture-based o marcada como `live_llm` opt-in.
+
+---
+
 ## TODO-243-A: Excepción estrecha para umbrales prospectivos en grounding narrativo
 
 **What:** Evaluar si `validate_narrative_grounding` debe permitir números técnicos dentro de contextos explícitamente prospectivos, como "Condición mínima de éxito", "target futuro" o recomendaciones de monitoreo, sin tratarlos como métricas ejecutadas del notebook.

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -3155,10 +3155,10 @@ def m4_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
 # v7 — NODO: M5 QUESTIONS GENERATOR (Módulo Recomendación)
 # ─────────────────────────────────────────────────────────
 def m5_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
-    """Genera 3 preguntas de Junta Directiva del Módulo 5.
+    """Genera la consigna única de memorándum final del Módulo 5.
 
     v9: usa GeneradorPreguntasM5Output (PreguntaM5) — solucion_esperada sin límite
-    de 60 palabras, 4 párrafos (250-300 palabras), para calificación comparativa por IA.
+    de 60 palabras, en formato memorándum modelo, para calificación comparativa por IA.
     doc1_preguntas_complejas se pasa como historial de referencia (no como fuente):
     el LLM lo usa para no repetir temas ya evaluados en M1.
     Corre DESPUÉS de synthesis_phase1_sync — necesita m5_content del state.
@@ -3198,9 +3198,12 @@ def m5_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
         ).invoke(M5_QUESTIONS_GENERATOR_PROMPT.format(**context))
 
         preguntas = [p.model_dump() for p in resultado.preguntas]
-        print(f"[m5_questions_generator] {len(preguntas)} preguntas Junta Directiva")
+        print(f"[m5_questions_generator] {len(preguntas)} memorándum final")
         return {"m5_questions": preguntas, "current_agent": "m5_questions_generator"}
     except RuntimeError:
+        raise
+    except (ValidationError, OutputParserException, ValueError) as e:
+        logger.warning("[m5_questions_generator] OUTPUT INVÁLIDO (reintentando/fallando): %s", e)
         raise
     except Exception as e:
         err_msg = str(e)
@@ -4488,14 +4491,14 @@ def eda_phase2_sync(state: ADAMState) -> dict:
 def synthesis_phase1_sync(state: ADAMState) -> dict:
     """Fan-in 1: m5_content + teaching_note_part1 listos.
     Después de este barrier, m5_questions_generator corre primero (secuencial),
-    luego teaching_note_part2 con m5_questions disponibles.
+    luego teaching_note_part2 con la consigna M5 disponible.
     """
     print("[synthesis_phase1_sync] Barrier 1 OK — m5_content disponible")
     return {}
 
 
 def synthesis_phase2_sync(state: ADAMState) -> dict:
-    """Fan-in 2: teaching_note_part2 + m5_questions listos.
+    """Fan-in 2: teaching_note_part2 + consigna M5 listos.
     Concatena las 2 partes de la Teaching Note en doc3_teaching_note.
     """
     part1 = state.get("doc3_teaching_note_part1", "")
@@ -4509,7 +4512,7 @@ def synthesis_phase2_sync(state: ADAMState) -> dict:
 # v9 — M5 CONTENT GENERATOR: Informe de Resolución (Junta Directiva)
 # Genera el reto final VISIBLE PARA EL ESTUDIANTE con 3 secciones:
 #   Sección 1: Insight Destacado del Caso (sin spoiler — "El Dilema Directivo")
-#   Sección 2: Introducción al reto de Junta Directiva + regla de 4 párrafos
+#   Sección 2: Introducción al reto de Junta Directiva + estructura de memorándum
 #   Sección 3: Cierre del Sistema ADAM
 # is_docente_only = False: este artefacto es student-facing.
 # ─────────────────────────────────────────────────────────
@@ -4518,7 +4521,7 @@ def m5_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
 
     Redeseñado en v9: el artefacto es visible para el estudiante como reto de Junta
     Directiva. Contiene Insight Destacado (sin spoiler de decisión), introducción al
-    reto y cierre del sistema. Las solucion_esperada se generan en m5_questions_generator
+    reto y cierre del sistema. La solucion_esperada se genera en m5_questions_generator
     y son filtradas por frontend_output_adapter antes de llegar al estudiante.
     """
     try:
@@ -4869,7 +4872,7 @@ eda_graph = eda_builder.compile()
 # Ref: LangGraph docs — "Compose Graphs as Subgraphs" / "How to add and use subgraphs".
 #
 # Post-sync1 es SECUENCIAL: m5_questions_generator → teaching_note_part2 → sync2.
-# Ventaja: teaching_note_part2 recibe m5_questions ya escritos en state.
+# Ventaja: teaching_note_part2 recibe la consigna M5 ya escrita en state.
 synthesis_builder = StateGraph(ADAMState)
 synthesis_builder.add_node(
     "m5_content_generator",
@@ -4902,7 +4905,7 @@ synthesis_builder.add_edge(START, "teaching_note_part1")
 synthesis_builder.add_edge("m5_content_generator", "synthesis_phase1_sync")
 synthesis_builder.add_edge("teaching_note_part1", "synthesis_phase1_sync")
 
-# Secuencial post-sync1: m5_questions disponibles para teaching_note_part2.
+# Secuencial post-sync1: consigna M5 disponible para teaching_note_part2.
 synthesis_builder.add_edge("synthesis_phase1_sync", "m5_questions_generator")
 synthesis_builder.add_edge("m5_questions_generator", "teaching_note_part2")
 synthesis_builder.add_edge("teaching_note_part2", "synthesis_phase2_sync")

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -1532,14 +1532,14 @@ Eres el Sintetizador Pedagógico de ADAM. Tu misión es presentar al estudiante 
 final del caso, asumiendo el rol del comité evaluador de la Junta Directiva.
 
 ⚠️ VISIBILIDAD: Este documento ES VISIBLE PARA EL ESTUDIANTE.
-   Las solucion_esperada de las preguntas (generadas por el nodo siguiente) son SOLO
-   VISIBLES PARA EL DOCENTE y se filtran en el output adapter antes de llegar al frontend.
+  La solucion_esperada del memorándum final (generada por el nodo siguiente) es SOLO
+  VISIBLE PARA EL DOCENTE y se filtra en el output adapter antes de llegar al frontend.
    GENERA EL CONTENIDO COMPLETO — el filtro lo gestiona el sistema, no este prompt.
 
 # Your Mission
 Generar el DOCUMENTO 5 — INFORME DE RESOLUCIÓN (TEACHING NOTE AVANZADA) en Markdown puro.
 Estructura EXACTA: encabezado de Junta Directiva + SECCIÓN 1 + SECCIÓN 2 (introducción al reto)
-+ SECCIÓN 3. Las 3 preguntas del reto son generadas por el nodo m5_questions_generator.
++ SECCIÓN 3. La consigna única del memorándum final es generada por el nodo m5_questions_generator.
 
 # How You Work (Workflow)
 1. **Lee el recorrido M1→M4:** dilema, opciones (A/B/C), hallazgos de datos, riesgos del M3,
@@ -1568,9 +1568,8 @@ Estructura EXACTA: encabezado de Junta Directiva + SECCIÓN 1 + SECCIÓN 2 (intr
 ## 🏛️ Informe de Resolución — Junta Directiva de {nombre_empresa}
 
 *El Comité de Evaluación ha revisado los análisis M1–M4. Como miembro de la Junta Directiva,
-debes estructurar tu recomendación final respondiendo cada pregunta con exactamente 4 párrafos
-(250-300 palabras total): concepto teórico → aplicación al caso → implicación ejecutiva →
-conexión con marco académico.*
+debes estructurar una recomendación final en formato memorándum: decisión explícita,
+evidencia del caso, riesgo principal, mitigación y plan de implementación.*
 
 ---
 
@@ -1591,17 +1590,18 @@ conexión con marco académico.*
 
 ### SECCIÓN 2: Tu Reto como Junta Directiva
 
-El comité evaluador presentará 3 preguntas de alto nivel que debes responder
-defendiendo tu postura con evidencia de los módulos M1–M4.
+El comité evaluador presentará una única consigna de memorándum ejecutivo. Tu respuesta debe
+tomar la decisión final del caso y defenderla con evidencia de los módulos M1–M4.
 
-**Regla de los 4 Párrafos (obligatoria para cada respuesta):**
-1. **Concepto teórico:** Explica el principio de negocio o metodológico relevante.
-2. **Aplicación al caso:** Conecta el concepto con los datos y hallazgos específicos del caso.
-3. **Implicación ejecutiva:** Argumenta cómo este análisis define la decisión de la Junta.
-4. **Marco académico:** Relaciona tu postura con un framework reconocido
-    (Porter, Kahneman, Prahalad, Kotter u otro marco sólido — sin citar fuentes externas inventadas).
+**Estructura esperada del memorándum:**
+1. **Decisión:** nombra la opción o curso de acción recomendado.
+2. **Evidencia:** conecta la decisión con datos y hallazgos específicos del caso.
+3. **Riesgo y mitigación:** responde al principal riesgo identificado en M3/M4.
+4. **Implementación:** define responsables, horizonte y métricas de seguimiento.
+5. **Criterio académico:** relaciona la postura con un framework reconocido
+  (Porter, Kahneman, Prahalad, Kotter u otro marco sólido — sin citar fuentes externas inventadas).
 
-*Las preguntas aparecerán a continuación en el sistema.*
+*La consigna del memorándum aparecerá a continuación en el sistema.*
 
 ---
 
@@ -1720,41 +1720,42 @@ Eres el Comité Evaluador de la Junta Directiva en ADAM, especializado en evalua
 ejecutiva y liderazgo bajo incertidumbre real.
 
 # Your Mission
-Generar EXACTAMENTE 3 preguntas de evaluación final usando el JSON schema provisto.
-Cada pregunta somete al estudiante a un escrutinio riguroso como si fuera presentado ante
-la Junta Directiva. Las `solucion_esperada` son respuestas modelo completas de 4 párrafos
-que el docente usa como referencia de preview y el sistema de IA usa para calificación comparativa.
+Generar EXACTAMENTE 1 consigna de evaluación final usando el JSON schema provisto.
+La consigna debe pedir al estudiante un memorándum ejecutivo donde tome la decisión final
+del caso ante la Junta Directiva. La `solucion_esperada` es un memorándum modelo que el
+docente usa como referencia de preview y el sistema de IA usa para calificación comparativa.
 
 # JSON Schema Obligatorio (claves EXACTAS — usa GeneradorPreguntasM5Output)
 [
   {{
     "numero": 1,
     "titulo": "string corto (≤8 palabras)",
-    "enunciado": "string (pregunta de la Junta — referencia explícita a módulos anteriores)",
-    "solucion_esperada": "string (respuesta modelo de 4 párrafos, 250-300 palabras — ver formato abajo)",
+    "enunciado": "string (consigna para redactar el memorándum final — referencia explícita a módulos anteriores)",
+    "solucion_esperada": "string (memorándum modelo docente-only — ver formato abajo)",
     "bloom_level": "evaluation|synthesis",
     "modules_integrated": ["M1", "M2", ...],
     "is_solucion_docente_only": true
-  }},
-  ...
+  }}
 ]
 
 ⚠️ FORMATO CRÍTICO DE JSON — PREVENCIÓN DE PARSING FAILURES:
 - El campo solucion_esperada contiene texto largo multi-párrafo.
-- Separa los 4 párrafos con \\n\\n dentro del string JSON.
+- Separa los párrafos con \\n\\n dentro del string JSON.
 - Escapa TODAS las comillas dobles internas con \\" dentro del string.
 - NUNCA uses bullet points (-, *, •) dentro de solucion_esperada — solo texto corrido.
 - Valida mentalmente que el JSON sea parseable antes de responder.
 - NUNCA generes un campo adicional fuera del schema — solo los 7 campos definidos.
 
-# Formato Obligatorio de `solucion_esperada` (4 párrafos, 250-300 palabras totales)
-Párrafo 1 — Concepto teórico (50-70 palabras): explica el principio de negocio o metodológico
-  relevante para responder esta pregunta.
-Párrafo 2 — Aplicación al caso (70-90 palabras): conecta el concepto con los datos concretos
-  del caso (métricas de M2, riesgos de M3, proyecciones de M4). Cita al menos 1 valor numérico.
-Párrafo 3 — Implicación ejecutiva (70-90 palabras): argumenta cómo este análisis define la
-  decisión de la Junta. Menciona la opción (A/B/C) y su justificación empírica.
-Párrafo 4 — Marco académico (40-60 palabras): relaciona la postura con un framework reconocido.
+# Formato Obligatorio de `solucion_esperada` (memorándum modelo, 350-500 palabras)
+Párrafo 1 — Decisión ejecutiva: nombra la opción (A/B/C) o curso de acción recomendado,
+  explica el criterio rector y conecta con la pregunta eje directiva.
+Párrafo 2 — Evidencia del caso: usa datos concretos de M2/Exhibits/M4 y hallazgos de M3.
+  Incluye al menos 2 valores numéricos anclados en el caso cuando existan.
+Párrafo 3 — Riesgo y mitigación: responde explícitamente a `{main_risk_from_m3_m4}` con una
+  mitigación específica, responsable y observable.
+Párrafo 4 — Implementación: define los primeros hitos dentro de `{implementation_timeframe}`,
+  con área responsable y métrica de seguimiento.
+Párrafo 5 — Criterio académico: relaciona la postura con un framework reconocido.
   REGLA ANTI-ALUCINACIÓN: citar SOLO frameworks ampliamente reconocidos (Porter, Kahneman,
   Prahalad, Kotter, Christensen, Osterwalder). Formato: "Según [Marco/Autor] ([concepto])..."
   PROHIBIDO inventar títulos de fuentes externas, años específicos o autores desconocidos.
@@ -1763,15 +1764,16 @@ Párrafo 4 — Marco académico (40-60 palabras): relaciona la postura con un fr
 1. **Lee el contexto completo:** m5_content (informe de resolución), hallazgos M3/M4.
 2. **Revisa el historial de M1 como referencia:** {doc1_preguntas_complejas}
    → Úsalo SOLO para no repetir temas ya evaluados. NO copies ni adaptes estas preguntas.
-   → Las 3 preguntas de M5 se generan libremente basadas en hallazgos frescos de M3 y M4.
-3. **Diseña las 3 preguntas** según las estructuras fijas abajo.
-4. **Redacta solucion_esperada** para cada una siguiendo el formato de 4 párrafos.
-   Cuenta palabras antes de finalizar: cada solucion_esperada DEBE tener 250-300 palabras.
+   → La consigna M5 debe integrar hallazgos frescos de M3 y M4 sin duplicar M1.
+3. **Diseña 1 consigna** que obligue al estudiante a redactar un memorándum final de decisión.
+4. **Redacta solucion_esperada** como memorándum modelo siguiendo el formato anterior.
+   Cuenta palabras antes de finalizar: la solucion_esperada DEBE tener 350-500 palabras.
 
 # Your Boundaries
-- EXACTAMENTE 3 preguntas — ni más, ni menos.
-- P2 DEBE usar el `{main_risk_from_m3_m4}` inyectado — es el push-back específico del caso.
-- P3 DEBE usar `{implementation_timeframe}` para un marco temporal realista.
+- EXACTAMENTE 1 consigna — ni más, ni menos.
+- El enunciado DEBE pedir un memorándum ejecutivo, no una respuesta corta ni una lista de bullets.
+- El enunciado DEBE exigir decisión final explícita, evidencia del caso, riesgo/mitigación y plan de implementación.
+- La solucion_esperada DEBE usar `{main_risk_from_m3_m4}` y `{implementation_timeframe}`.
 - solucion_esperada: NUNCA menciones fuentes externas inventadas. Solo frameworks reconocidos sin año.
 - **Idioma de salida: {output_language}**
 
@@ -1779,23 +1781,17 @@ Párrafo 4 — Marco académico (40-60 palabras): relaciona la postura con un fr
 - Si es "business": Defensa ejecutiva, trade-offs financieros, plan con KPIs, rol del CFO.
 - Si es "ml_ds": Justificación metodológica, límites del modelo, gobernanza de datos, rol del CTO.
 
-# Estructura Fija de las 3 Preguntas
+# Estructura Fija de la Consigna
 
-**P1 (synthesis — integra M1+M2+M4):**
-Pitch ejecutivo de 2 minutos ante la Junta. Describe el problema central del caso,
-la solución que recomiendas y su impacto financiero proyectado.
-Obligatorio: citar exactamente 2 datos duros del M2 o M4 para hacer la recomendación creíble.
+**Memorándum final (evaluation + synthesis — integra M1+M2/M3+M4+M5):**
+Pide al estudiante redactar un memorándum dirigido a la Junta Directiva de {nombre_empresa}.
+El memorándum debe tomar una decisión final, justificarla con evidencia del caso, responder al
+riesgo principal "{main_risk_from_m3_m4}" y proponer implementación dentro de
+{implementation_timeframe}. Si el caso no tiene M2 o M3 ejecutado, debe basarse en Exhibits,
+M4 y el dilema M1 sin inventar datos.
 
-**P2 (evaluation — integra M3+M4):**
-El [CFO si "business" / CTO si "ml_ds"] rechaza tu propuesta argumentando que:
-"{main_risk_from_m3_m4}".
-¿Cómo refutas esa objeción con evidencia concreta de los módulos M3 y M4?
-Debes proponer una mitigación específica y cuantificada, no solo reconocer el riesgo.
-
-**P3 (synthesis — integra M4+M5):**
-Define los 3 primeros hitos de implementación de tu recomendación dentro de
-{implementation_timeframe}.
-Para cada hito: acción concreta, área/rol responsable y métrica que certifica su cumplimiento.
+`modules_integrated` debe incluir todos los módulos realmente usados. Para harvard_with_eda,
+usa ["M1", "M2", "M3", "M4", "M5"]. Para harvard_only, usa ["M1", "M4", "M5"].
 
 # Context
 {m5_content}

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -418,31 +418,31 @@ class GeneradorPreguntasOutput(BaseModel):
 
 
 # ═══════════════════════════════════════════════════════
-# MÓDULO 5 — Preguntas Junta Directiva (schema aislado de PreguntaMinimalista)
-# Diferencia clave: solucion_esperada sin límite de 60 palabras — es la
-# respuesta modelo completa de 4 párrafos (250-300 palabras) que el sistema
-# de IA usará como referencia de calificación comparativa.
+# MÓDULO 5 — Memorándum final (schema aislado de PreguntaMinimalista)
+# Diferencia clave: solucion_esperada sin límite de 60 palabras — es el
+# memorándum modelo que el docente usa como referencia de calificación comparativa.
 # is_solucion_docente_only = True siempre — se filtra en frontend_output_adapter.
 # ═══════════════════════════════════════════════════════
 
 class PreguntaM5(BaseModel):
-    """Pregunta del Módulo 5 — Evaluación Junta Directiva.
+    """Pregunta única del Módulo 5 — Memorándum de decisión final.
 
     Diferencias vs PreguntaMinimalista:
-      - solucion_esperada: sin límite de palabras (respuesta modelo 4 párrafos, 250-300 palabras)
+      - numero: siempre 1 (un único reto final tipo memorándum)
+      - solucion_esperada: memorándum modelo con decisión, evidencia, riesgo y plan
       - bloom_level: restringido a 'evaluation' | 'synthesis'
       - modules_integrated: requerido (siempre integra múltiples módulos)
       - is_solucion_docente_only: siempre True — frontend_output_adapter filtra este campo
     """
-    numero: int = Field(description="Número secuencial de la pregunta (1, 2 o 3)")
+    numero: Literal[1] = Field(description="Número fijo del reto final: siempre 1")
     titulo: str = Field(description="Título corto y descriptivo de la pregunta (≤8 palabras)")
-    enunciado: str = Field(description="Pregunta dirigida al estudiante en su rol de Junta Directiva")
+    enunciado: str = Field(description="Consigna dirigida al estudiante para redactar el memorándum final")
     solucion_esperada: str = Field(
         description=(
-            "Respuesta modelo completa en exactamente 4 párrafos (250-300 palabras total). "
-            "Párrafo 1: concepto teórico. Párrafo 2: aplicación a datos del caso. "
-            "Párrafo 3: implicación ejecutiva. Párrafo 4: marco académico reconocido. "
-            "Visible SOLO al docente. Usada como referencia para calificación por IA."
+            "Memorándum modelo docente-only que toma una decisión final del caso, "
+            "usa evidencia concreta de M1-M4, aborda el riesgo principal, define un "
+            "plan de implementación y explicita el razonamiento académico/gerencial. "
+            "Visible SOLO al docente. Usado como referencia para calificación por IA."
         )
     )
     bloom_level: Literal["evaluation", "synthesis"]
@@ -456,8 +456,12 @@ class PreguntaM5(BaseModel):
 
 
 class GeneradorPreguntasM5Output(BaseModel):
-    """Salida del m5_questions_generator — EXACTAMENTE 3 preguntas de Junta Directiva."""
-    preguntas: list[PreguntaM5] = Field(description="Exactamente 3 preguntas de evaluación final")
+    """Salida del m5_questions_generator — exactamente 1 memorándum final."""
+    preguntas: list[PreguntaM5] = Field(
+        min_length=1,
+        max_length=1,
+        description="Exactamente 1 consigna de memorándum de decisión final",
+    )
 
 
 # ═══════════════════════════════════════════════════════

--- a/backend/tests/test_issue242_pedagogical_coherence.py
+++ b/backend/tests/test_issue242_pedagogical_coherence.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from pydantic import ValidationError
 
 from case_generator import graph as graph_module
 from case_generator.orchestration.frontend_output_adapter import (
@@ -26,6 +27,7 @@ from case_generator.prompts import (
 )
 from case_generator.tools_and_schemas import (
     CaseArchitectOutput,
+    GeneradorPreguntasM5Output,
     PreguntaMinimalista,
 )
 from shared.case_sanitization import build_teacher_case_review_payload
@@ -126,6 +128,32 @@ def _valid_question_payload() -> dict[str, object]:
     }
 
 
+def _valid_m5_memo_question_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "numero": 1,
+        "titulo": "Memorándum ejecutivo",
+        "enunciado": (
+            "Redacta un memorándum ejecutivo para la Junta Directiva que tome la "
+            "decisión final del caso, use evidencia de M1-M4, responda al riesgo "
+            "principal y defina un plan de implementación."
+        ),
+        "solucion_esperada": (
+            "La recomendación debe tomar una decisión explícita, explicar el criterio "
+            "ejecutivo y conectar la postura con la pregunta eje.\n\n"
+            "La evidencia debe usar datos del caso y distinguir hallazgos de M2, M3 y M4 "
+            "sin inventar cifras.\n\n"
+            "El memo debe responder al riesgo principal con mitigación responsable y observable.\n\n"
+            "La implementación debe definir hitos, responsables y métricas dentro del plazo.\n\n"
+            "El cierre debe relacionar la decisión con un marco académico reconocido."
+        ),
+        "bloom_level": "synthesis",
+        "modules_integrated": ["M1", "M2", "M3", "M4", "M5"],
+        "is_solucion_docente_only": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
 def _classification_state() -> dict[str, object]:
     return {
         "studentProfile": "ml_ds",
@@ -149,6 +177,33 @@ def test_question_contract_drops_legacy_rubric_metadata() -> None:
 
     assert "rubric" not in question.model_dump()
     assert not hasattr(question, "rubric")
+
+
+def test_m5_output_contract_requires_exactly_one_memo_question() -> None:
+    valid = GeneradorPreguntasM5Output.model_validate(
+        {"preguntas": [_valid_m5_memo_question_payload()]}
+    )
+
+    assert len(valid.preguntas) == 1
+    assert valid.preguntas[0].numero == 1
+
+    with pytest.raises(ValidationError):
+        GeneradorPreguntasM5Output.model_validate({"preguntas": []})
+
+    with pytest.raises(ValidationError):
+        GeneradorPreguntasM5Output.model_validate(
+            {
+                "preguntas": [
+                    _valid_m5_memo_question_payload(),
+                    _valid_m5_memo_question_payload(),
+                ]
+            }
+        )
+
+    with pytest.raises(ValidationError):
+        GeneradorPreguntasM5Output.model_validate(
+            {"preguntas": [_valid_m5_memo_question_payload(numero=2)]}
+        )
 
 
 def test_case_architect_output_accepts_optional_pregunta_eje_and_legacy_absence() -> None:
@@ -255,6 +310,17 @@ def test_question_prompts_do_not_request_teacher_rubrics() -> None:
         assert "rúbrica para docente" not in prompt
 
 
+def test_m5_prompts_request_single_final_memo_without_legacy_three_question_copy() -> None:
+    assert "EXACTAMENTE 1 consigna" in M5_QUESTIONS_GENERATOR_PROMPT
+    assert "memorándum ejecutivo" in M5_QUESTIONS_GENERATOR_PROMPT
+    assert "decisión final" in M5_QUESTIONS_GENERATOR_PROMPT
+    assert "EXACTAMENTE 3 preguntas" not in M5_QUESTIONS_GENERATOR_PROMPT
+    assert "Las 3 preguntas" not in M5_QUESTIONS_GENERATOR_PROMPT
+    assert "Diseña las 3 preguntas" not in M5_QUESTIONS_GENERATOR_PROMPT
+    assert "3 preguntas" not in M5_CONTENT_GENERATOR_PROMPT
+    assert "una única consigna de memorándum ejecutivo" in M5_CONTENT_GENERATOR_PROMPT
+
+
 @pytest.mark.parametrize(
     ("node_name", "llm_factory_name", "expected"),
     [
@@ -268,11 +334,6 @@ def test_question_prompts_do_not_request_teacher_rubrics() -> None:
             "m3_questions_generator",
             "_get_writer_llm",
             {"m3_questions": [], "current_agent": "m3_questions_generator"},
-        ),
-        (
-            "m5_questions_generator",
-            "_get_m5_llm",
-            {"m5_questions": [], "current_agent": "m5_questions_generator"},
         ),
     ],
 )
@@ -292,6 +353,40 @@ def test_question_nodes_degrade_on_structured_output_errors(
     result = node(_classification_state(), {})  # type: ignore[arg-type]
 
     assert result == expected
+
+
+def test_m5_question_node_generates_single_final_memo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_llm = _FakeStructuredLLM(
+        [{"preguntas": [_valid_m5_memo_question_payload()]}]
+    )
+    monkeypatch.setattr(
+        graph_module,
+        "_get_m5_llm",
+        lambda *args, **kwargs: fake_llm,
+    )
+
+    result = graph_module.m5_questions_generator(_classification_state(), {})  # type: ignore[arg-type]
+
+    assert result["current_agent"] == "m5_questions_generator"
+    assert result["m5_questions"] == [_valid_m5_memo_question_payload()]
+    assert len(fake_llm.prompts) == 1
+    assert "EXACTAMENTE 1 consigna" in fake_llm.prompts[0]
+    assert "memorándum ejecutivo" in fake_llm.prompts[0]
+
+
+def test_m5_question_node_reraises_structured_output_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        graph_module,
+        "_get_m5_llm",
+        lambda *args, **kwargs: _FailingStructuredLLM(),
+    )
+
+    with pytest.raises(ValueError, match="structured parse failed"):
+        graph_module.m5_questions_generator(_classification_state(), {})  # type: ignore[arg-type]
 
 
 def test_question_parse_errors_still_degrade_outside_classification_contract(

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -34,7 +34,7 @@ export interface PreguntaMinimalista {
 // El frontend las fusiona con m5Questions para la vista docente.
 export interface M5QuestionSolution {
     numero: number;
-    solucion_esperada: string;  // respuesta modelo completa de 4 párrafos (250-300 palabras)
+    solucion_esperada: string;  // memorándum modelo docente-only para la decisión final
 }
 
 // Module 2 EDA questions use a richer structured answer schema.
@@ -128,7 +128,7 @@ export interface CaseContent {
     // ── v7: preguntas de módulos de impacto y recomendación ──
     m4Questions?: PreguntaMinimalista[];         // generadas por m4_questions_generator
     m5Questions?: PreguntaMinimalista[];         // generadas por m5_questions_generator (solucion_esperada ausente — filtrada)
-    m5QuestionsSolutions?: M5QuestionSolution[]; // docente-only: solucion_esperada de M5 (4 párrafos, 250-300 palabras)
+    m5QuestionsSolutions?: M5QuestionSolution[]; // docente-only: memorándum modelo de M5
 
     // ── v8: contenido adicional de módulos ──
     m3Content?: string;

--- a/frontend/src/shared/case-viewer/modules/M5ExecutiveReport.test.tsx
+++ b/frontend/src/shared/case-viewer/modules/M5ExecutiveReport.test.tsx
@@ -54,4 +54,46 @@ describe("M5ExecutiveReport", () => {
         expect(within(table).getByText("Ajustar umbral de aprobación")).toBeInTheDocument();
         expect(within(table).getByText("Random Forest")).toBeInTheDocument();
     });
+
+    it("renders one final memo question with the teacher-only model answer merged", () => {
+        const renderPreguntas = vi.fn(() => <div data-testid="memo-question">Memo rendered</div>);
+
+        render(
+            <M5ExecutiveReport
+                result={result}
+                content={{
+                    m5Questions: [
+                        {
+                            numero: 1,
+                            titulo: "Memorándum ejecutivo",
+                            enunciado: "Redacta el memorándum final para la Junta Directiva.",
+                            bloom_level: "synthesis",
+                            modules_integrated: ["M1", "M4", "M5"],
+                            is_solucion_docente_only: true,
+                        },
+                    ],
+                    m5QuestionsSolutions: [
+                        {
+                            numero: 1,
+                            solucion_esperada: "Memo modelo con decisión, evidencia, riesgo y plan.",
+                        },
+                    ],
+                }}
+                md={{ m5Content: null }}
+                isEDA={false}
+                isMLDS={false}
+                renderPreguntas={renderPreguntas}
+            />,
+        );
+
+        expect(screen.getByText("Memorándum — Decisión Final")).toBeInTheDocument();
+        expect(screen.getByTestId("memo-question")).toBeInTheDocument();
+        expect(renderPreguntas).toHaveBeenCalledWith("m5", [
+            expect.objectContaining({
+                numero: 1,
+                titulo: "Memorándum ejecutivo",
+                solucion_esperada: "Memo modelo con decisión, evidencia, riesgo y plan.",
+            }),
+        ]);
+    });
 });

--- a/frontend/src/shared/case-viewer/modules/M5ExecutiveReport.tsx
+++ b/frontend/src/shared/case-viewer/modules/M5ExecutiveReport.tsx
@@ -37,7 +37,7 @@ export function M5ExecutiveReport({ content, md, isEDA, isMLDS, renderPreguntas 
                 />
             )}
 
-            {/* 3 preguntas de Junta Directiva con respuestas modelo para el docente */}
+            {/* Memorándum final con respuesta modelo para el docente */}
             {content.m5Questions && content.m5Questions.length > 0 && (() => {
                 const solutionsMap = Object.fromEntries(
                     (content.m5QuestionsSolutions ?? []).map(s => [s.numero, s.solucion_esperada])
@@ -48,7 +48,7 @@ export function M5ExecutiveReport({ content, md, isEDA, isMLDS, renderPreguntas 
                 }));
                 return (
                     <>
-                        <div className="section-divider mb-8"><span>Preguntas — Junta Directiva</span></div>
+                        <div className="section-divider mb-8"><span>Memorándum — Decisión Final</span></div>
                         {renderPreguntas("m5", enrichedQuestions)}
                     </>
                 );


### PR DESCRIPTION
## Summary
- Change M5 from a three-question final board flow to one final decision memo while preserving the existing `m5_questions` / `m5Questions` contract as a one-item array.
- Enforce the exact-one M5 memo invariant in `GeneradorPreguntasM5Output` and make invalid M5 structured output retry/fail instead of silently degrading to an empty final task.
- Update M5 prompt copy, teacher preview label, TypeScript comments, deterministic backend/frontend tests, and deferred TODOs for a future dedicated `m5Memo` contract/eval suite.

## Validation
- `uv run --directory backend pytest tests/test_issue242_pedagogical_coherence.py tests/test_issue243_narrative_grounding.py tests/test_case_sanitization.py -q` — 73 passed
- `npm --prefix frontend run test -- src/shared/case-viewer/modules/M5ExecutiveReport.test.tsx src/features/teacher-case-submission-detail/__tests__/toCanonicalCaseOutput.test.ts` — 2 files / 9 tests passed
- `git diff --check`
- `uv run --directory backend pytest -q` — 714 passed, 13 skipped, 1 warning
- `uv run --directory backend mypy src` — success
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test` — 60 files / 427 tests passed
- `npm --prefix frontend run build` — built successfully

## Notes
- Remote secret scanning could not run because GitHub Advanced Security is not enabled for this repository.