### PR TITLE
feat(case-generator): enforce three M1 questions

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -125,6 +125,7 @@ from case_generator.tools_and_schemas import (
     CaseArchitectOutput,
     EDAAnnotateOnlyOutput,
     EDAChartGeneratorOutput,
+    GeneradorPreguntasM1Output,
     GeneradorPreguntasOutput,
     GeneradorPreguntasM5Output,
     EDAQuestionsOutput,
@@ -983,7 +984,7 @@ def case_writer(state: ADAMState, config: RunnableConfig) -> dict:
 # NODO 2b — CASE QUESTIONS (Flash, paralelo con 2a)
 # ─────────────────────────────────────────────────────────
 def case_questions(state: ADAMState, config: RunnableConfig) -> dict:
-    """Genera las 6 preguntas de discusión del caso."""
+    """Genera las 3 preguntas de discusión M1 del caso."""
     cfg = Configuration.from_runnable_config(config)
     # Fix M-07: 0.5 en vez de 0.7 — preguntas estructuradas Bloom L4-L6
     # requieren consistencia pedagógica, no creatividad narrativa.
@@ -1006,13 +1007,16 @@ def case_questions(state: ADAMState, config: RunnableConfig) -> dict:
     prompt = CASE_QUESTIONS_PROMPT.format(**context)
 
     try:
-        resultado: GeneradorPreguntasOutput = llm.with_structured_output(
-            GeneradorPreguntasOutput
+        resultado: GeneradorPreguntasM1Output = llm.with_structured_output(
+            GeneradorPreguntasM1Output
         ).invoke(prompt)
         
         preguntas_dict = [p.model_dump() for p in resultado.preguntas]
         print(f"[case_questions] {len(preguntas_dict)} preguntas generadas")
     except RuntimeError:
+        raise
+    except (ValidationError, OutputParserException, ValueError) as e:
+        logger.warning("[case_questions] OUTPUT INVÁLIDO (reintentando/fallando): %s", e)
         raise
     except Exception as e:
         logger.error("[case_questions] ERROR tras reintentos: %s", e, exc_info=True)
@@ -3181,8 +3185,9 @@ def m5_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
                 "analysis": 2,
             }.get(str(q.get("bloom_level", "")), 3)
         )
-        # Fallback: si no hay preguntas con bloom_level, usar las últimas 3 (P4/P5/P6
-        # son siempre analysis/evaluation/synthesis por diseño del CASE_QUESTIONS_PROMPT)
+        # Fallback histórico: si no hay bloom_level, usar las últimas 3 disponibles.
+        # Payloads nuevos de M1 tienen 3 preguntas balanceadas; el filtro anterior
+        # debe capturar las preguntas complejas por bloom_level cuando el campo existe.
         if not complex_q and all_q:
             complex_q = all_q[-3:]
 

--- a/backend/src/case_generator/prompts.py
+++ b/backend/src/case_generator/prompts.py
@@ -317,13 +317,13 @@ CASE_QUESTIONS_PROMPT = """\
 Eres el Evaluador del Módulo 1 en ADAM, un diseñador instruccional experto en casos Harvard.
 
 # Your Mission
-Generar EXACTAMENTE 6 preguntas pedagógicas usando el JSON schema provisto, que validen
+Generar EXACTAMENTE 3 preguntas pedagógicas usando el JSON schema provisto, que validen
 que el estudiante comprendió el entorno antes de procesar datos.
 
 # JSON Schema Obligatorio (respeta tipos y claves EXACTAS — sin añadir ni eliminar campos)
 [
   {{
-    "numero": 1,                        // integer, 1-6
+    "numero": 1,                        // integer, 1-3
     "titulo": "string corto (≤8 palabras)",
     "enunciado": "string (pregunta completa)",
     "solucion_esperada": "string (máx 60 palabras / 3 líneas)",
@@ -347,7 +347,7 @@ que el estudiante comprendió el entorno antes de procesar datos.
 - Respuesta ESTRICTA al JSON schema arriba. PROHIBIDO Markdown suelto o texto fuera del JSON.
 - NUNCA menciones Python, SQL, algoritmos, código.
 - Las preguntas DEBEN nombrar la empresa ficticia, sus métricas y sus Exhibits.
-- Progresión cognitiva obligatoria: P1-P2 → comprehension, P3-P4 → analysis, P5-P6 → evaluation/synthesis.
+- Progresión cognitiva obligatoria: P1 → comprehension, P2 → analysis, P3 → evaluation/synthesis.
 - **Idioma de salida: {output_language}**
 
 # Perfil del estudiante: {student_profile}
@@ -358,21 +358,17 @@ que el estudiante comprendió el entorno antes de procesar datos.
   Evaluar: traducción del problema de negocio a problema de datos, variable objetivo,
   limitaciones de información disponible, hipótesis de trabajo analíticas.
 
-# Estructura de las 6 preguntas
+# Estructura de las 3 preguntas
 - **P1 (comprehension):** "¿De qué trata realmente el caso?" — diferencia entre síntoma y causa raíz.
   Referencia obligatoria a Exhibit 1 o 2.
-- **P2 (comprehension):** Qué información es incierta vs confirmada. Referencia a Exhibit específico.
-- **P3 (analysis):**
-  "business" → cruzar intereses de al menos 2 stakeholders del Exhibit 3.
-  "ml_ds" → definir variable objetivo operacionalmente con los datos disponibles.
-- **P4 (analysis):**
-  "business" → impacto financiero de NO decidir (costo de inacción).
-  "ml_ds" → identificar hipótesis de trabajo y su forma de falsación.
-- **P5 (evaluation):** Elegir entre A, B o C con información INCOMPLETA disponible en M1.
-  Justificar con datos de Exhibits (no con intuición).
-  NOTA PEDAGÓGICA: Esta es una hipótesis temprana. El estudiante SABRÁ que puede cambiar en M2-M4.
-  Incluir en el enunciado: "Tu respuesta es una hipótesis inicial que revisarás con datos en M2."
-- **P6 (synthesis):** Cuál es el supuesto más frágil del dilema y cómo lo verificarías.
+- **P2 (analysis):**
+  "business" → cruzar el interés de al menos 2 stakeholders del Exhibit 3 con una métrica de Exhibit 1 o 2.
+  "ml_ds" → definir la variable objetivo operacionalmente y formular una hipótesis falsable con los datos disponibles.
+- **P3 (evaluation/synthesis):** Elegir entre A, B o C con información INCOMPLETA disponible en M1.
+  Justificar con datos de Exhibits (no con intuición), nombrar el supuesto más frágil y proponer cómo verificarlo.
+  Usa `bloom_level`: "synthesis" si integra supuesto + verificación; "evaluation" si se centra en elegir A/B/C.
+  NOTA PEDAGÓGICA: Esta es una hipótesis temprana. El estudiante SABRÁ que puede cambiar con evidencia posterior del caso.
+  Incluir en el enunciado: "Tu respuesta es una hipótesis inicial que revisarás con evidencia posterior del caso."
 
 # Context
 {architect_output}

--- a/backend/src/case_generator/state.py
+++ b/backend/src/case_generator/state.py
@@ -96,7 +96,7 @@ class ADAMState(CanonicalInputState):
     doc1_narrativa: str          # caso_negocio (2,500–3,000 palabras)
 
     # ── Preguntas generadas por case_questions ─────────
-    doc1_preguntas: list[dict]   # 6 preguntas serializadas de PreguntaMinimalista
+    doc1_preguntas: list[dict]   # 3 preguntas serializadas de PreguntaMinimalista
 
     # ── Documentos generados por eda_text_analyst ──────
     doc2_eda: str                # reporte EDA completo en Markdown

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -417,6 +417,28 @@ class GeneradorPreguntasOutput(BaseModel):
     preguntas: list[PreguntaMinimalista] = Field(description="Lista de preguntas generadas")
 
 
+class GeneradorPreguntasM1Output(BaseModel):
+    """Salida del case_questions — exactamente 3 preguntas M1."""
+    preguntas: list[PreguntaMinimalista] = Field(
+        min_length=3,
+        max_length=3,
+        description="Exactamente 3 preguntas pedagógicas del Módulo 1",
+    )
+
+    @field_validator("preguntas")
+    @classmethod
+    def _validate_sequential_numbers(
+        cls,
+        preguntas: list[PreguntaMinimalista],
+    ) -> list[PreguntaMinimalista]:
+        numeros = [pregunta.numero for pregunta in preguntas]
+        if numeros != [1, 2, 3]:
+            raise ValueError(
+                "Las preguntas M1 deben estar numeradas exactamente como 1, 2, 3."
+            )
+        return preguntas
+
+
 # ═══════════════════════════════════════════════════════
 # MÓDULO 5 — Memorándum final (schema aislado de PreguntaMinimalista)
 # Diferencia clave: solucion_esperada sin límite de 60 palabras — es el

--- a/backend/tests/test_issue242_pedagogical_coherence.py
+++ b/backend/tests/test_issue242_pedagogical_coherence.py
@@ -27,6 +27,7 @@ from case_generator.prompts import (
 )
 from case_generator.tools_and_schemas import (
     CaseArchitectOutput,
+    GeneradorPreguntasM1Output,
     GeneradorPreguntasM5Output,
     PreguntaMinimalista,
 )
@@ -113,8 +114,8 @@ def _valid_m5_matrix() -> str:
 """.strip()
 
 
-def _valid_question_payload() -> dict[str, object]:
-    return {
+def _valid_question_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
         "numero": 1,
         "titulo": "Decision inicial",
         "enunciado": "¿Qué decisión defenderías con la evidencia disponible?",
@@ -126,6 +127,40 @@ def _valid_question_payload() -> dict[str, object]:
             {"criterio": "Decision", "descriptor": "Formula una postura defendible", "peso": 25},
         ],
     }
+    payload.update(overrides)
+    return payload
+
+
+def _valid_m1_question_payloads() -> list[dict[str, object]]:
+    return [
+        {
+            "numero": 1,
+            "titulo": "Raiz del dilema",
+            "enunciado": "¿Cuál es la causa raíz del dilema de RetenCo según Exhibit 1?",
+            "solucion_esperada": "Debe distinguir síntoma operativo de causa económica usando Exhibit 1.",
+            "bloom_level": "comprehension",
+            "exhibit_ref": "Exhibit 1",
+        },
+        {
+            "numero": 2,
+            "titulo": "Trade-off operativo",
+            "enunciado": "¿Qué trade-off surge al cruzar stakeholders de Exhibit 3 con Exhibit 2?",
+            "solucion_esperada": "Debe conectar incentivos de dos actores con una métrica operativa concreta.",
+            "bloom_level": "analysis",
+            "exhibit_ref": "Exhibit 3",
+        },
+        {
+            "numero": 3,
+            "titulo": "Supuesto fragil",
+            "enunciado": (
+                "Tu respuesta es una hipótesis inicial que revisarás con evidencia "
+                "posterior del caso. ¿Qué opción defenderías y qué supuesto verificarías?"
+            ),
+            "solucion_esperada": "Debe elegir A/B/C, justificar con Exhibits y nombrar el supuesto crítico a validar.",
+            "bloom_level": "synthesis",
+            "exhibit_ref": "Exhibit 2",
+        },
+    ]
 
 
 def _valid_m5_memo_question_payload(**overrides: object) -> dict[str, object]:
@@ -177,6 +212,41 @@ def test_question_contract_drops_legacy_rubric_metadata() -> None:
 
     assert "rubric" not in question.model_dump()
     assert not hasattr(question, "rubric")
+
+
+def test_m1_output_contract_requires_exactly_three_numbered_questions() -> None:
+    valid = GeneradorPreguntasM1Output.model_validate(
+        {"preguntas": _valid_m1_question_payloads()}
+    )
+
+    assert [question.numero for question in valid.preguntas] == [1, 2, 3]
+
+    with pytest.raises(ValidationError):
+        GeneradorPreguntasM1Output.model_validate({"preguntas": []})
+
+    with pytest.raises(ValidationError):
+        GeneradorPreguntasM1Output.model_validate(
+            {"preguntas": _valid_m1_question_payloads()[:2]}
+        )
+
+    with pytest.raises(ValidationError):
+        GeneradorPreguntasM1Output.model_validate(
+            {
+                "preguntas": _valid_m1_question_payloads()
+                + [_valid_question_payload(numero=4)]
+            }
+        )
+
+    with pytest.raises(ValidationError):
+        GeneradorPreguntasM1Output.model_validate(
+            {
+                "preguntas": [
+                    _valid_question_payload(numero=1),
+                    _valid_question_payload(numero=3),
+                    _valid_question_payload(numero=2),
+                ]
+            }
+        )
 
 
 def test_m5_output_contract_requires_exactly_one_memo_question() -> None:
@@ -310,6 +380,17 @@ def test_question_prompts_do_not_request_teacher_rubrics() -> None:
         assert "rúbrica para docente" not in prompt
 
 
+def test_case_questions_prompt_requests_three_balanced_m1_questions() -> None:
+    assert "EXACTAMENTE 3 preguntas" in CASE_QUESTIONS_PROMPT
+    assert "EXACTAMENTE 6 preguntas" not in CASE_QUESTIONS_PROMPT
+    assert "integer, 1-3" in CASE_QUESTIONS_PROMPT
+    assert "integer, 1-6" not in CASE_QUESTIONS_PROMPT
+    assert "P1 (comprehension)" in CASE_QUESTIONS_PROMPT
+    assert "P2 (analysis)" in CASE_QUESTIONS_PROMPT
+    assert "P3 (evaluation/synthesis)" in CASE_QUESTIONS_PROMPT
+    assert "Tu respuesta es una hipótesis inicial" in CASE_QUESTIONS_PROMPT
+
+
 def test_m5_prompts_request_single_final_memo_without_legacy_three_question_copy() -> None:
     assert "EXACTAMENTE 1 consigna" in M5_QUESTIONS_GENERATOR_PROMPT
     assert "memorándum ejecutivo" in M5_QUESTIONS_GENERATOR_PROMPT
@@ -324,7 +405,6 @@ def test_m5_prompts_request_single_final_memo_without_legacy_three_question_copy
 @pytest.mark.parametrize(
     ("node_name", "llm_factory_name", "expected"),
     [
-        ("case_questions", "_get_writer_llm", {"doc1_preguntas": []}),
         (
             "eda_questions_generator",
             "_get_writer_llm",
@@ -355,6 +435,66 @@ def test_question_nodes_degrade_on_structured_output_errors(
     assert result == expected
 
 
+def test_case_question_node_generates_exactly_three_m1_questions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_llm = _FakeStructuredLLM(
+        [{"preguntas": _valid_m1_question_payloads()}]
+    )
+    monkeypatch.setattr(
+        graph_module,
+        "_get_writer_llm",
+        lambda *args, **kwargs: fake_llm,
+    )
+
+    result = graph_module.case_questions(_classification_state(), {})  # type: ignore[arg-type]
+
+    assert len(result["doc1_preguntas"]) == 3
+    assert [q["numero"] for q in result["doc1_preguntas"]] == [1, 2, 3]
+    assert [q["bloom_level"] for q in result["doc1_preguntas"]] == [
+        "comprehension",
+        "analysis",
+        "synthesis",
+    ]
+    assert len(fake_llm.prompts) == 1
+    assert "EXACTAMENTE 3 preguntas" in fake_llm.prompts[0]
+
+
+@pytest.mark.parametrize(
+    "questions",
+    [
+        _valid_m1_question_payloads()[:2],
+        _valid_m1_question_payloads() + [_valid_question_payload(numero=4)],
+    ],
+)
+def test_case_question_node_reraises_invalid_m1_question_counts(
+    monkeypatch: pytest.MonkeyPatch,
+    questions: list[dict[str, object]],
+) -> None:
+    fake_llm = _FakeStructuredLLM([{"preguntas": questions}])
+    monkeypatch.setattr(
+        graph_module,
+        "_get_writer_llm",
+        lambda *args, **kwargs: fake_llm,
+    )
+
+    with pytest.raises(ValidationError):
+        graph_module.case_questions(_classification_state(), {})  # type: ignore[arg-type]
+
+
+def test_case_question_node_reraises_structured_output_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        graph_module,
+        "_get_writer_llm",
+        lambda *args, **kwargs: _FailingStructuredLLM(),
+    )
+
+    with pytest.raises(ValueError, match="structured parse failed"):
+        graph_module.case_questions(_classification_state(), {})  # type: ignore[arg-type]
+
+
 def test_m5_question_node_generates_single_final_memo(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -376,6 +516,31 @@ def test_m5_question_node_generates_single_final_memo(
     assert "memorándum ejecutivo" in fake_llm.prompts[0]
 
 
+def test_m5_question_node_uses_complex_history_from_three_m1_questions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_llm = _FakeStructuredLLM(
+        [{"preguntas": [_valid_m5_memo_question_payload()]}]
+    )
+    monkeypatch.setattr(
+        graph_module,
+        "_get_m5_llm",
+        lambda *args, **kwargs: fake_llm,
+    )
+
+    result = graph_module.m5_questions_generator(  # type: ignore[arg-type]
+        {**_classification_state(), "doc1_preguntas": _valid_m1_question_payloads()},
+        {},
+    )
+
+    assert result["current_agent"] == "m5_questions_generator"
+    assert len(fake_llm.prompts) == 1
+    prompt = fake_llm.prompts[0]
+    assert "Trade-off operativo" in prompt
+    assert "Supuesto fragil" in prompt
+    assert "Raiz del dilema" not in prompt
+
+
 def test_m5_question_node_reraises_structured_output_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -389,7 +554,7 @@ def test_m5_question_node_reraises_structured_output_errors(
         graph_module.m5_questions_generator(_classification_state(), {})  # type: ignore[arg-type]
 
 
-def test_question_parse_errors_still_degrade_outside_classification_contract(
+def test_case_question_parse_errors_reraise_for_all_m1_profiles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -398,12 +563,11 @@ def test_question_parse_errors_still_degrade_outside_classification_contract(
         lambda *args, **kwargs: _FailingStructuredLLM(),
     )
 
-    result = graph_module.case_questions(  # type: ignore[arg-type]
-        {**_classification_state(), "studentProfile": "business"},
-        {},
-    )
-
-    assert result == {"doc1_preguntas": []}
+    with pytest.raises(ValueError, match="structured parse failed"):
+        graph_module.case_questions(  # type: ignore[arg-type]
+            {**_classification_state(), "studentProfile": "business"},
+            {},
+        )
 
 
 def test_m5_decision_matrix_validator_accepts_exact_contract() -> None:

--- a/backend/tests/test_issue242_pedagogical_coherence.py
+++ b/backend/tests/test_issue242_pedagogical_coherence.py
@@ -135,7 +135,7 @@ def _valid_m1_question_payloads() -> list[dict[str, object]]:
     return [
         {
             "numero": 1,
-            "titulo": "Raiz del dilema",
+            "titulo": "Raíz del dilema",
             "enunciado": "¿Cuál es la causa raíz del dilema de RetenCo según Exhibit 1?",
             "solucion_esperada": "Debe distinguir síntoma operativo de causa económica usando Exhibit 1.",
             "bloom_level": "comprehension",
@@ -151,7 +151,7 @@ def _valid_m1_question_payloads() -> list[dict[str, object]]:
         },
         {
             "numero": 3,
-            "titulo": "Supuesto fragil",
+            "titulo": "Supuesto frágil",
             "enunciado": (
                 "Tu respuesta es una hipótesis inicial que revisarás con evidencia "
                 "posterior del caso. ¿Qué opción defenderías y qué supuesto verificarías?"
@@ -537,8 +537,8 @@ def test_m5_question_node_uses_complex_history_from_three_m1_questions(
     assert len(fake_llm.prompts) == 1
     prompt = fake_llm.prompts[0]
     assert "Trade-off operativo" in prompt
-    assert "Supuesto fragil" in prompt
-    assert "Raiz del dilema" not in prompt
+    assert "Supuesto frágil" in prompt
+    assert "Raíz del dilema" not in prompt
 
 
 def test_m5_question_node_reraises_structured_output_errors(


### PR DESCRIPTION
## Summary
- Change M1 case question generation from 6 questions to exactly 3 balanced questions.
- Add an M1-only structured output contract enforcing length 3 and numbering `1, 2, 3` without tightening the shared M3/M4 question schema.
- Preserve M5 anti-duplication behavior by continuing to pass complex M1 questions as history and updating stale assumptions/comments.
- Add focused backend tests for the M1 contract, prompt guardrails, invalid count behavior, node behavior, and M1 -> M5 history coupling.

## Validation
- `uv run --directory backend pytest tests/test_issue242_pedagogical_coherence.py -q`
- `uv run --directory backend mypy src`
- `uv run --directory backend pytest -q`

Full backend result: `720 passed, 13 skipped, 1 warning`.
The warning is the existing sklearn warning in `tests/test_issue237_eda_charts_classification.py::test_target_continuous_returns_charts_anyway`.