### PR TITLE
Harden scenario prompt algorithm anchor

### DIFF
--- a/backend/src/case_generator/suggest_service.py
+++ b/backend/src/case_generator/suggest_service.py
@@ -590,25 +590,79 @@ def _build_algorithm_anchor_block(req: SuggestRequest) -> Optional[str]:
         return None
     family_label = FAMILY_LABELS.get(family, family)
     target_hint = _FAMILY_TARGET_HINT.get(family, "")
+    mode_label = "1 algoritmo (deep dive)" if req.mode == "single" else "2 algoritmos (baseline + challenger)"
+    case_scope = "Caso Harvard con EDA" if req.caseType == "harvard_with_eda" else "Caso Harvard narrativo"
+    eda_scope = req.edaDepth or "sin EDA"
+    unit_scope = req.topicUnit or "General"
+    profile_guidance = (
+        "Perfil business: formula el escenario como un dilema gerencial de "
+        "decisión. El algoritmo debe aparecer como soporte analítico para una "
+        "recomendación ejecutiva, sin convertir la pregunta guía en una clase "
+        "técnica de model selection."
+        if req.studentProfile == "business"
+        else
+        "Perfil ML/DS: formula el escenario como un reto analítico donde el "
+        "modelo elegido, sus métricas y su validación sean naturalmente "
+        "necesarios para resolver el dilema."
+    )
     lines = [
         "# Anclaje del Algoritmo Elegido por el Docente",
         "El docente YA seleccionó el algoritmo en el formulario. El escenario y la",
         "pregunta guía DEBEN ser coherentes con esta elección — NO la contradigas.",
         "",
+        "## Contexto pedagógico que DEBES usar",
+        f"- Módulo del syllabus: **{req.syllabusModule}**",
+        f"- Unidad temática: **{unit_scope}**",
+        f"- Alcance del caso generado: **{case_scope}**",
+        f"- Profundidad EDA/Python: **{eda_scope}; includePythonCode={req.includePythonCode}**",
+        f"- Perfil del curso: **{req.academicLevel}**",
+        f"- Perfil del estudiante: **{req.studentProfile}**",
+        f"- Modo de algoritmos/técnicas: **{req.mode} — {mode_label}**",
+        "",
         f"- Familia anclada: **{family} ({family_label})**",
         f"- Algoritmo principal: **{req.algorithmPrimary}**",
     ]
-    if req.algorithmChallenger and family_of(req.algorithmChallenger) == family:
+    if req.mode == "contrast" and req.algorithmChallenger and family_of(req.algorithmChallenger) == family:
         lines.append(f"- Challenger (misma familia): **{req.algorithmChallenger}**")
     lines.extend([
         "",
         "## Reglas duras de coherencia",
         f"1. `problemType` en tu respuesta DEBE ser exactamente `{family}`.",
         f"2. {target_hint}",
-        "3. La narrativa, los datos disponibles y el deadline deben hacer NATURAL",
-        f"   resolver el caso con un modelo de la familia `{family}`. Si la unidad",
-        "   temática del docente sugiere otra familia, prioriza el algoritmo elegido.",
-        "4. NO sugieras técnicas de otras familias en `suggestedTechniques`.",
+        "3. La narrativa, los datos disponibles, el deadline, el módulo y la",
+        f"   unidad temática deben hacer NATURAL resolver el caso con `{req.algorithmPrimary}`.",
+        "   Si la unidad temática sugiere otra familia, prioriza el algoritmo elegido",
+        "   sin dejar de conectar el dilema con el syllabus.",
+        f"4. {profile_guidance}",
+        "5. NO sugieras técnicas de otras familias en `suggestedTechniques`.",
+    ])
+    if req.mode == "single":
+        lines.extend([
+            "",
+            "## Restricción crítica de modo single",
+            f"- Este es un deep dive de **{req.algorithmPrimary}**.",
+            "- `scenarioDescription` y `guidingQuestion` deben enfocarse SOLO en ese algoritmo.",
+            "- NO compares contra Random Forest, XGBoost, Prophet, DBSCAN, Gradient Boosting",
+            "  ni contra ningún otro algoritmo, aunque pertenezca a la misma familia.",
+            "- La pregunta guía NO debe preguntar qué modelo elegir; debe preguntar cómo usar",
+            f"  **{req.algorithmPrimary}** para resolver el dilema del caso.",
+        ])
+    elif req.algorithmChallenger and family_of(req.algorithmChallenger) == family:
+        lines.extend([
+            "",
+            "## Restricción crítica de modo contrast",
+            f"- Compara ÚNICAMENTE **{req.algorithmPrimary}** vs **{req.algorithmChallenger}**.",
+            "- NO introduzcas terceros modelos ni alternativas fuera de esa pareja.",
+            "- La pregunta guía debe expresar el trade-off entre interpretabilidad, desempeño",
+            "  y decisión pedagógica usando solo esos dos algoritmos.",
+        ])
+    lines.extend([
+        "",
+        "## Reglas de calidad para escenario y pregunta",
+        "- `scenarioDescription`: 2-4 oraciones, empresa ficticia, tensión de negocio",
+        "  basada en datos, deadline concreto y ajuste natural al algoritmo elegido.",
+        "- `guidingQuestion`: 1 oración, dilema concreto, sin respuesta obvia y alineado",
+        "  con el modo de algoritmos seleccionado por el docente.",
     ])
     return "\n".join(lines)
 
@@ -829,7 +883,13 @@ async def generate_suggestion(req: SuggestRequest) -> SuggestResponse:
     # Invoke LLM
     model_name = os.getenv("STORYTELLER_MODEL", "gemini-3-flash-preview")
     # Subimos la temperatura a 0.7 para romper el sesgo hacia clasificación/regresión
-    llm = ChatGoogleGenerativeAI(model=model_name, temperature=0.7)
+    llm = ChatGoogleGenerativeAI(
+        model=model_name,
+        temperature=0.7,
+        thinking_level="high",
+        max_retries=2,
+        max_output_tokens=4096,
+    )
     result = await llm.ainvoke(prompt)
 
     # Parse output

--- a/backend/src/case_generator/suggest_service.py
+++ b/backend/src/case_generator/suggest_service.py
@@ -590,7 +590,19 @@ def _build_algorithm_anchor_block(req: SuggestRequest) -> Optional[str]:
         return None
     family_label = FAMILY_LABELS.get(family, family)
     target_hint = _FAMILY_TARGET_HINT.get(family, "")
-    mode_label = "1 algoritmo (deep dive)" if req.mode == "single" else "2 algoritmos (baseline + challenger)"
+    valid_challenger = (
+        req.algorithmChallenger
+        if req.mode == "contrast"
+        and req.algorithmChallenger
+        and family_of(req.algorithmChallenger) == family
+        else None
+    )
+    effective_mode = "contrast" if valid_challenger else "single"
+    mode_label = (
+        "1 algoritmo (deep dive)"
+        if effective_mode == "single"
+        else "2 algoritmos (baseline + challenger)"
+    )
     case_scope = "Caso Harvard con EDA" if req.caseType == "harvard_with_eda" else "Caso Harvard narrativo"
     eda_scope = req.edaDepth or "sin EDA"
     unit_scope = req.topicUnit or "General"
@@ -617,13 +629,13 @@ def _build_algorithm_anchor_block(req: SuggestRequest) -> Optional[str]:
         f"- Profundidad EDA/Python: **{eda_scope}; includePythonCode={req.includePythonCode}**",
         f"- Perfil del curso: **{req.academicLevel}**",
         f"- Perfil del estudiante: **{req.studentProfile}**",
-        f"- Modo de algoritmos/técnicas: **{req.mode} — {mode_label}**",
+        f"- Modo de algoritmos/técnicas: **{effective_mode} — {mode_label}**",
         "",
         f"- Familia anclada: **{family} ({family_label})**",
         f"- Algoritmo principal: **{req.algorithmPrimary}**",
     ]
-    if req.mode == "contrast" and req.algorithmChallenger and family_of(req.algorithmChallenger) == family:
-        lines.append(f"- Challenger (misma familia): **{req.algorithmChallenger}**")
+    if valid_challenger:
+        lines.append(f"- Challenger (misma familia): **{valid_challenger}**")
     lines.extend([
         "",
         "## Reglas duras de coherencia",
@@ -636,7 +648,7 @@ def _build_algorithm_anchor_block(req: SuggestRequest) -> Optional[str]:
         f"4. {profile_guidance}",
         "5. NO sugieras técnicas de otras familias en `suggestedTechniques`.",
     ])
-    if req.mode == "single":
+    if effective_mode == "single":
         lines.extend([
             "",
             "## Restricción crítica de modo single",
@@ -647,11 +659,11 @@ def _build_algorithm_anchor_block(req: SuggestRequest) -> Optional[str]:
             "- La pregunta guía NO debe preguntar qué modelo elegir; debe preguntar cómo usar",
             f"  **{req.algorithmPrimary}** para resolver el dilema del caso.",
         ])
-    elif req.algorithmChallenger and family_of(req.algorithmChallenger) == family:
+    elif valid_challenger:
         lines.extend([
             "",
             "## Restricción crítica de modo contrast",
-            f"- Compara ÚNICAMENTE **{req.algorithmPrimary}** vs **{req.algorithmChallenger}**.",
+            f"- Compara ÚNICAMENTE **{req.algorithmPrimary}** vs **{valid_challenger}**.",
             "- NO introduzcas terceros modelos ni alternativas fuera de esa pareja.",
             "- La pregunta guía debe expresar el trade-off entre interpretabilidad, desempeño",
             "  y decisión pedagógica usando solo esos dos algoritmos.",
@@ -888,7 +900,7 @@ async def generate_suggestion(req: SuggestRequest) -> SuggestResponse:
         temperature=0.7,
         thinking_level="high",
         max_retries=2,
-        max_output_tokens=4096,
+        max_output_tokens=8192,
     )
     result = await llm.ainvoke(prompt)
 

--- a/backend/tests/test_suggest_scenario_anchor.py
+++ b/backend/tests/test_suggest_scenario_anchor.py
@@ -186,6 +186,26 @@ def test_build_prompt_contrast_mode_limits_comparison_to_selected_pair() -> None
     assert "NO introduzcas terceros modelos" in prompt
 
 
+@pytest.mark.parametrize(
+    "challenger",
+    [None, "Random Forest"],
+)
+def test_build_prompt_invalid_contrast_anchor_degrades_to_single(
+    challenger: str | None,
+) -> None:
+    prompt = _build_prompt(
+        _base_req(
+            mode="contrast",
+            algorithmPrimary="ARIMA",
+            algorithmChallenger=challenger,
+        )
+    )
+    assert "Modo de algoritmos/técnicas: **single" in prompt
+    assert "Restricción crítica de modo single" in prompt
+    assert "Restricción crítica de modo contrast" not in prompt
+    assert "Challenger (misma familia)" not in prompt
+
+
 def test_build_prompt_business_anchor_uses_managerial_framing() -> None:
     prompt = _build_prompt(
         _base_req(
@@ -287,7 +307,10 @@ async def test_generate_suggestion_no_warning_when_coherent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_suggestion_uses_high_reasoning_flash_config() -> None:
+async def test_generate_suggestion_uses_high_reasoning_flash_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("STORYTELLER_MODEL", raising=False)
     llm_output = {
         "scenarioDescription": "Pronosticar demanda mensual de SKUs.",
         "guidingQuestion": "¿Cómo usar Prophet para anticipar la demanda del próximo trimestre?",
@@ -309,7 +332,7 @@ async def test_generate_suggestion_uses_high_reasoning_flash_config() -> None:
     assert kwargs["temperature"] == 0.7
     assert kwargs["thinking_level"] == "high"
     assert kwargs["max_retries"] == 2
-    assert kwargs["max_output_tokens"] == 4096
+    assert kwargs["max_output_tokens"] == 8192
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_suggest_scenario_anchor.py
+++ b/backend/tests/test_suggest_scenario_anchor.py
@@ -141,6 +141,77 @@ def test_build_prompt_anchor_includes_challenger_when_same_family() -> None:
     assert "Prophet" in prompt
 
 
+def test_build_prompt_anchor_includes_full_teacher_context() -> None:
+    prompt = _build_prompt(
+        _base_req(
+            subject="Analítica aplicada",
+            academicLevel="MBA ejecutivo",
+            syllabusModule="Gestión de riesgo operacional",
+            topicUnit="Modelos interpretables de riesgo",
+            caseType="harvard_with_eda",
+            edaDepth="charts_plus_code",
+            includePythonCode=True,
+            algorithmPrimary="Logistic Regression",
+        )
+    )
+    assert "Contexto pedagógico que DEBES usar" in prompt
+    assert "Gestión de riesgo operacional" in prompt
+    assert "Modelos interpretables de riesgo" in prompt
+    assert "MBA ejecutivo" in prompt
+    assert "charts_plus_code; includePythonCode=True" in prompt
+
+
+def test_build_prompt_single_mode_forbids_model_comparison() -> None:
+    prompt = _build_prompt(
+        _base_req(mode="single", algorithmPrimary="Logistic Regression")
+    )
+    assert "Modo de algoritmos/técnicas: **single" in prompt
+    assert "Restricción crítica de modo single" in prompt
+    assert "deep dive de **Logistic Regression**" in prompt
+    assert "NO compares contra Random Forest" in prompt
+    assert "La pregunta guía NO debe preguntar qué modelo elegir" in prompt
+
+
+def test_build_prompt_contrast_mode_limits_comparison_to_selected_pair() -> None:
+    prompt = _build_prompt(
+        _base_req(
+            mode="contrast",
+            algorithmPrimary="ARIMA",
+            algorithmChallenger="Prophet",
+        )
+    )
+    assert "Modo de algoritmos/técnicas: **contrast" in prompt
+    assert "Restricción crítica de modo contrast" in prompt
+    assert "Compara ÚNICAMENTE **ARIMA** vs **Prophet**" in prompt
+    assert "NO introduzcas terceros modelos" in prompt
+
+
+def test_build_prompt_business_anchor_uses_managerial_framing() -> None:
+    prompt = _build_prompt(
+        _base_req(
+            studentProfile="business",
+            algorithmPrimary="Logistic Regression",
+        )
+    )
+    assert "Perfil business" in prompt
+    assert "dilema gerencial" in prompt
+    assert "recomendación ejecutiva" in prompt
+    assert "sin convertir la pregunta guía en una clase técnica" in prompt
+
+
+def test_build_prompt_ml_ds_anchor_uses_model_evaluation_framing() -> None:
+    prompt = _build_prompt(
+        _base_req(
+            studentProfile="ml_ds",
+            algorithmPrimary="Logistic Regression",
+        )
+    )
+    assert "Perfil ML/DS" in prompt
+    assert "métricas" in prompt
+    assert "validación" in prompt
+    assert "modelo elegido" in prompt
+
+
 def test_build_prompt_anchor_skipped_for_unknown_algorithm() -> None:
     """Off-catalog name must NOT inject a misleading family pin."""
     prompt = _build_prompt(_base_req(algorithmPrimary="MagicAlgo9000"))
@@ -215,6 +286,32 @@ async def test_generate_suggestion_no_warning_when_coherent() -> None:
     assert resp.problemType == "serie_temporal"
 
 
+@pytest.mark.asyncio
+async def test_generate_suggestion_uses_high_reasoning_flash_config() -> None:
+    llm_output = {
+        "scenarioDescription": "Pronosticar demanda mensual de SKUs.",
+        "guidingQuestion": "¿Cómo usar Prophet para anticipar la demanda del próximo trimestre?",
+        "problemType": "serie_temporal",
+        "targetVariableType": "numeric",
+    }
+    fake = AsyncMock()
+    fake.ainvoke = AsyncMock(return_value=_FakeMessage(json.dumps(llm_output)))
+    with patch(
+        "case_generator.suggest_service.ChatGoogleGenerativeAI",
+        return_value=fake,
+    ) as llm_cls:
+        await generate_suggestion(
+            _base_req(intent=IntentEnum.scenario, algorithmPrimary="Prophet")
+        )
+
+    kwargs = llm_cls.call_args.kwargs
+    assert kwargs["model"] == "gemini-3-flash-preview"
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["thinking_level"] == "high"
+    assert kwargs["max_retries"] == 2
+    assert kwargs["max_output_tokens"] == 4096
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Live smoke (manual, gated by env)
 # ──────────────────────────────────────────────────────────────────────────────
@@ -233,3 +330,25 @@ async def test_live_anchor_prophet_yields_time_series_problem_type() -> None:
         f"Expected anchored prompt to pin problemType=serie_temporal; got "
         f"{resp.problemType!r}. Warning={resp.coherenceWarning!r}"
     )
+
+
+@pytest.mark.live_llm
+@pytest.mark.skipif(
+    os.getenv("RUN_LIVE_LLM_TESTS") != "1",
+    reason="Live LLM smoke; set RUN_LIVE_LLM_TESTS=1 to enable.",
+)
+@pytest.mark.asyncio
+async def test_live_single_logistic_regression_does_not_compare_random_forest() -> None:
+    resp = await generate_suggestion(
+        _base_req(
+            subject="Analítica de clientes",
+            syllabusModule="Modelos interpretables para decisiones comerciales",
+            topicUnit="Regresión logística aplicada",
+            intent=IntentEnum.scenario,
+            mode="single",
+            algorithmPrimary="Logistic Regression",
+        )
+    )
+    generated = f"{resp.scenarioDescription} {resp.guidingQuestion}".lower()
+    assert "random forest" not in generated
+    assert "logistic regression" in generated or "regresión logística" in generated


### PR DESCRIPTION
## Summary
- Strengthens the `/api/suggest` scenario anchor prompt with full pedagogical context from the teacher form: syllabus module, topic unit, case scope, student profile, algorithm mode, and selected algorithm(s).
- Makes single-mode prompts explicitly deep-dive only on the primary algorithm, preventing model-comparison framing such as Logistic Regression vs Random Forest.
- Configures the suggester Gemini client for `thinking_level="high"` with bounded retries/output tokens while keeping the existing `STORYTELLER_MODEL` override.
- Adds focused backend tests for prompt context, single vs contrast rules, business vs ML/DS framing, LLM configuration, and a gated live smoke.

## Scope Notes
- Prompt-only implementation by request: no corrective reprompt, no deterministic post-LLM detector, no frontend fallback changes.
- Existing family-level `coherenceWarning` behavior remains unchanged.

## Validation
- `uv run --directory backend pytest tests/test_suggest_scenario_anchor.py tests/test_issue230_algorithm_mode.py -q` -> 61 passed, 2 skipped
- `uv run --directory backend pytest -q` -> 729 passed, 14 skipped, 1 warning
- `uv run --directory backend mypy src` -> Success: no issues found in 52 source files

## Notes
- VS Code/Pylance reported unresolved imports for backend packages in the editor, but the configured backend environment validates with pytest and mypy.