### PR TITLE
feat: retire ARIMA and Prophet from active algorithm catalog (serie_temporal)

### DIFF
--- a/backend/src/case_generator/suggest_service.py
+++ b/backend/src/case_generator/suggest_service.py
@@ -147,40 +147,25 @@ ALGORITHM_CATALOG: list[dict[str, object]] = [
         "prerequisite": "≥2 columnas numéricas escalables (sin target). StandardScaler obligatorio.",
         "fragments_hint": ["valor", "monto", "cantidad", "score", "edad", "ingreso", "frecuencia"],
     },
-    # ── Series Temporales ───────────────────────────────────────────────────
-    {
-        "name": "ARIMA",
-        "family": "serie_temporal",
-        "family_label": FAMILY_LABELS["serie_temporal"],
-        "tier": "baseline",
-        "profile_visibility": ["business", "ml_ds"],
-        "prompt_key": "timeseries",
-        "visualization": "Forecast vs actual con eje fecha + Residuals vs tiempo",
-        "prerequisite": "Columna fecha parseable + columna numérica objetivo + ≥30 puntos.",
-        "fragments_hint": ["fecha", "date", "timestamp", "periodo", "mes", "dia", "year_month"],
-    },
-    {
-        "name": "Prophet",
-        "family": "serie_temporal",
-        "family_label": FAMILY_LABELS["serie_temporal"],
-        "tier": "challenger",
-        "profile_visibility": ["ml_ds"],
-        "prompt_key": "timeseries",
-        "visualization": "Forecast vs actual con eje fecha + Residuals vs tiempo (fallback ARIMA si Prophet no instalado)",
-        "prerequisite": "Columna fecha parseable + columna numérica objetivo + ≥30 puntos.",
-        "fragments_hint": ["fecha", "date", "timestamp", "periodo", "mes", "dia", "year_month"],
-    },
 ]
 
 
 def _validate_catalog_invariants() -> None:
-    """Fail-fast at import time so the catalog never ships violating its contract."""
+    """Fail-fast at import time so the catalog never ships violating its contract.
+
+    ``FAMILY_LABELS`` is the superset of all recognised families (including
+    legacy ones kept for historical job replay).  The active catalog may expose
+    a strict subset of those families — every catalog family must be a known
+    label, but not every label needs an active catalog entry.
+    """
     by_family: dict[str, list[dict[str, object]]] = {}
     for entry in ALGORITHM_CATALOG:
         by_family.setdefault(cast(str, entry["family"]), []).append(entry)
-    if set(by_family) != set(FAMILY_LABELS):
+    unknown_families = set(by_family) - set(FAMILY_LABELS)
+    if unknown_families:
         raise RuntimeError(
-            f"Catalog families {sorted(by_family)} != FAMILY_LABELS {sorted(FAMILY_LABELS)}"
+            f"Catalog uses unknown families {sorted(unknown_families)}; "
+            f"add them to FAMILY_LABELS first."
         )
     for family, entries in by_family.items():
         if len(entries) > 2:
@@ -230,7 +215,9 @@ _LEGACY_FAMILY_MAP: dict[str, str] = {
     "lasso": "regresion",
     "elastic net": "regresion",
     "svr": "regresion",
-    # time series surrogates
+    # time series surrogates (includes catalog algorithms now retired to legacy)
+    "arima": "serie_temporal",
+    "prophet": "serie_temporal",
     "stl": "serie_temporal",
     "lstm": "serie_temporal",
     "auto_arima": "serie_temporal",
@@ -585,16 +572,24 @@ def _build_algorithm_anchor_block(req: SuggestRequest) -> Optional[str]:
         return None
     family = family_of(req.algorithmPrimary)
     if not family:
-        # Off-catalog algorithm — refuse to anchor on a guess. Better to fall
-        # back to the global-taxonomy prompt than mislead the LLM.
+        # Algorithm not in the active catalog — try the legacy resolver so that
+        # historical picks (e.g. ARIMA, Prophet) still produce a valid anchor.
+        legacy = resolve_legacy_family(req.algorithmPrimary)
+        family = legacy[0] if legacy else None
+    if not family:
+        # Truly unknown algorithm — refuse to anchor on a guess.
         return None
     family_label = FAMILY_LABELS.get(family, family)
     target_hint = _FAMILY_TARGET_HINT.get(family, "")
+    challenger_family = family_of(req.algorithmChallenger) if req.algorithmChallenger else None
+    if not challenger_family and req.algorithmChallenger:
+        legacy_c = resolve_legacy_family(req.algorithmChallenger)
+        challenger_family = legacy_c[0] if legacy_c else None
     valid_challenger = (
         req.algorithmChallenger
         if req.mode == "contrast"
         and req.algorithmChallenger
-        and family_of(req.algorithmChallenger) == family
+        and challenger_family == family
         else None
     )
     effective_mode = "contrast" if valid_challenger else "single"
@@ -1048,6 +1043,10 @@ def _check_scenario_family_coherence(
     if not req.algorithmPrimary:
         return None
     expected_family = family_of(req.algorithmPrimary)
+    if not expected_family:
+        # Algorithm not in the active catalog — try the legacy resolver.
+        legacy = resolve_legacy_family(req.algorithmPrimary)
+        expected_family = legacy[0] if legacy else None
     if not expected_family:
         return None
     # Only meaningful when the LLM actually produced a scenario in this call.

--- a/backend/src/case_generator/suggest_service.py
+++ b/backend/src/case_generator/suggest_service.py
@@ -284,15 +284,36 @@ def resolve_legacy_family(legacy_name: str) -> Optional[tuple[str, str]]:
     return None
 
 
+# Static dispatch metadata for families retired from the active catalog.
+# Required so historical jobs that stored ARIMA or Prophet in task_payload
+# still dispatch correctly to the M3 notebook prompt via get_dispatch_meta()
+# in graph.py::m3_notebook_generator without raising a KeyError.
+_LEGACY_DISPATCH_META: dict[str, dict[str, object]] = {
+    "serie_temporal": {
+        "familia": "serie_temporal",
+        "family_label": FAMILY_LABELS["serie_temporal"],
+        "prompt_key": "timeseries",
+        "visualizacion": "Forecast vs actual con eje fecha + Residuals vs tiempo",
+        "prerequisito": "Columna fecha parseable + columna numérica objetivo + ≥30 puntos.",
+        "fragments_hint": ["fecha", "date", "timestamp", "periodo", "mes", "dia", "year_month"],
+    },
+}
+
+
 def get_dispatch_meta(family: str) -> dict[str, object]:
     """Aggregated per-family dispatch metadata for the M3 notebook prompt.
 
     Returns a single dict ``{familia, family_label, prompt_key, visualizacion,
     prerequisito, fragments_hint}``. Both algorithms in a family share the same
     ``prompt_key`` and use the same prerequisite, so we collapse them.
+
+    Falls back to ``_LEGACY_DISPATCH_META`` for families retired from the active
+    catalog (e.g. ``serie_temporal``) so historical job replay keeps working.
     """
     entries = [e for e in ALGORITHM_CATALOG if e["family"] == family]
     if not entries:
+        if family in _LEGACY_DISPATCH_META:
+            return _LEGACY_DISPATCH_META[family]
         raise KeyError(f"Unknown family: {family!r}")
     fragments: list[str] = []
     for e in entries:

--- a/backend/tests/test_issue230_algorithm_mode.py
+++ b/backend/tests/test_issue230_algorithm_mode.py
@@ -92,17 +92,17 @@ def test_catalog_ml_ds_excludes_lstm() -> None:
 
 def test_catalog_items_are_grouped_by_family() -> None:
     families = {it["family"] for it in _items("ml_ds")}
-    # Issue #233 — canonical 4-family taxonomy. nlp/recomendacion deprecated.
-    assert families == {"clasificacion", "regresion", "clustering", "serie_temporal"}
+    # serie_temporal retired from active catalog; ARIMA/Prophet moved to legacy map.
+    assert families == {"clasificacion", "regresion", "clustering"}
     # family_label is non-empty and human-readable.
     for it in _items("ml_ds"):
         assert it["family_label"] and isinstance(it["family_label"], str)
 
 
-# Issue #233 — 4×2 catalog invariants.
-def test_catalog_has_exactly_4_families() -> None:
+# serie_temporal removed from active catalog; 3 active families remain.
+def test_catalog_has_exactly_3_families() -> None:
     families = {it["family"] for it in _items("ml_ds")}
-    assert families == {"clasificacion", "regresion", "clustering", "serie_temporal"}
+    assert families == {"clasificacion", "regresion", "clustering"}
 
 
 def test_catalog_each_family_has_max_2_algorithms() -> None:
@@ -130,17 +130,20 @@ def test_catalog_business_only_baselines() -> None:
     for it in items:
         assert it["tier"] == "baseline", f"business no debe ver challengers: {it}"
     families = {it["family"] for it in items}
-    assert families == {"clasificacion", "regresion", "clustering", "serie_temporal"}
+    assert families == {"clasificacion", "regresion", "clustering"}
 
 
-def test_catalog_ml_ds_has_8_algorithms() -> None:
-    # 4 families × 2 tiers (baseline + challenger) = 8 entries for ml_ds.
-    assert len(_items("ml_ds")) == 8
+def test_catalog_ml_ds_has_6_algorithms() -> None:
+    # 3 active families × 2 tiers (baseline + challenger) = 6 entries for ml_ds.
+    # serie_temporal (ARIMA/Prophet) retired from active catalog.
+    assert len(_items("ml_ds")) == 6
 
 
 def test_catalog_no_legacy_algorithms_exposed() -> None:
     # Issue #233 — these names were removed from the canonical catalog.
-    forbidden = {"xgboost", "ridge", "lasso", "lstm", "svm", "naive bayes"}
+    # ARIMA and Prophet are added here as they were retired from the active
+    # catalog and moved to the legacy resolver map.
+    forbidden = {"xgboost", "ridge", "lasso", "lstm", "svm", "naive bayes", "arima", "prophet"}
     names = {it["name"].lower() for it in _items("ml_ds")}
     assert names.isdisjoint(forbidden), f"algoritmos legacy reaparecieron: {names & forbidden}"
 

--- a/backend/tests/test_m3_notebook_dispatch.py
+++ b/backend/tests/test_m3_notebook_dispatch.py
@@ -18,6 +18,7 @@ from case_generator.graph import (
     _strip_jupytext_for_validation,
     _validate_notebook_family_consistency,
 )
+from case_generator.suggest_service import get_dispatch_meta
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -289,3 +290,51 @@ def test_validator_still_catches_real_violations_after_filter() -> None:
     )
     violations = _validate_notebook_family_consistency("regresion", nb)
     assert "roc_auc_score" in violations
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# get_dispatch_meta — legacy family fallback (Issue #261)
+# Retiring ARIMA and Prophet from the active catalog must not break M3 dispatch
+# for historical jobs that already stored "serie_temporal" in task_payload.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_get_dispatch_meta_serie_temporal_does_not_raise() -> None:
+    """get_dispatch_meta must not raise KeyError for the retired serie_temporal family."""
+    meta = get_dispatch_meta("serie_temporal")
+    assert isinstance(meta, dict)
+
+
+def test_get_dispatch_meta_serie_temporal_returns_correct_prompt_key() -> None:
+    meta = get_dispatch_meta("serie_temporal")
+    assert meta["prompt_key"] == "timeseries"
+
+
+def test_get_dispatch_meta_serie_temporal_returns_required_keys() -> None:
+    meta = get_dispatch_meta("serie_temporal")
+    required = {"familia", "family_label", "prompt_key", "visualizacion", "prerequisito", "fragments_hint"}
+    assert required.issubset(meta.keys())
+
+
+def test_get_dispatch_meta_serie_temporal_family_label_is_string() -> None:
+    meta = get_dispatch_meta("serie_temporal")
+    assert isinstance(meta["family_label"], str) and meta["family_label"]
+
+
+def test_get_dispatch_meta_serie_temporal_fragments_hint_is_nonempty_list() -> None:
+    meta = get_dispatch_meta("serie_temporal")
+    hints = meta["fragments_hint"]
+    assert isinstance(hints, list) and len(hints) > 0
+
+
+def test_get_dispatch_meta_active_family_still_works() -> None:
+    """Active families must still resolve from the catalog (regression guard)."""
+    for family in ("clasificacion", "regresion", "clustering"):
+        meta = get_dispatch_meta(family)
+        assert meta["familia"] == family
+
+
+def test_get_dispatch_meta_unknown_family_raises_key_error() -> None:
+    """Truly unknown families must still raise KeyError (contract unchanged)."""
+    with pytest.raises(KeyError):
+        get_dispatch_meta("nlp_text_mining")


### PR DESCRIPTION
## Resumen

Elimina ARIMA (baseline) y Prophet (challenger) del catálogo activo `ALGORITHM_CATALOG`, dejando **3 familias activas** (`clasificacion`, `regresion`, `clustering`) con **6 entradas** (3×2).

Los trabajos de autoría históricos que ya contienen ARIMA o Prophet en su `task_payload` continúan funcionando sin cambios a través del resolver de familia legacy.

---

## Cambios

### `backend/src/case_generator/suggest_service.py`

| Cambio | Detalle |
|--------|---------|
| **Eliminar** entradas ARIMA y Prophet de `ALGORITHM_CATALOG` | La familia `serie_temporal` ya no aparece en el selector del formulario docente |
| **Agregar** `"arima"` y `"prophet"` a `_LEGACY_FAMILY_MAP` | Los jobs históricos con estos algoritmos continúan despachando al prompt `serie_temporal` vía `resolve_legacy_family()` — exactamente igual que `lstm`, `stl`, `auto_arima` |
| **Relajar** `_validate_catalog_invariants()` de igualdad a subconjunto | El catálogo puede exponer menos familias que las definidas en `FAMILY_LABELS`; `FAMILY_LABELS` es el superconjunto (incluye legacy). La validación ahora comprueba que toda familia del catálogo sea un label reconocido. |
| **Agregar fallback** `resolve_legacy_family()` en `_build_algorithm_anchor_block` y `_check_scenario_family_coherence` | El endpoint `/api/suggest` sigue anclando y evaluando coherencia correctamente cuando un cliente envía un nombre legacy (ARIMA, Prophet) |

### `backend/tests/test_issue230_algorithm_mode.py`

5 assertions que hardcodeaban el conteo 4-familias / 8-algoritmos actualizados:

| Test | Cambio |
|------|--------|
| `test_catalog_items_are_grouped_by_family` | Set esperado: `{clasificacion, regresion, clustering}` |
| `test_catalog_has_exactly_4_families` → `test_catalog_has_exactly_3_families` | Renombrado + set a 3 familias |
| `test_catalog_business_only_baselines` | Set esperado: 3 familias |
| `test_catalog_ml_ds_has_8_algorithms` → `test_catalog_ml_ds_has_6_algorithms` | `8 → 6`; comentario `3 families × 2 tiers = 6` |
| `test_catalog_no_legacy_algorithms_exposed` | `"arima"` y `"prophet"` añadidos al conjunto `forbidden` |

---

## Sin cambios en

- `PROMPT_BY_FAMILY["serie_temporal"]` — conservado para replay de jobs históricos
- `_FAMILY_PROHIBITED_PATTERNS["serie_temporal"]` — conservado; el validador sigue activo
- `graph.py` dispatch, notebook prompts, validators
- Frontend — consume el catálogo dinámicamente, sin hardcoding
- `FAMILY_LABELS`, `FAMILY_META`, `_FAMILY_TARGET_HINT` — conservados (el suggester los necesita para tipos de problema y prompts legacy)

---

## Verificación

```
763 passed, 14 skipped, 0 failed (suite completa)
```

Tests clave validados:
- `test_issue230_algorithm_mode.py` — 42/42 ✅
- `test_m3_notebook_dispatch.py` — `test_detect_canonical_timeseries` sigue pasando (ARIMA resuelve vía legacy map → `serie_temporal`) ✅
- `test_m3_notebook_per_family_prompts.py` — `PROMPT_BY_FAMILY` aún tiene 4 keys ✅
- `test_suggest_scenario_anchor.py` — 21/21 (anchor y coherence funcionan con nombres legacy) ✅

---

## Merge

Squash and merge según política del repo.