### PR TITLE
feat(m2): per-family dataset schema prompt dispatch for clasificacion

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -4,6 +4,89 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
+## TODO-M2-A: Especializar SCHEMA_DESIGNER_PROMPT_CLASSIFICATION para la familia clasificación
+
+**What:** Reemplazar el contenido de `SCHEMA_DESIGNER_PROMPT_CLASSIFICATION` en
+`backend/src/case_generator/prompts/clasificacion/dataset.py` con un prompt diseñado
+específicamente para casos de clasificación (target binario/multiclase, columnas de
+class-imbalance, vocabulario de features para LR/RF, restricciones de distribución
+de clases).
+
+**Why:** Actualmente el prompt es una copia idéntica del genérico `SCHEMA_DESIGNER_PROMPT`.
+La separación estructural ya existe (branch `feat/m2-dataset-family-dispatch`); lo que
+falta es la especialización del contenido. Un prompt específico de clasificación genera
+datasets de mayor calidad para M3 (notebook LR/RF) porque puede reforzar: columna `label`
+o `categoria` con distribución de clases realista, features correladas con el target,
+y ausencia de leakage por construcción.
+
+**Pros:** Mejor calidad del dataset para todos los casos `ml_ds + clasificacion`;
+permite controlar directamente el `class_imbalance_ratio` y el vocabulario de features
+sin depender de la heurística genérica del LLM.
+
+**Cons:** Requiere ingeniería de prompt, fixtures de evaluación para validar que no
+rompe el schema contract de Issue #225, y al menos un run live para confirmar calidad.
+
+**Context:** El fichero destino es `prompts/clasificacion/dataset.py`, variable
+`SCHEMA_DESIGNER_PROMPT_CLASSIFICATION`. El dispatch ya está cableado: `schema_designer()`
+en `graph.py` selecciona este prompt cuando `primary_family == "clasificacion"`. El
+cambio sólo toca la cadena de texto — no la lógica de dispatch ni el pipeline de datos.
+Empezar por identificar qué columnas ML son específicas de clasificación en el
+VOCABULARIO OBLIGATORIO y añadir reglas de distribución de clases para `label`/`categoria`.
+
+**Depends on / blocked by:** Branch `feat/m2-dataset-family-dispatch` mergeado a main.
+
+---
+
+## TODO-M2-B: Añadir dispatch de dataset para la familia regresión
+
+**What:** Crear `backend/src/case_generator/prompts/regresion/dataset.py` con
+`SCHEMA_DESIGNER_PROMPT_REGRESSION` y extender `SCHEMA_DESIGNER_PROMPT_BY_FAMILY`
+con la clave `"regresion"`.
+
+**Why:** Completa el patrón de separación por familia para regresión (target continuo,
+features numéricas correladas, sin columna de clase). Sigue el mismo patrón de 5 pasos
+establecido en `feat/m2-dataset-family-dispatch` para clasificación.
+
+**Pros:** Habilita especialización futura del schema de regresión sin afectar otras
+familias; la carpeta `prompts/regresion/` no existe aún — este TODO la crea.
+
+**Cons:** Requiere crear la carpeta, el módulo y el `__init__.py` de regresión antes
+de poder especializar el prompt. La estructura es idéntica a la de clasificación.
+
+**Context:** El dispatch en `schema_designer()` ya usa `.get(primary_family, SCHEMA_DESIGNER_PROMPT)`
+como fallback, por lo que la ausencia de la clave `"regresion"` no rompe nada hoy.
+Cuando se cree el prompt, sólo hay que añadir la clave al dict en `prompts/__init__.py`.
+Ver `prompts/clasificacion/dataset.py` como template exacto.
+
+**Depends on / blocked by:** TODO-M2-A (opcional — puede hacerse en paralelo si el
+prompt de regresión se define antes de especializar el de clasificación).
+
+---
+
+## TODO-M2-C: Añadir dispatch de dataset para la familia clustering
+
+**What:** Crear `backend/src/case_generator/prompts/clustering/dataset.py` con
+`SCHEMA_DESIGNER_PROMPT_CLUSTERING` y extender `SCHEMA_DESIGNER_PROMPT_BY_FAMILY`
+con la clave `"clustering"`.
+
+**Why:** Completa la cobertura de las 3 familias activas del catálogo (clasificacion,
+regresion, clustering). Clustering no tiene target column — el prompt debe reforzar
+eso explícitamente para evitar que el LLM genere una columna `label` o `categoria`.
+
+**Pros:** Cierra la brecha de calidad de dataset para jobs de clustering (K-Means);
+elimina el riesgo de que el prompt genérico genere un target innecesario.
+
+**Cons:** Mismos que TODO-M2-B. Tercera iteración del mismo patrón — bajo riesgo.
+
+**Context:** `serie_temporal` está retirada del catálogo activo y no necesita un
+prompt especializado en este ciclo. Cuando clustering esté hecho, las 3 familias
+activas tendrán su propio prompt de dataset, completando la arquitectura de dispatch.
+
+**Depends on / blocked by:** TODO-M2-B (regresion) y branch `feat/m2-dataset-family-dispatch`
+mergeado.
+
+---
+
 ## TODO-244-A: Test unitario React para badge `learning_type` en `AlgorithmSelector`
 
 **What:** Agregar un test Vitest + React Testing Library que renderice `AlgorithmSelector` con un catálogo mockeado y verifique que el badge "Supervisado" / "No Supervisado" se renderiza correctamente según el campo `learning_type` de cada ítem.

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -108,6 +108,7 @@ from case_generator.prompts import (
     TEACHING_NOTE_PART1_PROMPT,
     TEACHING_NOTE_PART2_PROMPT,
     SCHEMA_DESIGNER_PROMPT,
+    SCHEMA_DESIGNER_PROMPT_BY_FAMILY,
 )
 from case_generator.suggest_service import (
     family_of,
@@ -2456,6 +2457,14 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
         ", ".join(familias_detectadas) if familias_detectadas else "clasificacion"
     )
 
+    # Resolve primary family for per-family prompt dispatch (M2 dataset, Issue #233).
+    # _detect_algorithm_families is kept above for the vocabulary string; this separate
+    # call resolves the single primary family used to select the schema design prompt.
+    primary_family, _legacy_warn_schema = _resolve_primary_family(algoritmos_raw)
+    _schema_prompt = SCHEMA_DESIGNER_PROMPT_BY_FAMILY.get(
+        primary_family or "", SCHEMA_DESIGNER_PROMPT
+    )
+
     context = _build_base_context(state)
     context.update({
         "titulo": state.get("titulo", ""),
@@ -2470,7 +2479,7 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
             state.get("dataset_schema_required")
         ),
     })
-    prompt = SCHEMA_DESIGNER_PROMPT.format(**context)
+    prompt = _schema_prompt.format(**context)
 
     # Cadena de fallback resiliente alineada con el patrón del case_architect (M1):
     #   1) Pro thinking_level="medium" — primario (mantiene thinking; subir a "high"

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -37,6 +37,7 @@ from case_generator.prompts.clasificacion import (
     M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_RF_ONLY,
     M4_PROMPT_CLASSIFICATION,
     M5_PROMPT_CLASSIFICATION,
+    SCHEMA_DESIGNER_PROMPT_CLASSIFICATION,
 )
 
 
@@ -1366,6 +1367,16 @@ M5_PROMPT_BY_FAMILY: dict[str, str] = {
     "serie_temporal": M5_CONTENT_GENERATOR_PROMPT,
 }
 
+# ── SCHEMA_DESIGNER_PROMPT_BY_FAMILY — dispatch table consumed by
+# graph.py::schema_designer.  Keys MUST match values returned by
+# ``family_of(name)`` / ``resolve_legacy_family(name)`` in suggest_service.py.
+# Non-clasificacion families fall back to the generic SCHEMA_DESIGNER_PROMPT
+# until their specialised prompts are authored in future iterations.
+SCHEMA_DESIGNER_PROMPT_BY_FAMILY: dict[str, str] = {
+    "clasificacion": SCHEMA_DESIGNER_PROMPT_CLASSIFICATION,
+    # regresion, clustering, serie_temporal — deferred (future iterations)
+}
+
 
 M5_QUESTIONS_GENERATOR_PROMPT = """\
 # Your Identity
@@ -2542,6 +2553,8 @@ __all__ = [
   "ClassificationNotebookVariant",
   "PROMPT_BY_FAMILY",
   "SCHEMA_DESIGNER_PROMPT",
+  "SCHEMA_DESIGNER_PROMPT_BY_FAMILY",
+  "SCHEMA_DESIGNER_PROMPT_CLASSIFICATION",
   "TEACHING_NOTE_PART1_PROMPT",
   "TEACHING_NOTE_PART2_PROMPT",
 ]

--- a/backend/src/case_generator/prompts/clasificacion/__init__.py
+++ b/backend/src/case_generator/prompts/clasificacion/__init__.py
@@ -1,5 +1,8 @@
 """Classification-family prompt exports."""
 
+from case_generator.prompts.clasificacion.dataset import (
+    SCHEMA_DESIGNER_PROMPT_CLASSIFICATION,
+)
 from case_generator.prompts.clasificacion.narrative import (
     M3_CONTENT_PROMPT_CLASSIFICATION,
     M3_CONTENT_PROMPT_CLASSIFICATION_BY_VARIANT,
@@ -23,6 +26,7 @@ from case_generator.prompts.clasificacion.notebooks import (
 )
 
 __all__ = [
+    "SCHEMA_DESIGNER_PROMPT_CLASSIFICATION",
     "M3_CONTENT_PROMPT_CLASSIFICATION",
     "M3_CONTENT_PROMPT_CLASSIFICATION_LR_ONLY",
     "M3_CONTENT_PROMPT_CLASSIFICATION_RF_ONLY",

--- a/backend/src/case_generator/prompts/clasificacion/dataset.py
+++ b/backend/src/case_generator/prompts/clasificacion/dataset.py
@@ -1,0 +1,169 @@
+"""Dataset schema design prompt for the clasificacion algorithm family.
+
+This module is the landing zone for classification-specific dataset prompt
+specialization (Issue #233 / M2 per-family dispatch).
+
+Current state: the prompt is semantically identical to ``SCHEMA_DESIGNER_PROMPT``
+in ``prompts/__init__.py``.  The structural separation exists so that future
+iterations can tune vocabulary, target-column rules, class-imbalance constraints,
+and LR/RF-specific feature engineering *without* touching the generic prompt that
+serves all other families.
+
+# TODO: Specialize SCHEMA_DESIGNER_PROMPT_CLASSIFICATION for clasificacion
+#       (enforce binary target, class-imbalance columns, LR/RF feature vocabulary)
+#       after the per-family dispatch plumbing is confirmed stable in production.
+"""
+
+__all__ = ["SCHEMA_DESIGNER_PROMPT_CLASSIFICATION"]
+
+# Identical to SCHEMA_DESIGNER_PROMPT until specialized in a future iteration.
+# Do NOT edit this string to patch generic schema bugs — fix SCHEMA_DESIGNER_PROMPT
+# in prompts/__init__.py and then mirror the fix here to keep them in sync until
+# divergence is intentional.
+SCHEMA_DESIGNER_PROMPT_CLASSIFICATION = """\
+Diseña el schema de un dataset sintético para el caso de negocio dado.
+Perfil: {student_profile} | Industria: {industria}
+
+## Contrato dataset_schema_required (Issue #225 — fuente de verdad)
+{dataset_contract_block}
+
+REGLAS DE COBERTURA DEL CONTRATO (cuando NO esté vacío):
+- Tu `columns` DEBE incluir, con el mismo `name` exacto, la `target_column.name`
+  del contrato y TODAS las `feature_columns[*].name`.
+- El `type` de cada columna debe coincidir con el `dtype` del contrato.
+- Si una feature del contrato tiene `is_leakage_risk=true` o
+  `temporal_offset_months>0`, igual debes incluirla con su nombre exacto:
+  el bloqueo de leakage se gestiona downstream en M3 (no la omitas aquí).
+- Las categorías de `domain_features_required` deben estar cubiertas por al menos
+  una columna semánticamente alineada (puedes elegir su nombre concreto).
+- Si el contrato es `null` o `{{}}`, opera con las reglas heurísticas de abajo.
+
+## ESTRUCTURA DE OUTPUT OBLIGATORIA (JSON puro, sin markdown, sin claves extra)
+{{
+  "columns": [
+    {{
+      "name": "period",
+      "type": "str",
+      "description": "Período temporal (ej: '2024-01')",
+      "range_min": null,
+      "range_max": null,
+      "nullable": false,
+      "trend": null,
+      "dependency": null
+    }},
+    {{
+      "name": "revenue",
+      "type": "float",
+      "description": "Ingresos del período",
+      "range_min": <revenue_anual_absoluto / {max_rows} * 0.85>,
+      "range_max": <revenue_anual_absoluto / {max_rows} * 1.15>,
+      "nullable": false,
+      "trend": "up",
+      "dependency": null
+    }},
+    {{
+      "name": "churn_rate",
+      "type": "float",
+      "description": "Tasa de abandono mensual (0.0 a 1.0)",
+      "range_min": 0.02,
+      "range_max": 0.15,
+      "nullable": false,
+      "trend": null,
+      "dependency": {{
+        "depends_on": "revenue",
+        "relationship": "inverse",
+        "noise_factor": 0.1
+      }}
+    }},
+    {{
+      "name": "retention_m1",
+      "type": "float",
+      "description": "% de usuarios retenidos de la cohorte de ese period en el mes 1",
+      "range_min": 0.65,
+      "range_max": 0.95,
+      "nullable": false,
+      "trend": null,
+      "dependency": null
+    }},
+    {{
+      "name": "retention_m3",
+      "type": "float",
+      "description": "% de usuarios retenidos en el mes 3",
+      "range_min": 0.50,
+      "range_max": 0.80,
+      "nullable": false,
+      "trend": null,
+      "dependency": {{
+        "depends_on": "retention_m1",
+        "relationship": "linear",
+        "noise_factor": 0.05
+      }}
+    }}
+    ... más columnas según perfil ...
+  ],
+  "n_rows": <VER REGLA DE FILAS ABAJO>,
+  "time_granularity": "monthly",
+  "constraints": {{
+    "revenue_annual_total": <extraer del Exhibit 1 — año N — SIEMPRE en UNIDADES ABSOLUTAS.
+      Si el Exhibit dice "$150M" → escribir 150000000. Si dice "$18.5M" → 18500000.
+      NUNCA en millones (150), NUNCA con sufijo ("150M"), NUNCA en miles (150000 para $150M).>,
+    "cost_annual_total": <extraer del Exhibit 1 en unidades absolutas o null>,
+    "ebitda_annual_total": <extraer del Exhibit 1 o null>,
+    "tolerance_pct": 0.05,
+    "revenue_column": "revenue"
+  }},
+  "reasoning_summary": "<justificación en 1 línea>"
+}}
+
+## Regla de filas (n_rows)
+- Para {student_profile}="business": elige un entero ALEATORIO estrictamente entre 80 y 120. NO uses {max_rows}.
+- Para {student_profile}="ml_ds": usa exactamente {max_rows}.
+
+## Reglas para columnas
+- type DEBE ser exactamente: "int", "float", "str", o "date" (no "string", no "integer").
+- trend: "up" (crece), "down" (decrece), "stable" (sin tendencia), o null.
+- dependency: objeto con depends_on, relationship ("linear" o "inverse"), noise_factor (0.0-1.0), o null.
+  REGLA CRÍTICA: depends_on SOLO puede referenciar columnas de tipo "int" o "float".
+  Está estrictamente prohibido que depends_on apunte a columnas de tipo "str" o "date".
+- Para {student_profile}="business": EXACTAMENTE 10 columnas, nullable=false en todas.
+  Columnas obligatorias en este orden:
+  period, revenue, costs, margin_pct, churn_rate, nps,
+  retention_m1, retention_m3, retention_m6, retention_m12.
+  (CRÍTICO: Las columnas retention_mX representan el % de usuarios de esa cohorte
+  retenidos en el mes X. Son obligatorias para el heatmap de análisis de cohortes.
+  Asegúrate de que range_min/max respeten: retention_m1 > retention_m3 > retention_m6 > retention_m12.)
+- Para {student_profile}="ml_ds": MÍNIMO 14 columnas, al menos 2 con nullable=true.
+  Las primeras 12 columnas son FIJAS en este orden:
+  period, revenue, costs, margin_pct, churn_rate, nps,
+  retention_m1, retention_m3, retention_m6, retention_m12,
+  customer_ltv (nullable=true), engagement_score (nullable=true).
+  A partir de la columna 13, OBLIGATORIAMENTE debes generar las columnas necesarias
+  para satisfacer las familias ML requeridas para este caso: {ml_required_families}.
+  Usa EXACTAMENTE los nombres y reglas definidos en el VOCABULARIO OBLIGATORIO de abajo.
+  Puedes superar 14 columnas (ej. 15 o 16) si las familias requeridas así lo exigen.
+  NUNCA inventes nombres fuera del vocabulario.
+
+## VOCABULARIO OBLIGATORIO para columnas ML dinámicas (ml_ds)
+
+  | Familia ML         | Nombres exactos permitidos          | type          | Reglas de campo                                           |
+  |--------------------|-------------------------------------|---------------|-----------------------------------------------------------|
+  | NLP / text-mining  | ticket_text  O  comentario          | "str"         | range_min=null, range_max=null, trend=null, dep=null      |
+  | Clasificación      | categoria  O  label                 | "str"         | range_min=null, range_max=null, trend=null, dep=null      |
+  | Grafos             | origen  Y  destino  (par)           | "str"         | genera AMBAS columnas; mismas reglas de nulls             |
+  | Recomendación      | usuario, producto, rating           | "str"/"float" | genera las 3; rating: range_min=-1.0, range_max=5.0       |
+  | Sentimiento        | sentiment_score                     | "float"       | range_min=-1.0, range_max=1.0, trend=null, dep=null       |
+  | Anomalías          | transaction_amount                  | "float"       | range según el caso, trend=null, dep=null                 |
+
+  Reglas de uso:
+  1. Genera UNA columna por cada familia listada en {ml_required_families}, respetando los nombres exactos.
+  2. Para familias que requieren par (Grafos: origen+destino) o trío (Recomendación: usuario+producto+rating), genera TODAS las columnas del grupo.
+  3. Para columnas de tipo "str": SIEMPRE range_min=null, range_max=null, trend=null, dependency=null.
+- range_min/range_max: números para columnas numéricas, null para str/date.
+
+## Exhibits del caso
+### Exhibit 1 — Financiero (extrae revenue_annual_total de aquí)
+{financial_data}
+
+### Exhibit 2 — Operativo
+{operational_data}
+"""

--- a/backend/tests/test_m2_dataset_family_dispatch.py
+++ b/backend/tests/test_m2_dataset_family_dispatch.py
@@ -66,11 +66,12 @@ def test_dispatch_clasificacion_routes_to_classification_prompt() -> None:
     assert SCHEMA_DESIGNER_PROMPT_BY_FAMILY["clasificacion"] is SCHEMA_DESIGNER_PROMPT_CLASSIFICATION
 
 
-def test_dispatch_clasificacion_not_generic_prompt() -> None:
-    """The classification prompt object is distinct from the generic fallback.
-    This will fail (correctly) once the two prompts are intentionally diverged."""
-    # Currently they are identical strings but different objects — that's fine.
-    # This test guards that the dispatch key is present and resolvable.
+def test_dispatch_clasificacion_via_get_routes_to_classification_prompt() -> None:
+    """The .get() dispatch path (as used in graph.py schema_designer) resolves
+    "clasificacion" to SCHEMA_DESIGNER_PROMPT_CLASSIFICATION — not the fallback.
+    This mirrors the production call site:
+        SCHEMA_DESIGNER_PROMPT_BY_FAMILY.get(primary_family or "", SCHEMA_DESIGNER_PROMPT)
+    and guards that the key is present and the correct object is returned."""
     result = SCHEMA_DESIGNER_PROMPT_BY_FAMILY.get("clasificacion", SCHEMA_DESIGNER_PROMPT)
     assert result is SCHEMA_DESIGNER_PROMPT_CLASSIFICATION
 

--- a/backend/tests/test_m2_dataset_family_dispatch.py
+++ b/backend/tests/test_m2_dataset_family_dispatch.py
@@ -1,0 +1,133 @@
+"""Tests for M2 dataset schema per-family prompt dispatch.
+
+Verifies:
+  - SCHEMA_DESIGNER_PROMPT_CLASSIFICATION is importable from all expected paths.
+  - SCHEMA_DESIGNER_PROMPT_BY_FAMILY routes "clasificacion" to the classification
+    prompt and falls back to the generic SCHEMA_DESIGNER_PROMPT for all other
+    families (regresion, clustering, serie_temporal, unknown, and None).
+  - The classification prompt is a well-formed string with the required
+    format-string placeholders.
+
+These are pure unit tests — no LLM call, no DB, no fixtures required.
+"""
+
+import pytest
+
+from case_generator.prompts import (
+    SCHEMA_DESIGNER_PROMPT,
+    SCHEMA_DESIGNER_PROMPT_BY_FAMILY,
+    SCHEMA_DESIGNER_PROMPT_CLASSIFICATION,
+)
+
+
+# ---------------------------------------------------------------------------
+# Import smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_schema_designer_prompt_classification_importable_from_prompts_top() -> None:
+    """SCHEMA_DESIGNER_PROMPT_CLASSIFICATION is importable from the top-level
+    prompts package (ensures __all__ and re-export chain are wired correctly)."""
+    assert SCHEMA_DESIGNER_PROMPT_CLASSIFICATION is not None
+    assert isinstance(SCHEMA_DESIGNER_PROMPT_CLASSIFICATION, str)
+
+
+def test_schema_designer_prompt_classification_importable_from_subpackage() -> None:
+    """SCHEMA_DESIGNER_PROMPT_CLASSIFICATION is importable directly from the
+    clasificacion sub-package (ensures clasificacion/__init__.py re-exports it)."""
+    from case_generator.prompts.clasificacion import (  # noqa: PLC0415
+        SCHEMA_DESIGNER_PROMPT_CLASSIFICATION as from_sub,
+    )
+    assert from_sub is SCHEMA_DESIGNER_PROMPT_CLASSIFICATION
+
+
+def test_schema_designer_prompt_classification_importable_from_dataset_module() -> None:
+    """SCHEMA_DESIGNER_PROMPT_CLASSIFICATION is importable directly from the
+    leaf module clasificacion/dataset.py."""
+    from case_generator.prompts.clasificacion.dataset import (  # noqa: PLC0415
+        SCHEMA_DESIGNER_PROMPT_CLASSIFICATION as from_leaf,
+    )
+    assert from_leaf is SCHEMA_DESIGNER_PROMPT_CLASSIFICATION
+
+
+def test_schema_designer_prompt_by_family_importable() -> None:
+    """SCHEMA_DESIGNER_PROMPT_BY_FAMILY is importable from the top-level package."""
+    assert SCHEMA_DESIGNER_PROMPT_BY_FAMILY is not None
+    assert isinstance(SCHEMA_DESIGNER_PROMPT_BY_FAMILY, dict)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch correctness tests
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_clasificacion_routes_to_classification_prompt() -> None:
+    """The 'clasificacion' key maps to SCHEMA_DESIGNER_PROMPT_CLASSIFICATION."""
+    assert SCHEMA_DESIGNER_PROMPT_BY_FAMILY["clasificacion"] is SCHEMA_DESIGNER_PROMPT_CLASSIFICATION
+
+
+def test_dispatch_clasificacion_not_generic_prompt() -> None:
+    """The classification prompt object is distinct from the generic fallback.
+    This will fail (correctly) once the two prompts are intentionally diverged."""
+    # Currently they are identical strings but different objects — that's fine.
+    # This test guards that the dispatch key is present and resolvable.
+    result = SCHEMA_DESIGNER_PROMPT_BY_FAMILY.get("clasificacion", SCHEMA_DESIGNER_PROMPT)
+    assert result is SCHEMA_DESIGNER_PROMPT_CLASSIFICATION
+
+
+@pytest.mark.parametrize("family", ["regresion", "clustering", "serie_temporal"])
+def test_dispatch_non_clasificacion_families_fall_back_to_generic(family: str) -> None:
+    """Families without a specialised prompt fall back to the generic prompt."""
+    result = SCHEMA_DESIGNER_PROMPT_BY_FAMILY.get(family, SCHEMA_DESIGNER_PROMPT)
+    assert result is SCHEMA_DESIGNER_PROMPT
+
+
+def test_dispatch_unknown_family_falls_back_to_generic() -> None:
+    """An unrecognised family string falls back to the generic prompt via .get()."""
+    result = SCHEMA_DESIGNER_PROMPT_BY_FAMILY.get("unknown_family", SCHEMA_DESIGNER_PROMPT)
+    assert result is SCHEMA_DESIGNER_PROMPT
+
+
+def test_dispatch_none_family_falls_back_to_generic() -> None:
+    """A None primary_family (e.g. empty algoritmos list) falls back to generic."""
+    result = SCHEMA_DESIGNER_PROMPT_BY_FAMILY.get(None, SCHEMA_DESIGNER_PROMPT)  # type: ignore[arg-type]
+    assert result is SCHEMA_DESIGNER_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Prompt content integrity tests
+# ---------------------------------------------------------------------------
+
+_REQUIRED_PLACEHOLDERS = [
+    "{student_profile}",
+    "{industria}",
+    "{dataset_contract_block}",
+    "{max_rows}",
+    "{ml_required_families}",
+    "{financial_data}",
+    "{operational_data}",
+]
+
+
+@pytest.mark.parametrize("placeholder", _REQUIRED_PLACEHOLDERS)
+def test_classification_prompt_contains_required_placeholders(placeholder: str) -> None:
+    """SCHEMA_DESIGNER_PROMPT_CLASSIFICATION contains all format-string placeholders
+    that schema_designer() injects via context.update(). A missing placeholder would
+    cause a KeyError at runtime on every job submission."""
+    assert placeholder in SCHEMA_DESIGNER_PROMPT_CLASSIFICATION, (
+        f"Required placeholder {placeholder!r} is missing from "
+        "SCHEMA_DESIGNER_PROMPT_CLASSIFICATION"
+    )
+
+
+@pytest.mark.parametrize("placeholder", _REQUIRED_PLACEHOLDERS)
+def test_generic_prompt_still_contains_required_placeholders(placeholder: str) -> None:
+    """Regression guard: SCHEMA_DESIGNER_PROMPT retains all placeholders
+    (guards against accidental removal while editing the generic prompt)."""
+    assert placeholder in SCHEMA_DESIGNER_PROMPT, (
+        f"Required placeholder {placeholder!r} is missing from SCHEMA_DESIGNER_PROMPT"
+    )
+
+
+def test_classification_prompt_is_non_empty_string() -> None:
+    assert len(SCHEMA_DESIGNER_PROMPT_CLASSIFICATION.strip()) > 100


### PR DESCRIPTION
## Summary

Establishes the per-family prompt dispatch architecture for the M2 dataset schema generation pipeline, mirroring the existing `PROMPT_BY_FAMILY` / `M4_PROMPT_BY_FAMILY` / `M5_PROMPT_BY_FAMILY` pattern already proven in M3/M4/M5.

When a teacher selects an algorithm that belongs to the **clasificacion** family, `schema_designer()` now routes to a dedicated `SCHEMA_DESIGNER_PROMPT_CLASSIFICATION` instead of the generic prompt. No prompt content is changed in this iteration — the separation creates a clean, production-safe landing zone for future specialization (binary target, class-imbalance columns, LR/RF feature vocabulary) without touching the shared baseline.

## Changes

| File | Type | What |
|---|---|---|
| `prompts/clasificacion/dataset.py` | **NEW** | `SCHEMA_DESIGNER_PROMPT_CLASSIFICATION` — classification-specific prompt module |
| `prompts/clasificacion/__init__.py` | edit | re-exports `SCHEMA_DESIGNER_PROMPT_CLASSIFICATION` |
| `prompts/__init__.py` | edit | imports + `SCHEMA_DESIGNER_PROMPT_BY_FAMILY` dispatch dict + `__all__` entries |
| `graph.py` (`schema_designer`) | edit | `_resolve_primary_family()` call → `SCHEMA_DESIGNER_PROMPT_BY_FAMILY.get(primary_family or "", SCHEMA_DESIGNER_PROMPT)` |
| `tests/test_m2_dataset_family_dispatch.py` | **NEW** | 26 unit tests: import smoke (3 paths), dispatch routing (7 cases), placeholder integrity (14 cases), non-empty guard |
| `TODOS.md` | edit | Deferred: TODO-M2-A (specialize classification prompt), TODO-M2-B (regresion), TODO-M2-C (clustering) |

## Architecture

```
schema_designer() — dispatch flow
───────────────────────────────────────────────────────────────
  algoritmos_raw ──► _detect_algorithm_families()  [UNCHANGED]
       │                    └──► ml_required_families → context
       │
       └──────────► _resolve_primary_family()       [NEW call]
                           │
            ┌──────────────┴──────────────────────────────┐
            ▼                                             ▼
   family == "clasificacion"              family in {regresion, clustering,
            │                             serie_temporal, None/unknown}
            ▼                                             ▼
   SCHEMA_DESIGNER_PROMPT_CLASSIFICATION    SCHEMA_DESIGNER_PROMPT
   [new: clasificacion/dataset.py]          [fallback — UNCHANGED]
            │                                             │
            └──────────────┬──────────────────────────────┘
                           ▼
                  prompt.format(**context) → LLM
                  [data_generator → data_validator UNCHANGED]
```

## Non-Goals (this PR)
- Prompt content specialization for clasificacion (TODO-M2-A)
- Per-family prompts for regresion / clustering (TODO-M2-B, TODO-M2-C)
- Changes to `data_generator` or `data_validator` nodes
- `primary_family` in `ADAMState`

## Test Results
```
98 passed, 1 warning in 5.55s   ← new (26) + regression (72)
mypy: Success: no issues found in 4 source files
```

## Merge
Squash and merge per repo policy.