### PR TITLE
feat(m2): specialize clasificacion dataset schema -- 18 fixed cols, categoria int 0/1, 600 rows

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -4,36 +4,34 @@ Deuda técnica y mejoras diferidas identificadas durante el desarrollo.
 
 ---
 
-## TODO-M2-A: Especializar SCHEMA_DESIGNER_PROMPT_CLASSIFICATION para la familia clasificación
+## TODO-NORM-A: Actualizar RENAME_MAP en _normalize_ml_ds_columns para el schema de 18 columnas
 
-**What:** Reemplazar el contenido de `SCHEMA_DESIGNER_PROMPT_CLASSIFICATION` en
-`backend/src/case_generator/prompts/clasificacion/dataset.py` con un prompt diseñado
-específicamente para casos de clasificación (target binario/multiclase, columnas de
-class-imbalance, vocabulario de features para LR/RF, restricciones de distribución
-de clases).
+**What:** En `_normalize_ml_ds_columns()` en `backend/src/case_generator/graph.py` (~línea 1930),
+la entrada `"feature_adoption_pct" → ("categoria", "str")` del `RENAME_MAP` quedó obsoleta
+tras la especialización del prompt de clasificación. Si el LLM ignora parcialmente el nuevo
+prompt y emite `feature_adoption_pct`, la función lo renombra a `categoria` con `type="str"`
+y borra la `dependency` — deshaciendo silenciosamente la corrección del target binario.
 
-**Why:** Actualmente el prompt es una copia idéntica del genérico `SCHEMA_DESIGNER_PROMPT`.
-La separación estructural ya existe (branch `feat/m2-dataset-family-dispatch`); lo que
-falta es la especialización del contenido. Un prompt específico de clasificación genera
-datasets de mayor calidad para M3 (notebook LR/RF) porque puede reforzar: columna `label`
-o `categoria` con distribución de clases realista, features correladas con el target,
-y ausencia de leakage por construcción.
+**Why:** Cierra el último camino de corrupción silenciosa del tipo de `categoria`. Después de
+este TODO, una respuesta LLM no conforme con el nuevo prompt ya no puede producir un target
+de texto sin señal a través de la vía de legado.
 
-**Pros:** Mejor calidad del dataset para todos los casos `ml_ds + clasificacion`;
-permite controlar directamente el `class_imbalance_ratio` y el vocabulario de features
-sin depender de la heurística genérica del LLM.
+**Pros:** Elimina la posibilidad de que una respuesta LLM parcialmente incumplidora resulte
+en AUC ~0.50 en el notebook M3, incluso tras el rename de seguridad.
 
-**Cons:** Requiere ingeniería de prompt, fixtures de evaluación para validar que no
-rompe el schema contract de Issue #225, y al menos un run live para confirmar calidad.
+**Cons:** Requiere decidir si `feature_adoption_pct` se mapea a `("categoria", "int")` con
+una dependencia stub en `churn_rate`, o si simplemente se descarta. La opción más segura es:
+si aparece `feature_adoption_pct`, renombrar a `categoria` Y forzar `type="int"`,
+`range_min=0`, `range_max=1`, `dependency={"depends_on": "churn_rate", "relationship": "linear", "noise_factor": 0.30}`.
 
-**Context:** El fichero destino es `prompts/clasificacion/dataset.py`, variable
-`SCHEMA_DESIGNER_PROMPT_CLASSIFICATION`. El dispatch ya está cableado: `schema_designer()`
-en `graph.py` selecciona este prompt cuando `primary_family == "clasificacion"`. El
-cambio sólo toca la cadena de texto — no la lógica de dispatch ni el pipeline de datos.
-Empezar por identificar qué columnas ML son específicas de clasificación en el
-VOCABULARIO OBLIGATORIO y añadir reglas de distribución de clases para `label`/`categoria`.
+**Context:** Ver `_normalize_ml_ds_columns()` en `graph.py`. La función corre después de
+validación Pydantic como red de seguridad post-LLM. La entrada `feature_adoption_pct` del
+RENAME_MAP fue añadida cuando el prompt genérico permitía ese nombre de columna. Tras este
+PR, el prompt de clasificación emite `categoria: int` directamente, por lo que este camino
+no debería activarse en operación normal. Sin embargo, permanece como trampa para replays
+de `task_payload` legacy y para LLMs con respuestas parcialmente no conformes.
 
-**Depends on / blocked by:** Branch `feat/m2-dataset-family-dispatch` mergeado a main.
+**Depends on / blocked by:** PR de especialización del dataset de clasificación (M2) ya mergeado.
 
 ---
 
@@ -58,8 +56,7 @@ como fallback, por lo que la ausencia de la clave `"regresion"` no rompe nada ho
 Cuando se cree el prompt, sólo hay que añadir la clave al dict en `prompts/__init__.py`.
 Ver `prompts/clasificacion/dataset.py` como template exacto.
 
-**Depends on / blocked by:** TODO-M2-A (opcional — puede hacerse en paralelo si el
-prompt de regresión se define antes de especializar el de clasificación).
+**Depends on / blocked by:** Independiente — puede hacerse sin bloqueantes.
 
 ---
 

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -1863,8 +1863,16 @@ def _validate_and_correct_dataset(
 # HELPER — _build_fallback_schema (sin LLM, regex sobre Exhibit 1)
 # ─────────────────────────────────────────────────────────
 
-def _build_fallback_schema(state: ADAMState, max_rows: int, profile: str) -> dict:
-    """Schema mínimo si schema_designer falla. Extrae revenue con regex del Exhibit 1."""
+def _build_fallback_schema(
+    state: ADAMState, max_rows: int, profile: str, primary_family: str = "clasificacion"
+) -> dict:
+    """Schema mínimo si schema_designer falla. Extrae revenue con regex del Exhibit 1.
+
+    ``primary_family`` gates the ml_ds column extension: only "clasificacion" gets the
+    18-column binary-target schema; all other ml_ds families receive the 12-column
+    generic baseline (cols 1–10 + customer_ltv + engagement_score) so their M3
+    notebooks do not receive a classification-specific target.
+    """
     financial_text = state.get("doc1_anexo_financiero", "")
 
     revenue_match = re.search(r'[\$€]?\s*([\d,]+(?:\.\d+)?)\s*[Mm]', financial_text)
@@ -1892,7 +1900,7 @@ def _build_fallback_schema(state: ADAMState, max_rows: int, profile: str) -> dic
         {"name": "retention_m12", "type": "float", "description": "Retención cohorte mes 12", "range_min": 0.20, "range_max": 0.50, "nullable": False, "trend": None, "dependency": {"depends_on": "retention_m6", "relationship": "linear", "noise_factor": 0.05}},
     ]
 
-    if profile == "ml_ds":
+    if profile == "ml_ds" and primary_family == "clasificacion":
         # Columns 11–18 for clasificacion: binary churn target with signal.
         # customer_ltv / engagement_score keep nullable=True (5% null ratio);
         # cols 13–18 are fixed classification features; categoria is the binary
@@ -1907,6 +1915,15 @@ def _build_fallback_schema(state: ADAMState, max_rows: int, profile: str) -> dic
             {"name": "payment_failures",        "type": "int",   "description": "Número de fallos de pago en los últimos 3 meses",   "range_min": 0,    "range_max": 5,    "nullable": False, "trend": None, "dependency": {"depends_on": "churn_rate",       "relationship": "linear",  "noise_factor": 0.3}},
             {"name": "monthly_usage_pct",       "type": "float", "description": "Porcentaje de uso mensual del producto (0-1)",      "range_min": 0.0,  "range_max": 1.0,  "nullable": False, "trend": None, "dependency": {"depends_on": "engagement_score", "relationship": "linear",  "noise_factor": 0.1}},
             {"name": "categoria",               "type": "int",   "description": "Etiqueta binaria de clasificación: 0=activo, 1=en riesgo de churn", "range_min": 0, "range_max": 1, "nullable": False, "trend": None, "dependency": {"depends_on": "churn_rate", "relationship": "linear", "noise_factor": 0.30}},
+        ])
+    elif profile == "ml_ds":
+        # Generic ml_ds baseline (cols 11–12) for non-clasificacion families
+        # (regresion, clustering, serie_temporal, or unresolved primary_family).
+        # No classification target here — M3 prompts for those families derive
+        # their target from the base columns (e.g. revenue for regresion).
+        base_columns.extend([
+            {"name": "customer_ltv",     "type": "float", "description": "Customer lifetime value estimado",         "range_min": 500, "range_max": 5000, "nullable": True,  "trend": "up", "dependency": None},
+            {"name": "engagement_score", "type": "float", "description": "Score de engagement del usuario (0-1)",     "range_min": 0.1, "range_max": 0.95, "nullable": True,  "trend": None, "dependency": None},
         ])
 
     return {
@@ -2454,23 +2471,24 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
     Responsabilidad ÚNICA: diseñar. NO genera filas.
     """
     profile = state.get("studentProfile", "business")
-    # ml_ds: 600 filas (Issue #244 cascade: 600 ≤ 2000 → full GridSearchCV).
-    # business: 100 (midpoint de 80-120, usado para calcular rangos de revenue en
-    # el prompt; el LLM elige n_rows en 80-120).
-    max_rows = 600 if profile == "ml_ds" else 100
 
-    # Extraer familias ML requeridas para el Módulo 3 a partir del input del usuario.
-    # _detect_algorithm_families resuelve por catálogo (Issue #233) con fallback legacy.
+    # Resolve primary family BEFORE max_rows — both max_rows and the fallback schema
+    # branch by family. _detect_algorithm_families is kept for the prompt vocabulary
+    # string; _resolve_primary_family is the authoritative single-family resolver.
     algoritmos_raw = state.get("algoritmos", [])
     familias_detectadas = _detect_algorithm_families(algoritmos_raw) if algoritmos_raw else []
     ml_required_families = (
         ", ".join(familias_detectadas) if familias_detectadas else "clasificacion"
     )
-
-    # Resolve primary family for per-family prompt dispatch (M2 dataset, Issue #233).
-    # _detect_algorithm_families is kept above for the vocabulary string; this separate
-    # call resolves the single primary family used to select the schema design prompt.
     primary_family, _legacy_warn_schema = _resolve_primary_family(algoritmos_raw)
+
+    # ml_ds+clasificacion: 600 filas (Issue #240 cascade: 600 ≤ 2000 → full GridSearchCV).
+    # ml_ds+otras familias: 200 filas — el GridSearchCV size cascade es exclusivo del
+    # notebook de clasificacion; regresion/clustering no necesitan 600 filas.
+    # business: 100 (midpoint de 80-120; el LLM elige n_rows estrictamente entre 80-120).
+    _is_clasificacion_ml = profile == "ml_ds" and (primary_family or "") == "clasificacion"
+    max_rows = 600 if _is_clasificacion_ml else (200 if profile == "ml_ds" else 100)
+
     _schema_prompt = SCHEMA_DESIGNER_PROMPT_BY_FAMILY.get(
         primary_family or "", SCHEMA_DESIGNER_PROMPT
     )
@@ -2588,7 +2606,9 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
             logger.error("[schema_designer] %s ERROR: %s", model_label, e, exc_info=True)
 
     print("[schema_designer] todos los intentos fallaron — usando fallback schema")
-    fallback_schema = _build_fallback_schema(state, max_rows, profile)
+    fallback_schema = _build_fallback_schema(
+        state, max_rows, profile, primary_family=primary_family or ""
+    )
     # Issue #225 — incluso en fallback respetamos el contrato del architect.
     contract = state.get("dataset_schema_required")
     fallback_schema = _augment_schema_with_contract(fallback_schema, contract)

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2482,14 +2482,20 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
     )
     primary_family, _legacy_warn_schema = _resolve_primary_family(algoritmos_raw)
 
-    # Effective family: when _resolve_primary_family returns None (unrecognized or absent
-    # algorithms), ml_ds jobs must mirror _prepare_m3_notebook_generation_context(), which
-    # explicitly falls back to "clasificacion" (line ~4323). Without this alignment,
-    # schema_designer would emit a non-classification schema (no 'categoria', 200 rows,
-    # generic prompt) while M3 still generates a classification notebook — silent AUC
-    # collapse. Business jobs keep "" so the generic schema prompt fires (business profile
-    # does not go through algorithm selection and should not receive the 18-col schema).
-    _effective_family = primary_family or ("clasificacion" if profile == "ml_ds" else "")
+    # Effective family drives max_rows, prompt dispatch, and fallback schema branch.
+    #
+    # ml_ds: use the resolved family when available; fall back to "clasificacion" to
+    # mirror _prepare_m3_notebook_generation_context() (line ~4323), which makes the
+    # same explicit fallback so M3 and schema_designer always agree on the family.
+    # Without this alignment a None-family ml_ds job emits a non-classification schema
+    # (no 'categoria', 200 rows, generic prompt) while M3 generates a classification
+    # notebook — silent AUC collapse.
+    #
+    # business: always "" → generic schema prompt, regardless of primary_family.
+    # The classification and future family-specific prompts contain ml_ds-only sections
+    # (18-col contract, GridSearchCV row counts) that should never reach business cases.
+    # The generic prompt handles both profiles via its existing 10-col / 14-col rules.
+    _effective_family = (primary_family or "clasificacion") if profile == "ml_ds" else ""
 
     # ml_ds+clasificacion: 600 filas (Issue #240 cascade: 600 ≤ 2000 → full GridSearchCV).
     # ml_ds+otras familias: 200 filas — el GridSearchCV size cascade es exclusivo del

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2482,15 +2482,24 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
     )
     primary_family, _legacy_warn_schema = _resolve_primary_family(algoritmos_raw)
 
+    # Effective family: when _resolve_primary_family returns None (unrecognized or absent
+    # algorithms), ml_ds jobs must mirror _prepare_m3_notebook_generation_context(), which
+    # explicitly falls back to "clasificacion" (line ~4323). Without this alignment,
+    # schema_designer would emit a non-classification schema (no 'categoria', 200 rows,
+    # generic prompt) while M3 still generates a classification notebook — silent AUC
+    # collapse. Business jobs keep "" so the generic schema prompt fires (business profile
+    # does not go through algorithm selection and should not receive the 18-col schema).
+    _effective_family = primary_family or ("clasificacion" if profile == "ml_ds" else "")
+
     # ml_ds+clasificacion: 600 filas (Issue #240 cascade: 600 ≤ 2000 → full GridSearchCV).
     # ml_ds+otras familias: 200 filas — el GridSearchCV size cascade es exclusivo del
     # notebook de clasificacion; regresion/clustering no necesitan 600 filas.
     # business: 100 (midpoint de 80-120; el LLM elige n_rows estrictamente entre 80-120).
-    _is_clasificacion_ml = profile == "ml_ds" and (primary_family or "") == "clasificacion"
+    _is_clasificacion_ml = profile == "ml_ds" and _effective_family == "clasificacion"
     max_rows = 600 if _is_clasificacion_ml else (200 if profile == "ml_ds" else 100)
 
     _schema_prompt = SCHEMA_DESIGNER_PROMPT_BY_FAMILY.get(
-        primary_family or "", SCHEMA_DESIGNER_PROMPT
+        _effective_family, SCHEMA_DESIGNER_PROMPT
     )
 
     context = _build_base_context(state)
@@ -2607,7 +2616,7 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
 
     print("[schema_designer] todos los intentos fallaron — usando fallback schema")
     fallback_schema = _build_fallback_schema(
-        state, max_rows, profile, primary_family=primary_family or ""
+        state, max_rows, profile, primary_family=_effective_family
     )
     # Issue #225 — incluso en fallback respetamos el contrato del architect.
     contract = state.get("dataset_schema_required")

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -1893,11 +1893,20 @@ def _build_fallback_schema(state: ADAMState, max_rows: int, profile: str) -> dic
     ]
 
     if profile == "ml_ds":
+        # Columns 11–18 for clasificacion: binary churn target with signal.
+        # customer_ltv / engagement_score keep nullable=True (5% null ratio);
+        # cols 13–18 are fixed classification features; categoria is the binary
+        # target (int 0/1) correlated with churn_rate via linear dependency so
+        # LR/RF achieve AUC-ROC ≥ 0.70 instead of learning noise from a str target.
         base_columns.extend([
-            {"name": "customer_ltv",         "type": "float", "description": "Customer lifetime value",  "range_min": 500,  "range_max": 5000, "nullable": True,  "trend": "up",   "dependency": None},
-            {"name": "engagement_score",     "type": "float", "description": "Score de engagement 0-1", "range_min": 0.1,  "range_max": 0.95, "nullable": True,  "trend": None,   "dependency": None},
-            {"name": "ticket_text", "type": "str",   "description": "Texto libre de tickets o quejas del cliente",  "range_min": None, "range_max": None, "nullable": False, "trend": None, "dependency": None},
-            {"name": "categoria",   "type": "str",   "description": "Categoría o clasificación del registro",        "range_min": None, "range_max": None, "nullable": False, "trend": None, "dependency": None},
+            {"name": "customer_ltv",            "type": "float", "description": "Customer lifetime value estimado",                  "range_min": 500,  "range_max": 5000, "nullable": True,  "trend": "up", "dependency": None},
+            {"name": "engagement_score",        "type": "float", "description": "Score de engagement del usuario (0-1)",             "range_min": 0.1,  "range_max": 0.95, "nullable": True,  "trend": None, "dependency": None},
+            {"name": "days_since_last_login",   "type": "int",   "description": "Días desde el último login del usuario",            "range_min": 1,    "range_max": 180,  "nullable": False, "trend": None, "dependency": {"depends_on": "engagement_score", "relationship": "inverse", "noise_factor": 0.2}},
+            {"name": "support_tickets_count",   "type": "int",   "description": "Número de tickets de soporte abiertos",            "range_min": 0,    "range_max": 10,   "nullable": False, "trend": None, "dependency": {"depends_on": "nps",              "relationship": "inverse", "noise_factor": 0.2}},
+            {"name": "plan_tier",               "type": "int",   "description": "Nivel del plan contratado (1=básico, 2=estándar, 3=premium)", "range_min": 1, "range_max": 3, "nullable": False, "trend": None, "dependency": None},
+            {"name": "payment_failures",        "type": "int",   "description": "Número de fallos de pago en los últimos 3 meses",   "range_min": 0,    "range_max": 5,    "nullable": False, "trend": None, "dependency": {"depends_on": "churn_rate",       "relationship": "linear",  "noise_factor": 0.3}},
+            {"name": "monthly_usage_pct",       "type": "float", "description": "Porcentaje de uso mensual del producto (0-1)",      "range_min": 0.0,  "range_max": 1.0,  "nullable": False, "trend": None, "dependency": {"depends_on": "engagement_score", "relationship": "linear",  "noise_factor": 0.1}},
+            {"name": "categoria",               "type": "int",   "description": "Etiqueta binaria de clasificación: 0=activo, 1=en riesgo de churn", "range_min": 0, "range_max": 1, "nullable": False, "trend": None, "dependency": {"depends_on": "churn_rate", "relationship": "linear", "noise_factor": 0.30}},
         ])
 
     return {
@@ -2445,9 +2454,10 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: 
     Responsabilidad ÚNICA: diseñar. NO genera filas.
     """
     profile = state.get("studentProfile", "business")
-    # ml_ds: 200 filas (sin cambio). business: 100 (midpoint de 80-120, usado para
-    # calcular rangos de revenue en el prompt; el LLM elige n_rows en 80-120).
-    max_rows = 200 if profile == "ml_ds" else 100
+    # ml_ds: 600 filas (Issue #244 cascade: 600 ≤ 2000 → full GridSearchCV).
+    # business: 100 (midpoint de 80-120, usado para calcular rangos de revenue en
+    # el prompt; el LLM elige n_rows en 80-120).
+    max_rows = 600 if profile == "ml_ds" else 100
 
     # Extraer familias ML requeridas para el Módulo 3 a partir del input del usuario.
     # _detect_algorithm_families resuelve por catálogo (Issue #233) con fallback legacy.

--- a/backend/src/case_generator/prompts/clasificacion/dataset.py
+++ b/backend/src/case_generator/prompts/clasificacion/dataset.py
@@ -69,9 +69,17 @@ REGLAS DE COBERTURA DEL CONTRATO (cuando NO esté vacío):
 
 ## CONTRATO DE COLUMNAS PARA CLASIFICACION (ml_ds) — 18 columnas exactas
 
-Para {student_profile}="ml_ds" DEBES generar EXACTAMENTE estas 18 columnas en este orden.
-NUNCA generes columnas fuera de esta lista exacta.
-NUNCA uses type="str" para "categoria" — el notebook M3 requiere int para el target binario.
+Dos casos según el valor de `dataset_contract_block` arriba:
+
+**Caso A — contrato null o {{}} (sin dataset_schema_required):**
+DEBES generar EXACTAMENTE estas 18 columnas en este orden. No añadas columnas fuera de esta lista.
+
+**Caso B — contrato activo (dataset_schema_required no vacío):**
+Aplica las REGLAS DE COBERTURA DEL CONTRATO de arriba primero (cubre target + feature_columns).
+Usa las 18 columnas de abajo como base; completa con las columnas del contrato que no estén ya cubiertas.
+Puedes superar 18 columnas si el contrato lo requiere — la cobertura del contrato tiene prioridad.
+
+En AMBOS casos: NUNCA uses type="str" para "categoria" — el notebook M3 requiere int para el target binario.
 
 | # | name                    | type    | range_min | range_max | nullable | depends_on       | relationship | noise_factor |
 |---|-------------------------|---------|-----------|-----------|----------|------------------|--------------|--------------|

--- a/backend/src/case_generator/prompts/clasificacion/dataset.py
+++ b/backend/src/case_generator/prompts/clasificacion/dataset.py
@@ -1,28 +1,22 @@
 """Dataset schema design prompt for the clasificacion algorithm family.
 
-This module is the landing zone for classification-specific dataset prompt
-specialization (Issue #233 / M2 per-family dispatch).
+Specialized for binary classification (churn prediction):
+- 18 fixed columns for ml_ds profile (cols 1-12 shared; cols 13-18 classification-specific)
+- ``categoria`` is always ``int`` (0/1) with a ``dependency`` on ``churn_rate``
+  so LR/RF receive a ~70%-signal binary target (AUC-ROC ≥ 0.70) instead of a
+  random categorical string.
+- n_rows = {max_rows} (600 for ml_ds) → Issue #240 cascade: 600 ≤ 2000 → full GridSearchCV.
 
-Current state: the prompt is semantically identical to ``SCHEMA_DESIGNER_PROMPT``
-in ``prompts/__init__.py``.  The structural separation exists so that future
-iterations can tune vocabulary, target-column rules, class-imbalance constraints,
-and LR/RF-specific feature engineering *without* touching the generic prompt that
-serves all other families.
-
-# TODO: Specialize SCHEMA_DESIGNER_PROMPT_CLASSIFICATION for clasificacion
-#       (enforce binary target, class-imbalance columns, LR/RF feature vocabulary)
-#       after the per-family dispatch plumbing is confirmed stable in production.
+Do NOT diverge the 7 required placeholders or the REGLAS DE COBERTURA DEL CONTRATO
+section — both are validated by test_m2_dataset_family_dispatch.py.
 """
 
 __all__ = ["SCHEMA_DESIGNER_PROMPT_CLASSIFICATION"]
 
-# Identical to SCHEMA_DESIGNER_PROMPT until specialized in a future iteration.
-# Do NOT edit this string to patch generic schema bugs — fix SCHEMA_DESIGNER_PROMPT
-# in prompts/__init__.py and then mirror the fix here to keep them in sync until
-# divergence is intentional.
 SCHEMA_DESIGNER_PROMPT_CLASSIFICATION = """\
-Diseña el schema de un dataset sintético para el caso de negocio dado.
+Diseña el schema de un dataset sintético de CLASIFICACIÓN BINARIA para el caso de negocio dado.
 Perfil: {student_profile} | Industria: {industria}
+Familias ML requeridas (referencia): {ml_required_families}
 
 ## Contrato dataset_schema_required (Issue #225 — fuente de verdad)
 {dataset_contract_block}
@@ -36,71 +30,11 @@ REGLAS DE COBERTURA DEL CONTRATO (cuando NO esté vacío):
   el bloqueo de leakage se gestiona downstream en M3 (no la omitas aquí).
 - Las categorías de `domain_features_required` deben estar cubiertas por al menos
   una columna semánticamente alineada (puedes elegir su nombre concreto).
-- Si el contrato es `null` o `{{}}`, opera con las reglas heurísticas de abajo.
+- Si el contrato es `null` o `{{}}`, opera con el contrato de columnas fijo de abajo.
 
 ## ESTRUCTURA DE OUTPUT OBLIGATORIA (JSON puro, sin markdown, sin claves extra)
 {{
-  "columns": [
-    {{
-      "name": "period",
-      "type": "str",
-      "description": "Período temporal (ej: '2024-01')",
-      "range_min": null,
-      "range_max": null,
-      "nullable": false,
-      "trend": null,
-      "dependency": null
-    }},
-    {{
-      "name": "revenue",
-      "type": "float",
-      "description": "Ingresos del período",
-      "range_min": <revenue_anual_absoluto / {max_rows} * 0.85>,
-      "range_max": <revenue_anual_absoluto / {max_rows} * 1.15>,
-      "nullable": false,
-      "trend": "up",
-      "dependency": null
-    }},
-    {{
-      "name": "churn_rate",
-      "type": "float",
-      "description": "Tasa de abandono mensual (0.0 a 1.0)",
-      "range_min": 0.02,
-      "range_max": 0.15,
-      "nullable": false,
-      "trend": null,
-      "dependency": {{
-        "depends_on": "revenue",
-        "relationship": "inverse",
-        "noise_factor": 0.1
-      }}
-    }},
-    {{
-      "name": "retention_m1",
-      "type": "float",
-      "description": "% de usuarios retenidos de la cohorte de ese period en el mes 1",
-      "range_min": 0.65,
-      "range_max": 0.95,
-      "nullable": false,
-      "trend": null,
-      "dependency": null
-    }},
-    {{
-      "name": "retention_m3",
-      "type": "float",
-      "description": "% de usuarios retenidos en el mes 3",
-      "range_min": 0.50,
-      "range_max": 0.80,
-      "nullable": false,
-      "trend": null,
-      "dependency": {{
-        "depends_on": "retention_m1",
-        "relationship": "linear",
-        "noise_factor": 0.05
-      }}
-    }}
-    ... más columnas según perfil ...
-  ],
+  "columns": [ ... 18 columnas exactas para ml_ds, 10 para business — ver contratos abajo ... ],
   "n_rows": <VER REGLA DE FILAS ABAJO>,
   "time_granularity": "monthly",
   "constraints": {{
@@ -112,14 +46,14 @@ REGLAS DE COBERTURA DEL CONTRATO (cuando NO esté vacío):
     "tolerance_pct": 0.05,
     "revenue_column": "revenue"
   }},
-  "reasoning_summary": "<justificación en 1 línea>"
+  "reasoning_summary": "Dataset de clasificación binaria (predicción de churn) — columnas fijas por contrato de familia clasificacion. Target: categoria (int 0/1) correlado con churn_rate (noise_factor=0.30)."
 }}
 
 ## Regla de filas (n_rows)
 - Para {student_profile}="business": elige un entero ALEATORIO estrictamente entre 80 y 120. NO uses {max_rows}.
 - Para {student_profile}="ml_ds": usa exactamente {max_rows}.
 
-## Reglas para columnas
+## Reglas generales para columnas
 - type DEBE ser exactamente: "int", "float", "str", o "date" (no "string", no "integer").
 - trend: "up" (crece), "down" (decrece), "stable" (sin tendencia), o null.
 - dependency: objeto con depends_on, relationship ("linear" o "inverse"), noise_factor (0.0-1.0), o null.
@@ -132,33 +66,86 @@ REGLAS DE COBERTURA DEL CONTRATO (cuando NO esté vacío):
   (CRÍTICO: Las columnas retention_mX representan el % de usuarios de esa cohorte
   retenidos en el mes X. Son obligatorias para el heatmap de análisis de cohortes.
   Asegúrate de que range_min/max respeten: retention_m1 > retention_m3 > retention_m6 > retention_m12.)
-- Para {student_profile}="ml_ds": MÍNIMO 14 columnas, al menos 2 con nullable=true.
-  Las primeras 12 columnas son FIJAS en este orden:
-  period, revenue, costs, margin_pct, churn_rate, nps,
-  retention_m1, retention_m3, retention_m6, retention_m12,
-  customer_ltv (nullable=true), engagement_score (nullable=true).
-  A partir de la columna 13, OBLIGATORIAMENTE debes generar las columnas necesarias
-  para satisfacer las familias ML requeridas para este caso: {ml_required_families}.
-  Usa EXACTAMENTE los nombres y reglas definidos en el VOCABULARIO OBLIGATORIO de abajo.
-  Puedes superar 14 columnas (ej. 15 o 16) si las familias requeridas así lo exigen.
-  NUNCA inventes nombres fuera del vocabulario.
 
-## VOCABULARIO OBLIGATORIO para columnas ML dinámicas (ml_ds)
+## CONTRATO DE COLUMNAS PARA CLASIFICACION (ml_ds) — 18 columnas exactas
 
-  | Familia ML         | Nombres exactos permitidos          | type          | Reglas de campo                                           |
-  |--------------------|-------------------------------------|---------------|-----------------------------------------------------------|
-  | NLP / text-mining  | ticket_text  O  comentario          | "str"         | range_min=null, range_max=null, trend=null, dep=null      |
-  | Clasificación      | categoria  O  label                 | "str"         | range_min=null, range_max=null, trend=null, dep=null      |
-  | Grafos             | origen  Y  destino  (par)           | "str"         | genera AMBAS columnas; mismas reglas de nulls             |
-  | Recomendación      | usuario, producto, rating           | "str"/"float" | genera las 3; rating: range_min=-1.0, range_max=5.0       |
-  | Sentimiento        | sentiment_score                     | "float"       | range_min=-1.0, range_max=1.0, trend=null, dep=null       |
-  | Anomalías          | transaction_amount                  | "float"       | range según el caso, trend=null, dep=null                 |
+Para {student_profile}="ml_ds" DEBES generar EXACTAMENTE estas 18 columnas en este orden.
+NUNCA generes columnas fuera de esta lista exacta.
+NUNCA uses type="str" para "categoria" — el notebook M3 requiere int para el target binario.
 
-  Reglas de uso:
-  1. Genera UNA columna por cada familia listada en {ml_required_families}, respetando los nombres exactos.
-  2. Para familias que requieren par (Grafos: origen+destino) o trío (Recomendación: usuario+producto+rating), genera TODAS las columnas del grupo.
-  3. Para columnas de tipo "str": SIEMPRE range_min=null, range_max=null, trend=null, dependency=null.
-- range_min/range_max: números para columnas numéricas, null para str/date.
+| # | name                    | type    | range_min | range_max | nullable | depends_on       | relationship | noise_factor |
+|---|-------------------------|---------|-----------|-----------|----------|------------------|--------------|--------------|
+| 1 | period                  | str     | null      | null      | false    | —                | —            | —            |
+| 2 | revenue                 | float   | rev*0.85  | rev*1.15  | false    | —                | —            | —            |
+| 3 | costs                   | float   | rev*0.60  | rev*0.88  | false    | —                | —            | —            |
+| 4 | margin_pct              | float   | 10.0      | 35.0      | false    | —                | —            | —            |
+| 5 | churn_rate              | float   | 0.02      | 0.15      | false    | revenue          | inverse      | 0.1          |
+| 6 | nps                     | int     | 20        | 75        | false    | —                | —            | —            |
+| 7 | retention_m1            | float   | 0.65      | 0.95      | false    | —                | —            | —            |
+| 8 | retention_m3            | float   | 0.50      | 0.80      | false    | retention_m1     | linear       | 0.05         |
+| 9 | retention_m6            | float   | 0.35      | 0.65      | false    | retention_m3     | linear       | 0.05         |
+|10 | retention_m12           | float   | 0.20      | 0.50      | false    | retention_m6     | linear       | 0.05         |
+|11 | customer_ltv            | float   | 500       | 5000      | TRUE     | —                | —            | —            |
+|12 | engagement_score        | float   | 0.1       | 0.95      | TRUE     | —                | —            | —            |
+|13 | days_since_last_login   | int     | 1         | 180       | false    | engagement_score | inverse      | 0.2          |
+|14 | support_tickets_count   | int     | 0         | 10        | false    | nps              | inverse      | 0.2          |
+|15 | plan_tier               | int     | 1         | 3         | false    | —                | —            | —            |
+|16 | payment_failures        | int     | 0         | 5         | false    | churn_rate       | linear       | 0.3          |
+|17 | monthly_usage_pct       | float   | 0.0       | 1.0       | false    | engagement_score | linear       | 0.1          |
+|18 | categoria               | int     | 0         | 1         | false    | churn_rate       | linear       | 0.30         |
+
+Notas críticas:
+- cols 11 y 12 (customer_ltv, engagement_score) DEBEN tener nullable=true.
+- col 18 (categoria): type="int", range_min=0, range_max=1, trend=null.
+  dependency.depends_on="churn_rate", relationship="linear", noise_factor=0.30.
+  NUNCA type="str" para categoria — convierte el target en ruido aleatorio sin señal.
+- El data_generator normaliza el padre, agrega ruido gaussiano, y redondea a int → ~70% señal → AUC ≥ 0.70.
+- revenue en col 2 y 3: rev = revenue_annual_total / {max_rows} (por fila, no anual).
+
+## Ejemplo de columnas con dependency y target (JSON listo para emitir)
+
+  {{
+    "name": "days_since_last_login",
+    "type": "int",
+    "description": "Días desde el último login del usuario",
+    "range_min": 1,
+    "range_max": 180,
+    "nullable": false,
+    "trend": null,
+    "dependency": {{
+      "depends_on": "engagement_score",
+      "relationship": "inverse",
+      "noise_factor": 0.2
+    }}
+  }},
+  {{
+    "name": "support_tickets_count",
+    "type": "int",
+    "description": "Número de tickets de soporte abiertos en el período",
+    "range_min": 0,
+    "range_max": 10,
+    "nullable": false,
+    "trend": null,
+    "dependency": {{
+      "depends_on": "nps",
+      "relationship": "inverse",
+      "noise_factor": 0.2
+    }}
+  }},
+  {{
+    "name": "categoria",
+    "type": "int",
+    "description": "Etiqueta binaria de clasificación: 0=cliente activo, 1=en riesgo de churn",
+    "range_min": 0,
+    "range_max": 1,
+    "nullable": false,
+    "trend": null,
+    "dependency": {{
+      "depends_on": "churn_rate",
+      "relationship": "linear",
+      "noise_factor": 0.30
+    }}
+  }}
 
 ## Exhibits del caso
 ### Exhibit 1 — Financiero (extrae revenue_annual_total de aquí)

--- a/backend/src/case_generator/prompts/clasificacion/dataset.py
+++ b/backend/src/case_generator/prompts/clasificacion/dataset.py
@@ -85,8 +85,8 @@ NUNCA uses type="str" para "categoria" — el notebook M3 requiere int para el t
 | 8 | retention_m3            | float   | 0.50      | 0.80      | false    | retention_m1     | linear       | 0.05         |
 | 9 | retention_m6            | float   | 0.35      | 0.65      | false    | retention_m3     | linear       | 0.05         |
 |10 | retention_m12           | float   | 0.20      | 0.50      | false    | retention_m6     | linear       | 0.05         |
-|11 | customer_ltv            | float   | 500       | 5000      | TRUE     | —                | —            | —            |
-|12 | engagement_score        | float   | 0.1       | 0.95      | TRUE     | —                | —            | —            |
+|11 | customer_ltv            | float   | 500       | 5000      | true     | —                | —            | —            |
+|12 | engagement_score        | float   | 0.1       | 0.95      | true     | —                | —            | —            |
 |13 | days_since_last_login   | int     | 1         | 180       | false    | engagement_score | inverse      | 0.2          |
 |14 | support_tickets_count   | int     | 0         | 10        | false    | nps              | inverse      | 0.2          |
 |15 | plan_tier               | int     | 1         | 3         | false    | —                | —            | —            |

--- a/backend/tests/test_m2_dataset_family_dispatch.py
+++ b/backend/tests/test_m2_dataset_family_dispatch.py
@@ -177,7 +177,7 @@ def test_classification_prompt_specifies_categoria_as_int() -> None:
 
 
 def test_classification_fallback_schema_categoria_is_int_with_dependency() -> None:
-    """_build_fallback_schema for ml_ds must produce ``categoria`` as int 0/1
+    """_build_fallback_schema for ml_ds+clasificacion must produce ``categoria`` as int 0/1
     with a dependency on ``churn_rate``.
 
     The fallback runs when the primary LLM call fails (503, timeout, JSON parse
@@ -190,13 +190,15 @@ def test_classification_fallback_schema_categoria_is_int_with_dependency() -> No
     """
     from case_generator.graph import _build_fallback_schema  # noqa: PLC0415
 
-    result = _build_fallback_schema(state={}, max_rows=600, profile="ml_ds")  # type: ignore[arg-type]
+    result = _build_fallback_schema(  # type: ignore[arg-type]
+        state={}, max_rows=600, profile="ml_ds", primary_family="clasificacion"
+    )
 
     columns_by_name = {col["name"]: col for col in result["columns"]}
 
     # --- categoria presence and type ---
     assert "categoria" in columns_by_name, (
-        "_build_fallback_schema must include a 'categoria' column for ml_ds"
+        "_build_fallback_schema must include a 'categoria' column for ml_ds+clasificacion"
     )
     cat = columns_by_name["categoria"]
     assert cat["type"] == "int", (
@@ -222,3 +224,40 @@ def test_classification_fallback_schema_categoria_is_int_with_dependency() -> No
         "'ticket_text' is not part of the 18-column classification contract "
         "and must not appear in the ml_ds fallback schema"
     )
+
+
+@pytest.mark.parametrize("family", ["regresion", "clustering", "serie_temporal", ""])
+def test_non_clasificacion_fallback_schema_has_no_classification_columns(family: str) -> None:
+    """_build_fallback_schema for non-clasificacion ml_ds families must NOT emit
+    classification-specific columns (``categoria``, ``plan_tier``, ``payment_failures``,
+    etc.) that would cause regression/clustering M3 notebooks to fail.
+
+    These families' M3 notebooks derive their target from the base schema
+    (e.g. ``revenue`` for regresion; no target column for clustering).
+    The generic ml_ds baseline (customer_ltv + engagement_score, cols 11–12) is
+    still expected so downstream prompt augmentation works correctly.
+    """
+    from case_generator.graph import _build_fallback_schema  # noqa: PLC0415
+
+    result = _build_fallback_schema(  # type: ignore[arg-type]
+        state={}, max_rows=200, profile="ml_ds", primary_family=family
+    )
+    cols_by_name = {col["name"]: col for col in result["columns"]}
+
+    # Classification-specific columns must not appear for non-clasificacion families.
+    for classification_col in ("categoria", "plan_tier", "payment_failures",
+                               "days_since_last_login", "support_tickets_count",
+                               "monthly_usage_pct"):
+        assert classification_col not in cols_by_name, (
+            f"family={family!r}: classification column {classification_col!r} must not "
+            "appear in non-clasificacion fallback schema"
+        )
+
+    # Generic ml_ds baseline (customer_ltv + engagement_score) should still be present.
+    assert "customer_ltv" in cols_by_name, (
+        f"family={family!r}: fallback schema must still include 'customer_ltv'"
+    )
+    assert "engagement_score" in cols_by_name, (
+        f"family={family!r}: fallback schema must still include 'engagement_score'"
+    )
+    assert result["n_rows"] == 200

--- a/backend/tests/test_m2_dataset_family_dispatch.py
+++ b/backend/tests/test_m2_dataset_family_dispatch.py
@@ -132,3 +132,93 @@ def test_generic_prompt_still_contains_required_placeholders(placeholder: str) -
 
 def test_classification_prompt_is_non_empty_string() -> None:
     assert len(SCHEMA_DESIGNER_PROMPT_CLASSIFICATION.strip()) > 100
+
+
+# ---------------------------------------------------------------------------
+# Classification-specific semantic contracts
+# ---------------------------------------------------------------------------
+
+
+def test_classification_prompt_specifies_categoria_as_int() -> None:
+    """``categoria`` column in SCHEMA_DESIGNER_PROMPT_CLASSIFICATION must declare
+    type="int", not type="str".
+
+    A str target column causes the data_generator to emit random categorical
+    strings with zero signal, so LR/RF learn noise and AUC collapses to ~0.50.
+
+    The bounded-window regex (.{0,400}) avoids cross-column false positives that
+    would occur with ``.*?`` (re.DOTALL) spanning into the next column's "type" field.
+    Using ``[^}]*`` is unsafe here because the prompt uses doubled braces ``{{ }}``
+    for .format() escaping, which places literal ``}`` characters inside each column
+    block (inside the dependency sub-object).  The 400-char window is large enough
+    to cover any single column block including its dependency object.
+    """
+    import re  # noqa: PLC0415
+
+    positive = re.search(
+        r'"name"\s*:\s*"categoria".{0,400}"type"\s*:\s*"int"',
+        SCHEMA_DESIGNER_PROMPT_CLASSIFICATION,
+        re.DOTALL,
+    )
+    assert positive is not None, (
+        'SCHEMA_DESIGNER_PROMPT_CLASSIFICATION must declare "categoria" with '
+        '"type": "int" — a str target produces a random signal-free column'
+    )
+
+    negative = re.search(
+        r'"name"\s*:\s*"categoria".{0,400}"type"\s*:\s*"str"',
+        SCHEMA_DESIGNER_PROMPT_CLASSIFICATION,
+        re.DOTALL,
+    )
+    assert negative is None, (
+        'SCHEMA_DESIGNER_PROMPT_CLASSIFICATION must NOT declare "categoria" with '
+        '"type": "str" — that would make the binary target useless for classification'
+    )
+
+
+def test_classification_fallback_schema_categoria_is_int_with_dependency() -> None:
+    """_build_fallback_schema for ml_ds must produce ``categoria`` as int 0/1
+    with a dependency on ``churn_rate``.
+
+    The fallback runs when the primary LLM call fails (503, timeout, JSON parse
+    error).  Without this fix, the fallback emits ``categoria: str`` with no
+    dependency, causing the same AUC collapse as a bad LLM output — silently,
+    with no exception raised.
+
+    Also asserts that ``ticket_text`` is absent: it is not part of the 18-column
+    classification contract and would confuse the M3 notebook.
+    """
+    from case_generator.graph import _build_fallback_schema  # noqa: PLC0415
+
+    result = _build_fallback_schema(state={}, max_rows=600, profile="ml_ds")  # type: ignore[arg-type]
+
+    columns_by_name = {col["name"]: col for col in result["columns"]}
+
+    # --- categoria presence and type ---
+    assert "categoria" in columns_by_name, (
+        "_build_fallback_schema must include a 'categoria' column for ml_ds"
+    )
+    cat = columns_by_name["categoria"]
+    assert cat["type"] == "int", (
+        f"'categoria' must have type='int', got {cat['type']!r}"
+    )
+    assert cat["range_min"] == 0, f"categoria range_min must be 0, got {cat['range_min']}"
+    assert cat["range_max"] == 1, f"categoria range_max must be 1, got {cat['range_max']}"
+    assert cat["nullable"] is False, "categoria must be nullable=False"
+
+    # --- dependency on churn_rate ---
+    dep = cat.get("dependency")
+    assert dep is not None, (
+        "'categoria' must have a dependency on churn_rate so LR/RF receive a signal-bearing target"
+    )
+    assert dep["depends_on"] == "churn_rate", (
+        f"categoria dependency must point to 'churn_rate', got {dep['depends_on']!r}"
+    )
+    assert dep["relationship"] == "linear"
+    assert dep["noise_factor"] == pytest.approx(0.30)
+
+    # --- ticket_text must NOT be present in the 18-col classification schema ---
+    assert "ticket_text" not in columns_by_name, (
+        "'ticket_text' is not part of the 18-column classification contract "
+        "and must not appear in the ml_ds fallback schema"
+    )


### PR DESCRIPTION
## Summary

Specializes the M2 dataset schema for the `clasificacion` family: replaces the generic prompt copy with a fixed 18-column classification contract, raises `max_rows` to 600 for `ml_ds`, and hardens the LLM-failure fallback so it can never silently emit a string target.

## Changes

### `backend/src/case_generator/graph.py`
- **`schema_designer`** — `max_rows` raised 200 → 600 for `ml_ds`. Issue #240 cascade: 600 ≤ 2000 → full GridSearchCV / grilla completa.
- **`_build_fallback_schema`** — ml_ds block replaced from 4 generic columns (`ticket_text: str`, `categoria: str`) to 8-column classification-coherent block. `categoria` is now `int 0/1` with `depends_on=churn_rate`, `noise_factor=0.30`. Closes the silent critical gap: LLM timeout/503 previously produced a random string target with AUC ≈ 0.50.

### `backend/src/case_generator/prompts/clasificacion/dataset.py`
- **`SCHEMA_DESIGNER_PROMPT_CLASSIFICATION`** — full replacement with 18-column fixed classification schema. `categoria` is `int 0/1` with `churn_rate` dependency → ~70% signal → AUC ≥ 0.70. Removes stale multi-family VOCABULARIO OBLIGATORIO table. All 7 required format-string placeholders retained.

### `backend/tests/test_m2_dataset_family_dispatch.py`
- +2 semantic regression-guard tests (28 total):
  - `test_classification_prompt_specifies_categoria_as_int` — bounded-window regex asserts `type=int` and rejects `type=str` for the `categoria` column.
  - `test_classification_fallback_schema_categoria_is_int_with_dependency` — asserts `_build_fallback_schema` emits int 0/1 target with `churn_rate` dependency, no `ticket_text`, `n_rows==600`.

### `TODOS.md`
- Removed TODO-M2-A (completed by this PR).
- Added TODO-NORM-A: stale `RENAME_MAP` entry `feature_adoption_pct → ("categoria", "str")` in `_normalize_ml_ds_columns` — last live silent-corruption path, deferred.

## Validation

```
pytest tests/test_m2_dataset_family_dispatch.py  →  28 passed
pytest -q                                         →  806 passed, 14 skipped
mypy src                                          →  Success: no issues found in 58 source files
```

## Out of scope (deferred)
- `_normalize_ml_ds_columns` RENAME_MAP stale entry → TODO-NORM-A
- Prompt specialization for `regresion` and `clustering` families → TODO-M2-B / TODO-M2-C
