### PR TITLE
fix: strip internal (Issue #N) refs from all LLM-visible prompt strings

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -128,6 +128,37 @@ mergeado.
 
 ---
 
+## TODO-HYGIENE-A: Sanitizador post-generación de referencias de tickets
+
+**What:** Añadir un guard de runtime en los nodos de `graph.py` que procesan la salida
+del LLM para M2 (EDA narrative) y M3 (notebook content): después de recibir el texto
+del modelo, aplicar `re.sub(r"\(Issue #\d+[^)]*\)", "", text)` como paso de limpieza
+antes de persistir en el estado del job.
+
+**Why:** Los prompts ya están limpios (fix en rama `fix/strip-issue-refs-from-prompts`),
+pero los LLMs tienen memoria: un modelo puede haber sido entrenado con contenido interno
+o puede alucinar etiquetas del estilo `(Issue #XXX)` espontáneamente si ve patrones
+similares en el prompt. El sanitizador garantiza que ninguna referencia de ese tipo
+llegue jamás al output visible por docentes o estudiantes, incluso en ese escenario.
+
+**Scope:** ~10–15 líneas en los nodos relevantes de `graph.py`. Aplicar después del
+`_validate_notebook_family_consistency` / grounding checks. Sin afectar sentinelas
+(`# === SECTION:... ===`) ni la lógica de reprompt.
+
+**Pros:** Defensa en profundidad. Cierra el riesgo de regresión aunque el LLM alucine
+las etiquetas sin haberlas visto en el prompt.
+
+**Cons:** Regex post-proceso añade una pasada sobre el texto generado (muy bajo costo).
+Debe aplicarse ANTES de la validación de grounding narrativo para no interactuar con ella.
+
+**Context:** El PR `fix/strip-issue-refs-from-prompts` elimina las referencias de los
+prompts (causa raíz). Este TODO es la capa de defensa adicional runtime. Se puede
+implementar de forma independiente en un PR posterior de bajo riesgo.
+
+**Depends on / blocked by:** PR `fix/strip-issue-refs-from-prompts` mergeado.
+
+---
+
 ## TODO-243-A: Excepción estrecha para umbrales prospectivos en grounding narrativo
 
 **What:** Evaluar si `validate_narrative_grounding` debe permitir números técnicos dentro de contextos explícitamente prospectivos, como "Condición mínima de éxito", "target futuro" o recomendaciones de monitoreo, sin tratarlos como métricas ejecutadas del notebook.

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -153,7 +153,7 @@ Nombre, industria, tamaño. Protagonista decisor (nombre, cargo, presiones, esti
 ## instrucciones_estudiante (máx 100 palabras)
 Rol del estudiante y recordatorio de responder preguntas en plataforma.
 
-## pregunta_eje (Issue #242)
+## pregunta_eje
 Pregunta directiva central del caso. SOLO para {student_profile}="ml_ds" y
 {primary_family}="clasificacion"; en cualquier otro caso debe ser `null`.
 Debe obligar a una decisión ejecutiva defendible con evidencia M2/M3/M4 y matriz de costos.
@@ -174,7 +174,7 @@ Encabezado: `### Exhibit 3 — Mapa de Stakeholders`
 Tabla: Actor | Interés | Incentivo | Riesgo | Postura (A/B/C)
 Mín 6 actores (mín 4 para "undergrad").
 
-## dataset_schema_required (Issue #225 — contrato dataset↔dilema)
+## dataset_schema_required
 Objeto que declara qué dataset necesita el caso para que el dilema sea respondible
 con datos. **Obligatorio cuando {student_profile}="ml_ds"**. Para "business" puedes
 emitir `null` (el pipeline mantiene el comportamiento heurístico previo).
@@ -209,7 +209,7 @@ Reglas duras:
    Ej: si el dilema es "decidir cómo retener clientes", el target NO puede ser un
    código aleatorio sin relación causal. Debe ser una variable medible y observable
    en producción (ej: `churn_flag`, `delivery_delay_minutes`, `default_60d`).
-1bis. **Coherencia título↔target (Issue #228)**: el `name` y el `role` del target
+1bis. **Coherencia título↔target**: el `name` y el `role` del target
    deben reflejar el sustantivo central del `titulo`. Mapeo de referencia
    (no exhaustivo — adapta al caso, pero respeta la familia):
      - título habla de "retención"/"churn"/"abandono"/"fidelización" → target
@@ -229,7 +229,7 @@ Reglas duras:
    Ej: al predecir `churn_flag` del mes 0, las columnas `retention_m3`, `retention_m6`,
    `retention_m12` son leakage por construcción → marcarlas siempre.
 2bis. **Naming patterns que SIEMPRE son leakage cuando el target NO es de
-   familia retención (Issue #228)**: `retention_*`, `churn_*`, `nps`, `csat`,
+   familia retención**: `retention_*`, `churn_*`, `nps`, `csat`,
    `customer_ltv`, `complaint_*`, `cancellation_*`, `*_post_event`. Si tu
    target es operativo (delay/defecto/fraude/ventas) y declaras alguna de
    estas como feature, marca `is_leakage_risk=true` SIEMPRE — el pipeline
@@ -427,7 +427,7 @@ SCHEMA_DESIGNER_PROMPT = """\
 Diseña el schema de un dataset sintético para el caso de negocio dado.
 Perfil: {student_profile} | Industria: {industria}
 
-## Contrato dataset_schema_required (Issue #225 — fuente de verdad)
+## Contrato dataset_schema_required
 {dataset_contract_block}
 
 REGLAS DE COBERTURA DEL CONTRATO (cuando NO esté vacío):
@@ -620,7 +620,7 @@ usando exclusivamente los datos del dataset y los Exhibits provistos.
 - Si una métrica no muestra tendencia clara o anomalía: repórtala como ESTABLE.
   NO fuerces un hallazgo donde los datos no lo soportan.
 
-## Brechas dilema↔dataset (Issue #225 — data_gap_warnings)
+## Brechas dilema↔dataset
 {data_gap_warnings_block}
 
 REGLAS para brechas:
@@ -713,7 +713,7 @@ sobre charts ya construidos.
 Para CADA chart en `{charts_context_json}` escribe `description` y `notes`
 que ayuden al estudiante a leer la visualización en términos de negocio.
 
-# Hard Boundaries (Issue #237)
+# Hard Boundaries
 - NO modifiques `traces`, `layout`, `source`, `id`, `title`, `subtitle`,
   `chart_type` ni ningún número del chart. Esos campos son determinísticos
   y vienen del builder Python — NO son negociables.
@@ -1904,13 +1904,13 @@ Eres un ML Engineer generando la Sección 3 de un notebook Jupytext Percent para
 El notebook resuelve un problema de REGRESIÓN (target numérico continuo).
 Genera SOLO la continuación del notebook después de la Sección 3 del base template.
 
-# Contrato dataset_schema_required (Issue #225 — fuente canónica del target)
+# Contrato dataset_schema_required
 {dataset_contract_block}
 
-# Brechas de datos detectadas por el validador (data_gap_warnings)
+# Brechas de datos detectadas por el validador
 {data_gap_warnings_block}
 
-# Reglas CONTRACT-FIRST (Issue #225 — prioridad máxima)
+# Reglas CONTRACT-FIRST
 * Si el contrato declara `target_column.name`, usa ese nombre EXACTO. NO uses alias-matching.
 * Si el target del contrato no está en `df.columns`, imprime
   `print("⚠️ REQUISITO FALTANTE: target '<name>' del contrato no está en el dataset")` y SALTA el bloque.
@@ -1979,7 +1979,7 @@ D. NO importes nada que no esté en: numpy, pandas, matplotlib, seaborn, sklearn
 5. One-hot ANTES del split: `X = pd.get_dummies(df[feature_cols], drop_first=True, dummy_na=False)`.
 6. Si `X.shape[1] == 0`: imprime "⚠️ REQUISITO FALTANTE: sin features útiles tras higiene" y SALTA.
 
-# Atomic Cell Charting (Issue #228 — un gráfico por celda)
+# Atomic Cell Charting
 - PROHIBIDO `plt.subplots(1, N)` o `plt.subplots(N, M)` para mezclar gráficos heterogéneos.
 - Cada celda de visualización contiene exactamente UNA `plt.figure(...)` y UN `plt.show()`.
 - Por algoritmo, parte el bloque en sub-celdas:
@@ -2107,10 +2107,10 @@ Eres un ML Engineer generando la Sección 3 de un notebook Jupytext Percent para
 El notebook resuelve un problema de CLUSTERING NO SUPERVISADO.
 Genera SOLO la continuación del notebook después de la Sección 3 del base template.
 
-# Contrato dataset_schema_required (Issue #225)
+# Contrato dataset_schema_required
 {dataset_contract_block}
 
-# Brechas de datos detectadas por el validador (data_gap_warnings)
+# Brechas de datos detectadas por el validador
 {data_gap_warnings_block}
 
 # Reglas CONTRACT-FIRST
@@ -2176,7 +2176,7 @@ C. NO importes nada que no esté en: numpy, pandas, matplotlib, seaborn,
 5. `X = df[feature_cols].dropna()` (sin imputación con estadísticos — clustering es sensible a la imputación con la media).
 6. Si `X.shape[1] < 2` o `X.shape[0] < 10`: imprime "⚠️ REQUISITO FALTANTE..." y SALTA.
 
-# Atomic Cell Charting (Issue #228 — un gráfico por celda)
+# Atomic Cell Charting
 - PROHIBIDO `plt.subplots(1, N)` o `plt.subplots(N, M)` para mezclar gráficos heterogéneos.
 - Cada celda de visualización contiene exactamente UNA `plt.figure(...)` y UN `plt.show()`.
 - Por algoritmo, parte el bloque en sub-celdas:
@@ -2291,10 +2291,10 @@ Eres un ML Engineer generando la Sección 3 de un notebook Jupytext Percent para
 El notebook resuelve un problema de SERIES TEMPORALES (forecasting).
 Genera SOLO la continuación del notebook después de la Sección 3 del base template.
 
-# Contrato dataset_schema_required (Issue #225)
+# Contrato dataset_schema_required
 {dataset_contract_block}
 
-# Brechas de datos detectadas por el validador (data_gap_warnings)
+# Brechas de datos detectadas por el validador
 {data_gap_warnings_block}
 
 # Reglas CONTRACT-FIRST
@@ -2373,7 +2373,7 @@ D. NO importes nada que no esté en: numpy, pandas, matplotlib, seaborn,
   6. `print("Split temporal:", "train hasta", df[date_col].iloc[cut-1], "→ test desde", df[date_col].iloc[cut])`
 - PROHIBIDO `train_test_split(X, y, ...)` con `random_state` — se permite SOLO `TimeSeriesSplit` para CV.
 
-# Atomic Cell Charting (Issue #228 — un gráfico por celda)
+# Atomic Cell Charting
 - PROHIBIDO `plt.subplots(1, N)` o `plt.subplots(N, M)` para mezclar gráficos heterogéneos.
 - Cada celda de visualización contiene exactamente UNA `plt.figure(...)` y UN `plt.show()`.
 - Por algoritmo, parte el bloque en sub-celdas:

--- a/backend/src/case_generator/prompts/clasificacion/dataset.py
+++ b/backend/src/case_generator/prompts/clasificacion/dataset.py
@@ -18,7 +18,7 @@ Diseña el schema de un dataset sintético de CLASIFICACIÓN BINARIA para el cas
 Perfil: {student_profile} | Industria: {industria}
 Familias ML requeridas (referencia): {ml_required_families}
 
-## Contrato dataset_schema_required (Issue #225 — fuente de verdad)
+## Contrato dataset_schema_required
 {dataset_contract_block}
 
 REGLAS DE COBERTURA DEL CONTRATO (cuando NO esté vacío):

--- a/backend/src/case_generator/prompts/clasificacion/narrative.py
+++ b/backend/src/case_generator/prompts/clasificacion/narrative.py
@@ -10,7 +10,7 @@ from case_generator.prompts._shared import (
 
 _NARRATIVE_GROUNDING_CLASSIFICATION_BLOCK = """\
 
-# Grounding computado del notebook M3 (Issue #243 — solo clasificación)
+# Grounding computado del notebook M3
 {computed_metrics_block}
 
 # Prohibición literal de grounding narrativo
@@ -20,7 +20,7 @@ NUNCA cites estudios externos, autores, referencias académicas fabricadas ni es
 # ── LR-only deep dive ────────────────────────────────────────────────────────
 _M3_CLASSIFICATION_COHERENCE_BLOCK_LR_ONLY = """\
 
-# Coherencia pedagógica de clasificación — deep dive LR (Issue #242)
+# Coherencia pedagógica de clasificación — deep dive LR
 Este bloque aplica SOLO a jobs con algorithm_mode="single" y algoritmo Logistic Regression.
 
 El docente eligió un deep dive sobre un único modelo. NO menciones ni compares con Random
@@ -45,7 +45,7 @@ lectura con la pregunta eje y con el costo de elegir una opción A/B/C bajo ince
 # ── RF-only deep dive ─────────────────────────────────────────────────────────
 _M3_CLASSIFICATION_COHERENCE_BLOCK_RF_ONLY = """\
 
-# Coherencia pedagógica de clasificación — deep dive RF (Issue #242)
+# Coherencia pedagógica de clasificación — deep dive RF
 Este bloque aplica SOLO a jobs con algorithm_mode="single" y algoritmo Random Forest.
 
 El docente eligió un deep dive sobre un único modelo. NO menciones ni compares con Logistic
@@ -70,7 +70,7 @@ lectura con la pregunta eje y con el costo de elegir una opción A/B/C bajo ince
 # ── LR vs RF contrast ─────────────────────────────────────────────────────────
 _M3_CLASSIFICATION_COHERENCE_BLOCK_LR_RF_CONTRAST = """\
 
-# Coherencia pedagógica de clasificación — contraste LR vs RF (Issue #242)
+# Coherencia pedagógica de clasificación — contraste LR vs RF
 Este bloque aplica SOLO a jobs con algorithm_mode="contrast" (LR + RF) con perfil `ml_ds`.
 
 Pregunta eje directiva del caso:
@@ -93,7 +93,7 @@ con la pregunta eje y con el costo de elegir una opción A/B/C bajo incertidumbr
 
 _M5_CLASSIFICATION_DECISION_MATRIX_BLOCK = """\
 
-# Matriz de decisión ejecutiva (Issue #242 — solo clasificación)
+# Matriz de decisión ejecutiva (solo clasificación)
 Este documento M5 debe incluir una tabla Markdown con 4 a 6 filas y columnas EXACTAS:
 
 | acción | KPI esperado | riesgo | modelo soporte |

--- a/backend/src/case_generator/prompts/clasificacion/notebook.py
+++ b/backend/src/case_generator/prompts/clasificacion/notebook.py
@@ -5,13 +5,13 @@ Eres un ML Engineer generando la Sección 3 de un notebook Jupytext Percent para
 El notebook sigue la estructura pedagógica ADAM M3: Concepto → Gráfico Conceptual → Acción de Negocio.
 Genera SOLO la continuación del notebook, empezando después de la Sección 3 del base template.
 
-# Contrato dataset_schema_required (Issue #225 — fuente canónica del target)
+# Contrato dataset_schema_required
 {dataset_contract_block}
 
-# Brechas de datos detectadas por el validador (data_gap_warnings)
+# Brechas de datos detectadas por el validador
 {data_gap_warnings_block}
 
-# Reglas CONTRACT-FIRST (Issue #225 — prioridad máxima sobre toda heurística posterior)
+# Reglas CONTRACT-FIRST
 * Si el contrato declara `target_column.name`, USA ESE NOMBRE EXACTO como variable
   objetivo en TODO el notebook. NO uses alias-matching, NO uses "último categórico"
   ni ningún fallback heurístico para elegir el target.
@@ -240,7 +240,7 @@ K. EDA Express (Sección 3.0) OBLIGATORIA antes del primer bloque de algoritmo:
    - GUARDA de tamaño mínimo: si `len(df) < 50`, imprime una ADVERTENCIA visible
      ("⚠️ Dataset pequeño (n=<N>): los modelos posteriores son ilustrativos; las métricas
      tienen alta varianza”) para que el estudiante interprete los resultados con cautela.
-L. **Atomic Cell Charting (Issue #228 — un gráfico por celda)**: cada celda de
+L. **Atomic Cell Charting**: cada celda de
    código que muestre un plot DEBE contener exactamente UN `plt.show()` y UNA
    única figura visible. Reglas operativas:
    - **PROHIBIDO** `plt.subplots(1, N)` o `plt.subplots(N, M)` para mezclar
@@ -262,7 +262,7 @@ L. **Atomic Cell Charting (Issue #228 — un gráfico por celda)**: cada celda d
      consecutivos). NUNCA mezcles SHAP con cualquier otra cosa.
    - Cada celda de visualización debe terminar con `plt.tight_layout(); plt.show()`.
 
-M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO (Issue #236).**
+M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO.**
    Antes del bloque per-algoritmo, emite la **Sección 3.0.5** descrita más
    abajo en "Estructura OBLIGATORIA". Esa sección contiene OCHO celdas con
    sentinelas contractuales que el validador post-LLM verifica:
@@ -273,7 +273,7 @@ M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO (Issue #236).**
      - `# === SECTION:roc_curves ===`         → hold-out propio + curva ROC (LR vs RF) en una sola figura
      - `# === SECTION:pr_curves ===`          → curva Precision-Recall (LR vs RF) en una sola figura, reusando el hold-out
      - `# === SECTION:comparison_table ===`   → tabla pd.DataFrame final con las 7 columnas, hold-out reconstruido localmente
-     - `# === SECTION:cost_matrix ===`        → (Issue #238) curva costo-vs-threshold con confusion_matrix + predict_proba; eje Y en `currency` del contrato; línea vertical roja en threshold óptimo y línea gris en 0.5
+     - `# === SECTION:cost_matrix ===`        → curva costo-vs-threshold con confusion_matrix + predict_proba; eje Y en `currency` del contrato; línea vertical roja en threshold óptimo y línea gris en 0.5
    Reglas:
    * Las sentinelas se emiten LITERALMENTE como primera línea de su celda
      `# %%` (comentario Python). Si una sentinela falta, el job falla en
@@ -353,9 +353,8 @@ try:
 except Exception as e:
     print(f"⚠️ EDA Express falló: {{e}}")
 
-## Sección 3.0.5 — Bloque comparativo Harvard ml_ds (REGLA M, Issue #236)
-## Emite EXACTAMENTE las 8 celdas de código siguientes (Issue #238 añadió
-## la celda cost_matrix), EN ORDEN, con su
+## Sección 3.0.5 — Bloque comparativo Harvard ml_ds
+## Emite EXACTAMENTE las 8 celdas de código siguientes (la última es cost_matrix), EN ORDEN, con su
 ## sentinela como primera línea (comentario Python). Cada sentinela es
 ## contractual — el validador post-LLM rechaza el notebook y reprompt si falta.
 ## Este bloque es CASE-WIDE (una sola vez, para Logistic Regression vs
@@ -703,7 +702,7 @@ except Exception as e:
     print(f"⚠️ Tabla comparativa falló: {{e}}")
 
 # %% [markdown]
-# ### 3.0.6 — Matriz de costos del negocio + threshold tuning (Issue #238)
+# ### 3.0.6 — Matriz de costos del negocio + threshold tuning
 # El threshold default 0.5 SOLO es óptimo si FP y FN cuestan igual. En la
 # mayoría de los problemas de negocio (churn, fraude, mantenimiento) los
 # costos son asimétricos. Esta celda lee la matriz de costos del contrato
@@ -793,7 +792,7 @@ except Exception as e:
     print(f"⚠️ Cost matrix + threshold tuning falló: {{e}}")
 
 # %% [markdown]
-# ### 3.0.7 — Tuning hiperparámetros LogisticRegression (Issue #240)
+# ### 3.0.7 — Tuning hiperparámetros LogisticRegression
 # El `C` default no es óptimo. `GridSearchCV(scoring="roc_auc")` barre
 # `C ∈ [0.01, 0.1, 1, 10]` con `StratifiedKFold(5)` y refit del best
 # estimator sobre `X_train` completo.
@@ -889,7 +888,7 @@ except Exception as e:
     print(f"⚠️ Tuning LR falló: {{e}}")
 
 # %% [markdown]
-# ### 3.0.8 — Tuning hiperparámetros RandomForest (Issue #240)
+# ### 3.0.8 — Tuning hiperparámetros RandomForest
 # `RandomizedSearchCV(n_iter=10)` cubre el espacio `max_depth × min_samples_leaf
 # × n_estimators` sin barrer la grilla cartesiana entera. Mismo `scoring=
 # "roc_auc"` para que LR y RF sean comparables 1:1.
@@ -989,7 +988,7 @@ except Exception as e:
     print(f"⚠️ Tuning RF falló: {{e}}")
 
 # %% [markdown]
-# ### 3.0.9 — Interpretabilidad LR: odds ratios + CI bootstrap + VIF (Issue #240)
+# ### 3.0.9 — Interpretabilidad LR: odds ratios + CI bootstrap + VIF
 # Coeficientes en log-odds son ilegibles para el negocio. Convertimos a
 # odds ratios (`np.exp(coef_)`) e incluimos intervalos de confianza
 # bootstrap (`B=200`, `np.random.default_rng(42)`).
@@ -1137,7 +1136,7 @@ except Exception as e:
     print(f"⚠️ Interpretabilidad LR falló: {{e}}")
 
 # %% [markdown]
-# ### 3.0.10 — Interpretabilidad RF: permutation importance + PDP top-2 (Issue #240)
+# ### 3.0.10 — Interpretabilidad RF: permutation importance + PDP top-2
 # `feature_importances_` está sesgado a features de alta cardinalidad.
 # `permutation_importance` mide el drop real de score al permutar cada
 # feature en `X_test`. Después graficamos PDP sobre las top-2 features
@@ -1249,7 +1248,7 @@ except Exception as e:
     print(f"⚠️ Interpretabilidad RF falló: {{e}}")
 
 # %% [markdown]
-# ### 3.0.11 — Resumen ejecutable de métricas para grounding narrativo (Issue #239)
+# ### 3.0.11 — Resumen ejecutable de métricas para grounding narrativo
 # Esta celda emite exactamente una línea JSON estable. ADAM ejecuta el notebook
 # en backend, parsea esta marca y usa las métricas reales para anclar M4/M5.
 
@@ -1433,7 +1432,7 @@ except Exception as e:
 ## Si el algoritmo NO menciona "shap", OMITE esta celda completa (no la generes vacía).
 # %%
 try:
-    # SHAP atómico — REGLA J (Issue #228). NUNCA en subplot mixto.
+    # SHAP atómico — REGLA J. NUNCA en subplot mixto.
     # import shap
     # explainer = shap.TreeExplainer(model)
     # sample = X_test.sample(min(len(X_test), 200), random_state=42)

--- a/backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py
+++ b/backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py
@@ -153,17 +153,17 @@ def _replace_rule_m(prompt: str, variant: ClassificationNotebookVariant) -> str:
 
 
 INTRO_BY_VARIANT: dict[ClassificationNotebookVariant, str] = {
-    "lr_only": """## Sección 3.0.5 — Deep dive Logistic Regression (Issue #230)
+    "lr_only": """## Sección 3.0.5 — Deep dive Logistic Regression
 ## Emite SOLO celdas LR. No generes código ni texto de modelos no seleccionados.
 ## Las únicas celdas con gráficos son `roc_curves` y `cost_matrix`.
 
 """,
-    "rf_only": """## Sección 3.0.5 — Deep dive Random Forest (Issue #230)
+    "rf_only": """## Sección 3.0.5 — Deep dive Random Forest
 ## Emite SOLO celdas RF. No generes código ni texto de modelos no seleccionados.
 ## Las únicas celdas con gráficos son `roc_curves` y `cost_matrix`.
 
 """,
-    "lr_rf_contrast": """## Sección 3.0.5 — Contraste Logistic Regression vs Random Forest (Issue #230)
+    "lr_rf_contrast": """## Sección 3.0.5 — Contraste Logistic Regression vs Random Forest
 ## Emite celdas LR y RF, manteniendo máximo dos gráficos totales: ROC y matriz de costos.
 
 """,
@@ -600,7 +600,7 @@ except Exception as e:
 
 RF_INTERP_TABLE_ONLY_SECTION = """
 # %% [markdown]
-# ### 3.0.10 — Interpretabilidad RF: permutation importance tabular (Issue #240)
+# ### 3.0.10 — Interpretabilidad RF: permutation importance tabular
 # Se evita un gráfico adicional para respetar el límite de dos figuras del notebook.
 
 # %%

--- a/backend/tests/test_issue225_dataset_schema_contract.py
+++ b/backend/tests/test_issue225_dataset_schema_contract.py
@@ -337,7 +337,7 @@ def test_eda_text_analyst_prompt_renders_with_gap_warnings_block() -> None:
         data_gap_warnings_block="- feature 'retention_m12' marcada con riesgo de leakage",
     )
     assert "retention_m12" in out
-    assert "data_gap_warnings" in out
+    assert "Brechas" in out
 
 
 def test_m3_notebook_algo_prompt_renders_with_contract_and_gaps() -> None:

--- a/backend/tests/test_issue228_semantic_coherence_and_charts.py
+++ b/backend/tests/test_issue228_semantic_coherence_and_charts.py
@@ -234,7 +234,6 @@ def test_leakage_inference_does_not_mutate_input() -> None:
 def test_case_architect_prompt_contains_title_target_coherence_rule() -> None:
     """La regla 1bis de coherencia título↔target debe estar en el prompt."""
     assert "Coherencia título↔target" in CASE_ARCHITECT_PROMPT
-    assert "Issue #228" in CASE_ARCHITECT_PROMPT
     # Familias clave referenciadas.
     assert "churn_flag" in CASE_ARCHITECT_PROMPT
     assert "delivery_delay_minutes" in CASE_ARCHITECT_PROMPT
@@ -252,7 +251,6 @@ def test_case_architect_prompt_lists_leakage_naming_patterns() -> None:
 def test_m3_notebook_prompt_contains_atomic_cell_rule_l() -> None:
     """Regla L (Atomic Cell Charting) debe estar presente y mencionar el bug SHAP."""
     assert "Atomic Cell Charting" in M3_NOTEBOOK_ALGO_PROMPT
-    assert "Issue #228" in M3_NOTEBOOK_ALGO_PROMPT
     assert "PROHIBIDO" in M3_NOTEBOOK_ALGO_PROMPT
     assert "plt.subplots(1, N)" in M3_NOTEBOOK_ALGO_PROMPT
     # Sub-celdas 2a/2b/2c/2d deben aparecer.

--- a/backend/tests/test_m3_notebook_classification_hygiene.py
+++ b/backend/tests/test_m3_notebook_classification_hygiene.py
@@ -313,3 +313,38 @@ def test_prohibited_violations_remain_bare_strings_for_back_compat() -> None:
     violations = _validate_notebook_family_consistency("clasificacion", bad)
     # El token prohibido viene SIN prefijo FALTANTE.
     assert "from sklearn.cluster import" in violations
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Prompt hygiene: no internal issue-tracker labels in LLM-visible strings
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_classification_notebook_prompt_has_no_issue_references() -> None:
+    """El prompt del notebook de clasificación NO debe contener referencias a
+    tickets internos del tipo '(Issue #N)'. Si el LLM las lee, las reproduce
+    verbatim como subtítulos de celda Markdown visibles para docentes y
+    estudiantes en producción."""
+    import re
+    from case_generator.prompts.clasificacion.notebook import (
+        M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LEGACY,
+    )
+    from case_generator.prompts.clasificacion.notebooks._shared import (
+        INTRO_BY_VARIANT,
+        RF_INTERP_TABLE_ONLY_SECTION,
+    )
+
+    _issue_pattern = re.compile(r"\(Issue #\d+")
+
+    assert not _issue_pattern.search(M3_NOTEBOOK_ALGO_PROMPT), (
+        "M3_NOTEBOOK_ALGO_PROMPT contiene una referencia a un ticket interno"
+    )
+    assert not _issue_pattern.search(M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LEGACY), (
+        "M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LEGACY contiene una referencia a un ticket interno"
+    )
+    assert not _issue_pattern.search(RF_INTERP_TABLE_ONLY_SECTION), (
+        "RF_INTERP_TABLE_ONLY_SECTION contiene una referencia a un ticket interno"
+    )
+    for variant, header in INTRO_BY_VARIANT.items():
+        assert not _issue_pattern.search(header), (
+            f"INTRO_BY_VARIANT[{variant!r}] contiene una referencia a un ticket interno"
+        )

--- a/backend/tests/test_prompt_hygiene.py
+++ b/backend/tests/test_prompt_hygiene.py
@@ -1,0 +1,124 @@
+"""Static hygiene tests for LLM-visible prompt string literals.
+
+Guarantees that internal issue-tracker labels of the form ``(Issue #N)``
+never appear inside prompt constants that are sent to the LLM. If the LLM
+reads these labels it reproduces them verbatim in user-visible output
+(M2 EDA narrative subtitles, M3 notebook cell headings, etc.).
+
+These tests are:
+  - Zero LLM calls.
+  - Zero network access.
+  - Zero database access.
+  - Purely static: they import the prompt modules and inspect their
+    string constants with a regex.
+
+The guard covers all active prompt modules.  Code comments (``#`` lines
+*outside* triple-quoted prompt strings) are intentionally excluded — they
+are developer documentation and are never sent to the model.
+"""
+
+from __future__ import annotations
+
+import re
+import types
+
+import pytest
+
+# Pattern that must NEVER appear inside a prompt string sent to the LLM.
+# Matches "(Issue #" followed by one or more digits.
+_ISSUE_REF_PATTERN = re.compile(r"\(Issue #\d+")
+
+
+def _public_str_constants(module: types.ModuleType) -> list[tuple[str, str]]:
+    """Return (name, value) pairs for all public str constants in *module*."""
+    return [
+        (name, value)
+        for name, value in vars(module).items()
+        if not name.startswith("_") and isinstance(value, str)
+    ]
+
+
+def _assert_no_issue_refs(module_path: str, name: str, value: str) -> None:
+    match = _ISSUE_REF_PATTERN.search(value)
+    if match:
+        # Show a useful excerpt so the developer can find the exact location.
+        start = max(0, match.start() - 60)
+        excerpt = value[start : match.end() + 60].replace("\n", "\\n")
+        pytest.fail(
+            f"{module_path}.{name} contains an internal issue-tracker label "
+            f"that will be reproduced verbatim by the LLM.\n"
+            f"  Match: {match.group()!r}\n"
+            f"  Context: ...{excerpt!r}..."
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Top-level prompts module
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_prompts_init_has_no_issue_refs() -> None:
+    """All public string constants in ``case_generator.prompts`` are clean."""
+    import case_generator.prompts as mod
+
+    for name, value in _public_str_constants(mod):
+        _assert_no_issue_refs("case_generator.prompts", name, value)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Classification-family prompts
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_clasificacion_notebook_has_no_issue_refs() -> None:
+    """``case_generator.prompts.clasificacion.notebook`` is clean."""
+    import case_generator.prompts.clasificacion.notebook as mod
+
+    for name, value in _public_str_constants(mod):
+        _assert_no_issue_refs("case_generator.prompts.clasificacion.notebook", name, value)
+
+
+def test_clasificacion_narrative_has_no_issue_refs() -> None:
+    """``case_generator.prompts.clasificacion.narrative`` is clean."""
+    import case_generator.prompts.clasificacion.narrative as mod
+
+    for name, value in _public_str_constants(mod):
+        _assert_no_issue_refs("case_generator.prompts.clasificacion.narrative", name, value)
+
+
+def test_clasificacion_dataset_has_no_issue_refs() -> None:
+    """``case_generator.prompts.clasificacion.dataset`` is clean."""
+    import case_generator.prompts.clasificacion.dataset as mod
+
+    for name, value in _public_str_constants(mod):
+        _assert_no_issue_refs("case_generator.prompts.clasificacion.dataset", name, value)
+
+
+def test_clasificacion_notebooks_shared_has_no_issue_refs() -> None:
+    """All public string constants in ``_shared`` notebook helpers are clean.
+
+    This covers ``RF_INTERP_TABLE_ONLY_SECTION`` and the values inside
+    ``INTRO_BY_VARIANT``, ``CV_SECTIONS``, etc.
+    """
+    import case_generator.prompts.clasificacion.notebooks._shared as mod
+
+    # Public string constants at module level.
+    for name, value in _public_str_constants(mod):
+        _assert_no_issue_refs(
+            "case_generator.prompts.clasificacion.notebooks._shared", name, value
+        )
+
+    # Also inspect dict-valued constants whose values are strings.
+    for name, obj in vars(mod).items():
+        if name.startswith("_") or not isinstance(obj, dict):
+            continue
+        for key, value in obj.items():
+            if isinstance(value, str):
+                match = _ISSUE_REF_PATTERN.search(value)
+                if match:
+                    start = max(0, match.start() - 60)
+                    excerpt = value[start : match.end() + 60].replace("\n", "\\n")
+                    pytest.fail(
+                        f"case_generator.prompts.clasificacion.notebooks._shared"
+                        f".{name}[{key!r}] contains an internal issue-tracker label.\n"
+                        f"  Match: {match.group()!r}\n"
+                        f"  Context: ...{excerpt!r}..."
+                    )


### PR DESCRIPTION
## Problema

Las etiquetas de tickets internos del tipo (Issue #225), (Issue #228), (Issue #238), etc. aparecían como texto visible para docentes y estudiantes en la salida generada.

**Causa raíz:** Los encabezados de sección dentro de los strings de prompts (comillas triples) como:

\\\
## Brechas dilema↔dataset (Issue #225 — data_gap_warnings)
\\\

eran reproducidos literalmente por el LLM, resultando en subtítulos como \(Issue #225)\ en la narrativa EDA del M2. El mismo patrón hacía que los encabezados de celda del notebook Jupyter M3 mostraran \(Issue #238)\, \(Issue #240)\, etc. como headings visibles.

## Alcance del cambio

| Archivo | Ocurrencias eliminadas |
|---|---|
| \prompts/__init__.py\ | 13 (M2 EDA, SCHEMA_DESIGNER, prompts M3 regresión/clustering/serie_temporal) |
| \prompts/clasificacion/notebook.py\ | 12 (template principal + prompt legacy) |
| \prompts/clasificacion/notebooks/_shared.py\ | 4 (intros por variante, sección interpretabilidad RF) |
| \prompts/clasificacion/narrative.py\ | 5 (bloques de grounding M3/M4/M5) |
| \prompts/clasificacion/dataset.py\ | 1 (SCHEMA_DESIGNER clasificación) |
| **Total** | **35** |

## Tests

- **\	ests/test_prompt_hygiene.py\ (nuevo):** escaneo estático — importa todos los módulos de prompts y verifica que ninguna constante pública de tipo \str\ contenga el patrón \(Issue #N)\. Sin LLM, sin red, sin DB. Previene regresión.
- **\	est_m3_notebook_classification_hygiene.py\:** añadida \	est_classification_notebook_prompt_has_no_issue_references()\ para cubrir las constantes de clasificación explícitamente.
- **\	est_issue225_dataset_schema_contract.py\:** actualizada aserción obsoleta (\'data_gap_warnings' in out\) → verifica el header de sección real (\'Brechas' in out\).
- **\	est_issue228_semantic_coherence_and_charts.py\:** eliminadas dos aserciones que verificaban \'Issue #228'\ en los prompts; las reglas funcionales que guardaban siguen presentes y siendo verificadas.

Suite completa: **816 passed, 14 skipped**.

## Deuda técnica registrada

\TODOS.md\ — \TODO-HYGIENE-A\: sanitizador post-generación en \graph.py\ como defensa en profundidad contra alucinación de etiquetas de tickets por el LLM (independiente de este PR).

## Tipo de merge

Squash and merge sobre \main\.