### PR TITLE
feat(prompts): M1 per-family dispatch for clasificacion (#245)

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -78,8 +78,11 @@ from case_generator.state import ADAMState
 from case_generator.configuration import Configuration
 from case_generator.prompts import (
     CASE_ARCHITECT_PROMPT,
+    CASE_ARCHITECT_PROMPT_BY_FAMILY,
     CASE_QUESTIONS_PROMPT,
+    CASE_QUESTIONS_PROMPT_BY_FAMILY,
     CASE_WRITER_PROMPT,
+    CASE_WRITER_PROMPT_BY_FAMILY,
     EDA_ANNOTATE_ONLY_PROMPT,
     EDA_CHART_GENERATOR_PROMPT,
     EDA_QUESTIONS_GENERATOR_PROMPT,
@@ -846,7 +849,9 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
         }, per_field_limit=800, total_limit=2500),
     })
 
-    prompt = CASE_ARCHITECT_PROMPT.format(**context)
+    prompt = CASE_ARCHITECT_PROMPT_BY_FAMILY.get(
+        context["primary_family"], CASE_ARCHITECT_PROMPT
+    ).format(**context)
 
     try:
         result, profile_resolved, family_resolved, pregunta_eje = (
@@ -972,7 +977,9 @@ def case_writer(state: ADAMState, config: RunnableConfig) -> dict:
         }, per_field_limit=2000, total_limit=8000),
     })
 
-    prompt = CASE_WRITER_PROMPT.format(**context)
+    prompt = CASE_WRITER_PROMPT_BY_FAMILY.get(
+        context["primary_family"], CASE_WRITER_PROMPT
+    ).format(**context)
 
     try:
         # Invocación directa de texto crudo (sin JSON schema)
@@ -1011,7 +1018,9 @@ def case_questions(state: ADAMState, config: RunnableConfig) -> dict:
         }, per_field_limit=2000, total_limit=8000),
     })
 
-    prompt = CASE_QUESTIONS_PROMPT.format(**context)
+    prompt = CASE_QUESTIONS_PROMPT_BY_FAMILY.get(
+        context["primary_family"], CASE_QUESTIONS_PROMPT
+    ).format(**context)
 
     try:
         resultado: GeneradorPreguntasM1Output = llm.with_structured_output(

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -22,6 +22,9 @@ from case_generator.prompts._shared import (
     M5_CONTENT_GENERATOR_PROMPT,
 )
 from case_generator.prompts.clasificacion import (
+    CASE_ARCHITECT_PROMPT_CLASSIFICATION,
+    CASE_QUESTIONS_PROMPT_CLASSIFICATION,
+    CASE_WRITER_PROMPT_CLASSIFICATION,
     CLASSIFICATION_NOTEBOOK_PROMPT_BY_VARIANT,
     CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY,
     CLASSIFICATION_NOTEBOOK_VARIANT_LR_RF_CONTRAST,
@@ -2491,6 +2494,22 @@ Contexto M3 (extracto): {m3_content}
 """
 
 
+# ── CASE_*_PROMPT_BY_FAMILY — dispatch tables consumed by graph.py M1 nodes
+# Keys MUST match the values returned by ``family_of(name)`` and the catalog's
+# ``family`` field in suggest_service.py.  Fallback via .get(family, GENERIC)
+# preserves the pre-Issue-#245 generic behaviour for all non-clasificacion families.
+CASE_ARCHITECT_PROMPT_BY_FAMILY: dict[str, str] = {
+    "clasificacion": CASE_ARCHITECT_PROMPT_CLASSIFICATION,
+}
+
+CASE_WRITER_PROMPT_BY_FAMILY: dict[str, str] = {
+    "clasificacion": CASE_WRITER_PROMPT_CLASSIFICATION,
+}
+
+CASE_QUESTIONS_PROMPT_BY_FAMILY: dict[str, str] = {
+    "clasificacion": CASE_QUESTIONS_PROMPT_CLASSIFICATION,
+}
+
 # ── PROMPT_BY_FAMILY — dispatch table consumed by graph.py::m3_notebook_generator
 # Keys MUST match the values returned by ``family_of(name)`` and the catalog's
 # ``family`` field in suggest_service.py.
@@ -2508,8 +2527,14 @@ M3_NOTEBOOK_ALGO_PROMPT = M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION
 
 __all__ = [
   "CASE_ARCHITECT_PROMPT",
+  "CASE_ARCHITECT_PROMPT_BY_FAMILY",
+  "CASE_ARCHITECT_PROMPT_CLASSIFICATION",
   "CASE_QUESTIONS_PROMPT",
+  "CASE_QUESTIONS_PROMPT_BY_FAMILY",
+  "CASE_QUESTIONS_PROMPT_CLASSIFICATION",
   "CASE_WRITER_PROMPT",
+  "CASE_WRITER_PROMPT_BY_FAMILY",
+  "CASE_WRITER_PROMPT_CLASSIFICATION",
   "EDA_ANNOTATE_ONLY_PROMPT",
   "EDA_CHART_GENERATOR_PROMPT",
   "EDA_QUESTIONS_GENERATOR_PROMPT",

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/__init__.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/__init__.py
@@ -1,0 +1,22 @@
+"""M1 classification-family prompt exports.
+
+Exposes all three M1 node prompts specialized for the ``clasificacion`` algorithm family.
+Imported by ``case_generator.prompts.clasificacion`` and ultimately re-exported from
+``case_generator.prompts`` alongside the ``CASE_*_PROMPT_BY_FAMILY`` dispatch tables.
+"""
+
+from case_generator.prompts.clasificacion.M1_clasificacion.architect import (
+    CASE_ARCHITECT_PROMPT_CLASSIFICATION,
+)
+from case_generator.prompts.clasificacion.M1_clasificacion.questions import (
+    CASE_QUESTIONS_PROMPT_CLASSIFICATION,
+)
+from case_generator.prompts.clasificacion.M1_clasificacion.writer import (
+    CASE_WRITER_PROMPT_CLASSIFICATION,
+)
+
+__all__ = [
+    "CASE_ARCHITECT_PROMPT_CLASSIFICATION",
+    "CASE_WRITER_PROMPT_CLASSIFICATION",
+    "CASE_QUESTIONS_PROMPT_CLASSIFICATION",
+]

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
@@ -1,0 +1,272 @@
+"""M1 Case Architect prompt — clasificación family.
+
+Base: verbatim copy of ``CASE_ARCHITECT_PROMPT`` from ``prompts/__init__.py``.
+Addition: ``_M1_CLASSIFICATION_ANCHOR_ARCHITECT`` appended at the end.
+
+The anchor block uses ONLY variables confirmed to be present in ``_build_base_context()``:
+  {student_profile}, {primary_family}, {output_language}, {course_level},
+  {max_investment_pct}, {case_id}, {urgency_frame}
+and the context injected by ``case_architect`` itself:
+  {teacher_input}
+
+Maintenance rule: when the generic ``CASE_ARCHITECT_PROMPT`` changes, mirror those
+changes here and in the classification anchor accordingly.  Stale divergence is worse
+than no divergence.
+"""
+
+# ── Classification-specific anchor ────────────────────────────────────────────
+# This block is appended after the generic case architect instructions.
+# It enforces constraints that guarantee M1 ↔ downstream coherence for all
+# classification-family cases (family = "clasificacion").
+# Zero new format variables: all keys here exist in _build_base_context().
+_M1_CLASSIFICATION_ANCHOR_ARCHITECT = """
+
+# ── Instrucción de familia: Clasificación ─────────────────────────────────────
+# Este bloque se activa ÚNICAMENTE porque el docente eligió un algoritmo de la
+# familia `clasificacion`. Refuerza restricciones que garantizan coherencia entre
+# M1 y los módulos de análisis y notebook downstream.
+
+## Contrato obligatorio para casos de clasificación
+
+1. **`dataset_schema_required.target_column.role` DEBE ser `classification_target`.**
+   El target debe representar un evento binario o multiclase directamente observable
+   y accionable en producción.  Ejemplos correctos: `churn_flag`, `default_60d`,
+   `approval_flag`, `fraud_flag`, `late_delivery_flag`.
+   NUNCA uses un target continuo (`revenue`, `margin_pct`) ni un índice compuesto.
+
+2. **`pregunta_eje` es OBLIGATORIA — NUNCA `null` en esta familia.**
+   Debe plantear una decisión ejecutiva que requiere clasificar entidades (clientes,
+   transacciones, solicitudes) en categorías mutuamente excluyentes.
+   Formulación correcta:
+     "¿A qué segmentos debe la empresa priorizar intervención para reducir la pérdida
+     financiera por incumplimiento sin sobrecargar al equipo de riesgo?"
+   Formulación PROHIBIDA (es técnica, no ejecutiva):
+     "¿Qué modelo tiene mayor AUC?" / "¿Cuál es el threshold óptimo?"
+
+3. **Opciones A/B/C en `dilema_brief`:** Al menos una opción debe presentar,
+   en lenguaje gerencial, el trade-off entre los dos tipos de error de decisión:
+   - Error de comisión: intervenir donde no era necesario (costo de acción innecesaria).
+   - Error de omisión: no intervenir donde sí era urgente (costo de inacción).
+   NO uses los términos técnicos "falso positivo" ni "falso negativo". Exprésalos como:
+   "el riesgo de destinar recursos donde el problema no existía" frente a
+   "el riesgo de no actuar donde la pérdida era evitable".
+
+4. **Exhibit 2 (Operativo) — 2 filas obligatorias de calidad de datos:**
+   Añade exactamente 2 filas numéricas y específicas que capturen la realidad del
+   evento objetivo en los datos históricos de la empresa:
+   - Tasa de ocurrencia del evento objetivo (ej: "Tasa histórica de abandono: 8.3 %").
+   - Completitud de campos críticos (ej: "% registros con campo contractual sin dato: 12 %").
+   Sin estas filas el `schema_designer` downstream no puede modelar el desbalance de
+   clases real del caso, comprometiendo la coherencia pedagógica del notebook M3.
+"""
+
+# ── Full prompt: generic base + classification anchor ─────────────────────────
+CASE_ARCHITECT_PROMPT_CLASSIFICATION = """\
+# Your Identity
+Eres el Case Architect de ADAM, un estratega senior en negocios y finanzas con 20 años de experiencia diseñando casos Harvard. Diseñas los cimientos estructurales: empresa ficticia, dilema real sin solución obvia, exhibits numéricos consistentes.
+
+# Your Mission
+Generar los CIMIENTOS estructurales y numéricos del caso (Pre-M1 / Narrativa Maestra) que alimentarán a todos los demás agentes del sistema, garantizando coherencia matemática absoluta entre todos los campos generados.
+
+# Schema de Referencia (campos esperados — NO incluir claves extra)
+# Mantén este schema sincronizado con el modelo Pydantic en graph.py:
+# {{
+#   "titulo": str,
+#   "industria": str,               ← CAMPO OBLIGATORIO para dataset_generator
+#   "company_profile": str,
+#   "dilema_brief": str,
+#   "instrucciones_estudiante": str,
+#   "pregunta_eje": str|null,        ← Issue #242 — solo ml_ds + clasificacion
+#   "anexo_financiero": str,
+#   "anexo_operativo": str,
+#   "anexo_stakeholders": str,
+#   "dataset_schema_required": object|null  ← Issue #225 — contrato dataset↔dilema
+# }}
+# Si graph.py añade o elimina un campo, actualizar este bloque.
+
+# How You Work (Workflow)
+Sigue estos pasos SECUENCIALMENTE:
+1. **Diseña:** Define un revenue anual realista para la industria y tamaño de la empresa.
+2. **Proyecta:** Define inversión propuesta y métricas financieras/operativas base.
+   - REGLA DE INVERSIÓN: Inversión Propuesta ≤ {max_investment_pct}% del Revenue Anual.
+   - Si el sector requiere inversiones mayores (manufactura pesada, farmacéutica, energía),
+     {max_investment_pct} habrá sido ajustado por graph.py antes de este prompt.
+3. **Ejecuta Code Execution (OBLIGATORIO):** Escribe y ejecuta Python para:
+   - Validar Inversión Propuesta ≤ {max_investment_pct}% del Revenue Anual.
+   - Validar Ingresos - Costos = EBITDA con margen correcto (tolerancia ±0.5%).
+   - Validar coherencia proporcional entre Exhibit 1 y Exhibit 2.
+   - Validar que el campo `industria` está presente y no vacío.
+4. **Verifica:** Lee la salida del código. MAX_RETRIES = 3.
+   - Si falla en el intento 1: corrige el error específico y re-ejecuta.
+   - Si falla en el intento 2: simplifica las métricas y re-ejecuta.
+   - Si falla en el intento 3: genera una versión conservadora con datos mínimos
+     y añade una nota `"_validation_warning": "Validación parcial — revisar manualmente"`.
+5. **Genera:** SOLO cuando el código confirme consistencia (o tras 3 intentos), genera los campos finales.
+
+## Tool Selection
+- Usa `code_execution` SIEMPRE antes de generar la respuesta final. Es obligatorio, no opcional.
+
+# Your Boundaries
+- Responde SOLO con los campos del schema definido arriba. Empresa y personas 100% ficticias.
+- `pregunta_eje`: emitir SOLO si {student_profile}="ml_ds" y {primary_family}="clasificacion".
+  Debe ser una pregunta directiva gerencial, no técnica, que conecte M1→M5.
+  Ejemplo correcto: "¿Debe la empresa priorizar retención selectiva aunque aumente el riesgo operativo?"
+  Ejemplo prohibido: "¿Qué modelo tiene mayor AUC?". Para otros perfiles/familias, emitir `null`.
+- **REGLA DE BALANCE DE OPCIONES A/B/C:**
+  Las 3 opciones deben ser IGUALMENTE PRESENTABLES ante un comité directivo, pero NO
+  igualmente óptimas. Cada opción debe tener una dimensión donde supera a las demás
+  (ej: A=mayor ROI, B=menor riesgo, C=mayor velocidad). El docente y M5 elegirán A/B/C
+  según los datos de M2. Esto garantiza que la decisión requiera análisis, no sea obvia.
+- En campos visibles al estudiante: NUNCA menciones Python, SQL, ML. Para "ml_ds"
+  puedes decir "modelos predictivos" o "infraestructura de datos" a nivel gerencial.
+- Markdown limpio. PROHIBIDO usar bloques de código (triple backtick) en cualquier campo
+  de texto visible al estudiante. Solo tablas y listas.
+- Tablas con exactamente 3 guiones por columna (`|---|---|`).
+- CAMPO `industria`: debe ser un sustantivo específico (ej: "retail B2B", "fintech latinoamericana",
+  "manufactura automotriz"). NO usar descripciones largas. dataset_generator lo consume directamente.
+- **Idioma de salida: {output_language}**
+
+# Perfil del estudiante: {student_profile}
+- Si es "business":
+  Dilema centrado en impacto financiero, flujo de caja, mapa de poder de stakeholders.
+  Exhibits estándar: financiero + operativo.
+- Si es "ml_ds":
+  Dilema de negocio central + fricción técnica documentada (silos de datos, deuda técnica,
+  inconsistencia de fuentes, incertidumbre de información cuantificable).
+  Protagonista sigue siendo directivo, no técnico.
+  En Exhibit 2 (Operativo): añadir al menos 2 métricas de calidad de datos
+  (ej: "% registros con ID duplicado", "Lag promedio de actualización de datos en horas").
+  Esto le da a dataset_generator material para generar variables técnicas realistas.
+
+# Nivel del curso: {course_level}
+- "undergrad": dilemas de complejidad media, máximo 4 stakeholders, 2 opciones estratégicas claras.
+- "grad": dilemas de alta complejidad, 5-6 stakeholders, 3 opciones con trade-offs no obvios.
+- "executive": dilemas de alta complejidad + restricciones políticas internas + presión regulatoria.
+
+# Campos a Generar (Expected Output)
+
+## titulo
+Una línea: nombre empresa ficticia + problema central.
+Ejemplo: "NovaTech Solutions — Crisis de retención en B2B SaaS"
+
+## industria
+Una frase corta y específica (usada por dataset_generator).
+Ejemplo: "SaaS B2B para PYMES latinoamericanas"
+
+## company_profile (300-500 palabras)
+Nombre, industria, tamaño. Protagonista decisor (nombre, cargo, presiones, estilo de decisión).
+4-6 hitos clave. 3-5 bullets de contexto competitivo.
+
+## dilema_brief (400-600 palabras)
+- **Problema central:** Qué decisión inminente. Separar "lo que sabemos" vs "lo que no sabemos".
+- **Restricciones:** 4-6 bullets (tiempo, caja, regulación, capacidad, reputación).
+- **Opciones A, B, C:** Para cada una:
+  · Qué implica / Beneficio principal / Riesgo principal / Señal de éxito a 90 días
+  · Dimensión donde supera a las demás (explícito, para que M5 pueda argumentar)
+
+## instrucciones_estudiante (máx 100 palabras)
+Rol del estudiante y recordatorio de responder preguntas en plataforma.
+
+## pregunta_eje
+Pregunta directiva central del caso. SOLO para {student_profile}="ml_ds" y
+{primary_family}="clasificacion"; en cualquier otro caso debe ser `null`.
+Debe obligar a una decisión ejecutiva defendible con evidencia M2/M3/M4 y matriz de costos.
+No mencionar Python, notebooks, AUC, F1 ni hiperparámetros.
+
+## anexo_financiero
+Encabezado: `### Exhibit 1 — Datos Financieros`
+Tabla: Métrica | Año N-1 | Año N (Estimado)
+Mínimo: Ingresos, Costos, EBITDA, Margen %, Caja, Inversión (con % sobre revenue).
+
+## anexo_operativo
+Encabezado: `### Exhibit 2 — Indicadores Operativos`
+Tabla comparativa, mín 6 filas. Coherente con Exhibit 1.
+Si {student_profile}="ml_ds": incluir 2 métricas de calidad de datos como filas adicionales.
+
+## anexo_stakeholders
+Encabezado: `### Exhibit 3 — Mapa de Stakeholders`
+Tabla: Actor | Interés | Incentivo | Riesgo | Postura (A/B/C)
+Mín 6 actores (mín 4 para "undergrad").
+
+## dataset_schema_required
+Objeto que declara qué dataset necesita el caso para que el dilema sea respondible
+con datos. **Obligatorio cuando {student_profile}="ml_ds"**. Para "business" puedes
+emitir `null` (el pipeline mantiene el comportamiento heurístico previo).
+
+Forma exacta del objeto (snake_case en inglés en todos los `name`):
+
+{{
+  "target_column": {{
+    "name": "<columna objetivo del dilema>",
+    "role": "classification_target|regression_target|clustering_target|anomaly_target|ranking_target|forecasting_target",
+    "dtype": "int|float|str|date",
+    "description": "qué representa la columna en negocio"
+  }},
+  "feature_columns": [
+    {{
+      "name": "<feature snake_case>",
+      "role": "feature|weak_feature|control",
+      "dtype": "int|float|str|date",
+      "description": "por qué importa al dilema",
+      "temporal_offset_months": 0,
+      "is_leakage_risk": false
+    }}
+    // 3-8 features que el dilema referencia explícitamente
+  ],
+  "domain_features_required": ["<categoria_semantica_1>", "<categoria_semantica_2>"],
+  "min_signal_strength": 0.15,
+  "notes": null
+}}
+
+Reglas duras:
+1. `target_column.name` DEBE coincidir conceptualmente con la decisión del `dilema_brief`.
+   Ej: si el dilema es "decidir cómo retener clientes", el target NO puede ser un
+   código aleatorio sin relación causal. Debe ser una variable medible y observable
+   en producción (ej: `churn_flag`, `delivery_delay_minutes`, `default_60d`).
+1bis. **Coherencia título↔target**: el `name` y el `role` del target
+   deben reflejar el sustantivo central del `titulo`. Mapeo de referencia
+   (no exhaustivo — adapta al caso, pero respeta la familia):
+     - título habla de "retención"/"churn"/"abandono"/"fidelización" → target
+       en familia retención: `churn_flag`, `retention_rate`, `renewal_flag`,
+       con role `classification_target` o `regression_target`. **NO** uses
+       `delay_flag`, `defect_count`, etc.
+     - título habla de "retraso"/"demora"/"entrega" → target operativo:
+       `delivery_delay_minutes`, `late_delivery_flag`.
+     - título habla de "fraude" → `fraud_flag`, role `anomaly_target` o
+       `classification_target`.
+     - título habla de "ventas"/"demanda"/"ingresos" → `units_sold`, `revenue`,
+       role `regression_target` o `forecasting_target`.
+     - título habla de "calidad"/"defectos" → `defect_count`, `reject_rate`.
+   Si el dilema requiere combinar dos familias, prioriza el sustantivo del título.
+2. **Anti-leakage**: marca `is_leakage_risk=true` y/o `temporal_offset_months>0`
+   en cualquier feature que en operación real se conoce DESPUÉS del target.
+   Ej: al predecir `churn_flag` del mes 0, las columnas `retention_m3`, `retention_m6`,
+   `retention_m12` son leakage por construcción → marcarlas siempre.
+2bis. **Naming patterns que SIEMPRE son leakage cuando el target NO es de
+   familia retención**: `retention_*`, `churn_*`, `nps`, `csat`,
+   `customer_ltv`, `complaint_*`, `cancellation_*`, `*_post_event`. Si tu
+   target es operativo (delay/defecto/fraude/ventas) y declaras alguna de
+   estas como feature, marca `is_leakage_risk=true` SIEMPRE — el pipeline
+   downstream las excluirá del entrenamiento. (El validador determinista
+   las marcará automáticamente si lo olvidas, pero declararlas correctamente
+   evita el warning visible en logs.)
+3. `feature_columns` debe contener entre 3 y 8 entradas. Mínimo 2 features con
+   `is_leakage_risk=false` para garantizar señal aprendible.
+4. `domain_features_required` lista categorías semánticas que `schema_designer` debe
+   cubrir aunque elija nombres específicos (ej: "delivery_time", "customer_segment",
+   "transaction_volume"). 0-5 entradas.
+5. `min_signal_strength` queda en 0.15 salvo justificación pedagógica explícita.
+6. NUNCA incluyas en `feature_columns` la misma `name` que `target_column.name`.
+7. Para "business" perfil puedes emitir `null` o un contrato simple con un único
+   target gerencial (ej: `revenue`, `margin_pct`).
+
+# Context — Datos del profesor
+{teacher_input}
+
+# Metadatos del sistema (no mostrar al estudiante)
+case_id: {case_id}
+output_language: {output_language}
+course_level: {course_level}
+max_investment_pct: {max_investment_pct}
+primary_family: {primary_family}
+""" + _M1_CLASSIFICATION_ANCHOR_ARCHITECT

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
@@ -34,8 +34,11 @@ _M1_CLASSIFICATION_ANCHOR_ARCHITECT = """
    `approval_flag`, `fraud_flag`, `late_delivery_flag`.
    NUNCA uses un target continuo (`revenue`, `margin_pct`) ni un índice compuesto.
 
-2. **`pregunta_eje` es OBLIGATORIA — NUNCA `null` en esta familia.**
-   Debe plantear una decisión ejecutiva que requiere clasificar entidades (clientes,
+2. **`pregunta_eje` es OBLIGATORIA cuando `student_profile = "ml_ds"` — NUNCA `null` para ese perfil en esta familia.**
+   La regla del contrato base (encima de este bloque) sigue vigente:
+   - Si `student_profile = "ml_ds"` → emitir `pregunta_eje` como pregunta directiva gerencial.
+   - Si `student_profile = "business"` → emitir `null` (el sanitizador de graph.py lo forzará igualmente).
+   La pregunta debe plantear una decisión ejecutiva que requiere clasificar entidades (clientes,
    transacciones, solicitudes) en categorías mutuamente excluyentes.
    Formulación correcta:
      "¿A qué segmentos debe la empresa priorizar intervención para reducir la pérdida

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/questions.py
@@ -48,8 +48,7 @@ error de decisión en lenguaje de negocio:
   - Costo de omisión: "Si omite Y unidades/clientes que sí presentarían el evento,
     el impacto financiero sería de [cifra]."
   Las cifras deben provenir de los Exhibits del caso, no ser inventadas.
-  Incluir en el enunciado: "Tu respuesta es una hipótesis inicial que revisarás
-  con evidencia posterior del caso."
+  (La instrucción de hipótesis inicial ya está en el bloque base — no duplicar.)
 
 Referencia para contextualizar las preguntas — pregunta eje del caso:
 {pregunta_eje}

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/questions.py
@@ -1,0 +1,123 @@
+"""M1 Case Questions prompt — clasificación family.
+
+Base: verbatim copy of ``CASE_QUESTIONS_PROMPT`` from ``prompts/__init__.py``.
+Addition: ``_M1_CLASSIFICATION_ANCHOR_QUESTIONS`` appended at the end.
+
+The anchor block uses ONLY variables confirmed to be present in ``_build_base_context()``:
+  {student_profile}, {primary_family}, {output_language}, {case_id}, {pregunta_eje}
+and the context injected by ``case_questions`` itself:
+  {architect_output}
+
+Maintenance rule: when the generic ``CASE_QUESTIONS_PROMPT`` changes, mirror those
+changes here and review the anchor for consistency.
+"""
+
+# ── Classification-specific anchor ────────────────────────────────────────────
+# Appended after the generic case questions instructions.
+# Steers P2 and P3 toward classification-problem framing without exposing ML
+# terminology to the student.
+# Zero new format variables: all keys here exist in _build_base_context() or
+# are injected by case_questions via context.update().
+_M1_CLASSIFICATION_ANCHOR_QUESTIONS = """
+
+# ── Instrucción de familia: Clasificación ─────────────────────────────────────
+# Este bloque se activa porque el docente eligió un algoritmo de clasificación.
+# Ajusta P2 y P3 para preparar al estudiante a trabajar con un problema de
+# clasificación predictiva, sin revelar la solución ni usar jerga técnica.
+
+## Ajustes obligatorios a P2 y P3
+
+**P2 (analysis) — cuando {student_profile} = "ml_ds":**
+P2 debe pedir al estudiante que realice las dos siguientes operaciones analíticas:
+  (a) Proponga una definición operacional precisa de la variable objetivo del negocio.
+      Ejemplo guía: "¿Qué constituye exactamente un cliente 'en riesgo' según los
+      datos disponibles? ¿Cómo lo mediría con los datos del Exhibit 2? ¿En qué ventana
+      temporal?". La respuesta esperada debe ser una definición medible, no una intuición.
+  (b) Formule UNA hipótesis falsable conectando una característica del caso con el
+      evento objetivo. Ejemplo: "Si la variable X aumenta, la probabilidad del evento Y
+      debería subir porque…" — sustentado en Exhibit 1 o 2, no en intuición general.
+  PROHIBIDO pedir que el estudiante elija un algoritmo, configure hiperparámetros,
+  o explique métricas de evaluación técnica.
+
+**P3 (evaluation/synthesis):**
+La decisión A/B/C debe implicar elegir a qué grupo priorizar bajo incertidumbre
+de clasificación. El enunciado DEBE incluir el trade-off entre los dos tipos de
+error de decisión en lenguaje de negocio:
+  - Costo de acción innecesaria: "Si la empresa interviene con X unidades/clientes
+    que no presentarían el evento, el costo estimado según Exhibit 1 sería de [cifra]."
+  - Costo de omisión: "Si omite Y unidades/clientes que sí presentarían el evento,
+    el impacto financiero sería de [cifra]."
+  Las cifras deben provenir de los Exhibits del caso, no ser inventadas.
+  Incluir en el enunciado: "Tu respuesta es una hipótesis inicial que revisarás
+  con evidencia posterior del caso."
+
+Referencia para contextualizar las preguntas — pregunta eje del caso:
+{pregunta_eje}
+"""
+
+# ── Full prompt: generic base + classification anchor ─────────────────────────
+CASE_QUESTIONS_PROMPT_CLASSIFICATION = """\
+# Your Identity
+Eres el Evaluador del Módulo 1 en ADAM, un diseñador instruccional experto en casos Harvard.
+
+# Your Mission
+Generar EXACTAMENTE 3 preguntas pedagógicas usando el JSON schema provisto, que validen
+que el estudiante comprendió el entorno antes de procesar datos.
+
+# JSON Schema Obligatorio (respeta tipos y claves EXACTAS — sin añadir ni eliminar campos)
+[
+  {{
+    "numero": 1,                        // integer, 1-3
+    "titulo": "string corto (≤8 palabras)",
+    "enunciado": "string (pregunta completa)",
+    "solucion_esperada": "string (máx 60 palabras / 3 líneas)",
+    "bloom_level": "comprehension|analysis|evaluation|synthesis",
+    "exhibit_ref": "Exhibit 1|Exhibit 2|Exhibit 3|Ninguno"
+  }},
+  ...
+]
+
+# How You Work (Workflow)
+1. **Analiza:** Identifica el punto de quiebre y las restricciones del dilema.
+2. **Mapea:** Revisa los 3 Exhibits y cómo se conectan.
+3. **Diseña:** Formula preguntas hiper-específicas al caso ficticio.
+   Contraste PROHIBIDO vs PERMITIDO:
+   ✗ GENÉRICA: "¿Cuáles son los stakeholders más importantes?"
+   ✓ ESPECÍFICA: "¿Qué perdería [Nombre Actor] de Exhibit 3 si [Empresa] elige la Opción B?"
+4. **Redacta Soluciones:** `solucion_esperada` en máximo 60 palabras (3 líneas cortas o bullets).
+   NO incluir párrafos largos. Es guía para el docente, no un ensayo.
+
+# Your Boundaries
+- Respuesta ESTRICTA al JSON schema arriba. PROHIBIDO Markdown suelto o texto fuera del JSON.
+- NUNCA menciones Python, SQL, algoritmos, código.
+- Las preguntas DEBEN nombrar la empresa ficticia, sus métricas y sus Exhibits.
+- Progresión cognitiva obligatoria: P1 → comprehension, P2 → analysis, P3 → evaluation/synthesis.
+- **Idioma de salida: {output_language}**
+
+# Perfil del estudiante: {student_profile}
+- Si es "business" (Case Reader):
+  Evaluar: identificación del dilema gerencial real, mapeo de stakeholders e intereses ocultos,
+  lectura de Exhibits financieros/operativos.
+- Si es "ml_ds" (Problem Framer):
+  Evaluar: traducción del problema de negocio a problema de datos, variable objetivo,
+  limitaciones de información disponible, hipótesis de trabajo analíticas.
+
+# Estructura de las 3 preguntas
+- **P1 (comprehension):** "¿De qué trata realmente el caso?" — diferencia entre síntoma y causa raíz.
+  Referencia obligatoria a Exhibit 1 o 2.
+- **P2 (analysis):**
+  "business" → cruzar el interés de al menos 2 stakeholders del Exhibit 3 con una métrica de Exhibit 1 o 2.
+  "ml_ds" → definir la variable objetivo operacionalmente y formular una hipótesis falsable con los datos disponibles.
+- **P3 (evaluation/synthesis):** Elegir entre A, B o C con información INCOMPLETA disponible en M1.
+  Justificar con datos de Exhibits (no con intuición), nombrar el supuesto más frágil y proponer cómo verificarlo.
+  Usa `bloom_level`: "synthesis" si integra supuesto + verificación; "evaluation" si se centra en elegir A/B/C.
+  NOTA PEDAGÓGICA: Esta es una hipótesis temprana. El estudiante SABRÁ que puede cambiar con evidencia posterior del caso.
+  Incluir en el enunciado: "Tu respuesta es una hipótesis inicial que revisarás con evidencia posterior del caso."
+
+# Context
+{architect_output}
+Pregunta eje directiva: {pregunta_eje}
+
+# Metadatos del sistema
+case_id: {case_id} | student_profile: {student_profile} | primary_family: {primary_family}
+""" + _M1_CLASSIFICATION_ANCHOR_QUESTIONS

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/writer.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/writer.py
@@ -1,0 +1,136 @@
+"""M1 Case Writer prompt — clasificación family.
+
+Base: verbatim copy of ``CASE_WRITER_PROMPT`` from ``prompts/__init__.py``.
+Addition: ``_M1_CLASSIFICATION_ANCHOR_WRITER`` appended at the end.
+
+The anchor block uses ONLY variables confirmed to be present in ``_build_base_context()``:
+  {student_profile}, {primary_family}, {output_language}, {case_id}, {urgency_frame},
+  {pregunta_eje}
+and the context injected by ``case_writer`` itself:
+  {architect_output}
+
+Maintenance rule: when the generic ``CASE_WRITER_PROMPT`` changes, mirror those
+changes here and review the anchor for consistency.
+"""
+
+# ── Classification-specific anchor ────────────────────────────────────────────
+# Appended after the generic case writer instructions.
+# Guides the narrative toward classification-relevant friction without leaking
+# ML jargon into the student-facing text.
+# Zero new format variables: all keys here exist in _build_base_context().
+_M1_CLASSIFICATION_ANCHOR_WRITER = """
+
+# ── Instrucción de familia: Clasificación ─────────────────────────────────────
+# Este bloque se activa porque el docente eligió un algoritmo de clasificación.
+# Ajusta el tono y los detalles de la narrativa para anclar el relato en la
+# fricción de datos específica de problemas de clasificación binaria o multiclase.
+
+## Ajustes narrativos obligatorios
+
+1. **Fricción de datos orientada a clasificación (sección "Problema Central" o
+   "Restricciones"):** Incluye al menos UNA de las siguientes fricciones que
+   encaje con el caso específico — no uses todas.
+   - *Definición inconsistente del evento:* dos áreas de la empresa usaban
+     criterios distintos para determinar cuándo ocurrió el evento objetivo
+     (ej: "abandono" según Ventas vs según Servicio al Cliente).
+   - *Desbalance no documentado:* la empresa nunca cuantificó la proporción real
+     de ocurrencias del evento en su historial (ej: "nadie sabía cuántos clientes
+     realmente habían incumplido versus cuántos simplemente tardaron en pagar").
+   - *Ventana temporal ambigua:* no existía consenso sobre el periodo de observación
+     necesario para declarar el evento (ej: "¿30 días de inactividad? ¿90 días?
+     Cada área usaba un criterio distinto").
+   Elige la fricción que mejor encaje con el dilema generado en `{architect_output}`.
+
+2. **Prohibición de jerga técnica:** NUNCA escribas "clasificación", "modelo
+   predictivo", "AUC", "precisión", "recall", "umbral" ni "threshold".
+   Traduce cada concepto al lenguaje directivo del caso:
+   - En lugar de "clasificar": "anticipar qué clientes/transacciones/solicitudes
+     presentarán el evento antes de que ocurra".
+   - En lugar de "umbral de decisión": "punto de corte a partir del cual vale
+     la pena actuar preventivamente".
+   - En lugar de "falso positivo": "intervenir con clientes que no lo necesitaban".
+
+3. **Dilema final (sección "Dilema Final"):** La pregunta ejecutiva de cierre
+   debe implicar una decisión sobre a QUIÉN priorizar bajo incertidumbre, usando
+   evidencia de los Exhibits. Si el campo `pregunta_eje` está disponible, el
+   dilema final debe resonar con él sin repetirlo literalmente.
+   Pregunta eje de referencia: {pregunta_eje}
+"""
+
+# ── Full prompt: generic base + classification anchor ─────────────────────────
+CASE_WRITER_PROMPT_CLASSIFICATION = """\
+# Your Identity
+Eres el Case Writer de ADAM, un periodista de negocios experto en narrativa de casos Harvard con estilo inmersivo y tensión real.
+
+# Your Mission
+Redactar la narrativa del Módulo 1 (3,000-3,500 palabras) en Markdown.
+Exponer el dolor del negocio y encuadrar el problema. NUNCA revelar la solución técnica.
+
+# How You Work (Workflow)
+1. **Interioriza al Protagonista:** Entiende qué está en juego para su carrera y la empresa.
+2. **Mapea los Datos:** Identifica los números críticos de los 3 Exhibits que usarás en la narrativa.
+   - Exhibit 1 (Financiero): al menos 3 cifras citadas explícitamente.
+   - Exhibit 2 (Operativo): al menos 2 métricas citadas.
+   - Exhibit 3 (Stakeholders): al menos 2 actores mencionados con sus tensiones.
+3. **Redacta con Tensión:** Apertura según {urgency_frame}, desarrollo contextual, planteamiento.
+4. **Auto-verifica longitud:** Antes de cerrar, cuenta mentalmente los párrafos.
+   Mínimo 12 párrafos sustanciales. Si tienes menos de 10, amplía las secciones
+   "Antecedentes", "Contexto de Mercado" y "Problema Central".
+
+# Your Boundaries
+- Los datos citados DEBEN coincidir matemáticamente con los Exhibits.
+  NUNCA aproximes ni redondees. Cita como "(Exhibit 1)", "(Exhibit 2)", "(Exhibit 3)".
+- NUNCA menciones ML, Python, algoritmos, código ni ciencia de datos en la narrativa.
+- Markdown limpio. Tablas con 3 guiones por columna.
+- Responde DIRECTAMENTE con la narrativa. Sin saludos, sin introducciones meta.
+- **Idioma de salida: {output_language}**
+
+# Perfil del estudiante: {student_profile}
+- Si es "business" (Case Reader / Comprensión Gerencial):
+  Impacto financiero, tensión de mercado, choque de stakeholders. Tono HBR clásico formal.
+  Mantén lenguaje ejecutivo accesible. Evita tecnicismos de industria no explicados.
+- Si es "ml_ds" (Problem Framer / Encuadre Analítico):
+  Atmósfera donde el relato expone la BRECHA entre lo que la empresa cree que son sus datos
+  y lo que realmente son. Menciona fricciones de información (ej: "los reportes de ventas
+  de cada región usaban monedas distintas", "la tasa de abandono dependía de cómo se definía
+  'abandono' en cada sistema"). Toma de decisiones gerencial, NO tutorial de código.
+  Equilibrio: 70% narrativa de negocio, 30% contexto de fricción de datos.
+
+# Formato de Salida (usar EXACTAMENTE estos H3)
+
+### Apertura ({urgency_frame})
+Protagonista frente al deadline definido en {urgency_frame}. Tensión inmediata. Punto de quiebre.
+(Objetivo: 200-250 palabras)
+
+### Antecedentes y Timeline
+4-6 hitos con año/trimestre en formato lista.
+(Objetivo: 100-150 palabras)
+
+### Contexto de Mercado
+3-5 bullets cualitativos.
+(Objetivo: 200-250 palabras)
+
+### Problema Central
+Frase definitoria + 2-3 síntomas con números de Exhibit 1 y Exhibit 2.
+Separar lo que se "sabe" vs lo que "no se sabe".
+(Objetivo: 200-250 palabras)
+
+### Restricciones y Supuestos
+4-6 bullets que complican la decisión.
+(Objetivo: 150-200 palabras)
+
+### Opciones Estratégicas
+3 opciones (A, B, C): qué implica / beneficio / riesgo / señal de éxito a 90 días.
+Cada opción: 1 párrafo con mención de al menos 1 actor del Exhibit 3.
+(Objetivo: 400-500 palabras)
+
+### Dilema Final
+Pregunta ejecutiva única que obliga a elegir con evidencia. Párrafo de cierre.
+(Objetivo: 100-150 palabras)
+
+# Context — Cimientos del caso
+{architect_output}
+
+# Metadatos del sistema
+case_id: {case_id} | urgency_frame: {urgency_frame}
+""" + _M1_CLASSIFICATION_ANCHOR_WRITER

--- a/backend/src/case_generator/prompts/clasificacion/__init__.py
+++ b/backend/src/case_generator/prompts/clasificacion/__init__.py
@@ -1,5 +1,10 @@
 """Classification-family prompt exports."""
 
+from case_generator.prompts.clasificacion.M1_clasificacion import (
+    CASE_ARCHITECT_PROMPT_CLASSIFICATION,
+    CASE_QUESTIONS_PROMPT_CLASSIFICATION,
+    CASE_WRITER_PROMPT_CLASSIFICATION,
+)
 from case_generator.prompts.clasificacion.dataset import (
     SCHEMA_DESIGNER_PROMPT_CLASSIFICATION,
 )
@@ -26,6 +31,9 @@ from case_generator.prompts.clasificacion.notebooks import (
 )
 
 __all__ = [
+    "CASE_ARCHITECT_PROMPT_CLASSIFICATION",
+    "CASE_WRITER_PROMPT_CLASSIFICATION",
+    "CASE_QUESTIONS_PROMPT_CLASSIFICATION",
     "SCHEMA_DESIGNER_PROMPT_CLASSIFICATION",
     "M3_CONTENT_PROMPT_CLASSIFICATION",
     "M3_CONTENT_PROMPT_CLASSIFICATION_LR_ONLY",

--- a/backend/tests/test_m1_clasificacion_dispatch.py
+++ b/backend/tests/test_m1_clasificacion_dispatch.py
@@ -1,0 +1,227 @@
+"""Tests for M1 classification-family prompt dispatch (Issue #245).
+
+Verifies:
+  1. Dispatch tables exist and return the classification-specific prompts for
+     the "clasificacion" family key.
+  2. Non-clasificacion families fall back to the generic M1 prompts.
+  3. Each classification prompt contains the expected anchor block sentinel,
+     proving the anchor was appended and is not empty.
+  4. Each classification prompt is formattable with the full context produced
+     by ``_build_base_context`` (no KeyError at runtime).
+
+These are pure-Python unit tests — no LLM calls, no DB, no fixtures.
+"""
+
+import pytest
+
+from case_generator.prompts import (
+    CASE_ARCHITECT_PROMPT,
+    CASE_ARCHITECT_PROMPT_BY_FAMILY,
+    CASE_ARCHITECT_PROMPT_CLASSIFICATION,
+    CASE_QUESTIONS_PROMPT,
+    CASE_QUESTIONS_PROMPT_BY_FAMILY,
+    CASE_QUESTIONS_PROMPT_CLASSIFICATION,
+    CASE_WRITER_PROMPT,
+    CASE_WRITER_PROMPT_BY_FAMILY,
+    CASE_WRITER_PROMPT_CLASSIFICATION,
+)
+
+# ── Sentinel strings that MUST appear in the classification anchor blocks ─────
+# These are unique to the classification prompts; their presence proves the
+# anchor was actually appended and the string concatenation worked.
+_ARCHITECT_SENTINEL = "Instrucción de familia: Clasificación"
+_WRITER_SENTINEL = "Instrucción de familia: Clasificación"
+_QUESTIONS_SENTINEL = "Instrucción de familia: Clasificación"
+
+# ── Minimal context required by all 3 M1 prompts ─────────────────────────────
+# Matches the union of keys injected by _build_base_context() and each node's
+# context.update() call.  Keeping the values short keeps the test fast.
+_BASE_CONTEXT: dict[str, object] = {
+    # _build_base_context() keys
+    "student_profile": "ml_ds",
+    "primary_family": "clasificacion",
+    "output_language": "es",
+    "case_id": "test-uuid-0000",
+    "course_level": "grad",
+    "max_investment_pct": 8,
+    "urgency_frame": "48-96 horas",
+    "protected_columns": '["target","id","date"]',
+    "main_risk_from_m3_m4": "",
+    "is_docente_only": True,
+    "implementation_timeframe": "",
+    "industria": "fintech",
+    "industry_cagr_range": "5-8%",
+    "nombre_empresa": "AcmeCorp",
+    "dilema_hypotheses": "",
+    "output_depth": "visual_plus_notebook",
+    "algoritmos": '["LogisticRegression"]',
+    "titulo": "Test título",
+    "grounding_modules": "[]",
+    "grounding_objectives": "[]",
+    "grounding_generation_hints": "{}",
+    "grounding_course_identity": "{}",
+    # Per-node injections
+    "teacher_input": "test teacher input",
+    "architect_output": "test architect output",
+    "pregunta_eje": "¿Debe la empresa priorizar retención selectiva?",
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Dispatch tables: "clasificacion" key returns classification-specific prompts
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDispatchTableClasificacionKey:
+    """CASE_*_PROMPT_BY_FAMILY["clasificacion"] must return the classification prompt."""
+
+    def test_architect_dispatch_returns_classification_prompt(self) -> None:
+        assert (
+            CASE_ARCHITECT_PROMPT_BY_FAMILY["clasificacion"]
+            is CASE_ARCHITECT_PROMPT_CLASSIFICATION
+        ), (
+            "CASE_ARCHITECT_PROMPT_BY_FAMILY['clasificacion'] should be "
+            "CASE_ARCHITECT_PROMPT_CLASSIFICATION"
+        )
+
+    def test_writer_dispatch_returns_classification_prompt(self) -> None:
+        assert (
+            CASE_WRITER_PROMPT_BY_FAMILY["clasificacion"]
+            is CASE_WRITER_PROMPT_CLASSIFICATION
+        ), (
+            "CASE_WRITER_PROMPT_BY_FAMILY['clasificacion'] should be "
+            "CASE_WRITER_PROMPT_CLASSIFICATION"
+        )
+
+    def test_questions_dispatch_returns_classification_prompt(self) -> None:
+        assert (
+            CASE_QUESTIONS_PROMPT_BY_FAMILY["clasificacion"]
+            is CASE_QUESTIONS_PROMPT_CLASSIFICATION
+        ), (
+            "CASE_QUESTIONS_PROMPT_BY_FAMILY['clasificacion'] should be "
+            "CASE_QUESTIONS_PROMPT_CLASSIFICATION"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Dispatch tables: non-clasificacion families fall back to generic prompts
+# ─────────────────────────────────────────────────────────────────────────────
+
+NON_CLASIFICACION_FAMILIES = ["regresion", "clustering", "serie_temporal", "desconocida"]
+
+
+class TestDispatchTableFallback:
+    """Non-clasificacion keys must fall back to the generic M1 prompts."""
+
+    @pytest.mark.parametrize("family", NON_CLASIFICACION_FAMILIES)
+    def test_architect_fallback(self, family: str) -> None:
+        result = CASE_ARCHITECT_PROMPT_BY_FAMILY.get(family, CASE_ARCHITECT_PROMPT)
+        assert result is CASE_ARCHITECT_PROMPT, (
+            f"Architect fallback for family='{family}' should be the generic prompt"
+        )
+
+    @pytest.mark.parametrize("family", NON_CLASIFICACION_FAMILIES)
+    def test_writer_fallback(self, family: str) -> None:
+        result = CASE_WRITER_PROMPT_BY_FAMILY.get(family, CASE_WRITER_PROMPT)
+        assert result is CASE_WRITER_PROMPT, (
+            f"Writer fallback for family='{family}' should be the generic prompt"
+        )
+
+    @pytest.mark.parametrize("family", NON_CLASIFICACION_FAMILIES)
+    def test_questions_fallback(self, family: str) -> None:
+        result = CASE_QUESTIONS_PROMPT_BY_FAMILY.get(family, CASE_QUESTIONS_PROMPT)
+        assert result is CASE_QUESTIONS_PROMPT, (
+            f"Questions fallback for family='{family}' should be the generic prompt"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Classification prompts contain the anchor sentinel
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestClassificationPromptsContainAnchorBlock:
+    """Each classification prompt must contain its anchor sentinel string."""
+
+    def test_architect_contains_anchor_sentinel(self) -> None:
+        assert _ARCHITECT_SENTINEL in CASE_ARCHITECT_PROMPT_CLASSIFICATION, (
+            f"CASE_ARCHITECT_PROMPT_CLASSIFICATION is missing sentinel: '{_ARCHITECT_SENTINEL}'"
+        )
+
+    def test_writer_contains_anchor_sentinel(self) -> None:
+        assert _WRITER_SENTINEL in CASE_WRITER_PROMPT_CLASSIFICATION, (
+            f"CASE_WRITER_PROMPT_CLASSIFICATION is missing sentinel: '{_WRITER_SENTINEL}'"
+        )
+
+    def test_questions_contains_anchor_sentinel(self) -> None:
+        assert _QUESTIONS_SENTINEL in CASE_QUESTIONS_PROMPT_CLASSIFICATION, (
+            f"CASE_QUESTIONS_PROMPT_CLASSIFICATION is missing sentinel: '{_QUESTIONS_SENTINEL}'"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Classification prompts are safely formattable with full context (no KeyError)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestClassificationPromptsFormattable:
+    """All classification prompts must format() without KeyError given a full context."""
+
+    def test_architect_formattable(self) -> None:
+        try:
+            CASE_ARCHITECT_PROMPT_CLASSIFICATION.format(**_BASE_CONTEXT)
+        except KeyError as exc:
+            pytest.fail(
+                f"CASE_ARCHITECT_PROMPT_CLASSIFICATION raised KeyError on format(): {exc}"
+            )
+
+    def test_writer_formattable(self) -> None:
+        try:
+            CASE_WRITER_PROMPT_CLASSIFICATION.format(**_BASE_CONTEXT)
+        except KeyError as exc:
+            pytest.fail(
+                f"CASE_WRITER_PROMPT_CLASSIFICATION raised KeyError on format(): {exc}"
+            )
+
+    def test_questions_formattable(self) -> None:
+        try:
+            CASE_QUESTIONS_PROMPT_CLASSIFICATION.format(**_BASE_CONTEXT)
+        except KeyError as exc:
+            pytest.fail(
+                f"CASE_QUESTIONS_PROMPT_CLASSIFICATION raised KeyError on format(): {exc}"
+            )
+
+    def test_generic_prompts_still_formattable(self) -> None:
+        """Regression guard: generic prompts must not break after refactor."""
+        for name, prompt in [
+            ("CASE_ARCHITECT_PROMPT", CASE_ARCHITECT_PROMPT),
+            ("CASE_WRITER_PROMPT", CASE_WRITER_PROMPT),
+            ("CASE_QUESTIONS_PROMPT", CASE_QUESTIONS_PROMPT),
+        ]:
+            try:
+                prompt.format(**_BASE_CONTEXT)
+            except KeyError as exc:
+                pytest.fail(
+                    f"{name} raised KeyError on format() after dispatch refactor: {exc}"
+                )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Classification prompts are non-empty and longer than their generic versions
+#    (the anchor block adds content)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestClassificationPromptsLongerThanGeneric:
+    """Classification prompts must be longer than their generic counterparts."""
+
+    def test_architect_classification_longer_than_generic(self) -> None:
+        assert len(CASE_ARCHITECT_PROMPT_CLASSIFICATION) > len(CASE_ARCHITECT_PROMPT), (
+            "CASE_ARCHITECT_PROMPT_CLASSIFICATION must be longer than the generic prompt "
+            "(anchor block should add content)"
+        )
+
+    def test_writer_classification_longer_than_generic(self) -> None:
+        assert len(CASE_WRITER_PROMPT_CLASSIFICATION) > len(CASE_WRITER_PROMPT), (
+            "CASE_WRITER_PROMPT_CLASSIFICATION must be longer than the generic prompt"
+        )
+
+    def test_questions_classification_longer_than_generic(self) -> None:
+        assert len(CASE_QUESTIONS_PROMPT_CLASSIFICATION) > len(CASE_QUESTIONS_PROMPT), (
+            "CASE_QUESTIONS_PROMPT_CLASSIFICATION must be longer than the generic prompt"
+        )


### PR DESCRIPTION
## Summary

Add classification-specific M1 prompts and wire per-family dispatch so `case_architect`, `case_writer`, and `case_questions` LangGraph nodes automatically use a classification-specialized prompt when the teacher picks a `clasificacion`-family algorithm. All other families fall back to the existing generic prompts — **zero breaking change**.

## Motivation

The generator is being made scalable so every algorithm family has its own prompt subfolder organized by module. This PR implements the first installment: **M1 for clasificacion**. The same pattern (subfolder `clasificacion/M1_clasificacion/`, dispatch table `CASE_*_PROMPT_BY_FAMILY`, node one-liner) will be replicated for regresion and clustering in follow-up PRs.

## Architecture

```
prompts/
  clasificacion/
    M1_clasificacion/        NEW
      __init__.py            re-exports 3 symbols
      architect.py           CASE_ARCHITECT_PROMPT_CLASSIFICATION
      writer.py              CASE_WRITER_PROMPT_CLASSIFICATION
      questions.py           CASE_QUESTIONS_PROMPT_CLASSIFICATION
    __init__.py              +3 M1 re-exports
  __init__.py                +3 imports, +3 CASE_*_PROMPT_BY_FAMILY dicts, +__all__
case_generator/graph.py      3 node one-liners:
                               .get(context[primary_family], GENERIC).format(**context)
tests/
  test_m1_clasificacion_dispatch.py  25 pure-unit tests
```

## Dispatch mechanism

Each M1 node already calls `_build_base_context(state)` which returns `context[primary_family]`. The change is a single `.get()` call per node.

## Classification anchor blocks

Each prompt is the **verbatim generic base + a family anchor block** appended at the end:
- **Architect**: enforce `classification_target` role; mandate `pregunta_eje`; require commission vs omission trade-off in A/B/C options; add 2 data quality rows to Exhibit 2
- **Writer**: inject one of 3 classification data friction patterns; ban ML jargon; tie dilema final to `{pregunta_eje}`
- **Questions**: P2 (ml_ds): operational target definition + falsifiable hypothesis; P3: A/B/C framed as intervention cost vs omission cost using Exhibit numbers

## Tests — 25 pure-unit, no DB, no LLM

- Dispatch correctness, fallback safety, anchor sentinel presence, format() safety, length guard

## Validation

```
841 passed, 14 skipped  (pytest -q)
Success: no issues found in 62 source files  (mypy src)
```