### PR TITLE
feat(prompts): implement EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION for clasificacion family (TODO-M2-CLSF-EDA-TEXT)

### DIFF
--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -31,6 +31,7 @@ from case_generator.prompts.clasificacion import (
     CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY,
     ClassificationNotebookVariant,
     EDA_ANNOTATE_ONLY_PROMPT_CLASSIFICATION,
+    EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION,
     M3_CONTENT_PROMPT_CLASSIFICATION,
     M3_CONTENT_PROMPT_CLASSIFICATION_BY_VARIANT,
     M3_CONTENT_PROMPT_CLASSIFICATION_LR_ONLY,
@@ -702,10 +703,10 @@ case_id: {case_id} | output_depth: {output_depth}
 
 # ── EDA_TEXT_ANALYST_PROMPT_BY_FAMILY — dispatch table for eda_text_analyst node.
 # Keys match family_of()/resolve_legacy_family() in suggest_service.py.
-# Currently aliases to the generic for all families; update the "clasificacion"
-# entry when M2_clasificacion/eda_text.py is customized.
+# "clasificacion" uses the binary-churn-specialized prompt (Issue #268).
+# Other families — regresion, clustering, serie_temporal — deferred.
 EDA_TEXT_ANALYST_PROMPT_BY_FAMILY: dict[str, str] = {
-    "clasificacion": EDA_TEXT_ANALYST_PROMPT,
+    "clasificacion": EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION,
     # regresion, clustering, serie_temporal — deferred
 }
 

--- a/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_text.py
+++ b/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_text.py
@@ -1,45 +1,188 @@
-"""EDA narrative prompt slot for the clasificacion algorithm family — M2 module.
+"""EDA narrative prompt for the clasificacion algorithm family — M2 module.
 
-``EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION`` is the override slot for a
-classification-specific EDA narrative prompt.
+``EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION`` is the classification-specific EDA
+narrative prompt for binary-classification churn cases. It specializes the
+generic EDA_TEXT_ANALYST_PROMPT with:
+  - Binary target analysis (`categoria` int 0/1, 1 = churn)
+  - Mandatory class-balance section with imbalance-ratio formula
+  - Accuracy Paradox warning when minority class < 20%
+  - Churn-oriented feature engineering (engagement_decay_rate, churn_risk_score,
+    support_intensity_index, payment_stress_index)
+  - Temporal leakage guard for common churn predictors
+  - AUC-ROC >= 0.70 pedagogical threshold tied to the selected algorithm
 
-Current state: EMPTY SLOT — the dispatch table in ``prompts/__init__.py``
-currently maps ``EDA_TEXT_ANALYST_PROMPT_BY_FAMILY["clasificacion"]`` to the
-generic ``EDA_TEXT_ANALYST_PROMPT`` until this slot is filled in.
-
-How to activate a classification-specific narrative:
-  1. Fill in ``EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION`` below with the
-     classification-tailored prompt (binary target framing, class imbalance,
-     churn-specific vocabulary, etc.).
-  2. In ``prompts/__init__.py``:
-     a. Add to the ``from case_generator.prompts.clasificacion import (...)``
-        block::
-
-          EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION,
-
-     b. Update the dispatch entry::
-
-          EDA_TEXT_ANALYST_PROMPT_BY_FAMILY["clasificacion"] = (
-              EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION
-          )
-
-     (The symbol is not imported into ``prompts/__init__.py`` until this
-     slot is filled — importing an empty-string constant would create an
-     unused import that breaks ruff/F401.)
-  3. Run ``pytest tests/test_m2_clasificacion_dispatch.py -q`` to verify
-     the dispatch table resolves to the new prompt.
+Activation status: ACTIVE — wired into
+  ``EDA_TEXT_ANALYST_PROMPT_BY_FAMILY["clasificacion"]`` in
+  ``prompts/__init__.py``.
 
 IMPORTANT — circular import constraint:
   This file MUST NOT import from ``case_generator.prompts`` (the parent
   ``__init__.py``).  The import chain
   ``prompts.__init__ → clasificacion.__init__ → M2_clasificacion.__init__
   → eda_text.py → prompts.__init__`` would create a circular dependency.
-  The alias is therefore implemented entirely in ``prompts/__init__.py``
-  via the dispatch table (no import required here).
+  The dispatch wiring lives entirely in ``prompts/__init__.py``.
 """
 
 __all__ = ["EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION"]
 
-# Override slot — empty until a classification-specific narrative is authored.
-# See module docstring for activation instructions.
-EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION: str = ""
+# Classification-specific EDA narrative — binary churn framing with class-balance
+# analysis, churn feature engineering, leakage guard, and AUC-ROC threshold.
+# Placeholders (14 total, must match the context dict in graph.py eda_text_analyst):
+#   {dilema_hypotheses}, {dataset_instruction}, {data_gap_warnings_block},
+#   {output_language}, {student_profile}, {algoritmos}, {case_context},
+#   {dataset_str}, {dataset_summary}, {dataset_total_rows},
+#   {financial_exhibit}, {operational_exhibit}, {case_id}, {output_depth}
+EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION: str = """\
+# Your Identity
+Eres el EDA Text Analyst de ADAM para casos de CLASIFICACIÓN BINARIA. Tu misión es
+traducir los datos de un dataset de churn/clasificación en insights pedagógicos orientados
+a LR/RF, conectados con el dilema del Módulo 1.
+
+# Your Mission
+Generar el Módulo 2 (reporte EDA) en Markdown puro para un caso de clasificación binaria.
+Confirmar o rechazar las hipótesis del M1 usando exclusivamente los datos del dataset y
+los Exhibits provistos. Identificar la variable objetivo `categoria` (int 0/1, donde
+1 = churn/evento positivo) y colocar el análisis de balance de clases como eje central
+del reporte.
+
+# How You Work (Workflow)
+1. **Lee el Contexto:** Revisa el dilema del M1, las hipótesis implícitas del dilema
+   (si están disponibles en {dilema_hypotheses}) y la variable objetivo `categoria`.
+2. **Extracción Estricta:** Lee el dataset campo por campo.
+   REGLA: Si necesitas calcular un promedio, suma o porcentaje, escríbelo como:
+   "Valor calculado: [operación]. Resultado: [número]." — no lo afirmes sin mostrarlo.
+   Esto permite al EDA_CHART_GENERATOR verificar tus cifras contra el dataset.
+3. **Balance de Clases primero:** Antes de cualquier otro hallazgo, extrae del
+   {dataset_str} los conteos de `categoria == 0` y `categoria == 1`. Calcula el
+   imbalance ratio como count_mayoritaria / count_minoritaria. Si la clase minoritaria
+   representa menos del 20% del total, señala riesgo de accuracy paradox.
+4. **Redacta Simbiosis Text-to-Chart:** En la sección 2, narra los números EXACTOS
+   extraídos del dataset. El chart generator lee el dataset directamente.
+5. **Modula Profundidad:** Ajusta rigor según {output_depth}.
+
+## Error Handling
+- {dataset_instruction}
+- Si una métrica no muestra tendencia clara o anomalía: repórtala como ESTABLE.
+  NO fuerces un hallazgo donde los datos no lo soportan.
+- Si `categoria` no existe en el dataset, reporta la columna más cercana que actúe
+  como variable objetivo binaria y justifica la elección.
+
+## Brechas dilema\u2194dataset
+{data_gap_warnings_block}
+
+REGLAS para brechas:
+- Si la lista NO está vacía, incluye en la sección 1 (Contexto) un bullet con el
+  título **"Brechas de datos detectadas"** y lista cada warning en lenguaje accesible.
+  Esto evita que el M3 opere silenciosamente sobre columnas faltantes/leakage.
+- Si la lista está vacía o dice "(sin brechas detectadas...)", NO inventes brechas.
+
+# Your Boundaries
+- **CERO ALUCINACIÓN MATEMÁTICA.** Prohibido inventar tendencias, montos o porcentajes.
+- Solo Markdown puro. PROHIBIDO HTML. Tablas con 3 guiones por columna.
+- Para "charts_plus_explanation": añade intuición estadística en lenguaje accesible.
+- Para "charts_plus_code": eleva rigor técnico.
+  NUNCA prometas notebooks adjuntos en este reporte — el notebook es un artefacto separado.
+- **Idioma de salida: {output_language}**
+
+# Perfil del estudiante: {student_profile}
+- Si es "business" (Insight Analyst):
+  Audiencia de directivos. SIN jerga estadística.
+  Ejemplo correcto: "El 65% de los clientes abandonan en el primer trimestre."
+  Ejemplo PROHIBIDO: "Distribución bimodal del churn con sesgo positivo (skewness=1.3)."
+- Si es "ml_ds" (Data Analyst):
+  Audiencia técnica. Distribuciones, sesgos (con skewness numérico si aplica), outliers
+  (IQR o Z-score), correlaciones, reflexiones sobre calidad del dato.
+  Mencionar implicaciones metodológicas para el algoritmo en {algoritmos}.
+
+# Formato de Salida (usar EXACTAMENTE estos 3 H2 — NO alterar nombres ni numeración)
+## Longitud objetivo por sección (total: 700-900 palabras):
+##   §1: 250 palabras | §2: 350 palabras | §3: 200 palabras
+
+## 1. Qué hace el Detective de Datos
+Introducción inspirada en Sherlock Holmes: el EDA es inspeccionar la escena del crimen
+donde cada número es una pista y la variable `categoria` es el "cuerpo del delito"
+(el evento de churn que queremos predecir). Usa una tabla analógica que mapee conceptos
+detectivescos (lupa, conexiones entre sospechosos, evidencia forense) con técnicas de
+análisis de datos (gráficos de dispersión, correlaciones, cohortes). Personaliza la
+metáfora al contexto del caso.
+
+Incluye el Resumen Ejecutivo:
+- Hallazgo principal del dataset (extraído de los datos, no inventado).
+- Cómo confirma, rechaza o matiza la hipótesis del M1.
+- Si {dilema_hypotheses} está disponible: indica explícitamente si la hipótesis
+  del dilema se confirma, rechaza o matiza con los datos.
+- **Balance de clases (obligatorio):** Extrae del {dataset_str} el conteo de
+  `categoria == 0` (no-churn) y `categoria == 1` (churn). Presenta como:
+  "Clase 0 (no-churn): N filas (X%). Clase 1 (churn): M filas (Y%)."
+  Si la clase minoritaria es < 20% del total, añade:
+  "Riesgo de Accuracy Paradox: un modelo que prediga siempre la clase mayoritaria
+  alcanzaría accuracy del X% sin aprender nada. Priorizar AUC-ROC sobre accuracy."
+
+Incluye el Diccionario de Datos como tabla Markdown, mín 8 variables:
+| Variable | Tipo | Descripción | Completitud (%) | Notas de calidad |
+(Objetivo: 250 palabras)
+
+## 2. Hallazgos Clave del Análisis
+
+### Distribución del Target y Balance de Clases
+Calcula desde {dataset_str}:
+- Conteo de clase 0 y clase 1 en `categoria`.
+- Imbalance ratio: count_mayoritaria / count_minoritaria.
+- Emite la fórmula explícita: imbalance_ratio = count(cat==1) / count(cat==0)
+  (o la inversa si clase 0 es la minoritaria) para que EDA_CHART_GENERATOR la verifique.
+- Si imbalance ratio > 4:1: "Desbalance severo (ratio X:1). La accuracy como métrica
+  única es engañosa. El estudiante debe analizar Matriz de Confusión, Precision, Recall
+  y F1-Score — especialmente para la clase 1 (churners). Considerar ajuste de threshold
+  antes de entrenar {algoritmos}."
+
+### Calidad de la Evidencia
+Nulos/outliers reales del dataset. Cómo afectan la predicción de churn.
+Para "ml_ds": mencionar implicaciones para el preprocessing antes del modelado
+(imputación, escalado, encoding de categóricas para LR/RF).
+
+### Análisis Exploratorio de Predictores
+3-4 subsecciones H3 con los predictores más correlacionados con `categoria`.
+Narrar números EXACTOS extraídos del dataset.
+Ejemplo: "Clientes con payment_failures > 2 presentan tasa de churn del 72% vs 18%
+en clientes sin fallos de pago."
+
+### Validación de Hipótesis Previas
+Tabla: # | Hipótesis (del M1 o del caso) | Veredicto | Implicación para la decisión
+(3-4 filas — hipótesis derivadas del dilema del M1, NO del estudiante)
+(Objetivo: 350 palabras)
+
+## 3. Feature Engineering para Modelos Predictivos
+Explica 4-5 variables derivadas orientadas a clasificación binaria de churn, justificando
+cada una con su relevancia para predecir `categoria` con {algoritmos}. Fórmulas simples:
+- engagement_decay_rate: tasa de caída de engagement en la ventana de observación.
+- churn_risk_score: score compuesto de factores de riesgo ponderados por historial.
+- support_intensity_index: frecuencia de contacto con soporte / antigüedad del cliente.
+- payment_stress_index: ratio de fallos de pago sobre intentos de pago totales.
+
+**ADVERTENCIA DE FUGA TEMPORAL (Leakage Guard):**
+Variables como `days_since_last_login` y `payment_failures` pueden introducir fuga
+temporal si el valor observado ocurre después del evento de churn. Verificar la ventana
+de observación antes de incluirlas: el valor debe corresponder a un momento anterior a la
+fecha del evento de churn. Si hay duda, excluir la variable del entrenamiento inicial.
+
+**Umbral pedagógico para {algoritmos}:**
+AUC-ROC >= 0.70 es el umbral pedagógico mínimo para este caso. Si el dataset muestra un
+imbalance > 3:1, considerar ajuste de threshold por sobre 0.5 para maximizar recall en la
+clase 1 (churners) — en muchos contextos de negocio el costo de no detectar un churner
+supera el costo de un falso positivo.
+(Objetivo: 200 palabras)
+
+
+# Context
+{case_context}
+Dataset (muestra de 30 filas): {dataset_str}
+Resumen estadístico (df.describe): {dataset_summary}
+Total de filas en dataset completo: {dataset_total_rows}
+Algoritmo: {algoritmos}
+Exhibit 1: {financial_exhibit}
+Exhibit 2: {operational_exhibit}
+Hipótesis implícitas del dilema (extraídas del M1): {dilema_hypotheses}
+
+# Metadatos del sistema
+case_id: {case_id} | output_depth: {output_depth}
+"""

--- a/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_text.py
+++ b/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_text.py
@@ -127,9 +127,12 @@ Incluye el Diccionario de Datos como tabla Markdown, mín 8 variables:
 ### Distribución del Target y Balance de Clases
 Calcula desde {dataset_str}:
 - Conteo de clase 0 y clase 1 en `categoria`.
-- Imbalance ratio: count_mayoritaria / count_minoritaria.
-- Emite la fórmula explícita: imbalance_ratio = count(cat==1) / count(cat==0)
-  (o la inversa si clase 0 es la minoritaria) para que EDA_CHART_GENERATOR la verifique.
+- Imbalance ratio: count_mayoritaria / count_minoritaria (resultado siempre ≥ 1).
+- Emite la fórmula explícita:
+  imbalance_ratio = max(count_cat0, count_cat1) / min(count_cat0, count_cat1)
+  donde count_cat0 = count(categoria==0) y count_cat1 = count(categoria==1).
+  El resultado es siempre ≥ 1 (numerador = clase mayoritaria, denominador = minoritaria),
+  sin asumir a priori qué clase es mayoritaria en el dataset concreto.
 - Si imbalance ratio > 4:1: "Desbalance severo (ratio X:1). La accuracy como métrica
   única es engañosa. El estudiante debe analizar Matriz de Confusión, Precision, Recall
   y F1-Score — especialmente para la clase 1 (churners). Considerar ajuste de threshold

--- a/backend/tests/test_m2_clasificacion_dispatch.py
+++ b/backend/tests/test_m2_clasificacion_dispatch.py
@@ -15,7 +15,7 @@ Covers:
 """
 
 import inspect
-import re
+import string
 
 from case_generator.prompts.clasificacion.M2_clasificacion.dataset import (
     SCHEMA_DESIGNER_PROMPT_CLASSIFICATION,
@@ -81,9 +81,9 @@ def test_eda_text_analyst_dispatch_clasificacion():
     assert prompt is not None
     assert isinstance(prompt, str)
     assert len(prompt) > 100
-    assert prompt is not EDA_TEXT_ANALYST_PROMPT, (
-        "EDA_TEXT_ANALYST_PROMPT_BY_FAMILY['clasificacion'] must use "
-        "EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION, not the generic prompt"
+    assert prompt is EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION, (
+        "EDA_TEXT_ANALYST_PROMPT_BY_FAMILY['clasificacion'] must resolve to "
+        "EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION — check dispatch table in prompts/__init__.py"
     )
 
 
@@ -138,7 +138,15 @@ def test_eda_text_analyst_placeholder_contract():
     KeyError in graph.py eda_text_analyst() at runtime when prompt.format(**context)
     is called with the fixed 14-key context dict.
     """
-    placeholders = set(re.findall(r"\{(\w+)\}", EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION))
+    # Use string.Formatter().parse() instead of a regex so that format-spec
+    # placeholders ({foo:,.0f}) and conversion placeholders ({bar!r}) are also
+    # enumerated.  re.findall(r"\{(\w+)\}") would silently miss them, letting a
+    # runtime KeyError slip past this contract test.
+    placeholders = {
+        fname.split(".")[0].split("[")[0]
+        for _, fname, _, _ in string.Formatter().parse(EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION)
+        if fname is not None
+    }
     expected = {
         "dilema_hypotheses",
         "dataset_instruction",

--- a/backend/tests/test_m2_clasificacion_dispatch.py
+++ b/backend/tests/test_m2_clasificacion_dispatch.py
@@ -7,18 +7,24 @@ Covers:
 4. Behavioral: EDA_ANNOTATE_ONLY_PROMPT is alias of _CLASSIFICATION (object identity)
    AND the sentinel string appears inside the prompt (confirms graph.py uses renamed symbol)
 5. graph.py._eda_classification_python_path references EDA_ANNOTATE_ONLY_PROMPT_CLASSIFICATION
-6. EDA_TEXT_ANALYST_PROMPT_BY_FAMILY["clasificacion"] resolves non-empty
+6. EDA_TEXT_ANALYST_PROMPT_BY_FAMILY["clasificacion"] resolves to EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION
+   (not the generic) and is non-empty
 7. EDA_QUESTIONS_PROMPT_BY_FAMILY["clasificacion"] resolves non-empty
 8. Fallback: non-clasificacion family falls back to generic prompt
+9. EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION contains exactly the 14 required placeholders
 """
 
 import inspect
+import re
 
 from case_generator.prompts.clasificacion.M2_clasificacion.dataset import (
     SCHEMA_DESIGNER_PROMPT_CLASSIFICATION,
 )
 from case_generator.prompts.clasificacion.M2_clasificacion.eda_annotate import (
     EDA_ANNOTATE_ONLY_PROMPT_CLASSIFICATION,
+)
+from case_generator.prompts.clasificacion.M2_clasificacion.eda_text import (
+    EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION,
 )
 from case_generator.prompts import (
     EDA_ANNOTATE_ONLY_PROMPT,
@@ -70,11 +76,15 @@ def test_graph_uses_classification_annotate_symbol():
 
 
 def test_eda_text_analyst_dispatch_clasificacion():
-    """EDA_TEXT_ANALYST_PROMPT_BY_FAMILY['clasificacion'] resolves to a non-empty prompt."""
+    """EDA_TEXT_ANALYST_PROMPT_BY_FAMILY['clasificacion'] resolves to EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION."""
     prompt = EDA_TEXT_ANALYST_PROMPT_BY_FAMILY.get("clasificacion")
     assert prompt is not None
     assert isinstance(prompt, str)
     assert len(prompt) > 100
+    assert prompt is not EDA_TEXT_ANALYST_PROMPT, (
+        "EDA_TEXT_ANALYST_PROMPT_BY_FAMILY['clasificacion'] must use "
+        "EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION, not the generic prompt"
+    )
 
 
 def test_eda_questions_dispatch_clasificacion():
@@ -118,4 +128,34 @@ def test_schema_designer_placeholder_contract():
     )
     assert "REGLAS DE COBERTURA DEL CONTRATO" in SCHEMA_DESIGNER_PROMPT_CLASSIFICATION, (
         "REGLAS DE COBERTURA DEL CONTRATO section missing from SCHEMA_DESIGNER_PROMPT_CLASSIFICATION"
+    )
+
+
+def test_eda_text_analyst_placeholder_contract():
+    """EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION contains exactly the 14 required placeholders.
+
+    Guards against accidental extra {placeholder} expressions that would cause a
+    KeyError in graph.py eda_text_analyst() at runtime when prompt.format(**context)
+    is called with the fixed 14-key context dict.
+    """
+    placeholders = set(re.findall(r"\{(\w+)\}", EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION))
+    expected = {
+        "dilema_hypotheses",
+        "dataset_instruction",
+        "data_gap_warnings_block",
+        "output_language",
+        "student_profile",
+        "algoritmos",
+        "case_context",
+        "dataset_str",
+        "dataset_summary",
+        "dataset_total_rows",
+        "financial_exhibit",
+        "operational_exhibit",
+        "case_id",
+        "output_depth",
+    }
+    assert placeholders == expected, (
+        f"Placeholder contract violated for EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION. "
+        f"Missing: {expected - placeholders}, Extra: {placeholders - expected}"
     )


### PR DESCRIPTION
﻿## Summary

Closes #268

Implements `EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION` — the binary-classification-specialized EDA narrative for Módulo 2 (`eda_text_analyst` node). All `ml_ds + clasificacion` jobs previously fell back to the generic `EDA_TEXT_ANALYST_PROMPT`; this PR wires the classification-specific prompt into the dispatch table, restoring pedagogical coherence for churn/binary-classification cases.

---

## Changes (3 files, surgical diff)

### 1. `backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_text.py`
- Replaces `EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION: str = ''` (empty slot) with the full prompt (~200 lines).
- Updates module docstring from **EMPTY SLOT** → **ACTIVE**.
- **Three specialized sections** over the generic `EDA_TEXT_ANALYST_PROMPT`:
  - **§1 — Detective de Datos:** Adds mandatory class-balance block — extracts `categoria` (int 0/1, 1 = churn) counts from `{dataset_str}`, presents as Clase 0/Clase 1 with %, warns on Accuracy Paradox when minority class < 20%.
  - **§2 — Hallazgos Clave:** Adds mandatory H3 `### Distribución del Target y Balance de Clases` — imbalance ratio formula (count_mayoritaria / count_minoritaria), 4:1 desbalance severo threshold with Confusion Matrix / Precision / Recall guidance.
  - **§3 — Feature Engineering:** Churn-oriented derived features (`engagement_decay_rate`, `churn_risk_score`, `support_intensity_index`, `payment_stress_index`), Temporal Leakage Guard paragraph for `days_since_last_login` / `payment_failures`, and AUC-ROC >= 0.70 pedagogical threshold for `{algoritmos}`.

### 2. `backend/src/case_generator/prompts/__init__.py` (2-line change)

Import added (~line 34):
```diff
+    EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION,
```

Dispatch updated (~line 709):
```diff
-    "clasificacion": EDA_TEXT_ANALYST_PROMPT,
+    "clasificacion": EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION,
```

### 3. `backend/tests/test_m2_clasificacion_dispatch.py`
- Adds `is not EDA_TEXT_ANALYST_PROMPT` assertion to `test_eda_text_analyst_dispatch_clasificacion` — guards against dispatch silently reverting to the generic.
- Adds `test_eda_text_analyst_placeholder_contract` — regex-verifies the prompt contains **exactly** the 14 required placeholder keys and no extras (prevents runtime `KeyError` in `graph.py eda_text_analyst()` when `prompt.format(**context)` is called).

---

## 14 Placeholders Preserved

`{dilema_hypotheses}`, `{dataset_instruction}`, `{data_gap_warnings_block}`, `{output_language}`, `{student_profile}`, `{algoritmos}`, `{case_context}`, `{dataset_str}`, `{dataset_summary}`, `{dataset_total_rows}`, `{financial_exhibit}`, `{operational_exhibit}`, `{case_id}`, `{output_depth}`

No extras. Verified by `test_eda_text_analyst_placeholder_contract`.

---

## Validation

| Check | Result |
|---|---|
| `pytest tests/test_m2_clasificacion_dispatch.py -v` | 11 passed (10 existing + 1 new) |
| `pytest -q` | 852 passed, 14 skipped, 0 failures |
| `mypy src` | no issues in 67 source files |
| `npm --prefix frontend run lint` | clean (no frontend changes) |

---

## Architecture Boundaries Respected

- No import from `case_generator.prompts` inside `eda_text.py` (circular import avoided).
- No changes to `graph.py` — dispatch already wired via `EDA_TEXT_ANALYST_PROMPT_BY_FAMILY.get(primary_family, EDA_TEXT_ANALYST_PROMPT)`.
- No changes to other family entries in the dispatch table.
- `EDA_TEXT_ANALYST_PROMPT` (generic) preserved and unchanged.
