### PR TITLE
refactor(eda): remove stacked_top2_categorical chart, 6→5-chart panel

### DIFF
--- a/backend/src/case_generator/datagen/__init__.py
+++ b/backend/src/case_generator/datagen/__init__.py
@@ -4,7 +4,7 @@ This package hosts the small Python helpers that produce *bit-deterministic*
 artefacts for the teacher preview, replacing LLM-fabricated numbers in
 sensitive paths. Today it ships:
 
-* ``eda_charts_classification`` — 6-chart EDA panel for the
+* ``eda_charts_classification`` — 5-chart EDA panel for the
   ``ml_ds + clasificacion`` path.
 
 Future work (TODO-237-A/B/C) will extend the same pattern to ``regresion``

--- a/backend/src/case_generator/datagen/eda_charts_classification.py
+++ b/backend/src/case_generator/datagen/eda_charts_classification.py
@@ -1,4 +1,4 @@
-"""Issue #237 — Python-deterministic 6-chart EDA panel for classification.
+"""Issue #237 — Python-deterministic 5-chart EDA panel for classification.
 
 Pipeline (no LLM calls; numpy/pandas/sklearn only):
 
@@ -14,8 +14,7 @@ Pipeline (no LLM calls; numpy/pandas/sklearn only):
    │  2. missingness_heatmap        (heatmap, sample 500 rows)        │
    │  3. mutual_info_top8           (bar, MI(X, y) top 8)             │
    │  4. boxplots_top3_numeric      (box, by class, top-3 numeric)    │
-   │  5. stacked_top2_categorical   (bar stacked, normalized 100%)    │
-   │  6. pca_2d_scatter             (scatter, 2 PCs colored by class) │
+   │  5. pca_2d_scatter             (scatter, 2 PCs colored by class) │
    └──────────────────────────────────────────────────────────────────┘
                       ▼
             list[EDAChartSpec]  (data_source="python_builder",
@@ -30,8 +29,8 @@ Determinism guarantees:
 
 Failure policy:
   * Any unrecoverable error in a single chart builder → that chart is
-    skipped (not faked). The function returns ``len(charts) ≤ 6`` and the
-    caller (``eda_chart_generator``) caps to 6 and logs the gap.
+    skipped (not faked). The function returns ``len(charts) ≤ 5`` and the
+    caller (``eda_chart_generator``) caps to 5 and logs the gap.
   * Empty/None ``df`` → returns ``[]`` so the caller can fall back to the
     LLM-JSON path with a warning.
 """
@@ -50,8 +49,6 @@ logger = logging.getLogger("adam.graph")
 _MISSINGNESS_SAMPLE_ROWS = 500
 _MI_TOP_K = 8
 _BOX_TOP_K = 3
-_STACKED_TOP_K = 2
-_STACKED_MAX_CATEGORIES = 8  # per categorical column, by frequency
 _SOURCE_TEMPLATE = "Dataset ADAM — {case_id}"
 
 
@@ -330,94 +327,6 @@ def _build_boxplots_top3_numeric(
     }
 
 
-def _build_stacked_top2_categorical(
-    df: pd.DataFrame, target_col: str, source: str, categorical_cols: list[str]
-) -> dict[str, Any]:
-    if not categorical_cols:
-        return _empty_chart(
-            "stacked_top2_categorical",
-            "Composición de clases por features categóricas",
-            "Sin columnas categóricas disponibles",
-            "bar",
-            source,
-        )
-    # Pick top-2 by cardinality bounded ([2, _STACKED_MAX_CATEGORIES]).
-    nunique = df[categorical_cols].nunique(dropna=True)
-    candidates = [
-        c
-        for c in categorical_cols
-        if 2 <= int(nunique.get(c, 0)) <= _STACKED_MAX_CATEGORIES
-    ]
-    candidates = sorted(candidates, key=lambda c: int(nunique[c]), reverse=True)[
-        :_STACKED_TOP_K
-    ]
-    if not candidates:
-        return _empty_chart(
-            "stacked_top2_categorical",
-            "Composición de clases por features categóricas",
-            "Sin features categóricas con cardinalidad útil",
-            "bar",
-            source,
-        )
-
-    classes = sorted(df[target_col].dropna().astype(str).unique().tolist())
-    # Use subplots layout in plotly via xaxis/xaxis2 — simpler: one stacked
-    # bar chart per col concatenated with an "Origen" label.
-    traces: list[dict[str, Any]] = []
-    x_labels: list[str] = []
-    # Build (col, category) pairs as composite x labels.
-    composite_x: list[str] = []
-    pct_by_class: dict[str, list[float]] = {c: [] for c in classes}
-    for col in candidates:
-        # fillna BEFORE astype(str): otherwise NaN -> 'nan' string and the
-        # explicit __nan__ bucket is never created.
-        col_str = df[col].fillna("__nan__").astype(str)
-        cats = (
-            col_str
-            .value_counts()
-            .head(_STACKED_MAX_CATEGORIES)
-            .index.tolist()
-        )
-        cats = sorted(cats)
-        for cat in cats:
-            mask = col_str == cat
-            sub = df.loc[mask, target_col].astype(str)
-            total = max(int(sub.shape[0]), 1)
-            label = f"{col}={cat}"
-            composite_x.append(label)
-            for cls in classes:
-                pct = float((sub == cls).sum()) * 100.0 / total
-                pct_by_class[cls].append(round(pct, 6))
-    x_labels = composite_x
-    for cls in classes:
-        traces.append(
-            {
-                "type": "bar",
-                "x": x_labels,
-                "y": pct_by_class[cls],
-                "name": str(cls),
-            }
-        )
-    return {
-        "id": "stacked_top2_categorical",
-        "title": "Composición de clases por features categóricas",
-        "subtitle": f"Top {len(candidates)} categóricas, normalizado a 100%",
-        "library": "plotly",
-        "chart_type": "bar",
-        "traces": traces,
-        "layout": {
-            "template": "plotly_white",
-            "barmode": "stack",
-            "xaxis": {"title": "Feature = categoría"},
-            "yaxis": {"title": "% de clase", "range": [0, 100]},
-        },
-        "source": source,
-        "description": "",
-        "notes": "",
-        "data_source": "python_builder",
-    }
-
-
 def _build_pca_2d_scatter(
     df: pd.DataFrame, target_col: str, source: str, numeric_cols: list[str]
 ) -> dict[str, Any] | None:
@@ -425,7 +334,7 @@ def _build_pca_2d_scatter(
 
     Returns an empty-skeleton chart (via ``_empty_chart``) when there are
     fewer than 2 numeric features available, so the dispatcher always sees
-    a valid ``EDAChartSpec`` shape and the panel keeps a stable 6-chart
+    a valid ``EDAChartSpec`` shape and the panel keeps a stable 5-chart
     contract. Never returns ``None`` in the current implementation.
     """
     if len(numeric_cols) < 2:
@@ -489,7 +398,7 @@ def _build_pca_2d_scatter(
 def generate_classification_eda_charts(
     df: pd.DataFrame, target_col: str, contract: dict | None
 ) -> list[dict[str, Any]]:
-    """Build the 6-chart EDA panel deterministically.
+    """Build the 5-chart EDA panel deterministically.
 
     Returns a list of dicts shaped like ``EDAChartSpec`` (with
     ``data_source="python_builder"`` and empty ``description``/``notes``).
@@ -509,7 +418,7 @@ def generate_classification_eda_charts(
         return []
 
     source = _source_label(contract)
-    numeric_cols, categorical_cols = _split_columns(df, target_col)
+    numeric_cols, _ = _split_columns(df, target_col)
     charts: list[dict[str, Any]] = []
 
     builders: list[tuple[str, Any]] = [
@@ -519,12 +428,6 @@ def generate_classification_eda_charts(
         (
             "boxplots_top3_numeric",
             lambda: _build_boxplots_top3_numeric(df, target_col, source, numeric_cols),
-        ),
-        (
-            "stacked_top2_categorical",
-            lambda: _build_stacked_top2_categorical(
-                df, target_col, source, categorical_cols
-            ),
         ),
         (
             "pca_2d_scatter",

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -1387,7 +1387,7 @@ def _clamp(text: str, max_chars: int) -> str:
 def _eda_classification_python_path(
     state: ADAMState, config: RunnableConfig, contract: dict | None
 ) -> dict | None:
-    """Issue #237 — construye 6 charts EDA en Python y pide al LLM solo
+    """Issue #237 — construye 5 charts EDA en Python y pide al LLM solo
     `description` + `notes`. Devuelve el dict de update del nodo o ``None``
     si el path Python no aplica (deja que el caller use el LLM-JSON).
     """
@@ -1415,9 +1415,9 @@ def _eda_classification_python_path(
             )
             return None
 
-        # Cap defensivo: el contrato Issue #237 son 6 charts.
-        if len(charts) > 6:
-            charts = charts[:6]
+        # Cap defensivo: el contrato Issue #237 son 5 charts.
+        if len(charts) > 5:
+            charts = charts[:5]
 
         # Annotate-only: pedimos al LLM solo description/notes por id.
         try:

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -390,7 +390,7 @@ class EDAAnnotateOnlyOutput(BaseModel):
     """
 
     annotations: list[EDAAnnotateOnlyAnnotation] = Field(
-        description="Una entrada por chart Python-construido (≤6)"
+        description="Una entrada por chart Python-construido (≤5)"
     )
 
 

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -362,15 +362,15 @@ class EDAChartSpec(BaseModel):
 
 
 class EDAChartGeneratorOutput(BaseModel):
-    """Salida del EDA Chart Generator — 3 a 6 charts según path de generación.
+    """Salida del EDA Chart Generator — 3 a 5 charts según path de generación.
 
     Path LLM-JSON original (business y otras familias ml_ds): 3 charts.
-    Path Python-determinista (Issue #237, ml_ds + clasificación): 6 charts.
+    Path Python-determinista (Issue #237, ml_ds + clasificación): 5 charts.
     El cap final lo aplica el nodo `eda_chart_generator` en `graph.py`.
     """
 
     charts: list[EDAChartSpec] = Field(
-        description="Entre 3 y 6 charts estructurados para visualización (depende del path)."
+        description="Entre 3 y 5 charts estructurados para visualización (depende del path)."
     )
 
 

--- a/backend/tests/test_issue237_eda_charts_classification.py
+++ b/backend/tests/test_issue237_eda_charts_classification.py
@@ -63,17 +63,16 @@ CONTRACT = {"case_id": "test_case_237"}
 
 
 def test_happy_path_invariants(df_binary: pd.DataFrame) -> None:
-    """El happy path emite EXACTAMENTE 6 charts en el orden esperado, todos
+    """El happy path emite EXACTAMENTE 5 charts en el orden esperado, todos
     con `data_source=python_builder` y descriptions/notes vacías (anti-LLM).
     """
     charts = generate_classification_eda_charts(df_binary, "churn", CONTRACT)
-    assert len(charts) == 6
+    assert len(charts) == 5
     expected_ids = [
         "class_distribution",
         "missingness_heatmap",
         "mutual_info_top8",
         "boxplots_top3_numeric",
-        "stacked_top2_categorical",
         "pca_2d_scatter",
     ]
     assert [c["id"] for c in charts] == expected_ids
@@ -88,7 +87,7 @@ def test_happy_path_invariants(df_binary: pd.DataFrame) -> None:
 
 def test_target_multiclass(df_multiclass: pd.DataFrame) -> None:
     charts = generate_classification_eda_charts(df_multiclass, "label", CONTRACT)
-    assert len(charts) == 6
+    assert len(charts) == 5
     cd = next(c for c in charts if c["id"] == "class_distribution")
     classes_in_chart = cd["traces"][0]["x"]
     assert set(classes_in_chart) == {"bronze", "silver", "gold"}
@@ -199,7 +198,7 @@ def test_boundary_llm_cannot_alter_traces(df_binary: pd.DataFrame) -> None:
 
     assert update is not None
     charts = update["doc2_eda_charts"]
-    assert len(charts) == 6
+    assert len(charts) == 5
     cd = next(c for c in charts if c["id"] == "class_distribution")
     # description vino del LLM stub, traces sin tocar (vienen del builder).
     assert cd["description"] == "desc fake"
@@ -219,7 +218,7 @@ def test_boundary_llm_cannot_alter_traces(df_binary: pd.DataFrame) -> None:
 
 
 def test_llm_ghost_chart_id_is_silently_dropped(df_binary: pd.DataFrame) -> None:
-    """Si el LLM annotate-only devuelve un id que NO existe entre los 6
+    """Si el LLM annotate-only devuelve un id que NO existe entre los 5
     charts del builder, el id fantasma se descarta y NO se añade chart.
     """
     from case_generator.graph import _eda_classification_python_path
@@ -250,8 +249,8 @@ def test_llm_ghost_chart_id_is_silently_dropped(df_binary: pd.DataFrame) -> None
 
     assert update is not None
     charts = update["doc2_eda_charts"]
-    # Sigue siendo exactamente 6 — el ghost no se añade.
-    assert len(charts) == 6
+    # Sigue siendo exactamente 5 — el ghost no se añade.
+    assert len(charts) == 5
     chart_ids = {c["id"] for c in charts}
     assert "ghost_chart_does_not_exist" not in chart_ids
     # La annotation real sí se aplicó.


### PR DESCRIPTION
## Summary

Removes the **"Composición de clases por features categóricas"** stacked 100% bar chart from the Python-deterministic EDA panel for the `ml_ds + clasificacion` path.

The panel drops from **6 → 5 charts** to reduce LLM payload size and keep only the charts with the highest analytical signal.

---

## Charts removed

| ID | Title | Reason |
|---|---|---|
| `stacked_top2_categorical` | Composición de clases por features categóricas | Removed per product decision — low signal-to-payload ratio |

## Charts retained (in order)

1. `class_distribution` — Distribución de la variable objetivo
2. `missingness_heatmap` — Mapa de valores faltantes
3. `mutual_info_top8` — Top features por Mutual Information
4. `boxplots_top3_numeric` — Boxplots top features numéricas por clase
5. `pca_2d_scatter` — PCA 2D proyección coloreada por clase

---

## Files changed

| File | Change |
|---|---|
| `backend/src/case_generator/datagen/eda_charts_classification.py` | Delete `_build_stacked_top2_categorical()`, dead constants `_STACKED_TOP_K` / `_STACKED_MAX_CATEGORIES`, builder list entry, orphaned `categorical_cols` unpacking; update docstrings |
| `backend/src/case_generator/graph.py` | Update node docstring and defensive cap `> 6 → > 5` |
| `backend/src/case_generator/tools_and_schemas.py` | Update `EDAChartGeneratorOutput` docstring and Field description |
| `backend/src/case_generator/datagen/__init__.py` | Update package docstring |
| `backend/tests/test_issue237_eda_charts_classification.py` | Update 4 `len == 6 → 5` assertions, remove `stacked_top2_categorical` from `expected_ids` |

---

## Test results

```
905 passed, 14 skipped, 1 warning
```

All 10 `test_issue237_eda_charts_classification` tests pass. Full backend suite green.

---

## Checklist

- [x] No residual references to `stacked_top2_categorical` in source or tests
- [x] No residual `_STACKED_TOP_K` / `_STACKED_MAX_CATEGORIES` constants
- [x] Defensive cap updated to `> 5`
- [x] All docstrings updated to "5-chart"
- [x] `uv run --directory backend pytest -q` → 905 passed, 0 failures
- [x] No frontend changes needed (chart IDs consumed generically via `EDAChartSpec`)
