### PR TITLE
refactor(m2-eda): simplify solucion_esperada to single paragraph

### DIFF
--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -892,7 +892,7 @@ sesgo de confirmación y confusión entre correlación y causalidad.
 - Solo JSON schema. PROHIBIDO Markdown libre.
 - Toda pregunta referencia métricas, variables o gráficas reales y exactas del M2.
 - Las referencias a gráficos deben usar el `id` y `title` del `{chart_manifest}`.
-- El campo `literatura` debe basarse en tendencias conocidas del sector, sin inventar DOIs/URLs.
+- La referencia académica va integrada al final del párrafo `solucion_esperada` — sin inventar DOIs ni URLs.
 - **Idioma de salida: {output_language}**
 
 # Perfil del estudiante: {student_profile}

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -869,12 +869,7 @@ sesgo de confirmación y confusión entre correlación y causalidad.
     "numero": 1,
     "titulo": "string corto (≤8 palabras)",
     "enunciado": "string (pregunta completa referenciando datos reales del M2)",
-    "solucion_esperada": {{
-      "teoria": "string (concepto estadístico/analítico que el estudiante debe conocer, máx 40 palabras)",
-      "ejemplo": "string (ejemplo concreto del caso que ilustra el concepto, máx 40 palabras)",
-      "implicacion": "string (qué pasaría si el estudiante ignora este sesgo en su decisión, máx 40 palabras)",
-      "literatura": "string (referencia académica o tendencia conocida del sector, sin DOIs/URLs inventados, máx 30 palabras)"
-    }},
+    "solucion_esperada": "string (respuesta modelo en un párrafo fluido que integra concepto, ejemplo del caso e implicación ejecutiva; incluye referencia académica al final; máx 120 palabras; docente-only)",
     "bloom_level": "analysis|evaluation|synthesis",
     "chart_ref": "chart_01|chart_02|...|Ninguno",
     "exhibit_ref": "Exhibit 1|Exhibit 2|Dataset|Ninguno",
@@ -888,7 +883,9 @@ sesgo de confirmación y confusión entre correlación y causalidad.
 2. **Conecta:** Identifica el hallazgo más propenso a sesgo y la correlación más engañosa.
 3. **Diseña:** Preguntas que obliguen al estudiante a cuestionar lo que los datos PARECEN decir.
    Usa los IDs y títulos del `{chart_manifest}` para que las referencias sean precisas.
-4. **Redacta:** Cada campo de `solucion_esperada` por separado — son guías para el docente.
+4. **Redacta:** `solucion_esperada` como un párrafo fluido que integre el concepto, el ejemplo
+   concreto del caso y la implicación ejecutiva. Incluye la referencia académica al final.
+   Máx 120 palabras. No uses sub-campos ni estructuras anidadas — solo texto plano.
 5. **task_type siempre "text_response":** M2 no genera notebook — todas las preguntas son argumentativas.
 
 # Your Boundaries

--- a/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_questions.py
@@ -90,7 +90,7 @@ correlación/causalidad, sino los específicos de clasificación binaria:
 - Las referencias a gráficos: `chart_ref` contiene SOLO el `id` del chart (string exacto del
   manifest). Usa el `title` únicamente para identificar cuál chart seleccionar — nunca lo
   incluyas en el valor de `chart_ref`.
-- El campo `literatura` sin DOIs ni URLs inventados — solo referencia académica conocida.
+- La referencia académica va integrada al final del párrafo `solucion_esperada` — sin inventar DOIs ni URLs.
 - PROHIBIDO usar "sesgo de confirmación" o "correlación vs causalidad" como tema principal
   de P1 o P2 — esos pertenecen al prompt genérico para otras familias.
 - P1 es SIEMPRE accuracy_paradox (bloom: "analysis"), P2 es SIEMPRE precision_recall

--- a/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_questions.py
@@ -39,12 +39,7 @@ correlación/causalidad, sino los específicos de clasificación binaria:
       "numero": 1,
       "titulo": "string corto (≤8 palabras)",
       "enunciado": "string (pregunta completa que cita métricas y datos reales del M2)",
-      "solucion_esperada": {{
-        "teoria": "string (concepto estadístico/analítico que el estudiante debe conocer, máx 40 palabras)",
-        "ejemplo": "string (ejemplo concreto del caso que ilustra el concepto, máx 40 palabras)",
-        "implicacion": "string (consecuencia si el estudiante ignora este sesgo en su decisión, máx 40 palabras)",
-        "literatura": "string (referencia académica sin DOIs/URLs inventados, máx 30 palabras)"
-      }},
+      "solucion_esperada": "string (respuesta modelo en un párrafo fluido que integra concepto, ejemplo del caso e implicación ejecutiva; incluye referencia académica al final; máx 120 palabras; docente-only)",
       "bloom_level": "analysis",
       "chart_ref": "id del chart de distribución de clases del manifest, o null si no existe",
       "exhibit_ref": "Dataset",
@@ -54,12 +49,7 @@ correlación/causalidad, sino los específicos de clasificación binaria:
       "numero": 2,
       "titulo": "string corto (≤8 palabras)",
       "enunciado": "string (pregunta completa que cita threshold, churn rate y costo asimétrico reales del M2)",
-      "solucion_esperada": {{
-        "teoria": "string (máx 40 palabras)",
-        "ejemplo": "string (máx 40 palabras)",
-        "implicacion": "string (máx 40 palabras)",
-        "literatura": "string (sin DOIs/URLs inventados, máx 30 palabras)"
-      }},
+      "solucion_esperada": "string (respuesta modelo en un párrafo fluido; máx 120 palabras; docente-only)",
       "bloom_level": "synthesis",
       "chart_ref": "id del chart de correlación o scatter del manifest, o null si no hay uno relevante",
       "exhibit_ref": "Dataset",
@@ -88,7 +78,11 @@ correlación/causalidad, sino los específicos de clasificación binaria:
    - Exige que proponga un umbral concreto (ej: 0.3) con justificación cuantitativa.
 5. **Verifica** que cada pregunta obligue al estudiante a ir más allá de la métrica superficial
    (accuracy) hacia métricas de negocio (recall, F-beta, AUC-ROC, costo de retención).
-6. **task_type siempre "text_response"** — M2 no genera notebook; ambas preguntas son argumentativas.
+6. **Redacta solucion_esperada como un párrafo fluido** que integre el concepto estadístico,
+   el ejemplo concreto del caso y la implicación ejecutiva en una sola prosa coherente.
+   Incluye la referencia académica al final del párrafo. Máx 120 palabras. No uses
+   sub-campos ni estructuras anidadas — solo texto plano.
+7. **task_type siempre "text_response"** — M2 no genera notebook; ambas preguntas son argumentativas.
 
 # Your Boundaries
 - Solo JSON schema. PROHIBIDO Markdown libre fuera del JSON.
@@ -128,16 +122,13 @@ de estructura (sustituir X e Y con los valores reales del caso):
    poder predictivo sobre los clientes que se van? ¿Por qué el accuracy es una métrica engañosa
    en este contexto y qué alternativas debería usar el equipo para evaluar el modelo?"
 
-solucion_esperada:
-  teoria: "Accuracy paradox: un clasificador que predice siempre la clase mayoritaria obtiene
-    accuracy = proporción clase 0, sin ningún poder predictivo sobre la clase minoritaria."
-  ejemplo: (construir con el churn rate real de {eda_context}, ej: "Con churn 8%, un modelo
-    que siempre predice 'no churn' logra 92% accuracy capturando 0% de churners reales.")
-  implicacion: "Seleccionar LR o RF con threshold=0.5 en dataset 92/8 → el modelo 'funciona'
-    en accuracy pero pierde 40-60% de churners reales; el presupuesto de retención se dirige
-    al segmento equivocado."
-  literatura: "Chawla et al. (2002) 'SMOTE: Synthetic Minority Over-sampling Technique';
-    James et al. 'An Introduction to Statistical Learning' cap. sobre imbalanced data."
+solucion_esperada: (párrafo único, ej:)
+  "Con un churn rate del 8%, un modelo que siempre predice 'no churn' logra 92% de accuracy
+  sin capturar ni un solo churner real — eso es el accuracy paradox. Usar threshold=0.5 en
+  un dataset 92/8 implica que LR o RF 'funcionan' en accuracy pero el equipo pierde 40-60%
+  de churners reales y el presupuesto de retención se dirige al segmento equivocado. La
+  alternativa es evaluar con recall, F-beta (beta>1) o AUC-ROC. Ref: Chawla et al. (2002)
+  'SMOTE'; James et al. 'An Introduction to Statistical Learning' cap. sobre imbalanced data."
 
 chart_ref: id del chart de distribución de clases/target de {chart_manifest}
 exhibit_ref: "Dataset"
@@ -152,18 +143,14 @@ de estructura:
    Proponga un umbral concreto (distinto de 0.5) y justifique su elección usando F-beta con
    beta>1 o AUC-ROC. ¿Cómo afecta esta decisión la elección entre los modelos disponibles?"
 
-solucion_esperada:
-  teoria: "Precision-recall trade-off: bajar threshold de 0.5 a 0.3 aumenta recall (captura
-    más churners) a costa de reducir precision (más falsos positivos). F-beta con beta>1
-    penaliza más los falsos negativos que los positivos."
-  ejemplo: (construir con churn rate real de {eda_context}, ej: "Si churn rate = 8%,
-    threshold=0.5 → recall ~40%; threshold=0.3 → recall ~70% con +15pp de FP — la decisión
-    depende del ratio costo_retención / ingreso_perdido por churner.")
-  implicacion: "Elegir threshold=0.5 por default en datos imbalanceados → accuracy alta pero
-    KPI de negocio fallido: el equipo reporta 'modelo funciona' mientras pierde churners
-    reales y el churn rate no baja en producción."
-  literatura: "Provost & Fawcett 'Data Science for Business' (2013) cap. sobre costos
-    asimétricos; Fawcett (2006) 'An Introduction to ROC Analysis' Pattern Recognition Letters."
+solucion_esperada: (párrafo único, ej:)
+  "Bajar el threshold de 0.5 a 0.3 aumenta el recall capturando más churners a costa de más
+  falsos positivos — ese es el precision-recall trade-off. Con churn rate del 8%, threshold=0.5
+  puede dar recall ~40%; bajarlo a 0.3 sube el recall a ~70% con +15pp de falsos positivos.
+  La decisión depende del ratio costo_retención / ingreso_perdido por churner: si perder un
+  churner cuesta más que retener a un cliente leal, F-beta con beta>1 es la métrica correcta
+  sobre AUC-ROC. Ref: Provost & Fawcett 'Data Science for Business' (2013); Fawcett (2006)
+  'An Introduction to ROC Analysis' Pattern Recognition Letters."
 
 chart_ref: id del chart de correlación o scatter de {chart_manifest}, o null si no hay relevante
 exhibit_ref: "Dataset"

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -490,29 +490,18 @@ class GeneradorPreguntasM5Output(BaseModel):
 # MÓDULO 2 EDA — Preguntas Socráticas (aislado de PreguntaMinimalista)
 # ═══════════════════════════════════════════════════════
 
-class SolucionEsperadaEDA(BaseModel):
-    """Solución esperada estructurada para preguntas socráticas del EDA.
-    A diferencia de PreguntaMinimalista (string), este modelo descompone
-    la solución en campos semánticos para renderizado visual en el frontend.
-    """
-    teoria: str = Field(description="Concepto estadístico/analítico que el estudiante debe conocer (máx 40 palabras)")
-    ejemplo: str = Field(description="Ejemplo concreto del caso que ilustra el concepto (máx 40 palabras)")
-    implicacion: str = Field(description="Consecuencia si el estudiante ignora este sesgo en su decisión (máx 40 palabras)")
-    literatura: str = Field(description="Referencia académica o tendencia conocida del sector (sin DOIs/URLs inventados, máx 30 palabras)")
-
-
 class EDASocraticQuestion(BaseModel):
     """Pregunta socrática exclusiva del Módulo 2 EDA.
 
     Modelo AISLADO de PreguntaMinimalista para no romper M1, M3, M4, M5.
     Diferencias vs PreguntaMinimalista:
-      - solucion_esperada es SolucionEsperadaEDA (objeto) en vez de str
+      - solucion_esperada es str (párrafo único docente-only, máx 120 palabras)
       - task_type clasifica si la respuesta es texto o requiere notebook
     """
     numero: int = Field(description="Número secuencial de la pregunta (1 o 2)")
     titulo: str = Field(description="Título corto y descriptivo de la pregunta (≤8 palabras)")
     enunciado: str = Field(description="El cuerpo principal de la pregunta dirigido al estudiante")
-    solucion_esperada: SolucionEsperadaEDA = Field(description="Solución estructurada visible solo para el docente")
+    solucion_esperada: str = Field(description="Respuesta modelo en un párrafo fluido (máx 120 palabras, visible solo para el docente)")
     bloom_level: str = Field(description="Nivel Bloom: analysis|evaluation|synthesis")
     chart_ref: Optional[str] = Field(default=None, description="ID del gráfico referenciado (chart_01, etc.)")
     exhibit_ref: Optional[str] = Field(default=None, description="Exhibit 1|Exhibit 2|Dataset|Ninguno")

--- a/backend/tests/test_case_sanitization.py
+++ b/backend/tests/test_case_sanitization.py
@@ -44,10 +44,7 @@ def _build_canonical_output() -> dict[str, object]:
                     "numero": 2,
                     "titulo": "EDA 2",
                     "enunciado": "Interpreta el grafico.",
-                    "solucion_esperada": {
-                        "teoria": "Teoria",
-                        "ejemplo": "Ejemplo",
-                    },
+                    "solucion_esperada": "Teoria. Ejemplo.",
                     "task_type": "text_response",
                     "debug_logs": ["internal"],
                 }
@@ -75,10 +72,7 @@ def test_build_teacher_case_review_payload_keeps_solucion_esperada() -> None:
     assert payload["content"]["preguntaEje"] == "¿Debe la Junta priorizar retención selectiva?"
     assert payload["content"]["caseQuestions"][0]["solucion_esperada"] == "Solucion docente M1"
     assert "rubric" not in payload["content"]["caseQuestions"][0]
-    assert payload["content"]["edaQuestions"][0]["solucion_esperada"] == {
-        "teoria": "Teoria",
-        "ejemplo": "Ejemplo",
-    }
+    assert payload["content"]["edaQuestions"][0]["solucion_esperada"] == "Teoria. Ejemplo."
     assert payload["content"]["m5QuestionsSolutions"] == [
         {"numero": 5, "solucion_esperada": "Solucion separada M5"}
     ]

--- a/backend/tests/test_issue196_student_case_resolution.py
+++ b/backend/tests/test_issue196_student_case_resolution.py
@@ -148,12 +148,7 @@ def _build_canonical_output(title: str = "CrediAgil") -> dict[str, object]:
                     "numero": 2,
                     "titulo": "EDA 2",
                     "enunciado": "Interpreta el grafico.",
-                    "solucion_esperada": {
-                        "teoria": "Teoria",
-                        "ejemplo": "Ejemplo",
-                        "implicacion": "Implicacion",
-                        "literatura": "Literatura",
-                    },
+                    "solucion_esperada": "Teoria. Ejemplo. Implicacion. Literatura.",
                     "task_type": "text_response",
                 }
             ],

--- a/backend/tests/test_teacher_case_submission_detail.py
+++ b/backend/tests/test_teacher_case_submission_detail.py
@@ -131,10 +131,7 @@ def _build_canonical_output(*, include_m2: bool = True, include_m4: bool = True)
                 "numero": 2,
                 "titulo": "EDA 2",
                 "enunciado": "Interpreta el grafico.",
-                "solucion_esperada": {
-                    "teoria": "Teoria",
-                    "ejemplo": "Ejemplo",
-                },
+                "solucion_esperada": "Teoria. Ejemplo.",
                 "task_type": "text_response",
             }
         ]

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/toCanonicalCaseOutput.test.ts
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/toCanonicalCaseOutput.test.ts
@@ -163,12 +163,7 @@ describe("toCanonicalCaseOutput", () => {
                             titulo: "Hallazgo principal",
                             enunciado: "Interpreta el gráfico principal.",
                             task_type: "text_response",
-                            solucion_esperada: {
-                                teoria: "La variabilidad sugiere un proceso inestable.",
-                                ejemplo: "El percentil 95 revela dispersión entre cohortes.",
-                                implicacion: "Se requiere estandarizar el onboarding.",
-                                literatura: "Montgomery, control estadístico de procesos.",
-                            },
+                            solucion_esperada: "La variabilidad sugiere un proceso inestable con dispersión alta entre cohortes.",
                         },
                     ],
                 },
@@ -201,5 +196,54 @@ describe("toCanonicalCaseOutput", () => {
             titulo: "Hallazgo principal",
             task_type: "text_response",
         });
+    });
+
+    it("accepts legacy 4-field solucion_esperada from old DB records", () => {
+        const detail = createSubmissionDetailResponse({
+            case_view: {
+                studentProfile: null as never,
+                caseType: undefined,
+                content: {
+                    edaQuestions: [
+                        {
+                            numero: 1,
+                            titulo: "Sesgo de confirmación",
+                            enunciado: "¿Qué evidencia omitirías?",
+                            task_type: "text_response",
+                            solucion_esperada: {
+                                teoria: "El sesgo de confirmación filtra evidencia contraria.",
+                                ejemplo: "Solo se mira la tasa de aprobados.",
+                                implicacion: "Se toman decisiones sobre datos parciales.",
+                                literatura: "Kahneman, Thinking Fast and Slow.",
+                            } as unknown as string,
+                        },
+                    ],
+                },
+            },
+            modules: [
+                {
+                    id: "M2",
+                    title: "Módulo 2 · EDA",
+                    questions: [
+                        {
+                            id: "M2-Q1",
+                            order: 1,
+                            statement: "¿Qué evidencia omitirías?",
+                            context: "",
+                            expected_solution: "El sesgo de confirmación filtra evidencia contraria.",
+                            student_answer: "",
+                            student_answer_chars: 0,
+                            is_answer_from_draft: false,
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const result = toCanonicalCaseOutput(detail);
+        const edaQ = result.content.edaQuestions?.[0];
+
+        expect(typeof edaQ?.solucion_esperada).toBe("string");
+        expect((edaQ?.solucion_esperada as string).length).toBeGreaterThan(0);
     });
 });

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/toCanonicalCaseOutput.test.ts
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/toCanonicalCaseOutput.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import type { EDASocraticQuestion } from "@/shared/adam-types";
+
 import { toCanonicalCaseOutput } from "../toCanonicalCaseOutput";
 
 import { createSubmissionDetailResponse } from "./testData";
@@ -215,8 +217,8 @@ describe("toCanonicalCaseOutput", () => {
                                 ejemplo: "Solo se mira la tasa de aprobados.",
                                 implicacion: "Se toman decisiones sobre datos parciales.",
                                 literatura: "Kahneman, Thinking Fast and Slow.",
-                            } as unknown as string,
-                        },
+                            },
+                        } as unknown as EDASocraticQuestion,
                     ],
                 },
             },

--- a/frontend/src/features/teacher-case-submission-detail/toCanonicalCaseOutput.ts
+++ b/frontend/src/features/teacher-case-submission-detail/toCanonicalCaseOutput.ts
@@ -5,7 +5,6 @@ import type {
     EDAChartSpec,
     EDADepth,
     EDASocraticQuestion,
-    EDASolucionEsperada,
     M5QuestionSolution,
     PreguntaMinimalista,
     StudentProfile,
@@ -136,26 +135,22 @@ function sanitizeChartArray(value: unknown): EDAChartSpec[] | undefined {
     return charts.length > 0 ? charts : undefined;
 }
 
-function sanitizeEdaExpectedSolution(value: unknown): EDASolucionEsperada | null {
-    if (!isRecord(value)) {
-        return null;
+function sanitizeEdaExpectedSolution(value: unknown): string | null {
+    if (typeof value === "string" && value.trim()) {
+        return value;
     }
 
-    const teoria = readString(value.teoria);
-    const ejemplo = readString(value.ejemplo);
-    const implicacion = readString(value.implicacion);
-    const literatura = readString(value.literatura);
-
-    if (!teoria || !ejemplo || !implicacion || !literatura) {
-        return null;
+    if (isRecord(value)) {
+        // Backward compat: old DB records may store a 4-field {teoria, ejemplo, implicacion, literatura} object.
+        const parts = [value.teoria, value.ejemplo, value.implicacion, value.literatura]
+            .filter((v): v is string => typeof v === "string" && v.trim() !== "")
+            .map((v) => v.trim());
+        if (parts.length > 0) {
+            return parts.join(" ");
+        }
     }
 
-    return {
-        teoria,
-        ejemplo,
-        implicacion,
-        literatura,
-    };
+    return null;
 }
 
 function sanitizeMinimalQuestion(value: unknown): PreguntaMinimalista | null {

--- a/frontend/src/shared/adam-types.ts
+++ b/frontend/src/shared/adam-types.ts
@@ -37,19 +37,11 @@ export interface M5QuestionSolution {
     solucion_esperada: string;  // memorándum modelo docente-only para la decisión final
 }
 
-// Module 2 EDA questions use a richer structured answer schema.
-export interface EDASolucionEsperada {
-    teoria: string;
-    ejemplo: string;
-    implicacion: string;
-    literatura: string;
-}
-
 export interface EDASocraticQuestion {
     numero: number;
     titulo: string;
     enunciado: string;
-    solucion_esperada: EDASolucionEsperada;
+    solucion_esperada: string;
     bloom_level?: string;
     chart_ref?: string;
     exhibit_ref?: string;

--- a/frontend/src/shared/case-viewer/PreguntaCard.test.tsx
+++ b/frontend/src/shared/case-viewer/PreguntaCard.test.tsx
@@ -81,4 +81,32 @@ describe("PreguntaCard", () => {
         expect(screen.queryByText(/Solución Esperada/i)).not.toBeInTheDocument();
         expect(screen.queryByText("Conexión con la pregunta eje")).not.toBeInTheDocument();
     });
+
+    it("renders EDA question with legacy 4-field solucion_esperada without crashing", () => {
+        render(
+            <PreguntaCard
+                p={{
+                    numero: 2,
+                    titulo: "Sesgo EDA",
+                    enunciado: "¿Qué evidencia omitirías?",
+                    task_type: "text_response",
+                    solucion_esperada: {
+                        teoria: "El sesgo de confirmación filtra evidencia contraria.",
+                        ejemplo: "Solo se mira la tasa de aprobados.",
+                        implicacion: "Se toman decisiones sobre datos parciales.",
+                        literatura: "Kahneman, Thinking Fast and Slow.",
+                    },
+                } as unknown as PreguntaCardQuestion}
+                questionId="M2-Q1"
+                answer=""
+                onAnswerChange={vi.fn()}
+                readOnly={false}
+                showExpectedSolutions
+            />,
+        );
+
+        expect(screen.getByText("Solución Esperada — Solo Docentes")).toBeInTheDocument();
+        // Legacy fields are concatenated and rendered — at least one fragment is visible.
+        expect(screen.getByText(/sesgo de confirmaci/i)).toBeInTheDocument();
+    });
 });

--- a/frontend/src/shared/case-viewer/PreguntaCard.tsx
+++ b/frontend/src/shared/case-viewer/PreguntaCard.tsx
@@ -8,7 +8,8 @@ import { SolucionEsperadaRenderer } from "./SolucionEsperadaRenderer";
 export type QuestionRenderable = PreguntaMinimalista | EDASocraticQuestion;
 
 function isEDASocraticQuestion(question: QuestionRenderable): question is EDASocraticQuestion {
-    return "task_type" in question;
+    const t = (question as unknown as Record<string, unknown>).task_type;
+    return t === "text_response" || t === "notebook_task";
 }
 
 export function PreguntaCard({

--- a/frontend/src/shared/case-viewer/PreguntaCard.tsx
+++ b/frontend/src/shared/case-viewer/PreguntaCard.tsx
@@ -8,7 +8,7 @@ import { SolucionEsperadaRenderer } from "./SolucionEsperadaRenderer";
 export type QuestionRenderable = PreguntaMinimalista | EDASocraticQuestion;
 
 function isEDASocraticQuestion(question: QuestionRenderable): question is EDASocraticQuestion {
-    return typeof question.solucion_esperada === "object" && question.solucion_esperada !== null && "teoria" in question.solucion_esperada;
+    return "task_type" in question;
 }
 
 export function PreguntaCard({

--- a/frontend/src/shared/case-viewer/SolucionEsperadaRenderer.tsx
+++ b/frontend/src/shared/case-viewer/SolucionEsperadaRenderer.tsx
@@ -1,74 +1,26 @@
 import { marked } from "marked";
 
-import type { EDASolucionEsperada } from "@/shared/adam-types";
-
-export function SolucionEsperadaRenderer({ solucion }: { solucion: string | EDASolucionEsperada | undefined }) {
+export function SolucionEsperadaRenderer({ solucion }: { solucion: string | Record<string, unknown> | undefined }) {
     if (solucion === undefined || solucion === null) {
         return null;
     }
 
+    let text: string;
+
     if (typeof solucion === "string") {
-        const paragraphs = solucion.split(/\n\n+/).map((paragraph) => paragraph.trim()).filter(Boolean);
-
-        if (paragraphs.length === 4) {
-            const sections = [
-                { key: "C", label: "Concepto Teórico", bgClass: "bg-blue-100", textClass: "text-blue-700" },
-                { key: "A", label: "Aplicación al Caso", bgClass: "bg-emerald-100", textClass: "text-emerald-700" },
-                { key: "I", label: "Implicación Ejecutiva", bgClass: "bg-orange-100", textClass: "text-orange-700" },
-                { key: "M", label: "Marco Académico", bgClass: "bg-violet-100", textClass: "text-violet-700" },
-            ];
-
-            return (
-                <div className="space-y-3">
-                    {sections.map((section, index) => (
-                        <div key={section.key} className="flex items-start gap-2">
-                            <span className={`shrink-0 mt-0.5 w-5 h-5 rounded ${section.bgClass} ${section.textClass} flex items-center justify-center text-[10px] font-bold`}>
-                                {section.key}
-                            </span>
-                            <div>
-                                <strong className="text-amber-900 text-[11px] uppercase tracking-wider">{section.label}:</strong>
-                                <p className="text-amber-900/90 text-[13px] leading-relaxed mt-0.5">{paragraphs[index]}</p>
-                            </div>
-                        </div>
-                    ))}
-                </div>
-            );
-        }
-
-        const formatted = marked(solucion) as string;
-        return <div className="prose-case text-amber-900/90 text-[13px] leading-relaxed" dangerouslySetInnerHTML={{ __html: formatted }} />;
+        text = solucion;
+    } else {
+        // Backward compat: old DB records stored a {teoria, ejemplo, implicacion, literatura} object.
+        const parts = [solucion.teoria, solucion.ejemplo, solucion.implicacion, solucion.literatura]
+            .filter((v): v is string => typeof v === "string" && (v as string).trim() !== "")
+            .map((v) => (v as string).trim());
+        text = parts.join(" ");
     }
 
-    return (
-        <div className="space-y-3">
-            <div className="flex items-start gap-2">
-                <span className="shrink-0 mt-0.5 w-5 h-5 rounded bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold">T</span>
-                <div>
-                    <strong className="text-amber-900 text-[11px] uppercase tracking-wider">Teoría:</strong>
-                    <p className="text-amber-900/90 text-[13px] leading-relaxed mt-0.5">{solucion.teoria}</p>
-                </div>
-            </div>
-            <div className="flex items-start gap-2">
-                <span className="shrink-0 mt-0.5 w-5 h-5 rounded bg-emerald-100 text-emerald-700 flex items-center justify-center text-[10px] font-bold">E</span>
-                <div>
-                    <strong className="text-amber-900 text-[11px] uppercase tracking-wider">Ejemplo:</strong>
-                    <p className="text-amber-900/90 text-[13px] leading-relaxed mt-0.5">{solucion.ejemplo}</p>
-                </div>
-            </div>
-            <div className="flex items-start gap-2">
-                <span className="shrink-0 mt-0.5 w-5 h-5 rounded bg-orange-100 text-orange-700 flex items-center justify-center text-[10px] font-bold">I</span>
-                <div>
-                    <strong className="text-amber-900 text-[11px] uppercase tracking-wider">Implicación:</strong>
-                    <p className="text-amber-900/90 text-[13px] leading-relaxed mt-0.5">{solucion.implicacion}</p>
-                </div>
-            </div>
-            <div className="flex items-start gap-2">
-                <span className="shrink-0 mt-0.5 w-5 h-5 rounded bg-violet-100 text-violet-700 flex items-center justify-center text-[10px] font-bold">L</span>
-                <div>
-                    <strong className="text-amber-900 text-[11px] uppercase tracking-wider">Literatura:</strong>
-                    <p className="text-amber-900/90 text-[13px] leading-relaxed mt-0.5">{solucion.literatura}</p>
-                </div>
-            </div>
-        </div>
-    );
+    if (!text.trim()) {
+        return null;
+    }
+
+    const formatted = marked(text) as string;
+    return <div className="prose-case text-amber-900/90 text-[13px] leading-relaxed" dangerouslySetInnerHTML={{ __html: formatted }} />;
 }

--- a/frontend/src/shared/case-viewer/SolucionEsperadaRenderer.tsx
+++ b/frontend/src/shared/case-viewer/SolucionEsperadaRenderer.tsx
@@ -1,10 +1,23 @@
 import { Marked } from "marked";
 
-// Local marked instance that strips raw HTML blocks to prevent stored XSS via LLM-generated content.
-// Using a local instance avoids mutating the global marked configuration used elsewhere in the app.
+// Local marked instance that strips unsafe HTML from LLM-generated content.
+// - renderer.html: strips raw HTML blocks (e.g. <script>, <iframe>).
+// - renderer.link: allows only http/https/relative/anchor links; strips javascript:/data:/vbscript:
+//   by rendering the link text as plain text. Adds rel="noopener noreferrer" on external links.
+// Using a local instance avoids mutating the global marked config used by M1–M6 modules.
+const _SAFE_LINK_RE = /^https?:|^\/{1,2}|^#/;
 const _md = new Marked({
     renderer: {
         html: () => "",
+        link({ href, title, text }) {
+            if (!_SAFE_LINK_RE.test(href ?? "")) {
+                // Unsafe protocol (javascript:, data:, vbscript:, etc.) — render as plain text.
+                return text;
+            }
+            const titleAttr = title ? ` title="${title}"` : "";
+            const externalAttrs = /^https?:/.test(href ?? "") ? ' target="_blank" rel="noopener noreferrer"' : "";
+            return `<a href="${href}"${titleAttr}${externalAttrs}>${text}</a>`;
+        },
     },
 });
 

--- a/frontend/src/shared/case-viewer/SolucionEsperadaRenderer.tsx
+++ b/frontend/src/shared/case-viewer/SolucionEsperadaRenderer.tsx
@@ -1,4 +1,12 @@
-import { marked } from "marked";
+import { Marked } from "marked";
+
+// Local marked instance that strips raw HTML blocks to prevent stored XSS via LLM-generated content.
+// Using a local instance avoids mutating the global marked configuration used elsewhere in the app.
+const _md = new Marked({
+    renderer: {
+        html: () => "",
+    },
+});
 
 export function SolucionEsperadaRenderer({ solucion }: { solucion: string | Record<string, unknown> | undefined }) {
     if (solucion === undefined || solucion === null) {
@@ -21,6 +29,7 @@ export function SolucionEsperadaRenderer({ solucion }: { solucion: string | Reco
         return null;
     }
 
-    const formatted = marked(text) as string;
+    const formatted = _md.parse(text) as string;
     return <div className="prose-case text-amber-900/90 text-[13px] leading-relaxed" dangerouslySetInnerHTML={{ __html: formatted }} />;
+
 }

--- a/frontend/src/shared/case-viewer/SolucionEsperadaRenderer.tsx
+++ b/frontend/src/shared/case-viewer/SolucionEsperadaRenderer.tsx
@@ -1,22 +1,32 @@
 import { Marked } from "marked";
 
 // Local marked instance that strips unsafe HTML from LLM-generated content.
-// - renderer.html: strips raw HTML blocks (e.g. <script>, <iframe>).
-// - renderer.link: allows only http/https/relative/anchor links; strips javascript:/data:/vbscript:
-//   by rendering the link text as plain text. Adds rel="noopener noreferrer" on external links.
+// - renderer.html: strips raw HTML blocks and inline HTML (e.g. <script>, <iframe>).
+// - renderer.link: allows only http/https and site-relative (single slash or anchor) links.
+//   - Protocol-relative (//domain) and unsafe protocols (javascript:, data:, vbscript:) become plain text.
+//   - href and title are HTML-attribute-escaped to prevent attribute injection XSS.
+//   - External links get rel="noopener noreferrer" and open in a new tab.
 // Using a local instance avoids mutating the global marked config used by M1–M6 modules.
-const _SAFE_LINK_RE = /^https?:|^\/{1,2}|^#/;
+
+// Encode HTML special characters safe for use inside a double-quoted attribute value.
+const _esc = (s: string): string =>
+    s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+// Allow http/https and site-relative paths. Deliberately excludes protocol-relative (//domain)
+// as LLM-generated academic prose has no legitimate use for them.
+const _SAFE_LINK_RE = /^https?:|^\/(?!\/)|^#/;
 const _md = new Marked({
     renderer: {
         html: () => "",
         link({ href, title, text }) {
             if (!_SAFE_LINK_RE.test(href ?? "")) {
-                // Unsafe protocol (javascript:, data:, vbscript:, etc.) — render as plain text.
+                // Unsafe protocol (javascript:, data:, vbscript:, //, etc.) — render as plain text.
                 return text;
             }
-            const titleAttr = title ? ` title="${title}"` : "";
+            const safeHref = _esc(href ?? "");
+            const titleAttr = title ? ` title="${_esc(title)}"` : "";
             const externalAttrs = /^https?:/.test(href ?? "") ? ' target="_blank" rel="noopener noreferrer"' : "";
-            return `<a href="${href}"${titleAttr}${externalAttrs}>${text}</a>`;
+            return `<a href="${safeHref}"${titleAttr}${externalAttrs}>${text}</a>`;
         },
     },
 });


### PR DESCRIPTION
## Summary

Removes the structured SolucionEsperadaEDA schema (	eoria / ejemplo / implicacion / literatura) from M2 EDA Socratic questions and replaces it with a single plain paragraph string, matching how M1/M3/M4/M5 already work.

## Motivation

The 4-field breakdown was never surfaced as separate cards in the student view — it was docente-only guidance that ended up harder to read than a fluid paragraph. Teachers asked for a single coherent answer that integrates concept, case example, and executive implication.

## Changes

**Backend**
- 	ools_and_schemas.py: remove SolucionEsperadaEDA class; EDASocraticQuestion.solucion_esperada becomes str
- prompts/clasificacion/M2_clasificacion/eda_questions.py: collapse schema blocks to single string; update workflow step and filled examples
- prompts/__init__.py: same for generic fallback prompt (regresion/clustering/serie_temporal)
- Test fixtures in 	est_case_sanitization.py, 	est_issue196_student_case_resolution.py, 	est_teacher_case_submission_detail.py: plain strings instead of 4-field dicts

**Frontend**
- dam-types.ts: remove EDASolucionEsperada interface; solucion_esperada: string on EDASocraticQuestion
- 	oCanonicalCaseOutput.ts: rewrite sanitizeEdaExpectedSolution — accepts plain string (new) OR legacy 4-field object (backward compat: concatenates non-empty fields with space separator)
- SolucionEsperadaRenderer.tsx: simplified to one rendering path — legacy objects concatenated to string, then rendered via marked() in a prose-case div
- PreguntaCard.tsx: update isEDASocraticQuestion type guard from 'teoria' in solucion_esperada to 'task_type' in question (the only reliable structural distinguisher after both types now carry solucion_esperada: string)
- Tests: update existing EDA fixture; add backward-compat tests for 	oCanonicalCaseOutput and PreguntaCard with legacy 4-field objects

## Backward Compatibility

Old DB records that already have solucion_esperada: { teoria, ejemplo, implicacion, literatura } are handled silently: sanitizeEdaExpectedSolution and SolucionEsperadaRenderer both detect the object shape and concatenate the non-empty fields into a single paragraph string. No data loss.

## Validation

- Backend: **904 passed, 14 skipped**
- Frontend: **429 passed**, lint clean, build clean (tsc + vite)

## Architecture notes

- rontend_output_adapter.py required no changes — it passes doc2_preguntas_eda through _strip_question_metadata which only drops ubric; the serialized solucion_esperada string flows through unchanged.
- No migrations needed — solucion_esperada is stored inside a jsonb column (	ask_payload/case_output); old records degrade gracefully.