### PR TITLE
feat(#246): ConfusionMatrixDisplay en las 3 variantes de notebook clasificacion

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -35,6 +35,36 @@ de `task_payload` legacy y para LLMs con respuestas parcialmente no conformes.
 
 ---
 
+## TODO-CONFUSION-MULTICLASS: Extender confusion_matrix a casos multiclase
+
+**What:** La sección `# === SECTION:confusion_matrix ===` que se agrega en Issue #246 está
+protegida detrás de `if not is_binary or not can_model_binary: ...` — es decir, solo se
+ejecuta para clasificación binaria. Los casos multiclase (3+ clases) omiten la sección por
+completo con un `print(f"Bloque omitido: {modeling_skip_reason}")`.
+
+**Why:** La `ConfusionMatrixDisplay` es especialmente informativa en multiclase (matriz N×N
+con tasas de confusión entre clases). La restricción binaria actual cubre ~90% del catálogo
+Harvard ml_ds pero deja un gap pedagógico real para datasets como clasificación de tipos de
+crédito o segmentación de productos con 3+ categorías de respuesta.
+
+**Pros:** Elimina el mensaje de `Bloque omitido` para alumnos que trabajen con targets
+multiclase; los gráficos N×N normalizados por fila son didácticamente valiosos.
+
+**Cons:** Requiere redeseñar `comparison_table` y `cost_matrix` para multiclase (actualmente
+también binarias). La `cost_matrix` usa un sweep de thresholds que solo tiene sentido con
+probabilidades de clase positiva — en multiclase no hay un threshold único.
+
+**Context:** Esto NO se puede resolver solo en `confusion_matrix`: `cost_matrix` necesita ser
+rediseñada primero para multiclase, porque el notebook quedaría incoherente si se muestra
+una matriz multiclase pero la cost_matrix sigue asumiendo binario. La restricción actual es
+la posición correcta hasta que `cost_matrix` tenga un modo multiclase explícito.
+
+**Depends on / blocked by:** Rediseño de `cost_matrix` para multiclase (no existe aún).
+Una vez desbloqueado, quitar el guard `if not is_binary` en `confusion_matrix` y añadir
+`normalize="true"` para matrices N×N.
+
+---
+
 ## TODO-M2-B: Añadir dispatch de dataset para la familia regresión
 
 **What:** Crear `backend/src/case_generator/prompts/regresion/dataset.py` con

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -4042,6 +4042,7 @@ _FAMILY_PROHIBITED_PATTERNS: dict[str, tuple[str, ...]] = {
         "train_test_split(",
         "roc_auc_score",
         "confusion_matrix",
+        "ConfusionMatrixDisplay",
         "classification_report",
         "f1_score(",
         "mean_squared_error(",
@@ -4052,6 +4053,7 @@ _FAMILY_PROHIBITED_PATTERNS: dict[str, tuple[str, ...]] = {
         "train_test_split(",
         "roc_auc_score",
         "confusion_matrix",
+        "ConfusionMatrixDisplay",
         "classification_report",
         "silhouette_score(",
         "davies_bouldin_score(",
@@ -4061,6 +4063,7 @@ _FAMILY_PROHIBITED_PATTERNS: dict[str, tuple[str, ...]] = {
     "regresion": (
         "roc_auc_score",
         "confusion_matrix",
+        "ConfusionMatrixDisplay",
         "classification_report",
         "silhouette_score(",
         "davies_bouldin_score(",
@@ -4124,6 +4127,8 @@ _FAMILY_REQUIRED_SENTINELS: dict[str, tuple[str, ...]] = {
         "# === SECTION:roc_curves ===",
         "# === SECTION:pr_curves ===",
         "# === SECTION:comparison_table ===",
+        # Issue #246 — ConfusionMatrixDisplay normalizada por fila (umbral 0.5).
+        "# === SECTION:confusion_matrix ===",
         # Issue #238 — celda de threshold tuning con matriz de costos del negocio.
         "# === SECTION:cost_matrix ===",
         # Issue #240 — tuning + interpretabilidad avanzada (clasificacion ml_ds).
@@ -4151,6 +4156,10 @@ _FAMILY_REQUIRED_APIS: dict[str, tuple[str, ...]] = {
         # tienen que aparecer en código ejecutable, no solo en markdown.
         "confusion_matrix(",
         "predict_proba(",
+        # Issue #246 — celda confusion_matrix usa ConfusionMatrixDisplay para
+        # render visual normalizado por fila. Debe aparecer como import/call en
+        # código ejecutable, no solo en markdown.
+        "ConfusionMatrixDisplay",
         # Issue #240 — tuning + interpretabilidad avanzada para Harvard ml_ds.
         # tuning_lr usa GridSearchCV; tuning_rf usa RandomizedSearchCV;
         # interp_rf usa permutation_importance + PartialDependenceDisplay.
@@ -4170,6 +4179,7 @@ _CLASSIFICATION_REQUIRED_SENTINELS_BY_VARIANT: dict[str, tuple[str, ...]] = {
         "# === SECTION:roc_curves ===",
         "# === SECTION:pr_curves ===",
         "# === SECTION:comparison_table ===",
+        "# === SECTION:confusion_matrix ===",
         "# === SECTION:cost_matrix ===",
         "# === SECTION:tuning_lr ===",
         "# === SECTION:interp_lr ===",
@@ -4182,6 +4192,7 @@ _CLASSIFICATION_REQUIRED_SENTINELS_BY_VARIANT: dict[str, tuple[str, ...]] = {
         "# === SECTION:roc_curves ===",
         "# === SECTION:pr_curves ===",
         "# === SECTION:comparison_table ===",
+        "# === SECTION:confusion_matrix ===",
         "# === SECTION:cost_matrix ===",
         "# === SECTION:tuning_rf ===",
         "# === SECTION:interp_rf ===",
@@ -4201,6 +4212,7 @@ _CLASSIFICATION_REQUIRED_APIS_BY_VARIANT: dict[str, tuple[str, ...]] = {
         "train_test_split(",
         "confusion_matrix(",
         "predict_proba(",
+        "ConfusionMatrixDisplay",
         "GridSearchCV(",
     ),
     CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY: (
@@ -4213,6 +4225,7 @@ _CLASSIFICATION_REQUIRED_APIS_BY_VARIANT: dict[str, tuple[str, ...]] = {
         "train_test_split(",
         "confusion_matrix(",
         "predict_proba(",
+        "ConfusionMatrixDisplay",
         "RandomizedSearchCV(",
         "permutation_importance(",
         "PartialDependenceDisplay",

--- a/backend/src/case_generator/prompts/clasificacion/notebook.py
+++ b/backend/src/case_generator/prompts/clasificacion/notebook.py
@@ -264,7 +264,7 @@ L. **Atomic Cell Charting**: cada celda de
 
 M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO.**
    Antes del bloque per-algoritmo, emite la **Sección 3.0.5** descrita más
-   abajo en "Estructura OBLIGATORIA". Esa sección contiene OCHO celdas con
+   abajo en "Estructura OBLIGATORIA". Esa sección contiene NUEVE celdas con
    sentinelas contractuales que el validador post-LLM verifica:
      - `# === SECTION:dummy_baseline ===`     → bootstrap (target_col, y, feature_cols, X_raw, is_binary) + DummyClassifier (most_frequent + stratified)
      - `# === SECTION:pipeline_lr ===`        → Pipeline(ColumnTransformer + LogisticRegression)
@@ -273,6 +273,7 @@ M. **PEDAGOGÍA HARVARD ml_ds — bloque comparativo OBLIGATORIO.**
      - `# === SECTION:roc_curves ===`         → hold-out propio + curva ROC (LR vs RF) en una sola figura
      - `# === SECTION:pr_curves ===`          → curva Precision-Recall (LR vs RF) en una sola figura, reusando el hold-out
      - `# === SECTION:comparison_table ===`   → tabla pd.DataFrame final con las 7 columnas, hold-out reconstruido localmente
+     - `# === SECTION:confusion_matrix ===`   → ConfusionMatrixDisplay LR y RF en figura 1×2 (normalize="true"); umbral fijo 0.5; plt.show() #3 del bloque comparativo
      - `# === SECTION:cost_matrix ===`        → curva costo-vs-threshold con confusion_matrix + predict_proba; eje Y en `currency` del contrato; línea vertical roja en threshold óptimo y línea gris en 0.5
    Reglas:
    * Las sentinelas se emiten LITERALMENTE como primera línea de su celda
@@ -700,6 +701,47 @@ try:
             print(comparison.to_string(index=False))
 except Exception as e:
     print(f"⚠️ Tabla comparativa falló: {{e}}")
+
+# %% [markdown]
+# #### 3.0.5.8 Matriz de confusión (normalizada por fila)
+# Complemento visual de la tabla comparativa anterior. Muestra la tasa de
+# acierto por clase real (recall por clase) a umbral fijo 0.5.
+# Normalizar por fila es más informativo que conteos crudos en datasets
+# desbalanceados: un 95 % de TN junto a un 3 % de TP se leería como buen
+# rendimiento con conteos absolutos, pero la normalización lo expone.
+
+# %%
+# === SECTION:confusion_matrix ===
+try:
+  if not is_binary or not can_model_binary:
+    print(f"Bloque comparativo omitido: {{modeling_skip_reason}}")
+  else:
+        from sklearn.model_selection import train_test_split
+        from sklearn.metrics import ConfusionMatrixDisplay
+
+        _Xtr_cfm, _Xte_cfm, _ytr_cfm, _yte_cfm = train_test_split(
+            X_raw, y, test_size=0.2, random_state=42,
+            stratify=y if y.value_counts().min() >= 2 else None,
+        )
+        pipe_lr.fit(_Xtr_cfm, _ytr_cfm)
+        pipe_rf.fit(_Xtr_cfm, _ytr_cfm)
+        _ypred_lr_cfm = pipe_lr.predict(_Xte_cfm)
+        _ypred_rf_cfm = pipe_rf.predict(_Xte_cfm)
+
+        fig_cfm, axes_cfm = plt.subplots(1, 2, figsize=(10, 4))
+        ConfusionMatrixDisplay.from_predictions(
+            _yte_cfm, _ypred_lr_cfm, ax=axes_cfm[0],
+            colorbar=False, normalize="true", values_format=".2f",
+        )
+        axes_cfm[0].set_title("Matriz de confusión — LR (normalizada por fila)")
+        ConfusionMatrixDisplay.from_predictions(
+            _yte_cfm, _ypred_rf_cfm, ax=axes_cfm[1],
+            colorbar=False, normalize="true", values_format=".2f",
+        )
+        axes_cfm[1].set_title("Matriz de confusión — RF (normalizada por fila)")
+        plt.tight_layout(); plt.show()
+except Exception as e:
+    print(f"⚠️ Matriz de confusión falló: {{e}}")
 
 # %% [markdown]
 # ### 3.0.6 — Matriz de costos del negocio + threshold tuning

--- a/backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py
+++ b/backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py
@@ -133,11 +133,12 @@ def _replace_rule_m(prompt: str, variant: ClassificationNotebookVariant) -> str:
      - `SECTION:roc_curves`         → única figura ROC de la variante
      - `SECTION:pr_curves`          → cálculo AUC-PR sin plot adicional
      - `SECTION:comparison_table`   → tabla final con Dummy + modelo(s) seleccionado(s)
-     - `SECTION:cost_matrix`        → segunda y última figura: costo-vs-threshold
+     - `SECTION:confusion_matrix`   → ConfusionMatrixDisplay (normalize="true"); plt.show() #2 del bloque
+     - `SECTION:cost_matrix`        → tercera y última figura: costo-vs-threshold
      - `SECTION:metrics_summary_json` → marker JSON estable para grounding
    Reglas:
    * Nomenclatura heredada Rule L: Celda 2a (métricas), Celda 2b (visualización primaria), Celda 2c (importancia), Celda 2d (SHAP opcional).
-  * Máximo DOS celdas con llamada explícita de render en todo este bloque: ROC y matriz de costos.
+  * Máximo TRES celdas con llamada explícita de render en todo este bloque: ROC, matriz de confusión y matriz de costos.
    * Las sentinelas se emiten LITERALMENTE como primera línea de su celda `# %%`.
    * `dummy_baseline` fija `is_binary` y `can_model_binary`; cada celda posterior
      debe iniciar con `if not is_binary or not can_model_binary: ...`.
@@ -155,16 +156,16 @@ def _replace_rule_m(prompt: str, variant: ClassificationNotebookVariant) -> str:
 INTRO_BY_VARIANT: dict[ClassificationNotebookVariant, str] = {
     "lr_only": """## Sección 3.0.5 — Deep dive Logistic Regression
 ## Emite SOLO celdas LR. No generes código ni texto de modelos no seleccionados.
-## Las únicas celdas con gráficos son `roc_curves` y `cost_matrix`.
+## Las celdas con gráficos son: `roc_curves`, `confusion_matrix` y `cost_matrix`.
 
 """,
     "rf_only": """## Sección 3.0.5 — Deep dive Random Forest
 ## Emite SOLO celdas RF. No generes código ni texto de modelos no seleccionados.
-## Las únicas celdas con gráficos son `roc_curves` y `cost_matrix`.
+## Las celdas con gráficos son: `roc_curves`, `confusion_matrix` y `cost_matrix`.
 
 """,
     "lr_rf_contrast": """## Sección 3.0.5 — Contraste Logistic Regression vs Random Forest
-## Emite celdas LR y RF, manteniendo máximo dos gráficos totales: ROC y matriz de costos.
+## Emite celdas LR y RF, manteniendo tres gráficos totales: ROC, matriz de confusión y matriz de costos.
 
 """,
 }
@@ -598,10 +599,104 @@ except Exception as e:
 }
 
 
+CONFUSION_MATRIX_SECTIONS: dict[ClassificationNotebookVariant, str] = {
+    "lr_only": """
+# %% [markdown]
+# #### 3.0.5.8 Matriz de confusión — Logistic Regression (normalizada por fila)
+# Muestra la tasa de acierto por clase real a umbral fijo 0.5.
+# Normalizado por fila para que sea informativo en datasets desbalanceados.
+
+# %%
+# === SECTION:confusion_matrix ===
+try:
+  if not is_binary or not can_model_binary:
+    print(f"Bloque LR omitido: {{modeling_skip_reason}}")
+  else:
+    from sklearn.model_selection import train_test_split
+    from sklearn.metrics import ConfusionMatrixDisplay
+    _Xtr_cfm, _Xte_cfm, _ytr_cfm, _yte_cfm = train_test_split(
+        X_raw, y, test_size=0.2, random_state=42,
+        stratify=y if y.value_counts().min() >= 2 else None)
+    pipe_lr.fit(_Xtr_cfm, _ytr_cfm)
+    _ypred_lr_cfm = pipe_lr.predict(_Xte_cfm)
+    fig_cfm, ax_cfm = plt.subplots(figsize=(5, 4))
+    ConfusionMatrixDisplay.from_predictions(
+        _yte_cfm, _ypred_lr_cfm, ax=ax_cfm,
+        colorbar=False, normalize="true", values_format=".2f")
+    ax_cfm.set_title("Matriz de confusión — LR (normalizada por fila)")
+    plt.tight_layout(); plt.show()
+except Exception as e:
+  print(f"⚠️ Matriz de confusión LR falló: {{e}}")
+""",
+    "rf_only": """
+# %% [markdown]
+# #### 3.0.5.8 Matriz de confusión — Random Forest (normalizada por fila)
+# Muestra la tasa de acierto por clase real a umbral fijo 0.5.
+# Normalizado por fila para que sea informativo en datasets desbalanceados.
+
+# %%
+# === SECTION:confusion_matrix ===
+try:
+  if not is_binary or not can_model_binary:
+    print(f"Bloque RF omitido: {{modeling_skip_reason}}")
+  else:
+    from sklearn.model_selection import train_test_split
+    from sklearn.metrics import ConfusionMatrixDisplay
+    _Xtr_cfm, _Xte_cfm, _ytr_cfm, _yte_cfm = train_test_split(
+        X_raw, y, test_size=0.2, random_state=42,
+        stratify=y if y.value_counts().min() >= 2 else None)
+    pipe_rf.fit(_Xtr_cfm, _ytr_cfm)
+    _ypred_rf_cfm = pipe_rf.predict(_Xte_cfm)
+    fig_cfm, ax_cfm = plt.subplots(figsize=(5, 4))
+    ConfusionMatrixDisplay.from_predictions(
+        _yte_cfm, _ypred_rf_cfm, ax=ax_cfm,
+        colorbar=False, normalize="true", values_format=".2f")
+    ax_cfm.set_title("Matriz de confusión — RF (normalizada por fila)")
+    plt.tight_layout(); plt.show()
+except Exception as e:
+  print(f"⚠️ Matriz de confusión RF falló: {{e}}")
+""",
+    "lr_rf_contrast": """
+# %% [markdown]
+# #### 3.0.5.8 Matrices de confusión — LR y RF (normalizadas por fila)
+# Ambos modelos en una sola figura para comparación directa (Regla L atomic charting).
+# Normalizado por fila para que sea informativo en datasets desbalanceados.
+
+# %%
+# === SECTION:confusion_matrix ===
+try:
+  if not is_binary or not can_model_binary:
+    print(f"Bloque contraste omitido: {{modeling_skip_reason}}")
+  else:
+    from sklearn.model_selection import train_test_split
+    from sklearn.metrics import ConfusionMatrixDisplay
+    _Xtr_cfm, _Xte_cfm, _ytr_cfm, _yte_cfm = train_test_split(
+        X_raw, y, test_size=0.2, random_state=42,
+        stratify=y if y.value_counts().min() >= 2 else None)
+    pipe_lr.fit(_Xtr_cfm, _ytr_cfm)
+    pipe_rf.fit(_Xtr_cfm, _ytr_cfm)
+    _ypred_lr_cfm = pipe_lr.predict(_Xte_cfm)
+    _ypred_rf_cfm = pipe_rf.predict(_Xte_cfm)
+    fig_cfm, axes_cfm = plt.subplots(1, 2, figsize=(10, 4))
+    ConfusionMatrixDisplay.from_predictions(
+        _yte_cfm, _ypred_lr_cfm, ax=axes_cfm[0],
+        colorbar=False, normalize="true", values_format=".2f")
+    axes_cfm[0].set_title("Matriz de confusión — LR (normalizada por fila)")
+    ConfusionMatrixDisplay.from_predictions(
+        _yte_cfm, _ypred_rf_cfm, ax=axes_cfm[1],
+        colorbar=False, normalize="true", values_format=".2f")
+    axes_cfm[1].set_title("Matriz de confusión — RF (normalizada por fila)")
+    plt.tight_layout(); plt.show()
+except Exception as e:
+  print(f"⚠️ Matrices de confusión fallaron: {{e}}")
+""",
+}
+
+
 RF_INTERP_TABLE_ONLY_SECTION = """
 # %% [markdown]
 # ### 3.0.10 — Interpretabilidad RF: permutation importance tabular
-# Se evita un gráfico adicional para respetar el límite de dos figuras del notebook.
+# Se evita un gráfico adicional para respetar el presupuesto de tres figuras del notebook.
 
 # %%
 # === SECTION:interp_rf ===
@@ -641,7 +736,7 @@ try:
     perm_df = pd.DataFrame({{"feature": feature_names_rf, "importance_mean": perm.importances_mean, "importance_std": perm.importances_std}}).sort_values("importance_mean", ascending=False)
     print("Top 10 permutation importance (RF):")
     print(perm_df.head(10).to_string(index=False))
-    print("PartialDependenceDisplay disponible para análisis manual posterior; omitido aquí para respetar el límite de dos gráficos.")
+    print("PartialDependenceDisplay disponible para análisis manual posterior; omitido aquí para respetar el presupuesto de tres figuras.")
 except Exception as e:
   print(f"⚠️ Interpretabilidad RF falló: {{e}}")
 """
@@ -860,6 +955,7 @@ def build_classification_notebook_prompt(
     prompt = _replace_section(prompt, "# === SECTION:roc_curves ===", ROC_SECTIONS[variant])
     prompt = _replace_section(prompt, "# === SECTION:pr_curves ===", PR_SECTIONS[variant])
     prompt = _replace_section(prompt, "# === SECTION:comparison_table ===", COMPARISON_SECTIONS[variant])
+    prompt = _replace_section(prompt, "# === SECTION:confusion_matrix ===", CONFUSION_MATRIX_SECTIONS[variant])
     prompt = _replace_section(prompt, "# === SECTION:cost_matrix ===", COST_SECTIONS[variant])
     if variant in {"rf_only", "lr_rf_contrast"}:
         prompt = _replace_section(prompt, "# === SECTION:interp_rf ===", RF_INTERP_TABLE_ONLY_SECTION)

--- a/backend/tests/test_issue230_classification_notebook_variants.py
+++ b/backend/tests/test_issue230_classification_notebook_variants.py
@@ -148,8 +148,8 @@ def test_single_model_prompts_do_not_seed_unselected_model_text(
         ),
     ],
 )
-def test_variant_prompts_keep_two_chart_budget(prompt: str) -> None:
-    assert _executable_region(prompt).count("plt.show()") == 2
+def test_variant_prompts_keep_three_chart_budget(prompt: str) -> None:
+    assert _executable_region(prompt).count("plt.show()") == 3
 
 
 @pytest.mark.parametrize(
@@ -216,6 +216,7 @@ LR_ONLY_NOTEBOOK = """
 # === SECTION:roc_curves ===
 # === SECTION:pr_curves ===
 # === SECTION:comparison_table ===
+# === SECTION:confusion_matrix ===
 # === SECTION:cost_matrix ===
 # === SECTION:tuning_lr ===
 # === SECTION:interp_lr ===
@@ -223,7 +224,7 @@ LR_ONLY_NOTEBOOK = """
 from sklearn.compose import ColumnTransformer
 from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import confusion_matrix, precision_recall_curve, roc_curve
+from sklearn.metrics import ConfusionMatrixDisplay, confusion_matrix, precision_recall_curve, roc_curve
 from sklearn.model_selection import GridSearchCV, StratifiedKFold, cross_val_score, train_test_split
 
 dummy = DummyClassifier()
@@ -236,6 +237,7 @@ precision, recall, _ = precision_recall_curve(y_test, scores)
 matrix = confusion_matrix(y_test, y_test)
 probabilities = pipe_lr.predict_proba(X_test)
 search = GridSearchCV(pipe_lr, {}, cv=3)
+ConfusionMatrixDisplay.from_predictions(y_test, y_test)
 """
 
 RF_ONLY_NOTEBOOK = """
@@ -245,6 +247,7 @@ RF_ONLY_NOTEBOOK = """
 # === SECTION:roc_curves ===
 # === SECTION:pr_curves ===
 # === SECTION:comparison_table ===
+# === SECTION:confusion_matrix ===
 # === SECTION:cost_matrix ===
 # === SECTION:tuning_rf ===
 # === SECTION:interp_rf ===
@@ -253,7 +256,7 @@ from sklearn.compose import ColumnTransformer
 from sklearn.dummy import DummyClassifier
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.inspection import PartialDependenceDisplay, permutation_importance
-from sklearn.metrics import confusion_matrix, precision_recall_curve, roc_curve
+from sklearn.metrics import ConfusionMatrixDisplay, confusion_matrix, precision_recall_curve, roc_curve
 from sklearn.model_selection import RandomizedSearchCV, StratifiedKFold, cross_val_score, train_test_split
 
 dummy = DummyClassifier()
@@ -268,6 +271,7 @@ probabilities = pipe_rf.predict_proba(X_test)
 search = RandomizedSearchCV(pipe_rf, {}, n_iter=2)
 perm = permutation_importance(pipe_rf, X_test, y_test)
 PartialDependenceDisplay.from_estimator(pipe_rf, X_test, [0])
+ConfusionMatrixDisplay.from_predictions(y_test, y_test)
 """
 
 
@@ -297,6 +301,52 @@ def test_variant_validator_rejects_unselected_rf_in_lr_only() -> None:
 
     assert "RandomForestClassifier" in violations
     assert "pipe_rf" in violations
+
+
+@pytest.mark.parametrize(
+    ("variant", "prompt"),
+    [
+        pytest.param(
+            CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY,
+            M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LR_ONLY,
+            id="lr_only",
+        ),
+        pytest.param(
+            CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY,
+            M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_RF_ONLY,
+            id="rf_only",
+        ),
+        pytest.param(
+            CLASSIFICATION_NOTEBOOK_VARIANT_LR_RF_CONTRAST,
+            M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LR_RF_CONTRAST,
+            id="lr_rf_contrast",
+        ),
+    ],
+)
+def test_variant_prompts_contain_confusion_matrix_section(variant: str, prompt: str) -> None:
+    exec_region = _executable_region(prompt)
+    assert "# === SECTION:confusion_matrix ===" in exec_region
+    assert "ConfusionMatrixDisplay" in exec_region
+    assert 'normalize="true"' in exec_region
+
+
+def test_contrast_variant_confusion_matrix_uses_side_by_side_subplots() -> None:
+    exec_region = _executable_region(M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LR_RF_CONTRAST)
+    assert "plt.subplots(1, 2" in exec_region
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        pytest.param(M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LR_ONLY, id="lr_only"),
+        pytest.param(M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_RF_ONLY, id="rf_only"),
+    ],
+)
+def test_single_variant_confusion_matrix_does_not_use_side_by_side_subplots(
+    prompt: str,
+) -> None:
+    exec_region = _executable_region(prompt)
+    assert "plt.subplots(1, 2" not in exec_region
 
 
 def test_variant_validator_rejects_unselected_lr_in_rf_only() -> None:

--- a/backend/tests/test_issue238_cost_matrix.py
+++ b/backend/tests/test_issue238_cost_matrix.py
@@ -304,13 +304,16 @@ def test_required_sentinels_include_cost_matrix() -> None:
     sentinels = _FAMILY_REQUIRED_SENTINELS["clasificacion"]
     assert "# === SECTION:cost_matrix ===" in sentinels
     # Issue #239 amplía a 13 con metrics_summary_json, en el mismo diff que el executor.
-    assert len(sentinels) == 13
+    # Issue #246 amplía a 14 con confusion_matrix (ConfusionMatrixDisplay normalizada).
+    assert len(sentinels) == 14
 
 
 def test_required_apis_include_confusion_matrix_and_predict_proba() -> None:
     apis = _FAMILY_REQUIRED_APIS["clasificacion"]
     assert "confusion_matrix(" in apis
     assert "predict_proba(" in apis
+    # Issue #246 — ConfusionMatrixDisplay debe estar en el contrato de APIs.
+    assert "ConfusionMatrixDisplay" in apis
 
 
 def test_classification_prompt_emits_cost_matrix_sentinel_and_apis() -> None:

--- a/backend/tests/test_issue240_classification_tuning_interpretability.py
+++ b/backend/tests/test_issue240_classification_tuning_interpretability.py
@@ -207,8 +207,8 @@ def test_required_sentinels_extended_for_classification_only() -> None:
     cls = set(_FAMILY_REQUIRED_SENTINELS["clasificacion"])
     for sentinel in _NEW_SENTINELS:
         assert sentinel in cls
-    assert len(_FAMILY_REQUIRED_SENTINELS["clasificacion"]) == 13, (
-        f"expected 13 sentinels (8 prev + 4 issue240 + metrics summary), got "
+    assert len(_FAMILY_REQUIRED_SENTINELS["clasificacion"]) == 14, (
+        f"expected 14 sentinels (8 prev + 4 issue240 + metrics_summary_json + confusion_matrix), got "
         f"{len(_FAMILY_REQUIRED_SENTINELS['clasificacion'])}"
     )
     assert set(_FAMILY_REQUIRED_SENTINELS) == {"clasificacion"}
@@ -219,8 +219,8 @@ def test_required_apis_extended_for_classification_only() -> None:
     cls = set(_FAMILY_REQUIRED_APIS["clasificacion"])
     for token in _NEW_APIS:
         assert token in cls
-    assert len(_FAMILY_REQUIRED_APIS["clasificacion"]) == 13, (
-        f"expected 13 APIs (9 prev + 4 new), got "
+    assert len(_FAMILY_REQUIRED_APIS["clasificacion"]) == 14, (
+        f"expected 14 APIs (9 prev + 4 new + ConfusionMatrixDisplay), got "
         f"{len(_FAMILY_REQUIRED_APIS['clasificacion'])}"
     )
     assert set(_FAMILY_REQUIRED_APIS) == {"clasificacion"}
@@ -277,6 +277,7 @@ def test_validator_happy_path_with_full_2024_pedagogy() -> None:
         ")\n"
         "from sklearn.inspection import permutation_importance, PartialDependenceDisplay\n"
         "from sklearn.metrics import roc_curve, precision_recall_curve, confusion_matrix\n"
+        "from sklearn.metrics import ConfusionMatrixDisplay\n"
         "model = DummyClassifier(strategy='most_frequent')\n"
         "X_tr, X_te, y_tr, y_te = train_test_split(X, y, random_state=42)\n"
         "fpr, tpr, _ = roc_curve(y, scores)\n"
@@ -287,6 +288,7 @@ def test_validator_happy_path_with_full_2024_pedagogy() -> None:
         "search_rf = RandomizedSearchCV(model, {}, n_iter=2).fit(X_tr, y_tr)\n"
         "perm = permutation_importance(model, X_te, y_te)\n"
         "PartialDependenceDisplay.from_estimator(model, X_te, [0])\n"
+        "ConfusionMatrixDisplay.from_predictions(y_te, y_te)\n"
     )
     assert _validate_notebook_family_consistency("clasificacion", code) == []
 

--- a/backend/tests/test_m3_notebook_classification_hygiene.py
+++ b/backend/tests/test_m3_notebook_classification_hygiene.py
@@ -142,6 +142,7 @@ def test_prompt_still_renders_with_existing_substitution_vars() -> None:
 # Issue #240: 4 more sentinels (tuning_lr/tuning_rf/interp_lr/interp_rf) for
 # Harvard ml_ds tuning + advanced interpretability.
 # Issue #239: metrics_summary_json sentinel added atomically with the executor.
+# Issue #246: confusion_matrix sentinel added for ConfusionMatrixDisplay visual.
 _REQUIRED_SENTINELS = (
     "# === SECTION:dummy_baseline ===",
     "# === SECTION:pipeline_lr ===",
@@ -150,6 +151,7 @@ _REQUIRED_SENTINELS = (
     "# === SECTION:roc_curves ===",
     "# === SECTION:pr_curves ===",
     "# === SECTION:comparison_table ===",
+    "# === SECTION:confusion_matrix ===",
     "# === SECTION:cost_matrix ===",
     "# === SECTION:tuning_lr ===",
     "# === SECTION:tuning_rf ===",
@@ -176,6 +178,8 @@ _REQUIRED_API_TOKENS = (
     "RandomizedSearchCV(",
     "permutation_importance(",
     "PartialDependenceDisplay",
+    # Issue #246 — ConfusionMatrixDisplay visual normalizada por fila.
+    "ConfusionMatrixDisplay",
 )
 
 
@@ -255,6 +259,7 @@ def test_validator_passes_when_all_required_present() -> None:
         "from sklearn.model_selection import GridSearchCV, RandomizedSearchCV\n"
         "from sklearn.inspection import permutation_importance, PartialDependenceDisplay\n"
         "from sklearn.metrics import roc_curve, precision_recall_curve, confusion_matrix\n"
+        "from sklearn.metrics import ConfusionMatrixDisplay\n"
         "model = DummyClassifier(strategy='most_frequent')\n"
         "X_tr, X_te, y_tr, y_te = train_test_split(X, y, random_state=42)\n"
         "fpr, tpr, _ = roc_curve(y, scores)\n"
@@ -265,6 +270,7 @@ def test_validator_passes_when_all_required_present() -> None:
         "search_rf = RandomizedSearchCV(model, {}, n_iter=2).fit(X, y)\n"
         "perm = permutation_importance(model, X_te, y_te)\n"
         "PartialDependenceDisplay.from_estimator(model, X_te, [0])\n"
+        "ConfusionMatrixDisplay.from_predictions(y_te, y_te)\n"
     )
     assert _validate_notebook_family_consistency("clasificacion", code) == []
 

--- a/backend/tests/test_m3_notebook_dispatch.py
+++ b/backend/tests/test_m3_notebook_dispatch.py
@@ -78,6 +78,7 @@ CLEAN_CLASSIFICATION_CODE = """
 # === SECTION:roc_curves ===
 # === SECTION:pr_curves ===
 # === SECTION:comparison_table ===
+# === SECTION:confusion_matrix ===
 # === SECTION:cost_matrix ===
 # === SECTION:tuning_lr ===
 # === SECTION:tuning_rf ===
@@ -88,6 +89,7 @@ from sklearn.dummy import DummyClassifier
 from sklearn.compose import ColumnTransformer
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import roc_auc_score, confusion_matrix, roc_curve, precision_recall_curve
+from sklearn.metrics import ConfusionMatrixDisplay
 from sklearn.model_selection import StratifiedKFold, cross_val_score, train_test_split
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 from sklearn.inspection import permutation_importance, PartialDependenceDisplay
@@ -103,6 +105,7 @@ search_lr = GridSearchCV(model, {}, cv=3).fit(X_train, y_train)
 search_rf = RandomizedSearchCV(model, {}, n_iter=2).fit(X_train, y_train)
 perm = permutation_importance(model, X_test, y_test)
 PartialDependenceDisplay.from_estimator(model, X_test, [0])
+ConfusionMatrixDisplay.from_predictions(y_test, y_test)
 """
 
 CLEAN_CLUSTERING_CODE = """


### PR DESCRIPTION
## Summary

Adds a new `# === SECTION:confusion_matrix ===` section to all three Harvard ml_ds
classification notebook variants (`lr_only`, `rf_only`, `lr_rf_contrast`). The section
renders a `ConfusionMatrixDisplay` normalized by row (`normalize="true"`, `values_format=".2f"`)
at fixed threshold 0.5, placed between `comparison_table` and `cost_matrix` — making it the
2nd of 3 explicit `plt.show()` calls per Rule M.

## Changes

### Prompt layer
- **`notebook.py`** (legacy/contrast base): inserts the contrast `confusion_matrix` block
  (side-by-side 1x2 figure LR+RF); updates Rule M OCHO->NUEVE with the new sentinel entry
- **`notebooks/_shared.py`**: adds `CONFUSION_MATRIX_SECTIONS` per-variant dict —
  `lr_only`/`rf_only` use a single `plt.subplots(figsize=(5,4))` with one model;
  `lr_rf_contrast` uses `plt.subplots(1,2,figsize=(10,4))` with both models;
  updates `INTRO_BY_VARIANT` (2->3 charts) and `_replace_rule_m` (DOS->TRES);
  adds the `_replace_section` call in `build_classification_notebook_prompt`

### Validation layer
- **`graph.py`**: `_FAMILY_REQUIRED_SENTINELS["clasificacion"]` grows 13->14;
  `ConfusionMatrixDisplay` added to `_FAMILY_REQUIRED_APIS`; per-variant sentinel/API
  dicts updated; `ConfusionMatrixDisplay` added to `_FAMILY_PROHIBITED_PATTERNS` for
  `regresion`, `clustering`, `serie_temporal`

### Tests (4 new, several updated)
- **`test_issue230`**: chart budget renamed + updated 2->3; fixtures updated; 4 new tests:
  `test_variant_prompts_contain_confusion_matrix_section`,
  `test_contrast_variant_confusion_matrix_uses_side_by_side_subplots`,
  `test_single_variant_confusion_matrix_does_not_use_side_by_side_subplots`
- **`test_issue238`**: sentinel count 13->14; `ConfusionMatrixDisplay` API assertion added
- **`test_issue240`**: counts 13->14; happy-path fixture updated
- **`test_m3_notebook_classification_hygiene`** + **`test_m3_notebook_dispatch`**: fixtures updated

### Docs
- **`TODOS.md`**: adds `TODO-CONFUSION-MULTICLASS` (extend to multiclass; blocked on cost_matrix redesign)

## Test results

```
910 passed, 14 skipped -- 0 failures
```

## Notes
- Multiclass case is intentionally skipped with `if not is_binary or not can_model_binary`
  — see `TODO-CONFUSION-MULTICLASS` in TODOS.md
- All other families unaffected; `ConfusionMatrixDisplay` is now a prohibited pattern for
  regresion/clustering/serie_temporal
