### PR TITLE
feat(ui): remove (EDA) suffix from scope card label

### DIFF
--- a/frontend/src/features/teacher-authoring/AuthoringForm.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringForm.tsx
@@ -840,7 +840,7 @@ export function AuthoringForm({
                                                         </svg>
                                                     </div>
                                                     <div>
-                                                        <p className={`text-sm font-bold transition-colors ${caseType === "harvard_with_eda" ? "text-[#0144a0]" : "text-slate-600"}`}>Caso + Análisis de Datos (EDA)</p>
+                                                        <p className={`text-sm font-bold transition-colors ${caseType === "harvard_with_eda" ? "text-[#0144a0]" : "text-slate-600"}`}>Caso + Análisis de Datos</p>
                                                         <p className="text-xs text-slate-500 mt-1 leading-relaxed">Incluye análisis de datos, visualizaciones y, si aplica, notebook ejecutable en Google Colab.</p>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
## Summary

Remove the `(EDA)` suffix from the "Caso + Análisis de Datos (EDA)" scope card label in `AuthoringForm.tsx` so it reads **"Caso + Análisis de Datos"**.

## Change

- `frontend/src/features/teacher-authoring/AuthoringForm.tsx` — label text only, no logic changes.

## Validation

- [ ] `npm --prefix frontend run lint`
- [ ] `npm --prefix frontend run test`
- [ ] `npm --prefix frontend run build`