### PR TITLE
fix(eda): make business cohort heatmap legible and harden graph timeout

### DIFF
--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -67,6 +67,12 @@ SUPPORTED_CONTEXT_KEYS = [
 NARRATIVE_ARTIFACT_LIMIT = 30000
 EDA_ARTIFACT_LIMIT = 40000
 
+# End-to-end LangGraph execution budget per authoring job (~31 min). Raised from
+# 900s to accommodate ml_ds notebook execution + correction passes (issues #239/#240),
+# which can run long on heavy classification cases. Single source of truth — keep the
+# graph.py module docstring ("Timeout global") in sync if this changes.
+GRAPH_EXECUTION_TIMEOUT_SECONDS = 1900
+
 # Keep this list synchronized with frontend PIPELINE_STEPS ids in
 # frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx.
 CANONICAL_TIMELINE_STEP_IDS = (
@@ -1005,7 +1011,9 @@ class AuthoringService:
                 graph_task = register_authoring_task(
                     asyncio.create_task(_run_graph_stream(), name=f"authoring-job-{job_id}")
                 )
-                graph_output = await asyncio.wait_for(graph_task, timeout=900)
+                graph_output = await asyncio.wait_for(
+                    graph_task, timeout=GRAPH_EXECUTION_TIMEOUT_SECONDS
+                )
                 logger.info("AuthoringService: LangGraph execution finished for Job %s.", job_id)
             finally:
                 unregister_active_authoring_job(job_id)
@@ -1031,7 +1039,11 @@ class AuthoringService:
             )
             clean_room_reason = "authoring_checkpoint_bootstrap_timeout"
         except asyncio.TimeoutError:
-            logger.error("AuthoringService: TIMEOUT — Job %s exceeded 900s", job_id)
+            logger.error(
+                "AuthoringService: TIMEOUT — Job %s exceeded %ss",
+                job_id,
+                GRAPH_EXECUTION_TIMEOUT_SECONDS,
+            )
             error_code = "llm_timeout"
             error_msg = (
                 "Nuestros servidores de IA estan a maxima capacidad y el tiempo de espera se agoto. "

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -43,7 +43,7 @@ Resiliencia (v9):
   - .with_fallbacks: primary → gemini-2.5-flash automático en caída de API
   - Fallback graceful: todos los nodos LLM retornan sentinel en vez de raise
   - RetryPolicy: backoff exponencial (1s → 2s → 4s, max 30s, jitter ON)
-    - Timeout global: 900 segundos por job (authoring.py)
+    - Timeout global: 1900 segundos por job (authoring.GRAPH_EXECUTION_TIMEOUT_SECONDS)
   - AsyncPostgresSaver: checkpointer para resume-from-failure
     - get_graph(): singleton lazy por event loop para evitar reuse cruzado en tests/workers async
 """
@@ -1221,16 +1221,23 @@ def _calculate_eda_regressions(state: ADAMState, dataset: list[dict]) -> dict:
             key=lambda x: int(x.split("_m")[1])
         )
         if len(retention_cols) >= 2 and "period" in df.columns:
+            # Limita a las primeras MAX_COHORT_ROWS cohortes: legibles, todas
+            # históricas (empiezan en 2023-01 → sin fechas futuras) y las más
+            # observadas a M12. Sin recorte, las 80-120 filas del dataset business
+            # vuelven ilegible el heatmap y apilan las etiquetas de texto por celda
+            # en bandas verticales solapadas.
+            MAX_COHORT_ROWS = 12
+            cohort_df = df.head(MAX_COHORT_ROWS)
             # None en lugar de 0/NaN → Plotly los deja transparentes en el heatmap
             # (fillna(0) pintaría los huecos con el color más oscuro de la escala)
-            cohort_rounded = df[retention_cols].round(4)
+            cohort_rounded = cohort_df[retention_cols].round(4)
             cohort_z = [
                 [None if pd.isna(v) else float(v) for v in row]
                 for row in cohort_rounded.values.tolist()
             ]
             results["cohort_matrix"] = {
                 "x": [c.replace("retention_", "").upper() for c in retention_cols],
-                "y": df["period"].tolist(),
+                "y": cohort_df["period"].tolist(),
                 "z": cohort_z,
             }
 

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -774,6 +774,7 @@ Genera **EXACTAMENTE 3 gráficos** en este orden:
    - Tipo: `heatmap`
    - El motor Python inyectará la matriz de cohortes automáticamente. NO incluyas `x`, `y` ni `z` en el trace.
    - Dentro del trace incluye ÚNICAMENTE: `"type": "heatmap"`, `"colorscale": "YlOrRd"`, `"reversescale": true`, `"texttemplate": "%{{z:.0%}}"`, `"showscale": true`.
+   - En `layout` define `"yaxis": {{"type": "category", "title": "Cohorte"}}` y `"xaxis": {{"title": "Meses desde adquisición"}}` para que cada cohorte sea una fila etiquetada explícita.
    - Explicación Pedagógica: Mostrar la insostenibilidad del modelo actual observando cómo se degradan las cohortes mes a mes.
 
    **CASO B — Si NO existe `"cohort_matrix"` en `{precalculated_metrics}`:**

--- a/backend/tests/test_cohort_heatmap_row_cap.py
+++ b/backend/tests/test_cohort_heatmap_row_cap.py
@@ -1,0 +1,85 @@
+"""Tests for the business cohort-retention heatmap row cap.
+
+Surface tested:
+  - _calculate_eda_regressions caps cohort_matrix to the first MAX_COHORT_ROWS (12)
+    cohorts so the heatmap stays legible (the synthetic business dataset has 80-120
+    monthly cohorts, which rendered as illegible overlapping per-cell text).
+  - The cap preserves chronological order (first 12 ascending periods) and the
+    retention column axis (M1/M3/M6/M12), and z stays row-aligned with y.
+  - Datasets with fewer than 12 cohorts are returned uncapped.
+
+Cero LLMs, cero red, cero DB. Tests puros y rápidos.
+"""
+
+from __future__ import annotations
+
+from case_generator.graph import _calculate_eda_regressions
+
+
+def _make_cohort_dataset(n_rows: int) -> list[dict]:
+    """Build a synthetic business cohort dataset with ascending monthly periods.
+
+    Mirrors the deterministic generator: period 'YYYY-MM' ascending from 2023-01,
+    plus the four retention columns the M2 dataset contract defines.
+    """
+    rows: list[dict] = []
+    for i in range(n_rows):
+        year = 2023 + (i // 12)
+        month = (i % 12) + 1
+        rows.append(
+            {
+                "period": f"{year}-{month:02d}",
+                "revenue": 1000.0 + i,
+                "churn_rate": 0.10 + i * 0.001,
+                "retention_m1": 0.90 - i * 0.002,
+                "retention_m3": 0.75 - i * 0.002,
+                "retention_m6": 0.55 - i * 0.002,
+                "retention_m12": 0.35 - i * 0.002,
+            }
+        )
+    return rows
+
+
+def test_cohort_matrix_is_capped_to_twelve_rows() -> None:
+    """A 30-cohort dataset must yield exactly 12 rows in the heatmap matrix."""
+    dataset = _make_cohort_dataset(30)
+
+    result = _calculate_eda_regressions(state={}, dataset=dataset)
+
+    assert "cohort_matrix" in result
+    cohort = result["cohort_matrix"]
+    assert len(cohort["y"]) == 12
+    assert len(cohort["z"]) == 12
+    # z stays row-aligned with y and column-aligned with x.
+    assert all(len(row) == len(cohort["x"]) for row in cohort["z"])
+
+
+def test_cohort_matrix_keeps_first_twelve_chronological_cohorts() -> None:
+    """The cap selects the 12 earliest cohorts (chronological order preserved)."""
+    dataset = _make_cohort_dataset(30)
+
+    cohort = _calculate_eda_regressions(state={}, dataset=dataset)["cohort_matrix"]
+
+    expected_periods = [row["period"] for row in dataset[:12]]
+    assert cohort["y"] == expected_periods
+    assert cohort["y"][0] == "2023-01"
+    assert cohort["y"][-1] == "2023-12"
+
+
+def test_cohort_matrix_axis_labels_are_retention_months() -> None:
+    """x axis is the uppercased retention months (M1/M3/M6/M12)."""
+    dataset = _make_cohort_dataset(15)
+
+    cohort = _calculate_eda_regressions(state={}, dataset=dataset)["cohort_matrix"]
+
+    assert cohort["x"] == ["M1", "M3", "M6", "M12"]
+
+
+def test_cohort_matrix_below_cap_is_not_truncated() -> None:
+    """A dataset with fewer than 12 cohorts is returned in full."""
+    dataset = _make_cohort_dataset(5)
+
+    cohort = _calculate_eda_regressions(state={}, dataset=dataset)["cohort_matrix"]
+
+    assert len(cohort["y"]) == 5
+    assert len(cohort["z"]) == 5

--- a/frontend/src/shared/case-viewer/plotlyChartUtils.test.ts
+++ b/frontend/src/shared/case-viewer/plotlyChartUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeTraces } from "./plotlyChartUtils";
+
+function makeZ(rows: number, cols: number): number[][] {
+    return Array.from({ length: rows }, (_, r) =>
+        Array.from({ length: cols }, (_, c) => 0.5 + ((r + c) % 5) * 0.05),
+    );
+}
+
+function heatmap(
+    rows: number,
+    cols: number,
+    extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+    return { type: "heatmap", z: makeZ(rows, cols), colorscale: "YlOrRd", ...extra };
+}
+
+describe("sanitizeTraces — dense heatmap per-cell text handling", () => {
+    it("keeps the backend-provided texttemplate for a cohort-shaped (12×4) heatmap", () => {
+        const [out] = sanitizeTraces([
+            heatmap(12, 4, { texttemplate: "%{z:.0%}" }),
+        ]);
+
+        expect(out.texttemplate).toBe("%{z:.0%}");
+        expect(out.textfont).toBeDefined();
+    });
+
+    it("injects default text for a non-dense heatmap missing a texttemplate", () => {
+        const [out] = sanitizeTraces([heatmap(12, 4)]);
+
+        expect(out.texttemplate).toBe("%{z:.2f}");
+        expect(out.textfont).toEqual({ size: 11, color: "#ffffff" });
+    });
+
+    it("drops per-cell text on a dense (17×17 correlation-like) heatmap", () => {
+        const [out] = sanitizeTraces([
+            heatmap(17, 17, {
+                texttemplate: "%{z:.2f}",
+                textfont: { size: 11, color: "#ffffff" },
+            }),
+        ]);
+
+        expect(out.texttemplate).toBeUndefined();
+        expect(out.textfont).toBeUndefined();
+    });
+
+    it("treats a matrix as dense when only the column count exceeds 15", () => {
+        const [out] = sanitizeTraces([heatmap(4, 16, { texttemplate: "%{z:.2f}" })]);
+
+        expect(out.texttemplate).toBeUndefined();
+    });
+
+    it("keeps text at the 15×15 boundary (>15 is strict)", () => {
+        const [out] = sanitizeTraces([heatmap(15, 15, { texttemplate: "%{z:.2f}" })]);
+
+        expect(out.texttemplate).toBe("%{z:.2f}");
+    });
+
+    it("drops text once rows cross the boundary to 16", () => {
+        const [out] = sanitizeTraces([heatmap(16, 15, { texttemplate: "%{z:.2f}" })]);
+
+        expect(out.texttemplate).toBeUndefined();
+    });
+});

--- a/frontend/src/shared/case-viewer/plotlyChartUtils.ts
+++ b/frontend/src/shared/case-viewer/plotlyChartUtils.ts
@@ -151,11 +151,25 @@ export function sanitizeTraces(traces: Record<string, unknown>[]): Record<string
                 }
                 sanitized.zauto = false;
 
-                if (!sanitized.texttemplate) {
-                    sanitized.texttemplate = "%{z:.2f}";
-                }
-                if (sanitized.textfont == null) {
-                    sanitized.textfont = { size: 11, color: "#ffffff" };
+                const nRows = validation.normalizedZ.length;
+                const nCols = validation.normalizedZ[0]?.length ?? 0;
+                // Apunta a heatmaps densos (p.ej. la matriz de correlación ml_ds ~17×17).
+                // El heatmap de cohortes (12×4 tras el cap del backend MAX_COHORT_ROWS=12)
+                // NUNCA entra aquí y conserva su texto por celda vía el else.
+                const isDense = nRows > 15 || nCols > 15;
+                if (isDense) {
+                    // El texto por celda sobre una matriz densa se apila ilegible
+                    // en bandas solapadas. Dejar solo color + hover (aun si el
+                    // backend mandó texttemplate).
+                    delete sanitized.texttemplate;
+                    delete sanitized.textfont;
+                } else {
+                    if (!sanitized.texttemplate) {
+                        sanitized.texttemplate = "%{z:.2f}";
+                    }
+                    if (sanitized.textfont == null) {
+                        sanitized.textfont = { size: 11, color: "#ffffff" };
+                    }
                 }
             } else {
                 sanitized.z = [];


### PR DESCRIPTION
## Summary

Fixes the illegible **business cohort-retention heatmap**: the synthetic business dataset has 80–120 monthly cohorts, so the heatmap rendered with overlapping per-cell text in unreadable vertical bands.

### Cohort-heatmap fix
- **Backend** (`graph.py`): cap `cohort_matrix` to the 12 earliest cohorts (`MAX_COHORT_ROWS = 12`). The dataset is produced by the deterministic generator (`_generate_time_periods`, ascending `2023-01…`), so `head(12)` provably selects the 12 oldest cohorts — no `sort_values` needed.
- **Prompt** (`prompts/__init__.py`): the M2 EDA chart prompt now instructs the LLM to author an explicit `layout` (`yaxis: {type: category, title: "Cohorte"}`, `xaxis: {title: "Meses desde adquisición"}`) so each cohort is a labelled row. The engine still injects x/y/z.
- **Frontend** (`plotlyChartUtils.ts`): on dense (>15 rows/cols) heatmaps, drop per-cell `texttemplate`/`textfont` (keep color + hover). This targets the ml_ds ~17×17 correlation matrix; the 12×4 cohort heatmap keeps its labels (documented inline).

### Timeout hardening (kept on this branch by request)
The LangGraph end-to-end execution timeout was raised 900s → 1900s (~31 min) to fit ml_ds notebook execution + correction passes (issues #239/#240). Made production-grade here:
- extracted into the named constant `GRAPH_EXECUTION_TIMEOUT_SECONDS` (single source of truth);
- fixed two now-stale `900s` references (the timeout log in `authoring.py:1034` and the `graph.py` module docstring) that would otherwise misreport during a real timeout incident.

## Tests
- `backend/tests/test_cohort_heatmap_row_cap.py` — cap to 12 rows, chronological order preserved, `M1/M3/M6/M12` axis, uncapped below 12.
- `frontend/src/shared/case-viewer/plotlyChartUtils.test.ts` — dense (>15) drops text; 12×4 cohort and the 15×15 boundary keep text.

## Validation
- Backend: `pytest -q` → **920 passed, 14 skipped**; `mypy src` → **clean**.
- Frontend: `lint` clean, `test` → **444 passed**, `build` → **success**.

## Notes
Preceded by a 26-agent adversarial production-quality review. The core fix was confirmed sound and contract-safe; this PR additionally hardens the timeout and adds the test coverage the review flagged. Two local artifacts (`ADAM_pitch_profesores.pptx`, `adam-mockup-chatbot.html`) were deliberately left untracked and excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
