### PR TITLE
fix(dev): isolate pytest in a dedicated adam_test database so local data persists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,16 @@ npm --prefix frontend run test
 npm --prefix frontend run build
 ```
 
+The backend test suite runs against a **dedicated test database** (`adam_test`), never your
+development database. `backend/tests/conftest.py` (via `tests/_bootstrap_test_db.py`) rewrites
+`DATABASE_URL` to `adam_test` on the same local Postgres (host `5434`) before importing the app,
+so `pytest` — which does `DROP SCHEMA ... CASCADE` to rebuild the schema — can never wipe the
+users, profiles, and courses you created in the dev `postgres` database. CI keeps its own
+ephemeral `postgres` database (`GITHUB_ACTIONS=true` skips the rewrite). Override the local
+target with `TEST_DATABASE_URL`; the `_assert_local_schema_reset_target` guard refuses to reset
+anything but `adam_test` locally. To (re)create a working dev baseline after a deliberate reset or
+a fresh clone, run `uv run --directory backend python scripts/seed_dev.py` (idempotent).
+
 Issue 23 adds a migration test that creates and drops temporary databases. In the default
 local Docker Postgres this works with the `postgres` user. On other Postgres environments,
 the backend test suite now assumes `CREATE DATABASE` and `DROP DATABASE` privileges.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,16 @@ Use the repo-driven gstack runtime materialized from the pinned lock in `scripts
 - Frontend tests: `npm --prefix frontend run test`
 - Frontend build: `npm --prefix frontend run build`
 
+The backend test suite runs against a **dedicated test database** (`adam_test`), never your
+development database. `backend/tests/conftest.py` (via `tests/_bootstrap_test_db.py`) rewrites
+`DATABASE_URL` to `adam_test` on the same local Postgres (host `5434`) before importing the app,
+so `pytest` — which does `DROP SCHEMA ... CASCADE` to rebuild the schema — can never wipe the
+users, profiles, and courses you created in the dev `postgres` database. CI keeps its own
+ephemeral `postgres` database (`GITHUB_ACTIONS=true` skips the rewrite). Override the local
+target with `TEST_DATABASE_URL`; the `_assert_local_schema_reset_target` guard refuses to reset
+anything but `adam_test` locally. To (re)create a working dev baseline after a deliberate reset or
+a fresh clone, run `uv run --directory backend python scripts/seed_dev.py` (idempotent).
+
 Issue 23 adds a migration test that creates and drops temporary databases. In the default
 local Docker Postgres this works with the `postgres` user. On other Postgres environments,
 the backend test suite now assumes `CREATE DATABASE` and `DROP DATABASE` privileges.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,11 @@ Mientras GitHub no fuerce toda la proteccion de rama, el equipo adopta estas reg
 5. Abre un pull request.
 6. Usa `squash merge` cuando el PR este aprobado y con checks verdes.
 
-Si una migracion nueva endurece contratos de identidad o esquema, no parchees datos locales
-a mano para forzar que pase. Resetea la base local y vuelve a sembrarla antes de rerun
-`uv run --directory backend alembic upgrade head`.
+Correr `pytest` ya no borra tu base de desarrollo: la suite usa una base dedicada `adam_test`
+(ver `docs/runbooks/local-dev-auth.md`). Si una migracion nueva endurece contratos de
+identidad o esquema y necesitas una base limpia, no parchees datos a mano: resetea y vuelve a
+sembrar con `uv run --directory backend python scripts/seed_dev.py` (idempotente) antes de
+rerun `uv run --directory backend alembic upgrade head`.
 
 Si el cambio introduce SQL operativo fuera de Alembic, como `backend/sql/rls_policies.sql`,
 documenta explicitamente como y donde se aplica. No asumas que `alembic upgrade head`

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,6 +26,16 @@ DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/postgres
 # Example: postgresql+psycopg://postgres.<project_ref>:<password>@aws-0-<region>.pooler.supabase.com:6543/postgres
 # Keep ENVIRONMENT=production so shared.database selects NullPool for autoscaling workloads.
 
+# -- Test database (pytest) ---------------------------------------
+# The backend test suite NEVER uses the DATABASE_URL above. backend/tests/conftest.py
+# points pytest at a dedicated `adam_test` database on the same local Postgres, so running
+# tests can never wipe the users/profiles/courses you created in development.
+# Override only if you need a different test target (a guard rejects anything but adam_test locally):
+# TEST_DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5434/adam_test
+
+# Optional stable password for `scripts/seed_dev.py` accounts (else one is generated + printed).
+# SEED_DEV_PASSWORD=
+
 # -- Connection Pooling -------------------------------------------
 # Use DB_MAX_OVERFLOW=2 on Cloud Run (ephemeral instances).
 # Use DB_MAX_OVERFLOW=10 locally or on persistent VMs.

--- a/backend/scripts/seed_dev.py
+++ b/backend/scripts/seed_dev.py
@@ -1,0 +1,182 @@
+"""Idempotent local dev seed: a working university, accounts, and courses.
+
+Recreates a known baseline so you never have to click through the UI again after
+a deliberate database reset or a fresh clone. Safe to re-run: every entity is a
+get-or-create / upsert, so running it twice does not duplicate anything.
+
+It seeds two planes at once:
+  - Supabase Auth (local stack on :54321): the login users, via the same admin
+    client that ``scripts/provision_admin.py`` uses.
+  - App DB (local Postgres on :5434): profiles, memberships, the university, and
+    the courses, via the ORM.
+
+Prerequisites (see docs/runbooks/local-dev-auth.md):
+    docker compose up -d adam-edu-postgres   # app DB on 5434
+    supabase start                           # auth stack on 54321
+    uv run --directory backend alembic upgrade head
+
+Usage (from the repo root):
+    uv run --directory backend python scripts/seed_dev.py
+
+Login password: set ``SEED_DEV_PASSWORD`` in backend/.env for a stable password;
+otherwise a random one is generated and printed once. Seeded accounts do NOT
+require a password rotation, so you can log in immediately.
+"""
+
+# ruff: noqa: T201 — this is a CLI seeder; print is the intended output channel.
+
+from __future__ import annotations
+
+import secrets
+import string
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load backend/.env so DATABASE_URL and SUPABASE_* are available before the
+# shared.* singletons are constructed on import below.
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+from shared.auth import (  # noqa: E402 — must follow load_dotenv above
+    ensure_membership,
+    ensure_profile,
+    get_supabase_admin_client,
+)
+from shared.database import SessionLocal  # noqa: E402
+from shared.models import Course, Tenant  # noqa: E402
+
+DEV_UNIVERSITY_ID = "10000000-0000-0000-0000-000000000001"
+DEV_UNIVERSITY_NAME = "ADAM Dev University"
+
+# Stable login accounts. Dedicated @adam.local emails so the seed never collides
+# with accounts you create through the normal flow.
+SEED_ACCOUNTS: list[dict[str, str]] = [
+    {"email": "admin.dev@adam.local", "full_name": "Admin Dev", "role": "university_admin"},
+    {"email": "teacher.dev@adam.local", "full_name": "Profesor Dev", "role": "teacher"},
+    {"email": "student.dev@adam.local", "full_name": "Estudiante Dev", "role": "student"},
+]
+
+# Courses owned by the seeded teacher. Idempotent on (university_id, code, semester).
+SEED_COURSES: list[dict[str, object]] = [
+    {"code": "ADM-101", "title": "Analitica de Negocios I", "semester": "2026-I", "academic_level": "Pregrado", "max_students": 30},
+    {"code": "ADM-201", "title": "Ciencia de Datos Aplicada", "semester": "2026-I", "academic_level": "Maestría", "max_students": 25},
+]
+
+
+def _generate_temp_password(length: int = 20) -> str:
+    """Return a cryptographically secure temporary password."""
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def _resolve_password() -> tuple[str, bool]:
+    """Return (password, was_generated) honoring the SEED_DEV_PASSWORD knob."""
+    import os
+
+    configured = os.environ.get("SEED_DEV_PASSWORD", "").strip()
+    if configured:
+        return configured, False
+    return _generate_temp_password(), True
+
+
+def seed_dev() -> None:
+    """Create the dev university, login accounts, and courses (idempotent)."""
+    password, generated = _resolve_password()
+
+    try:
+        admin_client = get_supabase_admin_client()
+    except Exception as exc:  # pragma: no cover - environment guard
+        print(f"ERROR: no se pudo inicializar el cliente admin de Supabase: {exc}", file=sys.stderr)
+        print("Asegurate de que `supabase start` este corriendo y SUPABASE_* este en backend/.env.", file=sys.stderr)
+        sys.exit(1)
+
+    db = SessionLocal()
+    try:
+        # [1] University (tenant) — get-or-create.
+        tenant = db.get(Tenant, DEV_UNIVERSITY_ID)
+        if tenant is None:
+            tenant = Tenant(id=DEV_UNIVERSITY_ID, name=DEV_UNIVERSITY_NAME)
+            db.add(tenant)
+            db.flush()
+
+        # [2] Login accounts: Supabase Auth user + profile + membership.
+        teacher_membership_id: str | None = None
+        created_emails: list[str] = []
+        for account in SEED_ACCOUNTS:
+            result = admin_client.get_or_create_user_by_email(account["email"], password)
+            auth_user_id = result.user.id
+            if result.created:
+                created_emails.append(account["email"])
+
+            ensure_profile(db, user_id=auth_user_id, full_name=account["full_name"])
+            membership = ensure_membership(
+                db,
+                user_id=auth_user_id,
+                university_id=DEV_UNIVERSITY_ID,
+                role=account["role"],
+                must_rotate_password=False,
+            )
+            if account["role"] == "teacher":
+                teacher_membership_id = membership.id
+
+        db.flush()
+
+        # [3] Courses owned by the seeded teacher — get-or-create.
+        if teacher_membership_id is None:  # pragma: no cover - defensive
+            raise RuntimeError("seed teacher membership was not created")
+
+        created_courses: list[str] = []
+        for course_spec in SEED_COURSES:
+            existing = (
+                db.query(Course)
+                .filter(
+                    Course.university_id == DEV_UNIVERSITY_ID,
+                    Course.code == course_spec["code"],
+                    Course.semester == course_spec["semester"],
+                )
+                .first()
+            )
+            if existing is not None:
+                continue
+            db.add(
+                Course(
+                    university_id=DEV_UNIVERSITY_ID,
+                    teacher_membership_id=teacher_membership_id,
+                    title=course_spec["title"],
+                    code=course_spec["code"],
+                    semester=course_spec["semester"],
+                    academic_level=course_spec["academic_level"],
+                    max_students=course_spec["max_students"],
+                    status="active",
+                )
+            )
+            created_courses.append(str(course_spec["code"]))
+
+        db.commit()
+    except Exception as exc:
+        db.rollback()
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        db.close()
+
+    # [4] Summary. Keep output ASCII-only so it prints on Windows cp1252 consoles.
+    print("\n[OK] Seed de desarrollo aplicado (idempotente).")
+    print(f"  Universidad: {DEV_UNIVERSITY_NAME} ({DEV_UNIVERSITY_ID})")
+    print(f"  Cuentas: {', '.join(a['email'] for a in SEED_ACCOUNTS)}")
+    if created_emails:
+        print(f"  Nuevas en Supabase Auth: {', '.join(created_emails)}")
+    else:
+        print("  Las cuentas ya existian en Supabase Auth (contrasena sin cambios).")
+    if created_courses:
+        print(f"  Cursos creados: {', '.join(created_courses)}")
+    else:
+        print("  Los cursos ya existian.")
+    if generated and created_emails:
+        print(f"\n  Contrasena temporal (solo para cuentas nuevas): {password}")
+        print("  Para una contrasena estable, define SEED_DEV_PASSWORD en backend/.env y vuelve a correr.")
+
+
+if __name__ == "__main__":
+    seed_dev()

--- a/backend/tests/_bootstrap_test_db.py
+++ b/backend/tests/_bootstrap_test_db.py
@@ -1,0 +1,106 @@
+"""Bind the backend test suite to a dedicated ``adam_test`` database.
+
+Importing this module (which ``conftest.py`` does *before* any ``from shared.*``
+import) rewrites ``DATABASE_URL`` so the SQLAlchemy ``engine`` built inside
+``shared.database`` targets a throwaway test database instead of the developer's
+working database on ``localhost:5434/postgres``.
+
+This is what guarantees that running ``pytest`` never executes
+``DROP SCHEMA public CASCADE`` (see ``conftest.ensure_db_schema``) against the
+users, profiles and courses a developer created locally. CI
+(``GITHUB_ACTIONS=true``) keeps its own ephemeral database untouched.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+
+# Dedicated, throwaway database the test harness owns. It lives on the same
+# local Postgres container/port as the dev database, but under a different name,
+# so the dev database is never the DROP SCHEMA / TRUNCATE target.
+TEST_DB_NAME = "adam_test"
+_MAINTENANCE_DB_NAME = "postgres"
+
+
+def _read_database_url_from_env_file() -> str | None:
+    """Return ``DATABASE_URL`` parsed from ``backend/.env`` (best effort)."""
+    env_file = Path(__file__).resolve().parents[1] / ".env"
+    if not env_file.exists():
+        return None
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        if key.strip() == "DATABASE_URL":
+            return value.strip().strip('"').strip("'")
+    return None
+
+
+def _resolve_configured_database_url() -> str | None:
+    """Return the developer's configured ``DATABASE_URL`` (env wins over .env)."""
+    return os.environ.get("DATABASE_URL") or _read_database_url_from_env_file()
+
+
+def bootstrap_test_database_url() -> None:
+    """Point ``DATABASE_URL`` at the dedicated test database before app import.
+
+    Precedence:
+      1. CI (``GITHUB_ACTIONS=true``): leave ``DATABASE_URL`` untouched — CI uses
+         its own ephemeral Postgres service container.
+      2. ``TEST_DATABASE_URL`` set: use it verbatim (explicit override knob).
+      3. Otherwise: derive the dev URL with the database name swapped to
+         ``adam_test`` (driver/host/port/credentials preserved).
+    """
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        return
+
+    explicit = os.environ.get("TEST_DATABASE_URL")
+    if explicit:
+        os.environ["DATABASE_URL"] = explicit
+        return
+
+    configured = _resolve_configured_database_url()
+    if not configured:
+        return
+
+    test_url = make_url(configured).set(database=TEST_DB_NAME)
+    os.environ["DATABASE_URL"] = test_url.render_as_string(hide_password=False)
+
+
+def ensure_test_database_exists() -> None:
+    """Create the dedicated test database if it does not exist yet.
+
+    Connects to the server's maintenance database with ``AUTOCOMMIT`` because
+    ``CREATE DATABASE`` cannot run inside a transaction block. No-op in CI, where
+    the database is provisioned by the workflow service container.
+    """
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        return
+
+    target = make_url(os.environ["DATABASE_URL"])
+    if target.database in (None, _MAINTENANCE_DB_NAME):
+        # Defensive: never try to (re)create the maintenance database itself.
+        return
+
+    maintenance_url = target.set(database=_MAINTENANCE_DB_NAME)
+    maintenance_engine = create_engine(maintenance_url, isolation_level="AUTOCOMMIT")
+    try:
+        with maintenance_engine.connect() as connection:
+            already_exists = connection.execute(
+                text("SELECT 1 FROM pg_database WHERE datname = :name"),
+                {"name": target.database},
+            ).scalar()
+            if not already_exists:
+                # target.database is the module constant TEST_DB_NAME, never user input.
+                connection.execute(text(f'CREATE DATABASE "{target.database}"'))
+    finally:
+        maintenance_engine.dispose()
+
+
+# Run on import so the env var is set before conftest imports shared.app.
+bootstrap_test_database_url()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,25 +1,34 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Generator
-from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
 import os
 import threading
 import uuid
+from collections.abc import Callable, Generator
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 
-from alembic import command
-from alembic.config import Config
 import jwt
 import pytest
+
+# MUST import before any `from shared.*` below: importing this module rewrites
+# DATABASE_URL to point at the dedicated `adam_test` database, so the engine
+# built inside shared.database (via shared.app) never targets the dev database.
+from _bootstrap_test_db import TEST_DB_NAME, ensure_test_database_exists
+from alembic.config import Config
 from fastapi.testclient import TestClient
 from sqlalchemy import Connection, select, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, close_all_sessions, sessionmaker
 
+from alembic import command
 from shared.app import app
-from shared.auth import get_auth_settings, get_jwt_verifier, get_supabase_admin_auth_client
+from shared.auth import (
+    get_auth_settings,
+    get_jwt_verifier,
+    get_supabase_admin_auth_client,
+)
 from shared.database import (
     SessionLocal,
     clean_authoring_runtime,
@@ -29,9 +38,23 @@ from shared.database import (
     reset_session_factory_override,
     settings,
 )
-from shared.models import Base, Course, CourseAccessLink, CourseMembership, Invite, Membership, Profile, Syllabus, SyllabusRevision, Tenant, User
-from shared.syllabus_schema import TeacherSyllabusPayload, derive_syllabus_grounding_context
-
+from shared.models import (
+    Base,
+    Course,
+    CourseAccessLink,
+    CourseMembership,
+    Invite,
+    Membership,
+    Profile,
+    Syllabus,
+    SyllabusRevision,
+    Tenant,
+    User,
+)
+from shared.syllabus_schema import (
+    TeacherSyllabusPayload,
+    derive_syllabus_grounding_context,
+)
 
 _CHECKPOINT_TABLES = (
     "checkpoint_writes",
@@ -45,7 +68,14 @@ def _assert_local_schema_reset_target() -> None:
     allowed_hosts = {"localhost", "127.0.0.1"}
     if settings.environment == "production":
         raise RuntimeError("Refusing to reset test schema against a production database URL.")
-    is_repo_local_postgres = db_url.host in allowed_hosts and db_url.port == 5434
+    # Repo-local target MUST be the dedicated test database, never the dev DB.
+    # If the URL still points at the dev database (e.g. the bootstrap override
+    # did not run), refuse instead of dropping the developer's schema.
+    is_repo_local_test_db = (
+        db_url.host in allowed_hosts
+        and db_url.port == 5434
+        and db_url.database == TEST_DB_NAME
+    )
     is_github_actions_postgres = (
         os.getenv("GITHUB_ACTIONS") == "true"
         and db_url.host in allowed_hosts
@@ -53,10 +83,10 @@ def _assert_local_schema_reset_target() -> None:
         and db_url.database == "postgres"
         and db_url.username == "postgres"
     )
-    if not (is_repo_local_postgres or is_github_actions_postgres):
+    if not (is_repo_local_test_db or is_github_actions_postgres):
         raise RuntimeError(
             "Refusing to reset test schema outside approved local test targets "
-            "(repo-local localhost:5434 or GitHub Actions 127.0.0.1:5432/postgres, "
+            f"(repo-local localhost:5434/{TEST_DB_NAME} or GitHub Actions 127.0.0.1:5432/postgres, "
             f"got {db_url.host}:{db_url.port}/{db_url.database})."
         )
 
@@ -64,6 +94,7 @@ def _assert_local_schema_reset_target() -> None:
 def ensure_db_schema() -> None:
     """Recreate the local test schema from Alembic so checkpoint tables exist."""
     _assert_local_schema_reset_target()
+    ensure_test_database_exists()
     close_all_sessions()
     with engine.begin() as connection:
         connection.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))

--- a/docs/runbooks/local-dev-auth.md
+++ b/docs/runbooks/local-dev-auth.md
@@ -29,6 +29,14 @@ Este repo mantiene su base principal local fuera de Supabase CLI.
 No lo apuntes al Postgres interno de Supabase CLI.
 El launcher `uv run --directory backend python -m shared.app` ahora valida esto en startup y rechaza hosts remotos de Supabase cuando corres en `development`.
 
+### Tu data local no se borra al correr tests
+
+`pytest` reconstruye el esquema con `DROP SCHEMA public CASCADE`. Para que eso nunca toque tu base de desarrollo, la suite corre contra una base dedicada `adam_test` en el mismo Postgres local (`5434`): `backend/tests/conftest.py` reescribe `DATABASE_URL` a `adam_test` antes de importar la app, y un guardia se niega a resetear si el destino local no es `adam_test`. Tus usuarios, perfiles y cursos en la base `postgres` persisten entre cambios y entre corridas de tests. Puedes forzar otro destino con `TEST_DATABASE_URL`.
+
+### Seed de desarrollo: recrear una base de trabajo
+
+Si necesitas una base de trabajo desde cero (clon nuevo o reset deliberado), siembra una universidad, cuentas y cursos idempotentes con `uv run --directory backend python scripts/seed_dev.py`. Crea `admin.dev@adam.local`, `teacher.dev@adam.local` y `student.dev@adam.local` (sin rotacion de contrasena, con un par de cursos del profesor). Define `SEED_DEV_PASSWORD` en `backend/.env` para una contrasena estable; si no, se genera y se imprime una sola vez. Requiere `supabase start` para crear los usuarios de login en el stack local.
+
 ## Plano 2: auth local y tooling de Supabase
 
 Supabase CLI se usa para auth/session local y para obtener claves del stack local.


### PR DESCRIPTION
@
## Problem

Running `pytest` (which CLAUDE.md requires before every PR, and which `/ship`, `/qa`, `/review` all trigger) was destroying local development data on every run. The session-scoped `autouse` fixture `ensure_db_schema` executes `DROP SCHEMA public CASCADE` against `engine`, which was bound to the developers working database (`localhost:5434/postgres`). Profiles, memberships and courses were wiped each time — so a developer had to recreate users and courses from scratch after every change. (Supabase `auth.users` survived, but the lost profile/membership made logins unusable: `PROFILE_INCOMPLETE`.)

This was **not** a Docker/volume issue — the `adam-edu-postgres-data` volume persists correctly.

## Fix (test database isolation)

The suite now runs against a **dedicated `adam_test` database** on the same local Postgres (same container/port `5434`, different name), so the dev database is never the reset target.

- **`backend/tests/_bootstrap_test_db.py`** (new): before any `from shared.*` import, rewrites `DATABASE_URL` to `adam_test` (env-var precedence over `.env`) and creates the database if missing. No-op under `GITHUB_ACTIONS=true`, so CI keeps its ephemeral `postgres` DB. Override knob: `TEST_DATABASE_URL`.
- **`backend/tests/conftest.py`**: imports the bootstrap first (before `shared.app` builds the engine) and **hardens `_assert_local_schema_reset_target`** to refuse anything but `adam_test` locally — if the override ever fails to apply, the harness raises instead of dropping the dev schema.

## Recovery convenience

- **`backend/scripts/seed_dev.py`** (new): idempotent one-command dev baseline (university + admin/teacher/student accounts + courses), reusing `ensure_profile`/`ensure_membership` and the Supabase admin client. For fresh clones or deliberate resets.

## Docs

`docs/runbooks/local-dev-auth.md`, `backend/.env.example`, `CONTRIBUTING.md`, and the canonical `CLAUDE.md` + `AGENTS.md` (updated together per repo rules).

## Verification

- Sentinel row in dev DB **survives** a real `pytest` run; `adam_test` is created and used instead.
- Guard **refuses** (raises) when pointed at the dev `postgres` DB — no `DROP SCHEMA`.
- Full suite: **966 passed, 15 skipped**.
- `ruff` + `mypy src` clean.
- `seed_dev.py` runs and is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@