### PR TITLE
fix(eda): exclude zero-variance columns from EDA correlations (#294)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1264,3 +1264,56 @@ datos de Fase 0 antes de construir infra de cache explícito.
 
 **Depends on / blocked by:** Datos de Fase 0 (cuánto del costo es input estático) + confirmar
 soporte de context caching en `gemini-3.x-preview`.
+
+---
+
+## TODO-294-A: Investigar el origen aguas arriba de columnas numéricas constantes en el dataset sintético
+
+**What:** Rastrear por qué `_generate_dataset_from_schema` (`backend/src/case_generator/graph.py:2720`)
+emite una columna numérica de varianza cero en un dataset `business` de ~95 filas. Empezar por el
+loop de `independent_cols` (~línea 2778) y `_generate_independent_values`: la causa probable es una
+columna `int` con `range_min`/`range_max` muy próximos (o iguales, donde el guard `if low >= high:
+high = low + 1.0` deja un rango de 1) que tras el redondeo a entero produce todas las filas con el
+mismo valor. Prevenir la columna constante en el generador, o marcarla en `data_gap_warnings`.
+
+**Why:** El fix de Issue #294 (PR `fix/issue-294-eda-constant-column-corr`) trata el SÍNTOMA en el
+EDA (excluye las columnas constantes de la correlación para matar el `RuntimeWarning` de
+`np.corrcoef` y la "0 correlación" engañosa). Un dataset sintético de ~95 filas no debería tener
+una columna numérica de varianza cero en primer lugar — el origen del dato sigue abierto.
+
+**Pros:** Elimina el smell en la fuente; mejora el realismo del dataset para TODOS los casos, no solo
+el heatmap del EDA.
+
+**Cons:** Edita la lógica de generación del archivo más sensible del repo (`graph.py`, shape del
+schema), con mayor riesgo de regresión; requiere su propio repro y un schema de prueba que reproduzca
+el rango degenerado.
+
+**Context:** Detectado durante la implementación de Issue #294. El repro confirmó que el
+`RuntimeWarning` real venía de `Series.corr` (= `np.corrcoef`) en `graph.py:1239`, no de
+`DataFrame.corr` en 1183. El fix de EDA ya contiene el síntoma, así que este trabajo es
+independiente y de baja urgencia.
+
+**Depends on / blocked by:** PR de Issue #294 mergeado (síntoma ya contenido). Sin otros bloqueantes.
+
+---
+
+## TODO-294-B: Registrar columnas constantes excluidas en `data_gap_warnings`
+
+**What:** Cuando el fix de Issue #294 en `_calculate_eda_regressions` excluye una columna numérica
+constante, dejar una traza (p. ej. un append a `data_gap_warnings`) en vez de descartarla en
+silencio, para que docentes/devs vean el smell de datos.
+
+**Why:** La exclusión silenciosa oculta el mismo problema de calidad de datos que ataca
+[TODO-294-A]. Un breadcrumb hace visible la recurrencia sin reintroducir el `RuntimeWarning`.
+
+**Pros:** Señal barata de calidad de datos; conecta el síntoma (EDA) con su origen (generador).
+
+**Cons:** `_calculate_eda_regressions` hoy solo devuelve métricas precalculadas; cablear un warning
+implica confirmar la ruta de escritura de `data_gap_warnings` desde este nodo del grafo — un toque
+de contrato algo más amplio que el fix puramente local.
+
+**Context:** Diferido en la plan-eng-review de Issue #294 (TODO 2, decisión "A: add"). Conviene
+emparejarlo con [TODO-294-A] una vez confirmada la ruta de escritura de `data_gap_warnings`.
+
+**Depends on / blocked by:** Confirmar cómo se persiste `data_gap_warnings` desde el nodo de EDA.
+Idealmente junto con [TODO-294-A].

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -1176,9 +1176,18 @@ def _calculate_eda_regressions(state: ADAMState, dataset: list[dict]) -> dict:
         results: dict = {}
 
         # ── 1. Correlation matrix (siempre, independiente del target) ─────────
-        # Filtra solo numéricas, redondea, y reemplaza NaN (varianza cero) con 0
-        # para evitar errores de serialización JSON (json.dumps rechaza NaN nativo).
-        numeric_df = df.select_dtypes(include=["number"])
+        # Issue #294: una columna numérica de varianza cero (constante) tiene
+        # correlación INDEFINIDA (no 0). Incluirla hacía que Series.corr (np.corrcoef,
+        # usado más abajo contra el target) dividiera por std=0 y emitiera un
+        # RuntimeWarning, y que el heatmap mostrara una "0 correlación" engañosa.
+        # Calculamos las columnas constantes UNA vez y reutilizamos el set para la
+        # matriz y para las regresiones. fillna(0) queda solo como red de seguridad
+        # (json.dumps rechaza NaN nativo).
+        numeric_all = df.select_dtypes(include=["number"])
+        constant_cols = {
+            c for c in numeric_all.columns if numeric_all[c].nunique(dropna=True) <= 1
+        }
+        numeric_df = numeric_all.drop(columns=list(constant_cols))
         if len(numeric_df.columns) >= 2:
             corr_matrix = numeric_df.corr().round(2).fillna(0)
             results["correlation_matrix"] = {
@@ -1227,7 +1236,18 @@ def _calculate_eda_regressions(state: ADAMState, dataset: list[dict]) -> dict:
             else:
                 return results  # non-numeric target with >2 categories → skip regressions
 
-        numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
+        # Issue #294: un target constante haría que toda corr(feature, target) divida
+        # por std=0 (np.corrcoef). Sin regresiones útiles → devolvemos las matrices ya
+        # calculadas. (El fallback de _identify_target_variable es la última columna
+        # numérica, que podría ser justamente la constante.)
+        if target_col in constant_cols:
+            return results
+
+        numeric_cols = [
+            c
+            for c in df.select_dtypes(include=[np.number]).columns
+            if c not in constant_cols  # Issue #294: no correlacionar columnas constantes
+        ]
         if target_col in numeric_cols:
             numeric_cols.remove(target_col)
 

--- a/backend/tests/test_eda_correlation_constant_column.py
+++ b/backend/tests/test_eda_correlation_constant_column.py
@@ -1,0 +1,111 @@
+"""Tests for Issue #294 — zero-variance (constant) numeric columns in the EDA.
+
+Surface tested: `_calculate_eda_regressions` (a pure data-prep helper).
+
+A constant numeric column has an UNDEFINED Pearson correlation. Including it made
+`Series.corr` (pandas implements it as `np.corrcoef`, used at graph.py:1239 against the
+target) divide by std=0 and emit a `RuntimeWarning`, and made the heatmap show a
+misleading "0 correlation". The fix excludes constant columns from BOTH the correlation
+matrix and the regression loop, and skips regressions when the resolved target is itself
+constant.
+
+Detection note: we assert via `warnings.catch_warnings(record=True)` + `simplefilter("always")`
+and inspect the recorded list — NOT `simplefilter("error")`. The function wraps its body in a
+broad `try/except Exception` (graph.py:1266), and `RuntimeWarning` subclasses `Exception`, so a
+promoted warning would be swallowed and returned as `{}`, making an "it raises" assertion a no-op.
+
+Cero LLMs, cero red, cero DB. Tests puros y rápidos.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import warnings
+
+from case_generator.graph import _calculate_eda_regressions
+
+
+def _run_capturing_runtime_warnings(dataset: list[dict]) -> tuple[dict, list[warnings.WarningMessage]]:
+    """Call the helper while recording every warning; return (result, runtime_warnings)."""
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        result = _calculate_eda_regressions(state={}, dataset=dataset)
+    runtime = [w for w in recorded if issubclass(w.category, RuntimeWarning)]
+    return result, runtime
+
+
+def _dataset_with_constant_feature(n_rows: int = 95) -> list[dict]:
+    """Varying target ('revenue') + 2 varying numeric features + 1 constant feature."""
+    return [
+        {
+            "revenue": 1000.0 + i,        # target (heuristic matches 'revenue')
+            "marketing": 50.0 + (i % 7),  # varying feature
+            "visits": 200 - i,            # varying feature (anti-correlated with revenue)
+            "flat_col": 5,                # constant numeric feature — the offender
+        }
+        for i in range(n_rows)
+    ]
+
+
+# ── Branch C: regression loop / Series.corr(1239) — the real np.corrcoef site ──
+def test_constant_feature_emits_no_runtime_warning() -> None:
+    """A constant feature must not trigger the np.corrcoef RuntimeWarning at line 1239.
+
+    The dataset has a clear varying target ('revenue'), so the regression loop runs and a
+    `target_vs_*` key proves line 1239 was exercised (guards against a test that only hits
+    the matrix). On pre-fix code 'flat_col' reaches Series.corr(target) and warns.
+    """
+    result, runtime_warnings = _run_capturing_runtime_warnings(_dataset_with_constant_feature())
+
+    assert runtime_warnings == [], f"unexpected RuntimeWarning(s): {[str(w.message) for w in runtime_warnings]}"
+    assert any(k.startswith("target_vs_") for k in result), "regression loop did not run (line 1239 untested)"
+
+
+# ── Branch A: matrix excludes the constant column + strict-JSON serializable ──
+def test_constant_column_excluded_and_json_serializable() -> None:
+    """The constant column is absent from the matrix axes; z has no native NaN."""
+    result = _calculate_eda_regressions(state={}, dataset=_dataset_with_constant_feature())
+
+    matrix = result["correlation_matrix"]
+    assert "flat_col" not in matrix["x"] and "flat_col" not in matrix["y"]
+    assert "revenue" in matrix["x"]  # varying columns are kept
+    assert all(not math.isnan(v) for row in matrix["z"] for v in row)
+    # allow_nan=False makes json.dumps RAISE on native NaN (default would silently emit `NaN`).
+    json.dumps(result, allow_nan=False)
+
+
+# ── Branch B: fewer than 2 non-constant numeric columns → matrix omitted ──
+def test_single_varying_numeric_column_omits_matrix() -> None:
+    """One varying + one constant numeric column ⇒ no 'correlation_matrix' key.
+
+    Pre-fix both columns entered the matrix (2x2); post-fix only one non-constant column
+    remains, so the >=2-column guard drops the matrix entirely.
+    """
+    dataset = [
+        {"period": f"2023-{(i % 12) + 1:02d}", "segment": "A", "revenue": 1000.0 + i, "flat_col": 5}
+        for i in range(30)
+    ]
+
+    result = _calculate_eda_regressions(state={}, dataset=dataset)
+
+    assert "correlation_matrix" not in result
+
+
+# ── Constant-target guard: fallback target picker selects the constant last column ──
+def test_constant_target_emits_no_runtime_warning() -> None:
+    """When the resolved target is itself constant, regressions are skipped, not warned.
+
+    Column names avoid every `_identify_target_variable` heuristic keyword so it falls back
+    to the LAST numeric column ('gamma'), which is constant. Pre-fix every
+    feature.corr(constant_target) warns at line 1239; post-fix the guard returns early.
+    """
+    dataset = [
+        {"alpha": 1.0 + i, "beta": 100.0 - i, "gamma": 7}  # gamma constant + last numeric → target
+        for i in range(30)
+    ]
+
+    result, runtime_warnings = _run_capturing_runtime_warnings(dataset)
+
+    assert runtime_warnings == [], f"unexpected RuntimeWarning(s): {[str(w.message) for w in runtime_warnings]}"
+    assert not any(k.startswith("target_vs_") for k in result), "no regressions expected for a constant target"

--- a/backend/tests/test_eda_correlation_constant_column.py
+++ b/backend/tests/test_eda_correlation_constant_column.py
@@ -3,15 +3,15 @@
 Surface tested: `_calculate_eda_regressions` (a pure data-prep helper).
 
 A constant numeric column has an UNDEFINED Pearson correlation. Including it made
-`Series.corr` (pandas implements it as `np.corrcoef`, used at graph.py:1239 against the
-target) divide by std=0 and emit a `RuntimeWarning`, and made the heatmap show a
+`Series.corr` (pandas implements it as `np.corrcoef`, used in the regression loop against
+the target) divide by std=0 and emit a `RuntimeWarning`, and made the heatmap show a
 misleading "0 correlation". The fix excludes constant columns from BOTH the correlation
 matrix and the regression loop, and skips regressions when the resolved target is itself
 constant.
 
 Detection note: we assert via `warnings.catch_warnings(record=True)` + `simplefilter("always")`
-and inspect the recorded list — NOT `simplefilter("error")`. The function wraps its body in a
-broad `try/except Exception` (graph.py:1266), and `RuntimeWarning` subclasses `Exception`, so a
+and inspect the recorded list — NOT `simplefilter("error")`. `_calculate_eda_regressions` wraps
+its body in a broad `try/except Exception`, and `RuntimeWarning` subclasses `Exception`, so a
 promoted warning would be swallowed and returned as `{}`, making an "it raises" assertion a no-op.
 
 Cero LLMs, cero red, cero DB. Tests puros y rápidos.
@@ -109,3 +109,23 @@ def test_constant_target_emits_no_runtime_warning() -> None:
 
     assert runtime_warnings == [], f"unexpected RuntimeWarning(s): {[str(w.message) for w in runtime_warnings]}"
     assert not any(k.startswith("target_vs_") for k in result), "no regressions expected for a constant target"
+
+
+# ── All numeric columns constant (incl. an all-NaN float column) ──
+def test_all_constant_numeric_columns_no_warning_no_matrix() -> None:
+    """Every numeric column constant ⇒ no warning, no matrix; all-NaN column also excluded.
+
+    Recombines branch B (matrix omitted) with the constant-target guard, and locks in the
+    side effect that an all-NaN float column (nunique(dropna=True) == 0) is classified
+    constant and dropped. The result must stay strict-JSON serializable.
+    """
+    dataset = [
+        {"label": "A", "flat_int": 5, "flat_float": 2.0, "all_nan": float("nan")}
+        for _ in range(20)
+    ]
+
+    result, runtime_warnings = _run_capturing_runtime_warnings(dataset)
+
+    assert runtime_warnings == [], f"unexpected RuntimeWarning(s): {[str(w.message) for w in runtime_warnings]}"
+    assert "correlation_matrix" not in result
+    json.dumps(result, allow_nan=False)


### PR DESCRIPTION
## Summary

Fixes #294 — a zero-variance (constant) numeric column in the synthetic EDA dataset triggered `RuntimeWarning: invalid value encountered in divide` (from `np.corrcoef`) and made a constant column's *undefined* correlation render as a misleading "0" in the heatmap.

### Real call site (confirmed by repro) — corrects the issue's stated root cause

The issue/original plan pointed at `graph.py:1183` (`DataFrame.corr()`). A minimal repro under `warnings.simplefilter("error", RuntimeWarning)` showed that is **not** the emitter:

| call | implementation | warns? |
|---|---|---|
| `DataFrame.corr()` (line 1183) | Cython `libalgos.nancorr` | **no** |
| `Series.corr()` (line **1239**) | `np.corrcoef(a, b)[0,1]` | **yes** |

The captured stack pointed at `numpy/_function_base_impl.py:3023` ← **`graph.py:1239`** (`df[col].corr(df[target_col])` in the regression loop). A matrix-only fix would have left the warning in production. (Versions: numpy 2.4.4, pandas 3.0.2.)

## Change — `_calculate_eda_regressions` (one file, minimal diff)

Compute the constant-column set **once** and reuse it for both correlation paths:

1. **Matrix (1183):** drop constant columns before correlating → also fixes the misleading "0 correlation"; `fillna(0)` stays only as a serialization safety net.
2. **Regression loop (1239):** exclude constant columns from the feature list so `Series.corr` never divides by std=0.
3. **Constant-target guard:** `_identify_target_variable`'s fallback returns the *last numeric column*, which could itself be the constant one — so we skip regressions when the resolved target is constant (a constant target would make *every* `corr(feature, target)` warn).

No change to the `correlation_matrix = {x, y, z}` contract; `z` stays numeric (Plotly needs it). No prompt/LLM edits. `_inject_heatmap_matrices` is already None-safe, so a smaller/omitted matrix can't crash downstream.

## Tests — new `backend/tests/test_eda_correlation_constant_column.py` (pure: no DB/LLM/network)

4 tests, each **fails on `main`, passes with the fix**:
- `test_constant_feature_emits_no_runtime_warning` — no `RuntimeWarning`; asserts a `target_vs_*` key exists to prove line 1239 actually ran.
- `test_constant_column_excluded_and_json_serializable` — constant col absent from axes; `json.dumps(result, allow_nan=False)` does not raise.
- `test_single_varying_numeric_column_omits_matrix` — `<2` non-constant cols ⇒ no `correlation_matrix`.
- `test_constant_target_emits_no_runtime_warning` — fallback target is constant ⇒ regressions skipped, no warning.

**Detection note:** tests use `catch_warnings(record=True)`, **not** `simplefilter("error")` — the function's broad `try/except Exception` (line 1266) would swallow a promoted `RuntimeWarning` (`RuntimeWarning ⊂ Exception`), making an "it raises" assertion a no-op.

## Upstream data origin — deferred, not attacked

Why the generator emits a constant column in a ~95-row dataset (likely an `int` column with a near-zero `range_min`/`range_max` rounding flat) is out of scope here — editing generation logic in the most sensitive file is higher risk and the EDA fix already contains the symptom. Captured as **TODO-294-A** (source fix) and **TODO-294-B** (`data_gap_warnings` breadcrumb) in `TODOS.md`.

## Validation
- `uv run --directory backend pytest -q` → **970 passed, 15 skipped** (lone warning is a pre-existing unrelated sklearn `UserWarning`).
- `uv run --directory backend mypy src` → clean.
- `uv run --directory backend ruff check src/case_generator/graph.py --select F,I` → identical 3 pre-existing `I001` errors on `main` and this branch (**0 new**; they're unrelated import-sort issues in another function).

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)
