### PR TITLE
feat(business): honest Python-deterministic M2 charts + LR narrative for business profile

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -741,6 +741,107 @@ implementar de forma independiente en un PR posterior de bajo riesgo.
 
 **Depends on / blocked by:** Nuevo alcance de producto y endpoint backend dedicado para exponer y/o regenerar access links de forma autorizada. No bloquea #138.
 
+---
+
+## TODO-LR-M4M5: Conectar probabilidad LR ↔ impacto financiero en M4/M5 (business)
+
+**What:** Hacer que M4 (impacto económico) y M5 (resolución) del perfil business referencien
+explícitamente la decisión apoyada en regresión logística (probabilidad de abandono × valor del
+cliente en riesgo), en lenguaje gerencial. Hoy M4/M5 business caen al prompt default sin esa conexión.
+
+**Why:** La pregunta guía del caso ya pide priorizar "basándose en la probabilidad de abandono
+estimada por el modelo y el impacto financiero". El bloque LR de M3 (Issue 3A) abrió el arco; M4/M5
+aún no lo cierran.
+
+**Pros:** Coherencia narrativa completa del caso business+LR (M2→M3→M4→M5 alrededor del mismo modelo).
+
+**Cons:** Cruza el umbral de complejidad del cambio original; toca M4/M5 (área sensible) y posiblemente
+un dispatch business por familia; sube el riesgo cerca de entregas.
+
+**Context:** `_resolve_family_prompt` solo despacha para ml_ds; business usa el prompt default. La
+inserción debe ser análoga al bloque LR de M3 (gate `profile==business AND family==clasificacion`),
+empezando por `M4_CONTENT_GENERATOR_PROMPT` / `M5_CONTENT_GENERATOR_PROMPT` en `prompts/__init__.py`.
+Mantener lenguaje gerendial plano, sin jerga DS (igual que `M3_AUDIT_LR_BUSINESS_BLOCK`).
+
+**Depends on / blocked by:** Patrón de gate business+clasificacion introducido en el PR de
+"business LR + gráficos M2" (rama feature/business-lr-m2-charts).
+
+---
+
+## TODO-EDA-FAMILIES: Builder Python-determinista para regresión/clustering business
+
+**What:** Extender el path Python de charts EDA (hoy solo `clasificacion`) a `business+regresion` y
+`business+clustering`, reusando `datagen/eda_charts_common.py`.
+
+**Why:** Tras el PR de business+LR, solo clasificación tiene charts honestos deterministas para
+business; las otras familias siguen usando el path LLM-JSON (mismo riesgo de overclaim/charts malos).
+
+**Pros:** Calidad de charts uniforme en todas las familias del perfil business.
+
+**Cons:** Más builders + tests; fuera del caso de uso actual (clasificación/LR).
+
+**Context:** El dispatch en `graph.py::eda_chart_generator` gatea `primary_family == "clasificacion"`
+para enrutar a `_eda_business_python_path`. Replicar para regresión y clustering con sus charts
+propios (p. ej. real-vs-predicho para regresión; PCA 2D / elbow para clustering), reusando los
+helpers de `eda_charts_common.py` y el patrón de `eda_charts_business.py`.
+
+**Depends on / blocked by:** `eda_charts_common.py` y `eda_charts_business.py` introducidos en el PR
+de business+LR.
+
+---
+
+## TODO-OUTLIER-SCHEMA-AWARE: Inyección de outliers schema-aware (global, cross-profile)
+
+**What:** Reemplazar la heurística "primera columna numérica no-revenue × 3.5" de
+`_generate_dataset_from_schema` (graph.py, bloque `Fix B-05`) por una inyección de outliers
+controlada/declarada en el schema (qué columna, magnitud, cuántas filas).
+
+**Why:** La heurística "primera columna" es ciega y puede caer en una columna donde el outlier
+engaña la lectura (p. ej. `costs` → margen roto). El PR de business+LR solo mitiga el síntoma en
+business (excluye columnas financieras del target del outlier); ml_ds sigue con la heurística ciega.
+
+**Pros:** Outliers intencionales y pedagógicamente coherentes; menos artefactos engañosos en cualquier
+perfil; elimina la inconsistencia cost/margin latente en ml_ds.
+
+**Cons:** Toca el generador de datos compartido (afecta ml_ds — área sensible); requiere tests de
+regresión sobre notebooks ml_ds (AUC) que dependen de la distribución del dataset.
+
+**Context:** Ver el bloque `Fix B-05` en `_generate_dataset_from_schema` (graph.py). El PR de
+business+LR añadió un parámetro `profile` y excluye columnas financieras (revenue/cost/margin/ebitda)
+solo para business. La solución global declararía la inyección en el contrato del schema
+(`SCHEMA_DESIGNER_PROMPT`) en vez de inferirla por posición de columna.
+
+**Depends on / blocked by:** Coordinar con la reconciliación introducida en el PR de business+LR
+(parámetro `profile` en `_generate_dataset_from_schema`).
+
+---
+
+## TODO-EDA-BUILDER-POLISH: Pulido cosmético de los builders EDA Python (DRY + tono business)
+
+**What:** Dos nits cosméticos surgidos en la review adversarial del PR business+LR, diferidos por
+tocar el path de clasificación (sensible) para beneficio estético: (1) extraer un factory
+`chart_spec(...)` en `eda_charts_common.py` que colapse las 5 claves boilerplate del camino de
+éxito (library/description/notes/data_source/template), hoy repetidas en 7 dicts (4 business + 3
+clasificación); (2) suavizar la frase "qué riesgo de modelado anticipa" en
+`prompts/clasificacion/M2_clasificacion/eda_annotate.py:41` a un encuadre neutral de perfil
+(p. ej. "qué riesgo de decisión o de los datos anticipa"), o crear un
+`EDA_ANNOTATE_ONLY_PROMPT_BUSINESS` con tono gerencial coherente con `M3_AUDIT_LR_BUSINESS_BLOCK`.
+
+**Why:** (1) elimina duplicación residual (preferencia DRY del equipo); (2) el path business
+reutiliza el alias del prompt de clasificación, cuyo único rastro DS ("riesgo de modelado") riñe
+levemente con la regla "sin jerga DS" del perfil business.
+
+**Pros:** Builders más DRY y tono de anotaciones business 100% coherente.
+
+**Cons:** El factory refactoriza el builder de clasificación (ml_ds), que está verde y es sensible;
+la frase del annotate es compartida con ml_ds. Ambos son nits sin impacto de runtime.
+
+**Context:** Review adversarial del PR business+LR (verdict ship, 0 blockers). El factory es la
+duplicación que `eda_charts_common.py` aún no cubrió (solo extrajo `empty_chart`/`source_label`).
+La opción más limpia para (2) es un prompt business dedicado, pero añade superficie.
+
+**Depends on / blocked by:** Ninguno. Independiente; hacerlo cuando se toque el área de charts EDA.
+
 **Context:** Aceptado durante la revision de rediseño de Issue #127. El objetivo es que la solucion de clean-room sea invisible para quien escriba nuevos tests, pero explicita para quien mantenga el runtime. La documentacion debe referenciar el contrato centralizado una vez exista como superficie canonica.
 
 **Depends on / blocked by:** Depende de cerrar primero la implementacion de Issue #127 y de fijar cuales helpers quedan como API operativa estable para clean-room y diagnostico.

--- a/backend/src/case_generator/datagen/eda_charts_business.py
+++ b/backend/src/case_generator/datagen/eda_charts_business.py
@@ -1,0 +1,421 @@
+"""Python-deterministic 3-chart EDA panel for the BUSINESS profile.
+
+Mirror of ``eda_charts_classification.py`` (ml_ds) for the business audience.
+No LLM call builds the numbers — the LLM only annotates description/notes
+afterwards. This kills the class of bug where the legacy LLM-JSON path forced a
+dual-axis line chart and over-claimed correlations the data did not support.
+
+Pipeline (no LLM calls; pandas only):
+
+    df: pd.DataFrame   target_col: str   precalculated_metrics: dict   contract: dict
+         │                  │                      │                       │
+         └──────────────────┴──────────┬───────────┴───────────────────────┘
+                                        ▼
+        generate_business_eda_charts(df, target_col, precalculated_metrics, contract)
+                                        │
+                                        ▼
+   ┌────────────────────────────────────────────────────────────────────────────┐
+   │  1. financial_mirage   (scatter, líneas)   ingresos vs margen INDEXADOS      │
+   │                                            base 100 → una sola escala honesta │
+   │  2. churn_drivers      (bar horizontal)    |corr| reales con el objetivo,    │
+   │                                            eje fijo [0,1] → sin exagerar      │
+   │  3. cohort_collapse    (heatmap)           retención por cohorte             │
+   │                                            (reusa precalculated cohort_matrix)│
+   └────────────────────────────────────────────────────────────────────────────┘
+                                        ▼
+            list[EDAChartSpec]  (data_source="python_builder",
+                                  description="" / notes="" → LLM annotates)
+
+Honestidad por diseño (anti-overclaim del bug del –0.89):
+  * `financial_mirage` indexa ambas series a base 100 → comparables en UN eje
+    (sin doble-eje engañoso). Si los datos no muestran un colapso dramático,
+    el gráfico tampoco lo inventa.
+  * `churn_drivers` muestra la correlación ABSOLUTA real de cada variable con el
+    objetivo en un eje fijo [0, 1]; si ninguna supera |r|≥0.10 lo dice en `notes`.
+  * `cohort_collapse` reusa la matriz ya calculada y row-capped por
+    ``_calculate_eda_regressions`` (graph.py), no recomputa.
+
+Failure policy (igual que el builder de clasificación):
+  * Error en un builder → ese chart se omite (no se falsea).
+  * df vacío → ``[]`` para que el caller degrade (NO hace fallback al LLM-JSON;
+    ver Issue 5A en el plan).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pandas as pd
+
+from case_generator.datagen.eda_charts_common import empty_chart, source_label
+
+logger = logging.getLogger("adam.graph")
+
+# Cuántos drivers mostrar y el umbral bajo el cual avisamos "sin driver fuerte".
+_DRIVERS_TOP_K = 8
+_DRIVERS_MIN_ABS_CORR = 0.10
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Helpers
+# ───────────────────────────────────────────────────────────────────────
+
+
+def _sorted_by_period(df: pd.DataFrame) -> pd.DataFrame:
+    """Orden temporal estable (period es 'YYYY-MM', ordenable como str)."""
+    if "period" in df.columns:
+        try:
+            return df.sort_values("period")
+        except Exception:  # pragma: no cover - defensive
+            return df
+    return df
+
+
+def _indexed_base_100(series: pd.Series) -> list[float | None] | None:
+    """Indexa una serie numérica a base 100 sobre su primer valor válido.
+
+    Devuelve ``None`` (→ el caller degrada a placeholder honesto) cuando indexar
+    NO conservaría la dirección real de la serie:
+      * primer valor no positivo (base ≤ 0): dividir por una base negativa
+        INVIERTE el signo de la pendiente — una métrica que mejora (p. ej. margen
+        de -10% a -5%) se vería como caída. Es exactamente el engaño visual que
+        este builder existe para eliminar.
+      * cualquier valor ≤ 0 en la serie: el índice cruza/explota alrededor de cero
+        y distorsiona la escala comparativa (un margen que colapsa a pérdida).
+    En ambos casos preferimos omitir la traza con una nota honesta antes que
+    graficar una lectura engañosa. ``None`` por celda preserva los huecos (NaN).
+    """
+    numeric = pd.to_numeric(series, errors="coerce")
+    valid = numeric.dropna()
+    if valid.empty:
+        return None
+    base = float(valid.iloc[0])
+    if base <= 0:
+        return None
+    if (valid <= 0).any():
+        return None
+    return [round(float(v) / base * 100, 2) if pd.notna(v) else None for v in numeric]
+
+
+def _target_correlations(
+    df: pd.DataFrame, target_col: str, precalculated_metrics: dict | None
+) -> dict[str, float]:
+    """``{feature: |corr con el objetivo|}``.
+
+    Prefiere la ``correlation_matrix`` ya calculada (consistencia con otras
+    vistas y exclusión de columnas constantes ya aplicada). Si no está
+    disponible, calcula directamente del df (≤120 filas, trivial).
+    """
+    pm = precalculated_metrics or {}
+    cm = pm.get("correlation_matrix")
+    if isinstance(cm, dict):
+        cols = cm.get("x") or []
+        z = cm.get("z") or []
+        if target_col in cols:
+            ti = cols.index(target_col)
+            out: dict[str, float] = {}
+            for j, name in enumerate(cols):
+                if name == target_col:
+                    continue
+                try:
+                    out[name] = abs(float(z[ti][j]))
+                except (TypeError, ValueError, IndexError):
+                    continue
+            if out:
+                return out
+
+    # Fallback: cálculo directo, excluyendo columnas constantes (corr indefinida).
+    numeric = df.select_dtypes(include="number")
+    if target_col not in numeric.columns:
+        return {}
+    out = {}
+    for name in numeric.columns:
+        if name == target_col:
+            continue
+        if numeric[name].nunique(dropna=True) <= 1:
+            continue
+        corr = numeric[name].corr(numeric[target_col])
+        if pd.notna(corr):
+            out[name] = abs(float(corr))
+    return out
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Chart builders (cada uno devuelve un dict con forma EDAChartSpec)
+# ───────────────────────────────────────────────────────────────────────
+
+
+def _build_financial_mirage(df: pd.DataFrame, source: str) -> dict[str, Any]:
+    """Ingresos vs margen indexados a base 100 en una sola escala (sin doble-eje).
+
+    Reemplaza el `scatter mode:lines` de doble eje Y del prompt legacy, que
+    distorsionaba la comparación al darle escalas independientes a cada serie.
+    """
+    if "period" not in df.columns or "revenue" not in df.columns:
+        return empty_chart(
+            "financial_mirage",
+            "El espejismo del crecimiento",
+            "Faltan columnas 'period' y/o 'revenue'",
+            "scatter",
+            source,
+            notes="No se encontraron las columnas period y revenue para la tendencia.",
+        )
+
+    d = _sorted_by_period(df)
+    periods = [str(p) for p in d["period"].tolist()]
+    traces: list[dict[str, Any]] = []
+
+    rev_idx = _indexed_base_100(d["revenue"])
+    if rev_idx is not None:
+        traces.append(
+            {
+                "type": "scatter",
+                "mode": "lines+markers",
+                "x": periods,
+                "y": rev_idx,
+                "name": "Ingresos (índice)",
+            }
+        )
+
+    margin_note = ""
+    if "margin_pct" in d.columns:
+        marg_idx = _indexed_base_100(d["margin_pct"])
+        if marg_idx is not None:
+            traces.append(
+                {
+                    "type": "scatter",
+                    "mode": "lines+markers",
+                    "x": periods,
+                    "y": marg_idx,
+                    "name": "Margen % (índice)",
+                }
+            )
+        else:
+            # Margen con períodos no positivos: indexarlo distorsionaría la lectura
+            # (inversión de signo o explosión de escala). Lo omitimos y lo decimos.
+            margin_note = (
+                "El margen tuvo períodos no positivos; se omite del índice comparativo "
+                "para no distorsionar la lectura. Revisar el margen crudo en el M2."
+            )
+
+    if not traces:
+        return empty_chart(
+            "financial_mirage",
+            "El espejismo del crecimiento",
+            "Sin valores numéricos válidos para indexar",
+            "scatter",
+            source,
+            notes="No fue posible indexar ingresos ni margen (primer valor nulo, cero o negativo).",
+        )
+
+    return {
+        "id": "financial_mirage",
+        "title": "El espejismo del crecimiento",
+        "subtitle": "Ingresos y margen indexados (base 100 = primer período) en una escala comparable",
+        "library": "plotly",
+        "chart_type": "scatter",
+        "traces": traces,
+        "layout": {
+            "template": "plotly_white",
+            "xaxis": {"title": "Período"},
+            "yaxis": {"title": "Índice (base 100 = primer período)"},
+            "showlegend": True,
+        },
+        "source": source,
+        "description": "",
+        "notes": margin_note,
+        "data_source": "python_builder",
+    }
+
+
+def _build_churn_drivers(
+    df: pd.DataFrame, target_col: str, precalculated_metrics: dict | None, source: str
+) -> dict[str, Any]:
+    """Barra horizontal de |correlación| real de cada variable con el objetivo.
+
+    Reemplaza el scatter+recta que afirmaba un –0.89 que los puntos no
+    respaldaban. El eje fijo [0, 1] impide exagerar correlaciones pequeñas, y si
+    ninguna supera el umbral lo decimos en `notes` en vez de sugerir un driver.
+    """
+    corrs = _target_correlations(df, target_col, precalculated_metrics)
+    if not corrs:
+        return empty_chart(
+            "churn_drivers",
+            "Factores asociados al abandono",
+            "Sin correlaciones calculables con el objetivo",
+            "bar",
+            source,
+            notes="No se pudieron calcular correlaciones con la variable objetivo.",
+        )
+
+    pairs = sorted(corrs.items(), key=lambda kv: kv[1], reverse=True)[:_DRIVERS_TOP_K]
+    feats = [p[0] for p in pairs]
+    vals = [round(p[1], 3) for p in pairs]
+    strongest = vals[0] if vals else 0.0
+    note = (
+        "Ninguna variable supera |correlación| ≥ 0.10 con el objetivo: no hay un "
+        "driver lineal fuerte en estos datos; interpretar con cautela."
+        if strongest < _DRIVERS_MIN_ABS_CORR
+        else ""
+    )
+
+    target_label = target_col or "objetivo"
+    return {
+        "id": "churn_drivers",
+        "title": "Factores asociados al abandono",
+        "subtitle": f"Correlación absoluta de cada variable con {target_label} (mayor = más asociada)",
+        "library": "plotly",
+        "chart_type": "bar",
+        "traces": [
+            {
+                "type": "bar",
+                "x": vals,
+                "y": feats,
+                "orientation": "h",
+                "name": "|correlación|",
+                "text": [f"{v:.2f}" for v in vals],
+                "textposition": "outside",
+            }
+        ],
+        "layout": {
+            "template": "plotly_white",
+            # Eje fijo [0,1]: |corr| siempre cae aquí → no exagera magnitudes.
+            "xaxis": {"title": f"|correlación| con {target_label}", "range": [0, 1]},
+            "yaxis": {"title": "Variable", "autorange": "reversed"},
+            "showlegend": False,
+        },
+        "source": source,
+        "description": "",
+        "notes": note,
+        "data_source": "python_builder",
+    }
+
+
+def _build_cohort_collapse(
+    df: pd.DataFrame, target_col: str, precalculated_metrics: dict | None, source: str
+) -> dict[str, Any]:
+    """Heatmap de retención por cohorte (reusa la matriz ya row-capped).
+
+    Si no hay matriz de cohortes, cae a una caja (box) de la distribución del
+    objetivo — nunca falsea una cohorte inexistente.
+    """
+    pm = precalculated_metrics or {}
+    cohort = pm.get("cohort_matrix")
+    if isinstance(cohort, dict) and cohort.get("z"):
+        return {
+            "id": "cohort_collapse",
+            "title": "El colapso del valor (Retención de Cohortes)",
+            "subtitle": "% de usuarios retenidos por cohorte de ingreso a lo largo del tiempo",
+            "library": "plotly",
+            "chart_type": "heatmap",
+            "traces": [
+                {
+                    "type": "heatmap",
+                    "x": cohort.get("x", []),
+                    "y": cohort.get("y", []),
+                    "z": cohort["z"],
+                    "colorscale": "YlOrRd",
+                    "reversescale": True,
+                    "texttemplate": "%{z:.0%}",
+                    "showscale": True,
+                }
+            ],
+            "layout": {
+                "template": "plotly_white",
+                "xaxis": {"title": "Meses desde adquisición"},
+                "yaxis": {"type": "category", "title": "Cohorte"},
+            },
+            "source": source,
+            "description": "",
+            "notes": "",
+            "data_source": "python_builder",
+        }
+
+    # Fallback: distribución del objetivo (sin cohortes que graficar).
+    if target_col in df.columns and pd.api.types.is_numeric_dtype(df[target_col]):
+        vals = pd.to_numeric(df[target_col], errors="coerce").dropna().tolist()
+        if vals:
+            return {
+                "id": "target_distribution",
+                "title": f"Distribución de {target_col}",
+                "subtitle": "Dispersión y valores atípicos del indicador central del caso",
+                "library": "plotly",
+                "chart_type": "box",
+                "traces": [
+                    {
+                        "type": "box",
+                        "y": vals,
+                        "name": target_col,
+                        "boxpoints": "outliers",
+                    }
+                ],
+                "layout": {
+                    "template": "plotly_white",
+                    "yaxis": {"title": target_col},
+                    "showlegend": False,
+                },
+                "source": source,
+                "description": "",
+                "notes": "",
+                "data_source": "python_builder",
+            }
+
+    return empty_chart(
+        "cohort_collapse",
+        "El colapso del valor (Retención de Cohortes)",
+        "Sin columnas de retención ni objetivo numérico",
+        "heatmap",
+        source,
+        notes="No hay matriz de cohortes ni objetivo numérico para graficar.",
+    )
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Public entrypoint
+# ───────────────────────────────────────────────────────────────────────
+
+
+def generate_business_eda_charts(
+    df: pd.DataFrame,
+    target_col: str,
+    precalculated_metrics: dict | None,
+    contract: dict | None,
+) -> list[dict[str, Any]]:
+    """Construye el panel EDA de 3 charts del perfil business deterministicamente.
+
+    Devuelve dicts con forma ``EDAChartSpec`` (``data_source="python_builder"``,
+    ``description``/``notes`` vacíos → el caller fusiona anotaciones del LLM).
+
+    En fallo duro (df vacío) devuelve ``[]``. El caller degrada con panel vacío y
+    NO hace fallback al LLM-JSON (Issue 5A).
+    """
+    if df is None or df.empty:
+        logger.warning("[eda_charts_business] df vacío — devolviendo []")
+        return []
+
+    source = source_label(contract)
+    charts: list[dict[str, Any]] = []
+
+    builders: list[tuple[str, Any]] = [
+        ("financial_mirage", lambda: _build_financial_mirage(df, source)),
+        (
+            "churn_drivers",
+            lambda: _build_churn_drivers(df, target_col, precalculated_metrics, source),
+        ),
+        (
+            "cohort_collapse",
+            lambda: _build_cohort_collapse(df, target_col, precalculated_metrics, source),
+        ),
+    ]
+    for cid, fn in builders:
+        try:
+            out = fn()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "[eda_charts_business] chart %s falló: %s — se omite", cid, exc
+            )
+            continue
+        if out is not None:
+            charts.append(out)
+    return charts

--- a/backend/src/case_generator/datagen/eda_charts_classification.py
+++ b/backend/src/case_generator/datagen/eda_charts_classification.py
@@ -40,48 +40,13 @@ from typing import Any
 
 import pandas as pd
 
+from case_generator.datagen.eda_charts_common import empty_chart, source_label
+
 logger = logging.getLogger("adam.graph")
 
 # ── Defensive caps (keep payloads small for FE/Plotly) ────────────────
 _MISSINGNESS_SAMPLE_ROWS = 500
 _MI_TOP_K = 8
-_SOURCE_TEMPLATE = "Dataset ADAM — {case_id}"
-
-
-# ───────────────────────────────────────────────────────────────────────
-# Helpers
-# ───────────────────────────────────────────────────────────────────────
-
-
-def _source_label(contract: dict | None) -> str:
-    case_id = ""
-    if isinstance(contract, dict):
-        case_id = str(contract.get("case_id") or contract.get("caso_id") or "")
-    return _SOURCE_TEMPLATE.format(case_id=case_id) if case_id else "Dataset ADAM"
-
-
-def _empty_chart(
-    chart_id: str,
-    title: str,
-    subtitle: str,
-    chart_type: str,
-    source: str,
-    notes: str = "",
-) -> dict[str, Any]:
-    """Skeleton with empty traces — used when a builder cannot run safely."""
-    return {
-        "id": chart_id,
-        "title": title,
-        "subtitle": subtitle,
-        "library": "plotly",
-        "chart_type": chart_type,
-        "traces": [],
-        "layout": {"template": "plotly_white"},
-        "source": source,
-        "description": "",
-        "notes": notes,
-        "data_source": "python_builder",
-    }
 
 
 # ───────────────────────────────────────────────────────────────────────
@@ -131,7 +96,7 @@ def _build_missingness_heatmap(
 ) -> dict[str, Any]:
     n_rows = len(df)
     if n_rows == 0:
-        return _empty_chart(
+        return empty_chart(
             "missingness_heatmap",
             "Mapa de valores faltantes",
             "Sin filas para muestrear",
@@ -143,7 +108,7 @@ def _build_missingness_heatmap(
     )
     cols = [c for c in sorted(sample.columns) if c != target_col]
     if not cols:
-        return _empty_chart(
+        return empty_chart(
             "missingness_heatmap",
             "Mapa de valores faltantes",
             "Sin features fuera del target",
@@ -190,7 +155,7 @@ def _build_mutual_info_top8(
 
     feature_cols = [c for c in sorted(df.columns) if c != target_col]
     if not feature_cols:
-        return _empty_chart(
+        return empty_chart(
             "mutual_info_top8",
             "Top features por Mutual Information",
             "Sin features disponibles",
@@ -282,7 +247,7 @@ def generate_classification_eda_charts(
         )
         return []
 
-    source = _source_label(contract)
+    source = source_label(contract)
     charts: list[dict[str, Any]] = []
 
     builders: list[tuple[str, Any]] = [

--- a/backend/src/case_generator/datagen/eda_charts_common.py
+++ b/backend/src/case_generator/datagen/eda_charts_common.py
@@ -1,0 +1,62 @@
+"""Shared helpers for the Python-deterministic EDA chart builders.
+
+Both the classification builder (``eda_charts_classification.py``, ml_ds) and
+the business builder (``eda_charts_business.py``) emit the same
+``EDAChartSpec``-shaped dicts and share the same source-label and empty-chart
+skeleton logic. This module is the single home for that shared surface so the
+two sibling builders never drift or duplicate it.
+
+    contract (dataset_schema_required) ──► _source_label() ──► "Dataset ADAM — {case_id}"
+
+    builder cannot run safely         ──► _empty_chart() ──► spec with traces=[]
+
+Every dict returned by the builders carries ``data_source="python_builder"``
+so downstream telemetry can tell the deterministic path apart from the legacy
+LLM-JSON path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Source label shown in every chart footer. Shared by both builders.
+SOURCE_TEMPLATE = "Dataset ADAM — {case_id}"
+
+
+def source_label(contract: dict | None) -> str:
+    """Build the chart ``source`` footer from the dataset contract.
+
+    Falls back to a bare ``"Dataset ADAM"`` when no case id is present.
+    """
+    case_id = ""
+    if isinstance(contract, dict):
+        case_id = str(contract.get("case_id") or contract.get("caso_id") or "")
+    return SOURCE_TEMPLATE.format(case_id=case_id) if case_id else "Dataset ADAM"
+
+
+def empty_chart(
+    chart_id: str,
+    title: str,
+    subtitle: str,
+    chart_type: str,
+    source: str,
+    notes: str = "",
+) -> dict[str, Any]:
+    """Skeleton spec with empty traces — used when a builder cannot run safely.
+
+    Returning this (rather than raising) lets a panel render a labelled,
+    empty placeholder instead of dropping the chart silently.
+    """
+    return {
+        "id": chart_id,
+        "title": title,
+        "subtitle": subtitle,
+        "library": "plotly",
+        "chart_type": chart_type,
+        "traces": [],
+        "layout": {"template": "plotly_white"},
+        "source": source,
+        "description": "",
+        "notes": notes,
+        "data_source": "python_builder",
+    }

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -97,6 +97,7 @@ from case_generator.prompts import (
     CASE_QUESTIONS_PROMPT_BY_FAMILY,
     CASE_WRITER_PROMPT,
     CASE_WRITER_PROMPT_BY_FAMILY,
+    EDA_ANNOTATE_ONLY_PROMPT,
     EDA_ANNOTATE_ONLY_PROMPT_CLASSIFICATION,
     EDA_CHART_GENERATOR_PROMPT,
     EDA_QUESTIONS_GENERATOR_PROMPT,
@@ -114,6 +115,7 @@ from case_generator.prompts import (
     M5_QUESTIONS_GENERATOR_PROMPT,
     M5_QUESTIONS_PROMPT_BY_FAMILY,
     # v8 M3 — prompts por perfil (aliases backward-compat también disponibles)
+    M3_AUDIT_LR_BUSINESS_BLOCK,
     M3_AUDIT_PROMPT,
     M3_EXPERIMENT_PROMPT,
     M3_AUDIT_QUESTIONS_PROMPT,
@@ -161,6 +163,9 @@ from case_generator.tools_and_schemas import (
     GeneradorPreguntasM5Output,
     EDAQuestionsOutput,
     DatasetSchema,
+)
+from case_generator.datagen.eda_charts_business import (
+    generate_business_eda_charts,
 )
 from case_generator.datagen.eda_charts_classification import (
     generate_classification_eda_charts,
@@ -1384,11 +1389,107 @@ def _clamp(text: str, max_chars: int) -> str:
     return text if len(text) <= max_chars else text[: max_chars - 1] + "…"
 
 
+def _annotate_validate_emit(
+    charts: list[dict],
+    state: ADAMState,
+    config: RunnableConfig,
+    annotate_prompt: str,
+) -> dict | None:
+    """Cola compartida de los paths EDA Python-deterministas (clasif + business).
+
+    Pide al LLM SOLO `description`/`notes` (annotate-only), fusiona con los charts
+    ya construidos en Python (sin tocar números), valida contra
+    ``EDAChartGeneratorOutput`` y devuelve el update del nodo, o ``None`` si nada
+    validó. El boundary del LLM nunca tumba el panel: si la anotación falla, se
+    sirven los charts sin texto LLM (preservando los `notes` del builder, p. ej.
+    el aviso anti-overclaim del chart de drivers).
+    """
+    # Cap defensivo: el contrato son ≤5 charts.
+    if len(charts) > 5:
+        charts = charts[:5]
+
+    try:
+        cfg = Configuration.from_runnable_config(config)
+        llm = _get_chart_llm(cfg.writer_model, temperature=0.3, thinking_level="minimal")
+        charts_context = [
+            {
+                "id": c.get("id", ""),
+                "title": c.get("title", ""),
+                "subtitle": c.get("subtitle", ""),
+                "chart_type": c.get("chart_type", ""),
+            }
+            for c in charts
+        ]
+        prompt = annotate_prompt.format(
+            charts_context_json=json.dumps(charts_context, ensure_ascii=False),
+            case_id=state.get("case_id", "") or state.get("titulo", ""),
+            student_profile=state.get("studentProfile", "business"),
+            output_language=state.get("output_language", "es"),
+        )
+        ann_result: EDAAnnotateOnlyOutput = llm.with_structured_output(
+            EDAAnnotateOnlyOutput
+        ).invoke(prompt)
+        ann_by_id: dict[str, tuple[str, str]] = {}
+        for ann in (ann_result.annotations or []):
+            if not ann.id:
+                continue
+            ann_by_id[ann.id] = (
+                _clamp(ann.description or "", 500),
+                _clamp(ann.notes or "", 300),
+            )
+    except Exception as ann_err:  # noqa: BLE001
+        # Boundary: errores del LLM nunca tumban el panel.
+        logger.warning(
+            "[eda_chart_generator/py] annotate-only LLM falló (%s) — sirviendo charts sin anotaciones",
+            ann_err,
+        )
+        ann_by_id = {}
+
+    # Merge defensivo: solo description/notes; preservamos data_source y los
+    # `notes` factuales del builder (p. ej. el caveat anti-overclaim). El caveat va
+    # ÍNTEGRO y primero; la nota pedagógica del LLM se presupuesta al espacio restante
+    # y se clampa con elipsis (no se corta a media palabra). Total ≤ 300 chars.
+    for c in charts:
+        cid = c.get("id", "")
+        desc, llm_notes = ann_by_id.get(cid, ("", ""))
+        c["description"] = desc or c.get("description", "") or ""
+        builder_notes = (c.get("notes", "") or "").strip()
+        sep = " " if builder_notes and llm_notes else ""
+        budget = max(0, 300 - len(builder_notes) - len(sep))
+        llm_tail = _clamp(llm_notes, budget) if budget else ""
+        c["notes"] = (builder_notes + sep + llm_tail).strip()
+        c["data_source"] = "python_builder"
+
+    # Validamos contra el schema (descartamos charts que rompan el contrato).
+    validated: list[dict] = []
+    for c in charts:
+        try:
+            spec = EDAChartGeneratorOutput.model_validate({"charts": [c]})
+            validated.append(spec.charts[0].model_dump())
+        except Exception as ve:  # noqa: BLE001
+            logger.warning(
+                "[eda_chart_generator/py] chart %s falló validación: %s — se omite",
+                c.get("id"), ve,
+            )
+
+    if not validated:
+        return None
+
+    logger.info(
+        "[eda_chart_generator/py] panel Python-determinista emitido: %d/%d charts",
+        len(validated), len(charts),
+    )
+    return {
+        "doc2_eda_charts": validated,
+        "current_agent": "eda_chart_generator",
+    }
+
+
 def _eda_classification_python_path(
     state: ADAMState, config: RunnableConfig, contract: dict | None
 ) -> dict | None:
-    """Issue #237 — construye 5 charts EDA en Python y pide al LLM solo
-    `description` + `notes`. Devuelve el dict de update del nodo o ``None``
+    """Issue #237 — construye los charts EDA de clasificación (ml_ds) en Python y
+    pide al LLM solo `description`/`notes`. Devuelve el update del nodo o ``None``
     si el path Python no aplica (deja que el caller use el LLM-JSON).
     """
     try:
@@ -1415,82 +1516,9 @@ def _eda_classification_python_path(
             )
             return None
 
-        # Cap defensivo: el contrato Issue #237 son 5 charts.
-        if len(charts) > 5:
-            charts = charts[:5]
-
-        # Annotate-only: pedimos al LLM solo description/notes por id.
-        try:
-            cfg = Configuration.from_runnable_config(config)
-            llm = _get_chart_llm(cfg.writer_model, temperature=0.3, thinking_level="minimal")
-            charts_context = [
-                {
-                    "id": c.get("id", ""),
-                    "title": c.get("title", ""),
-                    "subtitle": c.get("subtitle", ""),
-                    "chart_type": c.get("chart_type", ""),
-                }
-                for c in charts
-            ]
-            prompt = EDA_ANNOTATE_ONLY_PROMPT_CLASSIFICATION.format(
-                charts_context_json=json.dumps(charts_context, ensure_ascii=False),
-                case_id=state.get("case_id", "") or state.get("titulo", ""),
-                student_profile=state.get("studentProfile", "ml_ds"),
-                output_language=state.get("output_language", "es"),
-            )
-            ann_result: EDAAnnotateOnlyOutput = llm.with_structured_output(
-                EDAAnnotateOnlyOutput
-            ).invoke(prompt)
-            ann_by_id: dict[str, tuple[str, str]] = {}
-            for ann in (ann_result.annotations or []):
-                if not ann.id:
-                    continue
-                ann_by_id[ann.id] = (
-                    _clamp(ann.description or "", 500),
-                    _clamp(ann.notes or "", 300),
-                )
-        except Exception as ann_err:  # noqa: BLE001
-            # Boundary Issue #237: errores del LLM nunca tumban el panel.
-            logger.warning(
-                "[eda_chart_generator/py] annotate-only LLM falló (%s) — sirviendo charts sin anotaciones",
-                ann_err,
-            )
-            ann_by_id = {}
-
-        # Merge defensivo: solo description/notes; preservamos data_source.
-        for c in charts:
-            cid = c.get("id", "")
-            desc, notes = ann_by_id.get(cid, ("", ""))
-            c["description"] = desc
-            c["notes"] = notes
-            c["data_source"] = "python_builder"
-
-        # Validamos contra el schema antes de devolver (descartamos charts que rompan el contrato).
-        validated: list[dict] = []
-        for c in charts:
-            try:
-                spec = EDAChartGeneratorOutput.model_validate({"charts": [c]})
-                validated.append(spec.charts[0].model_dump())
-            except Exception as ve:  # noqa: BLE001
-                logger.warning(
-                    "[eda_chart_generator/py] chart %s falló validación: %s — se omite",
-                    c.get("id"), ve,
-                )
-
-        if not validated:
-            logger.warning(
-                "[eda_chart_generator/py] todos los charts fallaron validación — fallback a path LLM"
-            )
-            return None
-
-        logger.info(
-            "[eda_chart_generator/py] panel Python-determinista emitido: %d/%d charts",
-            len(validated), len(charts),
+        return _annotate_validate_emit(
+            charts, state, config, EDA_ANNOTATE_ONLY_PROMPT_CLASSIFICATION
         )
-        return {
-            "doc2_eda_charts": validated,
-            "current_agent": "eda_chart_generator",
-        }
     except Exception as e:  # noqa: BLE001
         logger.error(
             "[eda_chart_generator/py] ERROR no recuperable: %s — fallback a path LLM",
@@ -1499,23 +1527,74 @@ def _eda_classification_python_path(
         return None
 
 
+def _eda_business_python_path(
+    state: ADAMState, config: RunnableConfig, contract: dict | None
+) -> dict | None:
+    """Path Python-determinista del perfil business (mirror del de clasificación).
+
+    Construye el panel honesto de 3 charts (`generate_business_eda_charts`) y pide
+    al LLM solo `description`/`notes`. Consume `precalculated_metrics`
+    (`_calculate_eda_regressions`) para la matriz de cohortes y las correlaciones.
+
+    Devuelve el update del nodo o ``None`` en fallo. A diferencia del path ml_ds,
+    el caller NO hace fallback al LLM-JSON (Issue 5A): ``None`` → panel vacío, para
+    no reintroducir nunca los charts LLM de baja calidad que este cambio retira.
+    """
+    try:
+        import pandas as pd  # noqa: PLC0415 — local para no penalizar imports globales
+
+        dataset = state.get("doc7_dataset") or []
+        if not dataset:
+            logger.warning(
+                "[eda_chart_generator/business] doc7_dataset vacío — panel vacío (sin fallback LLM)"
+            )
+            return None
+        df = pd.DataFrame(dataset)
+        # target_col puede quedar vacío: el chart financiero y el de cohortes no lo
+        # necesitan; el de drivers degrada a placeholder con aviso.
+        target_col = _identify_target_variable(state, df)
+        precalculated = _calculate_eda_regressions(state, dataset)
+
+        charts = generate_business_eda_charts(df, target_col, precalculated, contract)
+        if not charts:
+            logger.warning(
+                "[eda_chart_generator/business] builder devolvió 0 charts — panel vacío (sin fallback LLM)"
+            )
+            return None
+
+        return _annotate_validate_emit(charts, state, config, EDA_ANNOTATE_ONLY_PROMPT)
+    except Exception as e:  # noqa: BLE001
+        logger.error(
+            "[eda_chart_generator/business] ERROR no recuperable: %s — panel vacío (sin fallback LLM)",
+            e, exc_info=True,
+        )
+        return None
+
+
 def eda_chart_generator(state: ADAMState, config: RunnableConfig) -> dict:
-    """Extrae los charts JSON del reporte EDA (Documento 2 — parte charts).
+    """Extrae los charts del reporte EDA (Documento 2 — parte charts).
 
-    Contrato: el path LLM-JSON legacy emite exactamente 3 charts. El path
-    Python-determinista (Issue #237, ml_ds + clasificacion) emite 6 charts.
+    Dispatch de generación (charts deterministas Python vs. LLM-JSON legacy):
 
-    Issue #237 — para `studentProfile == "ml_ds"` y familia primaria
-    `clasificacion`, los 6 charts se generan deterministicamente en Python
-    y el LLM solo escribe `description`/`notes`. El path original
-    (LLM-JSON monolítico) queda intacto para business y otras familias.
+        familia clasificacion + perfil ml_ds   → _eda_classification_python_path
+                                                  (Issue #237; 3 charts; LLM solo anota)
+                                                  fallback → LLM-JSON si el path Python falla
+        familia clasificacion + perfil business → _eda_business_python_path
+                                                  (3 charts honestos; LLM solo anota)
+                                                  SIN fallback LLM (Issue 5A): falla → panel vacío
+        cualquier otra combinación              → path LLM-JSON (EDA_CHART_GENERATOR_PROMPT)
+
+    Los paths Python construyen TODOS los números en pandas y el LLM solo escribe
+    `description`/`notes` — eso elimina las correlaciones sobre-afirmadas y los
+    doble-ejes engañosos del path LLM-JSON. El path LLM-JSON queda solo para
+    business+otras-familias y ml_ds+otras-familias (y como fallback de ml_ds+clasif).
     """
     eda_report = state.get("doc2_eda", "")
     if not eda_report or "No disponible" in eda_report:
         print("[eda_chart_generator] Skipping: no hay reporte EDA válido")
         return {"doc2_eda_charts": [], "current_agent": "eda_chart_generator"}
 
-    # ── Issue #237 dispatch ──────────────────────────────────────────────
+    # ── Dispatch a paths Python-deterministas (clasificacion) ────────────
     profile = state.get("studentProfile", "business")
     task_payload_obj = state.get("task_payload") or {}
     algoritmos_disp: list[str] = []
@@ -1524,12 +1603,23 @@ def eda_chart_generator(state: ADAMState, config: RunnableConfig) -> dict:
     if not algoritmos_disp:
         algoritmos_disp = list(state.get("algoritmos") or [])
     primary_family, _legacy_warn = _resolve_primary_family(algoritmos_disp)
-    if profile == "ml_ds" and primary_family == "clasificacion":
+    if primary_family == "clasificacion":
         contract = state.get("dataset_schema_required")
-        py_update = _eda_classification_python_path(state, config, contract)
-        if py_update is not None:
-            return py_update
-        # else: fall through to legacy LLM-JSON path with warning already logged.
+        if profile == "ml_ds":
+            py_update = _eda_classification_python_path(state, config, contract)
+            if py_update is not None:
+                return py_update
+            # else: fall through to legacy LLM-JSON path (warning already logged).
+        elif profile == "business":
+            # Issue 5A: el builder business NUNCA cae al LLM-JSON (el path que
+            # producía los charts malos). Falla → panel vacío degradado.
+            py_update = _eda_business_python_path(state, config, contract)
+            if py_update is not None:
+                return py_update
+            logger.warning(
+                "[eda_chart_generator] business builder no produjo charts — panel vacío (sin fallback LLM)"
+            )
+            return {"doc2_eda_charts": [], "current_agent": "eda_chart_generator"}
 
     try:
         cfg = Configuration.from_runnable_config(config)
@@ -2737,11 +2827,15 @@ def _generate_independent_values(
 # HELPER — _generate_dataset_from_schema (Python puro, 0 tokens LLM)
 # ─────────────────────────────────────────────────────────
 
-def _generate_dataset_from_schema(schema: dict) -> list:
+def _generate_dataset_from_schema(schema: dict, profile: str = "business") -> list:
     """
     Genera filas de datos a partir del schema producido por schema_designer.
     Vectorizado con numpy. Cero tokens LLM. Determinista con seed derivado del schema.
     Soporta trend (up/down/stable) y dependency (linear/inverse) por columna.
+
+    ``profile`` ("business" | "ml_ds") solo afecta el target de la inyección de
+    outliers (Fix B-05): en business se excluyen las columnas de coherencia
+    financiera para no romper el panel M2. ml_ds conserva su comportamiento.
     """
     import numpy as np
 
@@ -2936,12 +3030,22 @@ def _generate_dataset_from_schema(schema: dict) -> list:
                     row[curr] = round(min(float(cv), max_allowed), 4)
 
     # ── Fix B-05: Inyectar outliers para ejercicios EDA (n_rows >= 50) ──
+    # Business: EXCLUIMOS las columnas de coherencia financiera
+    # (revenue/cost/margin/ebitda) del target del outlier. El panel M2 business
+    # grafica margen e ingresos indexados; un ×3.5 sobre `costs` distorsionaría esa
+    # lectura. Así el outlier cae en una métrica de comportamiento (p. ej. churn),
+    # más relevante para un caso de deserción. ml_ds conserva su comportamiento.
+    _financial_tokens = ("revenue", "cost", "margin", "ebitda")
     numeric_non_revenue = [
         c for c in columns
         if c["type"] in ("float", "int")
         and c["name"] != revenue_col
         and not c["name"].startswith("period")
         and not c["name"].startswith("retention_")
+        and not (
+            profile == "business"
+            and any(tok in c["name"].lower() for tok in _financial_tokens)
+        )
     ]
     if numeric_non_revenue and n_rows >= 50:
         target_col_def = numeric_non_revenue[0]
@@ -2953,7 +3057,12 @@ def _generate_dataset_from_schema(schema: dict) -> list:
                 original = float(rows[idx][target_col])
                 outlier_val = original * 3.5
                 if col_range_max is not None and float(col_range_max) > 0:
-                    outlier_val = min(outlier_val, float(col_range_max) * 2)
+                    # business: el atípico respeta el range_max declarado en vez de
+                    # 2× (evita p. ej. churn 0.30 cuando el schema declaró [0.02,0.15],
+                    # que además debilitaba la correlación nps↔churn que el panel
+                    # presenta como driver real). ml_ds conserva el cap ×2 histórico.
+                    cap_mult = 1.0 if profile == "business" else 2.0
+                    outlier_val = min(outlier_val, float(col_range_max) * cap_mult)
                 rows[idx][target_col] = round(outlier_val, 2)
 
     print(f"[_generate_dataset_from_schema] {len(rows)} filas generadas, {len(columns)} columnas")
@@ -2981,7 +3090,7 @@ def data_generator(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: A
         if profile == "business":
             schema["n_rows"] = max(80, min(120, schema.get("n_rows", 100)))
 
-        rows = _generate_dataset_from_schema(schema)
+        rows = _generate_dataset_from_schema(schema, profile=profile)
         constraints = schema.get("constraints", {})
         constraints_with_count = {**constraints, "n_rows_expected": schema.get("n_rows", 100)}
 
@@ -3867,6 +3976,10 @@ def m3_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
         context.update({
             "contexto_m1": state.get("doc1_narrativa", "")[:8000],
             "contexto_m2": state.get("doc2_eda", "") or "DATASET_UNAVAILABLE",
+            # Default vacío: solo business+clasificacion lo rellena (más abajo).
+            # M3_AUDIT_PROMPT referencia {lr_business_block}; los prompts ml_ds no,
+            # así que la clave extra es ignorada por .format() en ese branch.
+            "lr_business_block": "",
         })
 
         profile = state.get("studentProfile", "business")
@@ -3942,6 +4055,13 @@ def m3_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
             prompt = M3_AUDIT_PROMPT
             tag = "m3_audit"
             m3_mode = "audit"
+            # LR-business (light, Issue 3A): si el algoritmo es de la familia
+            # clasificacion (p. ej. Logistic Regression), inyectamos el bloque que
+            # hace al auditor razonar sobre la decisión apoyada en el modelo, en
+            # lenguaje gerencial y SIN jerga DS. Otras familias business → sin bloque.
+            _business_family, _ = _resolve_primary_family(_extract_state_algoritmos(state))
+            if _business_family == "clasificacion":
+                context["lr_business_block"] = M3_AUDIT_LR_BUSINESS_BLOCK
             # business: contenido narrativo de auditoría sin notebook downstream;
             # Flash-medium con fallback a 2.5-flash (ya en _get_writer_llm) basta.
             llm = _get_writer_llm(cfg.writer_model, temperature=0.6, thinking_level="medium")

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -553,6 +553,17 @@ REGLAS DE COBERTURA DEL CONTRATO (cuando NO esté vacío):
   (CRÍTICO: Las columnas retention_mX representan el % de usuarios de esa cohorte
   retenidos en el mes X. Son obligatorias para el heatmap de análisis de cohortes.
   Asegúrate de que range_min/max respeten: retention_m1 > retention_m3 > retention_m6 > retention_m12.)
+
+  DEPENDENCIAS OBLIGATORIAS (business) — para que el Módulo 2 muestre relaciones
+  REALES y verificables (no correlaciones inventadas) y un margen financiero legible:
+  - `churn_rate`: dependency {{"depends_on": "revenue", "relationship": "inverse", "noise_factor": 0.15}}.
+  - `costs`: dependency {{"depends_on": "revenue", "relationship": "linear", "noise_factor": 0.12}}.
+    noise_factor BAJO a propósito: así el costo sigue al ingreso y el margen por fila
+    queda en una banda realista (NO genera meses con costos > ingresos ni márgenes absurdos).
+  - `nps`: dependency {{"depends_on": "revenue", "relationship": "linear", "noise_factor": 0.30}}.
+    Esto liga NPS y churn de forma INVERSA a través de revenue: una causa raíz real
+    (mayor satisfacción ↔ menor abandono) que el estudiante puede descubrir en los datos.
+  - `margin_pct`: dependency=null SIEMPRE (el generador lo recalcula como (revenue−costs)/revenue·100).
 - Para {student_profile}="ml_ds": MÍNIMO 14 columnas, al menos 2 con nullable=true.
   Las primeras 12 columnas son FIJAS en este orden:
   period, revenue, costs, margin_pct, churn_rate, nps,
@@ -997,7 +1008,7 @@ falló durante harvard_with_eda — M3 nunca se ejecuta en harvard_only):
 # Perfil del estudiante: business (Decision Evidence Reviewer)
 Riesgo gerencial. Hechos vs inferencias. Confiabilidad de fuentes (Alta/Media/Baja).
 Información faltante que un directivo necesitaría para decidir con confianza.
-
+{lr_business_block}
 # Formato de Salida (usar EXACTAMENTE estos H3)
 ## Longitud objetivo: 650-850 palabras
 
@@ -1031,6 +1042,34 @@ case_id: {case_id} | student_profile: {student_profile}
 
 # Alias backward-compatible — no usar en código nuevo
 M3_CONTENT_GENERATOR_PROMPT = M3_AUDIT_PROMPT
+
+
+# ── Bloque de coherencia LR para business (gated: profile==business AND
+# family==clasificacion). Se inyecta en {lr_business_block} de M3_AUDIT_PROMPT.
+# Lenguaje gerencial PLANO — sin jerga de ciencia de datos (nada de coeficientes,
+# log-odds, AUC). Teje la conciencia del modelo en las secciones 3.1–3.5 ya
+# existentes; NO agrega secciones nuevas. Cero placeholders de .format() (texto
+# estático) para que la concatenación con M3_AUDIT_PROMPT no rompa el formateo.
+M3_AUDIT_LR_BUSINESS_BLOCK = """
+# Enfoque del caso: decisión apoyada en un modelo de probabilidad de abandono
+La decisión de este caso se apoyará en un modelo de **regresión logística** que estima,
+para cada cliente, una **probabilidad de abandono** (un número entre 0% y 100%) a partir de
+las variables del negocio. NO expliques matemática, fórmulas ni términos técnicos
+(coeficientes, log-odds, AUC, umbrales estadísticos): el lector es un directivo, no un
+científico de datos. Audita la decisión en lenguaje gerencial, integrando estos puntos
+en las secciones 3.1–3.5 (NO agregues secciones nuevas):
+- **Qué hace el modelo (3.1):** ordena a los clientes por riesgo de abandono para priorizar
+  intervenciones; es una ayuda a la decisión, no una verdad. Su utilidad depende de que los
+  datos del M2 sean representativos del futuro.
+- **Supuesto clave a auditar (3.2):** que las relaciones vistas en el M2 (p. ej. menor
+  satisfacción ↔ mayor abandono) se mantendrán y son accionables. Si no, priorizar por
+  probabilidad podría desviar el presupuesto de retención hacia el lugar equivocado.
+- **Trade-off de la decisión (3.3):** intervenir sobre un cliente que NO iba a abandonar
+  (falsa alarma → gasto de retención desperdiciado) frente a no intervenir sobre uno que SÍ
+  abandona (abandono no evitado → ingreso perdido). Nombra ambos costos en términos del caso.
+- **Información faltante (3.4):** qué dato falta para confiar en priorizar por probabilidad
+  (p. ej. el costo real de cada intervención y la efectividad histórica de las retenciones).
+"""
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -2410,6 +2449,7 @@ __all__ = [
   "EDA_QUESTIONS_PROMPT_BY_FAMILY",
   "EDA_TEXT_ANALYST_PROMPT",
   "EDA_TEXT_ANALYST_PROMPT_BY_FAMILY",
+  "M3_AUDIT_LR_BUSINESS_BLOCK",
   "M3_AUDIT_PROMPT",
   "M3_AUDIT_QUESTIONS_PROMPT",
   "M3_CLASSIFICATION_QUESTIONS_BY_VARIANT",

--- a/backend/tests/integration/test_business_lr_live.py
+++ b/backend/tests/integration/test_business_lr_live.py
@@ -1,0 +1,102 @@
+"""Live e2e (opt-in) — business + Logistic Regression (Issue 8A del plan).
+
+Ejecutar SOLO con:
+    RUN_LIVE_LLM_TESTS=1 uv run --directory backend pytest -m live_llm \
+        tests/integration/test_business_lr_live.py -q -s
+
+Verifica el arco completo del cambio business+LR:
+  * Los charts del M2 vienen del builder Python-determinista (`python_builder`),
+    no del path LLM-JSON que producía los gráficos malos.
+  * El set honesto aparece (financial_mirage + churn_drivers + cohorte/box).
+  * El M3 razona la decisión apoyada en regresión logística en lenguaje gerencial.
+  * El dataset sintético tiene una correlación NPS↔churn REAL (no inventada).
+"""
+
+import uuid
+
+import pandas as pd
+import pytest
+
+pytestmark = [pytest.mark.live_llm, pytest.mark.asyncio]
+
+BUSINESS_LR_PAYLOAD = {
+    "messages": [("user", "Generar caso business + Logistic Regression")],
+    "subject": "Estrategia de Retención",
+    "syllabusModule": "Gestión de Clientes",
+    "academicLevel": "Maestría",
+    "industry": "Educación Digital",
+    "caseType": "harvard_with_eda",
+    "studentProfile": "business",
+    "edaDepth": "charts_only",
+    "guidingQuestion": (
+        "¿Qué estrategia de intervención debería priorizar la dirección para mitigar la "
+        "deserción, basándose en la probabilidad de abandono estimada por el modelo?"
+    ),
+    "scenarioDescription": (
+        "Una universidad digital enfrenta una tasa de deserción del 22% en sus nuevas "
+        "certificaciones y debe asignar un fondo limitado de becas de retención."
+    ),
+    "suggestedTechniques": ["Logistic Regression"],
+    "includePythonCode": False,
+}
+
+# Tokens de jerga DS que el M3 business NO debería exponer como explicación técnica.
+_JARGON = ("log-odds", "odds ratio", "auc", "roc", "gridsearch", "coeficiente de regresión")
+
+
+async def test_business_lr_e2e() -> None:
+    from case_generator.graph import get_graph
+
+    graph = await get_graph()
+    config = {"configurable": {"thread_id": f"business-lr-live-{uuid.uuid4()}"}}
+
+    final_state: dict = {}
+    async for event in graph.astream(BUSINESS_LR_PAYLOAD, config=config, stream_mode="updates"):
+        for _node, node_output in event.items():
+            if isinstance(node_output, dict):
+                final_state.update(node_output)
+
+    errors: list[str] = []
+
+    # 1. Charts M2 vienen del builder Python-determinista.
+    charts = final_state.get("doc2_eda_charts", [])
+    if not charts:
+        errors.append("[FAIL] doc2_eda_charts vacío — el builder business no emitió panel")
+    else:
+        non_python = [c.get("id") for c in charts if c.get("data_source") != "python_builder"]
+        if non_python:
+            errors.append(f"[FAIL] charts no-deterministas (LLM-JSON): {non_python}")
+        ids = {c.get("id") for c in charts}
+        if "financial_mirage" not in ids or "churn_drivers" not in ids:
+            errors.append(f"[FAIL] faltan charts honestos esperados; ids={ids}")
+        # Anti-doble-eje: ningún chart financiero define yaxis2.
+        for c in charts:
+            if c.get("id") == "financial_mirage" and "yaxis2" in (c.get("layout") or {}):
+                errors.append("[FAIL] financial_mirage reintrodujo el doble eje Y")
+
+    # 2. M3 razona la decisión LR en lenguaje gerencial.
+    m3 = (final_state.get("m3_content") or "").lower()
+    if not m3 or m3.startswith("[m3_not_executed]"):
+        errors.append("[FAIL] m3_content ausente o no ejecutado")
+    else:
+        if "probabilidad de abandono" not in m3 and "regresión logística" not in m3:
+            errors.append("[FAIL] M3 no menciona la decisión apoyada en el modelo LR")
+        jargon_found = [t for t in _JARGON if t in m3]
+        if jargon_found:
+            errors.append(f"[FAIL] M3 business expone jerga DS: {jargon_found}")
+
+    # 3. El dataset tiene una correlación NPS↔churn REAL.
+    dataset = final_state.get("doc7_dataset", [])
+    if dataset:
+        df = pd.DataFrame(dataset)
+        if {"nps", "churn_rate"}.issubset(df.columns):
+            corr = df["nps"].corr(df["churn_rate"])
+            if not (corr < -0.2):
+                errors.append(f"[FAIL] NPS↔churn no correlacionan negativamente (corr={corr:.2f})")
+
+    # 4. business no genera notebook.
+    for nb in ("m3_notebook_code", "doc6_notebook"):
+        if final_state.get(nb):
+            errors.append(f"[FAIL] {nb} presente en business (solo ml_ds genera notebook)")
+
+    assert not errors, "\n".join(errors)

--- a/backend/tests/test_eda_charts_business.py
+++ b/backend/tests/test_eda_charts_business.py
@@ -1,0 +1,544 @@
+"""Tests deterministas para el panel EDA Python del perfil BUSINESS.
+
+Cubre, sin LLM:
+  * El builder puro `generate_business_eda_charts` (estructura, honestidad,
+    anti-doble-eje, anti-overclaim, fallbacks).
+  * El merge annotate-only vía `_eda_business_python_path` (el LLM solo anota).
+  * La reconciliación de datos en `_generate_dataset_from_schema`
+    (márgenes realistas, NPS↔churn correlacionados, outlier fuera de las
+    columnas financieras en business).
+  * El cableado del bloque LR-business en `M3_AUDIT_PROMPT`.
+
+Las aserciones son por PROPIEDAD (no por valores exactos) porque el seed de
+`_generate_dataset_from_schema` deriva de `hash(...)`, que el intérprete
+aleatoriza entre procesos. Las propiedades estructurales se cumplen con
+cualquier seed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from case_generator.datagen.eda_charts_business import generate_business_eda_charts
+
+CONTRACT = {"case_id": "test_case_business"}
+
+
+# ─────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def df_business() -> pd.DataFrame:
+    """12 meses; revenue sube, churn baja, nps sube (→ nps↔churn negativo)."""
+    periods = [f"2023-{m:02d}" for m in range(1, 13)]
+    revenue = [100_000 + i * 2_000 for i in range(12)]
+    costs = [round(r * 0.7, 2) for r in revenue]
+    margin_pct = [round((r - c) / r * 100, 2) for r, c in zip(revenue, costs)]
+    churn = [round(0.20 - i * 0.005, 4) for i in range(12)]
+    nps = [30 + i * 2 for i in range(12)]
+    return pd.DataFrame(
+        {
+            "period": periods,
+            "revenue": revenue,
+            "costs": costs,
+            "margin_pct": margin_pct,
+            "churn_rate": churn,
+            "nps": nps,
+            "retention_m1": [0.90] * 12,
+            "retention_m3": [0.70] * 12,
+            "retention_m6": [0.50] * 12,
+            "retention_m12": [0.30] * 12,
+        }
+    )
+
+
+@pytest.fixture
+def precalc_with_cohort() -> dict:
+    """Métricas precalculadas con matriz de correlación + cohortes (forma real)."""
+    return {
+        "correlation_matrix": {
+            "x": ["revenue", "costs", "churn_rate", "nps"],
+            "y": ["revenue", "costs", "churn_rate", "nps"],
+            "z": [
+                [1.0, 0.8, -0.9, 0.7],
+                [0.8, 1.0, -0.5, 0.4],
+                [-0.9, -0.5, 1.0, -0.85],  # fila del target churn_rate
+                [0.7, 0.4, -0.85, 1.0],
+            ],
+        },
+        "cohort_matrix": {
+            "x": ["M1", "M3", "M6", "M12"],
+            "y": ["2023-01", "2023-02", "2023-03"],
+            "z": [
+                [0.90, 0.70, 0.50, 0.30],
+                [0.91, 0.72, 0.52, 0.31],
+                [0.89, 0.68, 0.49, 0.29],
+            ],
+        },
+    }
+
+
+# ─────────────────────────────────────────────────────────
+# Builder puro — estructura
+# ─────────────────────────────────────────────────────────
+
+
+def test_happy_path_three_charts_in_order(df_business, precalc_with_cohort) -> None:
+    charts = generate_business_eda_charts(
+        df_business, "churn_rate", precalc_with_cohort, CONTRACT
+    )
+    assert [c["id"] for c in charts] == [
+        "financial_mirage",
+        "churn_drivers",
+        "cohort_collapse",
+    ]
+    assert all(c["data_source"] == "python_builder" for c in charts)
+    assert all(c["library"] == "plotly" for c in charts)
+
+
+def test_empty_df_returns_empty_list() -> None:
+    assert generate_business_eda_charts(pd.DataFrame(), "churn_rate", {}, CONTRACT) == []
+
+
+# ─────────────────────────────────────────────────────────
+# financial_mirage — anti-doble-eje (la regresión clave del bug)
+# ─────────────────────────────────────────────────────────
+
+
+def test_financial_mirage_has_no_dual_axis(df_business, precalc_with_cohort) -> None:
+    """Nunca debe reaparecer el doble eje Y engañoso del path legacy."""
+    charts = generate_business_eda_charts(
+        df_business, "churn_rate", precalc_with_cohort, CONTRACT
+    )
+    fin = next(c for c in charts if c["id"] == "financial_mirage")
+    assert fin["chart_type"] == "scatter"
+    assert "yaxis2" not in fin["layout"]
+    for trace in fin["traces"]:
+        assert trace.get("yaxis") != "y2"
+    # base 100 → primer valor indexado de cada serie es exactamente 100.0
+    for trace in fin["traces"]:
+        assert trace["y"][0] == 100.0
+    assert "base 100" in fin["layout"]["yaxis"]["title"].lower()
+
+
+def test_financial_mirage_missing_revenue_degrades(df_business) -> None:
+    df = df_business.drop(columns=["revenue"])
+    charts = generate_business_eda_charts(df, "churn_rate", {}, CONTRACT)
+    fin = next(c for c in charts if c["id"] == "financial_mirage")
+    assert fin["traces"] == []  # placeholder, no inventa series
+
+
+# ─────────────────────────────────────────────────────────
+# churn_drivers — honestidad (anti-overclaim del –0.89)
+# ─────────────────────────────────────────────────────────
+
+
+def test_churn_drivers_values_come_from_precalculated_corr(
+    df_business, precalc_with_cohort
+) -> None:
+    """Las magnitudes mostradas == |corr| reales de la matriz precalculada,
+    ordenadas desc. NO números inventados por el LLM.
+    """
+    charts = generate_business_eda_charts(
+        df_business, "churn_rate", precalc_with_cohort, CONTRACT
+    )
+    drivers = next(c for c in charts if c["id"] == "churn_drivers")
+    trace = drivers["traces"][0]
+    assert drivers["chart_type"] == "bar"
+    assert trace["orientation"] == "h"
+    # |corr| de churn_rate vs {revenue:0.9, nps:0.85, costs:0.5} → orden desc
+    assert trace["y"] == ["revenue", "nps", "costs"]
+    assert trace["x"] == [0.9, 0.85, 0.5]
+    # Eje fijo [0,1] impide exagerar magnitudes pequeñas.
+    assert drivers["layout"]["xaxis"]["range"] == [0, 1]
+
+
+def test_churn_drivers_fallback_computes_from_df(df_business) -> None:
+    """Sin correlation_matrix precalculada, computa |corr| del df (no se rinde)."""
+    charts = generate_business_eda_charts(df_business, "churn_rate", {}, CONTRACT)
+    drivers = next(c for c in charts if c["id"] == "churn_drivers")
+    trace = drivers["traces"][0]
+    # nps sube y churn baja → |corr| alto y real.
+    nps_idx = trace["y"].index("nps")
+    assert trace["x"][nps_idx] > 0.8
+
+
+def test_churn_drivers_no_computable_correlations_returns_empty() -> None:
+    """Sin features con varianza (todo constante), no hay correlaciones → placeholder."""
+    df = pd.DataFrame(
+        {
+            "period": [f"2023-{m:02d}" for m in range(1, 13)],
+            "revenue": [100_000] * 12,  # constante → excluida
+            "churn_rate": [0.1, 0.2] * 6,
+            "nps": [50] * 12,  # constante → corr indefinida → excluida
+        }
+    )
+    charts = generate_business_eda_charts(df, "churn_rate", {}, CONTRACT)
+    drivers = next(c for c in charts if c["id"] == "churn_drivers")
+    assert drivers["traces"] == []  # placeholder honesto, sin barras inventadas
+
+
+def test_churn_drivers_weak_but_present_correlation_is_flagged() -> None:
+    """Con 0 < |corr| < 0.10 el chart SÍ dibuja la barra real Y avisa que no hay driver fuerte.
+
+    Ejercita la rama anti-overclaim (`strongest < _DRIVERS_MIN_ABS_CORR` con barras),
+    que la aserción tautológica previa nunca alcanzaba.
+    """
+    df = pd.DataFrame(
+        {
+            "period": [f"2023-{m:02d}" for m in range(1, 13)],
+            "revenue": list(range(100, 112)),
+            "churn_rate": [0.1] * 12,
+        }
+    )
+    precalc = {
+        "correlation_matrix": {
+            "x": ["revenue", "churn_rate"],
+            "y": ["revenue", "churn_rate"],
+            "z": [[1.0, 0.05], [0.05, 1.0]],  # |corr| revenue↔churn = 0.05 < 0.10
+        }
+    }
+    charts = generate_business_eda_charts(df, "churn_rate", precalc, CONTRACT)
+    drivers = next(c for c in charts if c["id"] == "churn_drivers")
+    assert drivers["traces"] != []  # hay barra real
+    assert drivers["traces"][0]["x"] == [0.05]
+    assert "0.10" in drivers["notes"]  # nota de cautela explícita
+    assert drivers["layout"]["xaxis"]["range"] == [0, 1]  # eje fijo anti-exageración
+
+
+# ─────────────────────────────────────────────────────────
+# cohort_collapse — reusa la matriz precalculada / fallback box
+# ─────────────────────────────────────────────────────────
+
+
+def test_cohort_collapse_uses_precalculated_matrix(
+    df_business, precalc_with_cohort
+) -> None:
+    charts = generate_business_eda_charts(
+        df_business, "churn_rate", precalc_with_cohort, CONTRACT
+    )
+    cohort = next(c for c in charts if c["id"] == "cohort_collapse")
+    assert cohort["chart_type"] == "heatmap"
+    assert cohort["traces"][0]["z"] == precalc_with_cohort["cohort_matrix"]["z"]
+
+
+def test_cohort_collapse_fallback_to_box(df_business) -> None:
+    """Sin cohort_matrix, cae a una caja del objetivo (no falsea cohortes)."""
+    charts = generate_business_eda_charts(df_business, "churn_rate", {}, CONTRACT)
+    third = charts[2]
+    assert third["id"] == "target_distribution"
+    assert third["chart_type"] == "box"
+
+
+# ─────────────────────────────────────────────────────────
+# _eda_business_python_path — el LLM solo anota (boundary)
+# ─────────────────────────────────────────────────────────
+
+
+def test_business_path_llm_only_annotates(df_business) -> None:
+    """El LLM annotate-only solo escribe description/notes; nunca toca los números."""
+    from case_generator.graph import _eda_business_python_path
+
+    state: dict[str, Any] = {
+        "doc7_dataset": df_business.to_dict(orient="records"),
+        "studentProfile": "business",
+        "task_payload": {"algoritmos": ["Logistic Regression"]},
+        "case_id": "test_case_business",
+    }
+    fake_ann = MagicMock()
+    fake_ann.annotations = [
+        MagicMock(id="financial_mirage", description="LLM desc", notes="LLM note"),
+    ]
+    chained = MagicMock()
+    chained.with_structured_output.return_value.invoke.return_value = fake_ann
+
+    with patch(
+        "case_generator.graph._get_chart_llm", return_value=chained
+    ), patch(
+        "case_generator.graph.Configuration.from_runnable_config",
+        return_value=MagicMock(writer_model="gemini-2.5-flash"),
+    ):
+        update = _eda_business_python_path(state, config=None, contract=CONTRACT)
+
+    assert update is not None
+    fin = next(c for c in update["doc2_eda_charts"] if c["id"] == "financial_mirage")
+    assert fin["description"] == "LLM desc"  # del LLM
+    assert fin["traces"][0]["y"][0] == 100.0  # del builder, intacto
+    assert fin["data_source"] == "python_builder"
+
+
+# ─────────────────────────────────────────────────────────
+# _generate_dataset_from_schema — reconciliación de datos (Issue 4A)
+# ─────────────────────────────────────────────────────────
+
+
+def _business_schema(n_rows: int = 100) -> dict:
+    return {
+        "n_rows": n_rows,
+        "time_granularity": "monthly",
+        "columns": [
+            {"name": "period", "type": "str", "range_min": None, "range_max": None, "nullable": False, "trend": None, "dependency": None},
+            {"name": "revenue", "type": "float", "range_min": 80_000, "range_max": 120_000, "nullable": False, "trend": "up", "dependency": None},
+            {"name": "costs", "type": "float", "range_min": 50_000, "range_max": 90_000, "nullable": False, "trend": None, "dependency": {"depends_on": "revenue", "relationship": "linear", "noise_factor": 0.12}},
+            {"name": "margin_pct", "type": "float", "range_min": 0, "range_max": 100, "nullable": False, "trend": None, "dependency": None},
+            {"name": "churn_rate", "type": "float", "range_min": 0.02, "range_max": 0.15, "nullable": False, "trend": None, "dependency": {"depends_on": "revenue", "relationship": "inverse", "noise_factor": 0.15}},
+            {"name": "nps", "type": "int", "range_min": 20, "range_max": 75, "nullable": False, "trend": None, "dependency": {"depends_on": "revenue", "relationship": "linear", "noise_factor": 0.30}},
+            {"name": "retention_m1", "type": "float", "range_min": 0.65, "range_max": 0.95, "nullable": False, "trend": None, "dependency": None},
+            {"name": "retention_m3", "type": "float", "range_min": 0.50, "range_max": 0.80, "nullable": False, "trend": None, "dependency": {"depends_on": "retention_m1", "relationship": "linear", "noise_factor": 0.05}},
+            {"name": "retention_m6", "type": "float", "range_min": 0.30, "range_max": 0.60, "nullable": False, "trend": None, "dependency": None},
+            {"name": "retention_m12", "type": "float", "range_min": 0.15, "range_max": 0.40, "nullable": False, "trend": None, "dependency": None},
+        ],
+        "constraints": {
+            "revenue_annual_total": 1_200_000,
+            "cost_annual_total": 800_000,
+            "revenue_column": "revenue",
+            "tolerance_pct": 0.05,
+        },
+    }
+
+
+def test_business_margins_are_realistic_no_minus_149() -> None:
+    """Con costs→revenue, el margen por fila queda en banda realista (sin –149%)."""
+    from case_generator.graph import _generate_dataset_from_schema
+
+    rows = _generate_dataset_from_schema(_business_schema(), profile="business")
+    margins = [r["margin_pct"] for r in rows if r.get("margin_pct") is not None]
+    assert margins
+    assert min(margins) > -50.0  # el bug producía -149%
+    assert sum(margins) / len(margins) > 0.0
+
+
+def test_business_nps_and_churn_are_genuinely_correlated() -> None:
+    """nps y churn quedan correlacionados inversamente vía revenue (driver real)."""
+    from case_generator.graph import _generate_dataset_from_schema
+
+    rows = _generate_dataset_from_schema(_business_schema(), profile="business")
+    df = pd.DataFrame(rows)
+    assert df["nps"].corr(df["churn_rate"]) < -0.3
+
+
+def test_business_outlier_avoids_financial_columns() -> None:
+    """El outlier (Fix B-05) NO toca columnas financieras en business; ml_ds sí."""
+    from case_generator.graph import _generate_dataset_from_schema
+
+    biz = pd.DataFrame(_generate_dataset_from_schema(_business_schema(), profile="business"))
+    # costs sigue a revenue (ruido bajo) → sin pico ×3.5.
+    assert biz["costs"].max() <= 2.0 * biz["costs"].median()
+
+    ml = pd.DataFrame(_generate_dataset_from_schema(_business_schema(), profile="ml_ds"))
+    # ml_ds conserva el comportamiento: el outlier cae en costs (primera no-revenue).
+    assert ml["costs"].max() > 2.0 * ml["costs"].median()
+
+
+# ─────────────────────────────────────────────────────────
+# M3 LR-business — cableado del bloque (Issue 3A)
+# ─────────────────────────────────────────────────────────
+
+
+def test_m3_audit_prompt_has_lr_placeholder() -> None:
+    from case_generator.prompts import M3_AUDIT_LR_BUSINESS_BLOCK, M3_AUDIT_PROMPT
+
+    assert "{lr_business_block}" in M3_AUDIT_PROMPT
+    assert "regresión logística" in M3_AUDIT_LR_BUSINESS_BLOCK
+    assert "probabilidad de abandono" in M3_AUDIT_LR_BUSINESS_BLOCK
+
+
+def test_m3_lr_block_gate_business_classification() -> None:
+    """business + Logistic Regression → el prompt M3 lleva el bloque LR;
+    business + clustering → no lo lleva.
+    """
+    from case_generator.graph import m3_content_generator
+
+    captured: dict[str, str] = {}
+
+    def _capture(*, node_name, llm, prompt, metrics_block, grounding_enabled):
+        captured["prompt"] = prompt
+        return "m3 content"
+
+    base_state = {
+        "doc1_narrativa": "n",
+        "doc2_eda": "eda report",
+        "studentProfile": "business",
+        "case_id": "c1",
+    }
+
+    with patch("case_generator.graph._invoke_narrative_with_grounding", _capture), patch(
+        "case_generator.graph.Configuration.from_runnable_config",
+        return_value=MagicMock(writer_model="gemini-2.5-flash"),
+    ), patch("case_generator.graph._get_writer_llm", return_value=MagicMock()):
+        m3_content_generator(
+            {**base_state, "task_payload": {"algoritmos": ["Logistic Regression"]}},
+            config=None,
+        )
+        assert "regresión logística" in captured["prompt"]
+
+        m3_content_generator(
+            {**base_state, "task_payload": {"algoritmos": ["K-Means"]}},
+            config=None,
+        )
+        assert "regresión logística" not in captured["prompt"]
+
+
+def test_lr_business_block_absent_from_ml_ds_prompts() -> None:
+    """Invariante 'ml_ds intacto': el bloque LR-business no está horneado en los
+    prompts ml_ds ni puede renderizar allí (no tienen el placeholder).
+    """
+    from case_generator.prompts import (
+        M3_AUDIT_LR_BUSINESS_BLOCK,
+        M3_CONTENT_PROMPT_CLASSIFICATION_BY_VARIANT,
+        M3_EXPERIMENT_PROMPT,
+    )
+
+    sentinel = "decisión apoyada en un modelo de probabilidad de abandono"
+    assert sentinel in M3_AUDIT_LR_BUSINESS_BLOCK
+    assert sentinel not in M3_EXPERIMENT_PROMPT
+    assert "{lr_business_block}" not in M3_EXPERIMENT_PROMPT
+    for variant_prompt in M3_CONTENT_PROMPT_CLASSIFICATION_BY_VARIANT.values():
+        assert sentinel not in variant_prompt
+        assert "{lr_business_block}" not in variant_prompt
+
+
+# ─────────────────────────────────────────────────────────
+# financial_mirage — honestidad ante márgenes no positivos (anti-inversión)
+# ─────────────────────────────────────────────────────────
+
+
+def test_financial_mirage_omits_margin_when_first_period_negative() -> None:
+    """Margen con primer período negativo: indexarlo INVERTIRÍA la dirección
+    (una mejora se vería como caída). Se omite con nota honesta; revenue se mantiene.
+    """
+    df = pd.DataFrame(
+        {
+            "period": [f"2023-{m:02d}" for m in range(1, 13)],
+            "revenue": [100_000 + i * 1_000 for i in range(12)],
+            # Pérdida que mejora: -8% → +16% (dirección ascendente real).
+            "margin_pct": [-8.0 + i * 2.0 for i in range(12)],
+        }
+    )
+    charts = generate_business_eda_charts(df, "churn_rate", {}, CONTRACT)
+    fin = next(c for c in charts if c["id"] == "financial_mirage")
+    names = [t.get("name") for t in fin["traces"]]
+    assert "Ingresos (índice)" in names  # revenue positivo → sí se indexa
+    assert "Margen % (índice)" not in names  # margen base negativa → omitido
+    assert "no positivos" in fin["notes"]
+
+
+def test_financial_mirage_omits_margin_when_series_crosses_zero() -> None:
+    """Base positiva pero la serie cruza a no-positivo: el índice explota alrededor
+    de cero → se omite la traza de margen (no se grafica una escala distorsionada).
+    """
+    df = pd.DataFrame(
+        {
+            "period": [f"2023-{m:02d}" for m in range(1, 6)],
+            "revenue": [100, 101, 102, 103, 104],
+            "margin_pct": [30.0, 20.0, -5.0, 10.0, 25.0],
+        }
+    )
+    charts = generate_business_eda_charts(df, "churn_rate", {}, CONTRACT)
+    fin = next(c for c in charts if c["id"] == "financial_mirage")
+    names = [t.get("name") for t in fin["traces"]]
+    assert "Margen % (índice)" not in names
+
+
+# ─────────────────────────────────────────────────────────
+# Outlier business respeta el range_max declarado (Issue #3)
+# ─────────────────────────────────────────────────────────
+
+
+def test_business_outlier_respects_declared_ranges() -> None:
+    """En business el outlier respeta el range_max declarado (churn ≤ 0.15, no 0.30),
+    sin violar el rango que el propio schema definió. ml_ds conserva el cap ×2.
+    """
+    from case_generator.graph import _generate_dataset_from_schema
+
+    schema = _business_schema()
+    df = pd.DataFrame(_generate_dataset_from_schema(schema, profile="business"))
+    for col in schema["columns"]:
+        rmax = col.get("range_max")
+        name = col["name"]
+        if (
+            rmax is not None
+            and name in df.columns
+            and pd.api.types.is_numeric_dtype(df[name])
+        ):
+            assert df[name].max() <= float(rmax) + 1e-9, f"{name} excede range_max {rmax}"
+    assert df["churn_rate"].max() <= 0.15 + 1e-9
+
+
+# ─────────────────────────────────────────────────────────
+# Dispatch 5A — business NUNCA cae al path LLM-JSON
+# ─────────────────────────────────────────────────────────
+
+
+def test_eda_chart_generator_business_empty_dataset_no_llm_fallback() -> None:
+    """Issue 5A: business+clasif con builder sin charts → panel vacío y NUNCA invoca
+    el path LLM-JSON (`_get_chart_llm`). Guarda el invariante central del cambio.
+    """
+    from case_generator import graph
+
+    state = {
+        "doc2_eda": "Reporte EDA válido del Módulo 2.",  # pasa el guard inicial
+        "doc7_dataset": [],  # fuerza _eda_business_python_path → None
+        "studentProfile": "business",
+        "task_payload": {"algoritmos": ["Logistic Regression"]},
+        "case_id": "c1",
+    }
+    with patch.object(graph, "_get_chart_llm") as mock_llm:
+        update = graph.eda_chart_generator(state, config=None)
+
+    assert update["doc2_eda_charts"] == []
+    assert update["current_agent"] == "eda_chart_generator"
+    mock_llm.assert_not_called()  # el path LLM-JSON nunca se ejecuta para business
+
+
+# ─────────────────────────────────────────────────────────
+# _annotate_validate_emit — el caveat factual del builder sobrevive el merge
+# ─────────────────────────────────────────────────────────
+
+
+def test_annotate_validate_emit_preserves_builder_caveat() -> None:
+    """El caveat factual del builder va PRIMERO e íntegro; la nota del LLM se clampa
+    al espacio restante (con elipsis), total ≤ 300. Cubre la lógica anti-overclaim
+    del merge que el happy-path (notes vacíos) nunca ejercita.
+    """
+    from case_generator.graph import _annotate_validate_emit
+
+    chart = {
+        "id": "churn_drivers",
+        "title": "T",
+        "subtitle": "S",
+        "library": "plotly",
+        "chart_type": "bar",
+        "traces": [{"type": "bar", "x": [0.05], "y": ["revenue"], "orientation": "h"}],
+        "layout": {"template": "plotly_white"},
+        "source": "Dataset ADAM",
+        "description": "",
+        "notes": "CAVEAT_BUILDER_FACTUAL",
+        "data_source": "python_builder",
+    }
+    fake_ann = MagicMock()
+    fake_ann.annotations = [
+        MagicMock(id="churn_drivers", description="D", notes="NOTA_LLM " * 60),
+    ]
+    chained = MagicMock()
+    chained.with_structured_output.return_value.invoke.return_value = fake_ann
+    prompt = "{charts_context_json} {case_id} {student_profile} {output_language}"
+
+    with patch("case_generator.graph._get_chart_llm", return_value=chained), patch(
+        "case_generator.graph.Configuration.from_runnable_config",
+        return_value=MagicMock(writer_model="gemini-2.5-flash"),
+    ):
+        update = _annotate_validate_emit(
+            [chart], {"studentProfile": "business"}, None, prompt
+        )
+
+    notes = update["doc2_eda_charts"][0]["notes"]
+    assert notes.startswith("CAVEAT_BUILDER_FACTUAL")  # caveat íntegro y primero
+    assert "NOTA_LLM" in notes  # la nota del LLM sobrevive (clampada)
+    assert len(notes) <= 300


### PR DESCRIPTION
## Context

El equipo invirtió fuertemente en el perfil **ml_ds** (charts Python-deterministas, notebooks, narrative grounding). El perfil **business** quedó atrás: usaba prompts genéricos y sus gráficos del Módulo 2 se generaban vía LLM-JSON con problemas de calidad visibles (doble-eje engañoso, correlación –0.89 sobre-afirmada que los datos no respaldaban). Este PR sube el perfil business al mismo estándar, para presentarlo ante la facultad de negocios.

## Cambios

### Stream A — Gráficos M2 honestos (builder Python-determinista)
- **`datagen/eda_charts_business.py` (nuevo)**, set honesto de 3 charts:
  - **`financial_mirage`**: ingresos + margen **indexados a base 100** en un solo eje → elimina el doble-eje engañoso. Omite la traza de margen con nota honesta cuando es no-positivo (evita inversión de signo / explosión de escala).
  - **`churn_drivers`**: barra de `|corr|` **reales** con el objetivo, eje fijo `[0,1]` → elimina la correlación sobre-afirmada; avisa si no hay driver fuerte.
  - **`cohort_collapse`**: reusa la matriz de cohortes precalculada (row-capped).
- Dispatch en `eda_chart_generator`: business+clasificación → builder Python; **nunca** cae al path LLM-JSON (Issue 5A) — degrada a panel vacío. El LLM solo anota.
- Helpers compartidos extraídos a **`datagen/eda_charts_common.py`** (DRY) + tail compartido `_annotate_validate_emit`.

### Datos (`graph.py` + `SCHEMA_DESIGNER_PROMPT`)
- El schema business declara dependencias genuinas `costs→revenue` y `nps→revenue` → márgenes realistas y NPS↔churn correlacionados de verdad (driver real, no un –0.89 fabricado).
- El outlier `Fix B-05` ya no toca columnas financieras en business y respeta el `range_max` declarado; **ml_ds sin cambios**.

### Stream B — LR narrativo (Issue 3A)
- `M3_AUDIT_LR_BUSINESS_BLOCK` inyectado en `M3_AUDIT_PROMPT` solo para business+clasificación, en **lenguaje gerencial plano** (sin jerga DS, sin notebook, sin métricas) — respeta el invariante "business nunca ejecuta".

## Revisión y validación
- **Review adversarial multi-agente** (6 dimensiones × 2 verificadores por hallazgo): veredicto **ship**, 0 blockers / 0 high. Todos los hallazgos confirmados fueron corregidos (guard anti-inversión de margen, outlier dentro de rango, merge de notas, + tests de regresión para 5A, gate ml_ds, anti-overclaim).
- backend **993 passed** / 16 skipped, **mypy clean** (80 files); frontend **444 passed** (contrato `EDAChartSpec` intacto, 0 cambios FE).
- Diferido en `TODOS.md`: LR→M4/M5, builder para otras familias business, refactor global de outliers, pulido DRY del factory de specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
