### PR TITLE
fix(eda): legible per-cell heatmap text via Plotly auto-contrast (cohort M12)

### DIFF
--- a/frontend/src/shared/case-viewer/plotlyChartUtils.test.ts
+++ b/frontend/src/shared/case-viewer/plotlyChartUtils.test.ts
@@ -26,11 +26,13 @@ describe("sanitizeTraces — dense heatmap per-cell text handling", () => {
         expect(out.textfont).toBeDefined();
     });
 
-    it("injects default text for a non-dense heatmap missing a texttemplate", () => {
+    it("injects default text WITHOUT a forced color so Plotly auto-contrasts per cell", () => {
         const [out] = sanitizeTraces([heatmap(12, 4)]);
 
         expect(out.texttemplate).toBe("%{z:.2f}");
-        expect(out.textfont).toEqual({ size: 11, color: "#ffffff" });
+        // No color: Plotly elige por celda un color legible (oscuro sobre celdas
+        // claras, blanco sobre oscuras). Forzar blanco ocultaba el texto en celdas pálidas.
+        expect(out.textfont).toEqual({ size: 11 });
     });
 
     it("drops per-cell text on a dense (17×17 correlation-like) heatmap", () => {

--- a/frontend/src/shared/case-viewer/plotlyChartUtils.ts
+++ b/frontend/src/shared/case-viewer/plotlyChartUtils.ts
@@ -168,7 +168,12 @@ export function sanitizeTraces(traces: Record<string, unknown>[]): Record<string
                         sanitized.texttemplate = "%{z:.2f}";
                     }
                     if (sanitized.textfont == null) {
-                        sanitized.textfont = { size: 11, color: "#ffffff" };
+                        // Sin color explícito: Plotly elige por celda un color que
+                        // contraste con el fondo (texto oscuro sobre celdas claras
+                        // como la columna M12 amarilla del heatmap de cohortes,
+                        // blanco sobre celdas oscuras). Forzar "#ffffff" volvía
+                        // ilegibles los porcentajes en las celdas pálidas.
+                        sanitized.textfont = { size: 11 };
                     }
                 }
             } else {


### PR DESCRIPTION
## Problema
El heatmap de retención de cohortes mostraba los porcentajes en **blanco fijo** en todas las celdas. En las celdas claras (columna **M12**, ~28–34%, amarillo pálido) el texto blanco quedaba **ilegible**.

## Causa
`sanitizeTraces` en `frontend/src/shared/case-viewer/plotlyChartUtils.ts` inyectaba `textfont: { size: 11, color: "#ffffff" }` por defecto en heatmaps no-densos cuando el backend no enviaba `textfont`. Un único color blanco no contrasta con el extremo claro de la escala `YlOrRd`.

## Fix
Quitar el color forzado (`{ size: 11 }`). Con `textfont.color` sin definir, **Plotly.js v3 elige por celda un color que contrasta** con el fondo: texto oscuro sobre celdas claras, blanco sobre oscuras. Una línea + test actualizado.

## Validación
- `plotlyChartUtils.test.ts` actualizado y verde.
- Frontend completo: **444 passed**.
- Solo frontend; sin cambios de backend ni de contrato.

Detectado al revisar el chart de cohortes de un caso real (columna M12 ilegible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
