### PR TITLE
fix(eda): honest temporal aggregation for financial_mirage margin legibility (#297)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -790,6 +790,33 @@ de business+LR.
 
 ---
 
+## TODO-297-A: El de-sawtooth de `financial_mirage` es solo de presentación (causa raíz intacta)
+
+**What:** Dejar registrado que el fix de Issue #297 (agregación temporal anual/trimestral en
+`_build_financial_mirage`) suaviza la sierra del margen SOLO en ese chart, vía display-aggregation.
+La causa raíz de la varianza por fila del margen sigue intacta: `costs` `noise_factor: 0.12`
+(`SCHEMA_DESIGNER_PROMPT`) + el recálculo `(rev-cost)/rev` en `_generate_dataset_from_schema`.
+
+**Why:** Cualquier futuro chart business que muestre el `margin_pct` MENSUAL crudo (sin agregar)
+volverá a verse como sierra. El fix no es un cambio de datos a propósito (cohortes, correlaciones
+y ml_ds quedan byte-idénticos), así que la deuda es consciente, no un descuido.
+
+**Pros:** Si más adelante se decide que el margen mensual crudo importa, hay un punto único documentado
+para reconsiderar bajar el `noise_factor` o suavizar en el data-gen (con su propio plan-eng-review).
+
+**Cons:** Mantener una nota de deuda que quizá nunca se accione. Bajo costo.
+
+**Context:** El grano se elige en `_detect_period_grain` (eda_charts_business.py): business genera
+80–120 meses → SIEMPRE cae en "annual" (~7–10 puntos). La rama "quarterly" (25–48 meses) es
+actualmente **inalcanzable en producción** (el clamp `n_rows` business es 80–120 mensual); existe por
+robustez y queda cubierta por test `test_financial_mirage_aggregates_quarterly_for_mid_horizon`. Si en
+el futuro el schema designer pudiera emitir granularidad más gruesa o se cambia el clamp, revisitar.
+
+**Depends on / blocked by:** Independiente. No bloquea nada; cerrar solo si se decide atacar la causa
+raíz de la varianza del margen en el data-gen (área sensible, requiere regresión de notebooks ml_ds).
+
+---
+
 ## TODO-OUTLIER-SCHEMA-AWARE: Inyección de outliers schema-aware (global, cross-profile)
 
 **What:** Reemplazar la heurística "primera columna numérica no-revenue × 3.5" de

--- a/backend/src/case_generator/datagen/eda_charts_business.py
+++ b/backend/src/case_generator/datagen/eda_charts_business.py
@@ -140,7 +140,11 @@ def _aggregate_by_grain(
         .mean(numeric_only=True)
     )
     agg_periods = means.index.astype(str).tolist()
-    series_map = {col: means[col] for col in value_cols}
+    # `numeric_only=True` descarta una columna presente pero no numérica
+    # (p. ej. object dtype con strings o todo None). El filtro `if col in
+    # means.columns` mantiene la paridad con el path crudo: esa traza se omite
+    # (luego `_indexed_base_100` la trata como ausente), sin tirar el chart entero.
+    series_map = {col: means[col] for col in value_cols if col in means.columns}
     return agg_periods, series_map
 
 

--- a/backend/src/case_generator/datagen/eda_charts_business.py
+++ b/backend/src/case_generator/datagen/eda_charts_business.py
@@ -17,6 +17,8 @@ Pipeline (no LLM calls; pandas only):
    ┌────────────────────────────────────────────────────────────────────────────┐
    │  1. financial_mirage   (scatter, líneas)   ingresos vs margen INDEXADOS      │
    │                                            base 100 → una sola escala honesta │
+   │                                            (agrega a anual/trimestral solo    │
+   │                                             para el display; lo declara)      │
    │  2. churn_drivers      (bar horizontal)    |corr| reales con el objetivo,    │
    │                                            eje fijo [0,1] → sin exagerar      │
    │  3. cohort_collapse    (heatmap)           retención por cohorte             │
@@ -44,6 +46,7 @@ Failure policy (igual que el builder de clasificación):
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import pandas as pd
@@ -55,6 +58,16 @@ logger = logging.getLogger("adam.graph")
 # Cuántos drivers mostrar y el umbral bajo el cual avisamos "sin driver fuerte".
 _DRIVERS_TOP_K = 8
 _DRIVERS_MIN_ABS_CORR = 0.10
+
+# Período mensual válido "YYYY-MM" con mes 01–12. Validar el mes (no solo \d{2})
+# hace que un mes malformado (p. ej. "2023-13") caiga al fallback honesto sin
+# agregación, en vez de producir una etiqueta de trimestre absurda (Q5/Q0).
+_PERIOD_MONTHLY_RE = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
+# Umbrales del grano de display (solo para financial_mirage). Business genera
+# 80–120 períodos mensuales → siempre cae en "annual" (~7–10 puntos). El grano
+# trimestral existe por robustez (datasets de 25–48 meses) y queda cubierto por test.
+_GRAIN_ANNUAL_MIN_MONTHS = 48
+_GRAIN_QUARTERLY_MIN_MONTHS = 24
 
 
 # ───────────────────────────────────────────────────────────────────────
@@ -70,6 +83,65 @@ def _sorted_by_period(df: pd.DataFrame) -> pd.DataFrame:
         except Exception:  # pragma: no cover - defensive
             return df
     return df
+
+
+def _detect_period_grain(periods: list[str]) -> str | None:
+    """Grano de display para `financial_mirage`: ``"annual"``, ``"quarterly"`` o ``None``.
+
+    Agregación de display HONESTA (solo suaviza/reduce puntos; el dataset no cambia):
+    business genera 80–120 períodos mensuales → la línea de margen sale como sierra
+    ruidosa que tapa el "espejismo". Agregar a un grano más grueso reduce los puntos
+    y el ruido a la vez, y se DECLARA en el subtítulo.
+
+    Devuelve ``None`` (= graficar crudo, sin sufijo de subtítulo) cuando:
+      * la lista está vacía, o
+      * NO todos los períodos son mensuales "YYYY-MM" con mes 01–12 (``all(...)``,
+        nunca ``any(...)``: mezclar formatos agregaría datos inconsistentes), o
+      * hay ≤ 24 meses (mensual ya se lee bien).
+
+    Con todos mensuales: ``> 48 → "annual"``, ``> 24 → "quarterly"``.
+    """
+    if not periods or not all(_PERIOD_MONTHLY_RE.match(p) for p in periods):
+        return None
+    n = len(periods)
+    if n > _GRAIN_ANNUAL_MIN_MONTHS:
+        return "annual"
+    if n > _GRAIN_QUARTERLY_MIN_MONTHS:
+        return "quarterly"
+    return None
+
+
+def _grain_key(period: str, grain: str) -> str:
+    """Clave de agrupación temporal para un período mensual "YYYY-MM" validado.
+
+    ``annual`` → ``"YYYY"``; ``quarterly`` → ``"YYYY-Qn"`` con ``n=(mes-1)//3+1``.
+    El llamador garantiza que ``period`` ya pasó ``_PERIOD_MONTHLY_RE`` (mes 01–12).
+    """
+    if grain == "annual":
+        return period[:4]
+    year, month = period.split("-")
+    return f"{year}-Q{(int(month) - 1) // 3 + 1}"
+
+
+def _aggregate_by_grain(
+    d: pd.DataFrame, value_cols: list[str], grain: str
+) -> tuple[list[str], dict[str, pd.Series]]:
+    """Promedia (media) las columnas de ``value_cols`` por grano temporal.
+
+    Devuelve ``(periods_agregados, {col: Serie de medias})`` SOLO para las columnas
+    presentes en ``value_cols`` (no asume que ``margin_pct`` exista → no tira el chart
+    entero si falta). ``groupby(sort=False)`` sobre un df ya ordenado por período, con
+    claves de grano monótonas, preserva el orden cronológico de forma determinista.
+    """
+    keys = [_grain_key(str(p), grain) for p in d["period"].tolist()]
+    means = (
+        d.assign(_grain_key=keys)
+        .groupby("_grain_key", sort=False)[value_cols]
+        .mean(numeric_only=True)
+    )
+    agg_periods = means.index.astype(str).tolist()
+    series_map = {col: means[col] for col in value_cols}
+    return agg_periods, series_map
 
 
 def _indexed_base_100(series: pd.Series) -> list[float | None] | None:
@@ -151,6 +223,13 @@ def _build_financial_mirage(df: pd.DataFrame, source: str) -> dict[str, Any]:
 
     Reemplaza el `scatter mode:lines` de doble eje Y del prompt legacy, que
     distorsionaba la comparación al darle escalas independientes a cada serie.
+
+    Antes de indexar, agrega la serie a un grano más grueso SOLO para el display
+    cuando hay muchos meses (business: 80–120 → anual). El dataset no cambia; la
+    agregación se declara en el subtítulo. Pipeline::
+
+        _sorted_by_period → _detect_period_grain → [_aggregate_by_grain (media)]
+                          → _indexed_base_100 (guardas intactas) → trace eje único
     """
     if "period" not in df.columns or "revenue" not in df.columns:
         return empty_chart(
@@ -163,10 +242,26 @@ def _build_financial_mirage(df: pd.DataFrame, source: str) -> dict[str, Any]:
         )
 
     d = _sorted_by_period(df)
-    periods = [str(p) for p in d["period"].tolist()]
+    raw_periods = [str(p) for p in d["period"].tolist()]
+
+    # Agregación temporal HONESTA solo para el display (el dataset no cambia).
+    # Reduce puntos y suaviza la sierra del margen, y se declara en el subtítulo.
+    value_cols = [c for c in ("revenue", "margin_pct") if c in d.columns]
+    grain = _detect_period_grain(raw_periods)
+    subtitle_suffix = ""
+    if grain is not None and value_cols:
+        periods, series = _aggregate_by_grain(d, value_cols, grain)
+        rev_series = series.get("revenue")
+        marg_series = series.get("margin_pct")
+        subtitle_suffix = " (promedio anual)" if grain == "annual" else " (promedio trimestral)"
+    else:
+        periods = raw_periods
+        rev_series = d["revenue"]
+        marg_series = d["margin_pct"] if "margin_pct" in d.columns else None
+
     traces: list[dict[str, Any]] = []
 
-    rev_idx = _indexed_base_100(d["revenue"])
+    rev_idx = _indexed_base_100(rev_series) if rev_series is not None else None
     if rev_idx is not None:
         traces.append(
             {
@@ -179,8 +274,8 @@ def _build_financial_mirage(df: pd.DataFrame, source: str) -> dict[str, Any]:
         )
 
     margin_note = ""
-    if "margin_pct" in d.columns:
-        marg_idx = _indexed_base_100(d["margin_pct"])
+    if marg_series is not None:
+        marg_idx = _indexed_base_100(marg_series)
         if marg_idx is not None:
             traces.append(
                 {
@@ -212,7 +307,10 @@ def _build_financial_mirage(df: pd.DataFrame, source: str) -> dict[str, Any]:
     return {
         "id": "financial_mirage",
         "title": "El espejismo del crecimiento",
-        "subtitle": "Ingresos y margen indexados (base 100 = primer período) en una escala comparable",
+        "subtitle": (
+            "Ingresos y margen indexados (base 100 = primer período) en una escala comparable"
+            + subtitle_suffix
+        ),
         "library": "plotly",
         "chart_type": "scatter",
         "traces": traces,

--- a/backend/tests/test_eda_charts_business.py
+++ b/backend/tests/test_eda_charts_business.py
@@ -24,6 +24,7 @@ import pandas as pd
 import pytest
 
 from case_generator.datagen.eda_charts_business import (
+    _aggregate_by_grain,
     _detect_period_grain,
     _indexed_base_100,
     generate_business_eda_charts,
@@ -596,7 +597,6 @@ def test_financial_mirage_aggregates_annual_for_long_horizon() -> None:
     rev = fin["traces"][0]
     assert rev["name"] == "Ingresos (índice)"
     assert len(rev["x"]) == 5  # 5 puntos anuales
-    assert len(rev["x"]) <= 10  # criterio: ≤ ~10 puntos
     assert rev["y"][0] == 100.0  # base 100 preservada tras agregar
     assert {t["name"] for t in fin["traces"]} == {
         "Ingresos (índice)",
@@ -677,8 +677,11 @@ def test_financial_mirage_aggregation_preserves_rising_trend() -> None:
 
 
 def test_financial_mirage_aggregation_reduces_margin_sawtooth() -> None:
-    # Sierra: alterna ±8 alrededor de 30 cada mes (ruido por fila, sin señal).
-    margin = [30.0 + (8.0 if i % 2 == 0 else -8.0) for i in range(60)]
+    # Sierra mensual (±8) sobre una deriva anual REAL y suave (−1/año). Agregar debe
+    # (a) aplanar la sierra y (b) preservar la deriva — no colapsar a una constante.
+    # La asimetría año-a-año hace que el test distinga el promedio honesto de un bug
+    # que aplane cualquier serie a constante (ese daría agg_y[0] == agg_y[-1]).
+    margin = [30.0 - (i // 12) * 1.0 + (8.0 if i % 2 == 0 else -8.0) for i in range(60)]
     df = _business_df_n(60, margin=margin)
     fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
     agg_y = next(t for t in fin["traces"] if "Margen" in t["name"])["y"]
@@ -691,6 +694,7 @@ def test_financial_mirage_aggregation_reduces_margin_sawtooth() -> None:
 
     assert max_raw_jump > 20  # la sierra cruda es ruidosa de verdad
     assert max_agg_jump < max_raw_jump / 4  # agregar la aplana
+    assert agg_y[0] > agg_y[-1]  # ...y preserva la deriva real (no colapsa a constante)
 
 
 # --- (g) si el margen AGREGADO cruza ≤ 0, se omite con nota (guarda intacta) ---
@@ -718,3 +722,62 @@ def test_financial_mirage_aggregation_without_margin_keeps_revenue() -> None:
     assert "Ingresos (índice)" in names  # solo revenue, pero no se cae el chart
     assert "promedio anual" in fin["subtitle"]
     assert len(fin["traces"][0]["x"]) == 5
+
+
+def test_financial_mirage_object_dtype_margin_keeps_revenue() -> None:
+    """Margen PRESENTE pero no numérico (object dtype): `numeric_only` lo descarta
+    al agregar; el chart e ingresos sobreviven (paridad con el path crudo, que
+    también omite solo esa traza). Sin el guard, esto tiraba el chart entero.
+    """
+    df = _business_df_n(60)
+    df["margin_pct"] = [None] * 60  # all-None → object dtype
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    names = [t.get("name") for t in fin["traces"]]
+    assert "Ingresos (índice)" in names  # no se cae el chart
+    assert "Margen % (índice)" not in names  # margen no numérico → omitido
+    assert "promedio anual" in fin["subtitle"]
+    assert len(fin["traces"][0]["x"]) == 5
+
+
+def test_financial_mirage_aggregation_orders_periods_chronologically() -> None:
+    """Aun con filas desordenadas, `_sorted_by_period` + `groupby(sort=False)`
+    entregan los períodos agregados en orden cronológico (contrato del docstring).
+    """
+    df = _business_df_n(60).sample(frac=1.0, random_state=0).reset_index(drop=True)
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    assert fin["traces"][0]["x"] == ["2023", "2024", "2025", "2026", "2027"]
+
+
+def test_financial_mirage_annual_caps_points_at_max_horizon() -> None:
+    """120 meses (tope del clamp business 80–120) → 10 puntos anuales (≤ ~10)."""
+    df = _business_df_n(120)
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    assert "promedio anual" in fin["subtitle"]
+    assert len(fin["traces"][0]["x"]) == 10  # 2023..2032
+    assert len(fin["traces"][0]["x"]) <= 10  # criterio de legibilidad
+
+
+# --- _aggregate_by_grain: fija la semántica de PROMEDIO (media, no suma/primero) ---
+
+
+def test_aggregate_by_grain_computes_means() -> None:
+    """Pin directo: agrega por MEDIA. (Indexar a base 100 oculta media vs suma en
+    buckets uniformes, así que se afirma el valor crudo del promedio aquí.)
+    """
+    df = _business_df_n(24)  # 2023-01..2024-12; revenue = 100_000 + i*1_000
+    periods, series = _aggregate_by_grain(df, ["revenue", "margin_pct"], "annual")
+    assert periods == ["2023", "2024"]
+    # 2023: i=0..11 → media de 100_000..111_000 = 105_500.0
+    # 2024: i=12..23 → media de 112_000..123_000 = 117_500.0
+    assert series["revenue"].tolist() == [105_500.0, 117_500.0]
+    assert series["margin_pct"].tolist() == [30.0, 30.0]  # media de una constante
+
+
+def test_aggregate_by_grain_uneven_buckets_use_mean_not_sum() -> None:
+    """Con buckets de tamaño distinto (año parcial) media != suma: la media mantiene
+    los niveles comparables; una suma inflaría el bucket de 12 meses ~12×.
+    """
+    df = _business_df_n(13)  # 2023 (12 meses) + 2024 (1 mes)
+    periods, series = _aggregate_by_grain(df, ["revenue"], "annual")
+    assert periods == ["2023", "2024"]
+    assert series["revenue"].tolist() == [105_500.0, 112_000.0]  # media, no suma

--- a/backend/tests/test_eda_charts_business.py
+++ b/backend/tests/test_eda_charts_business.py
@@ -23,7 +23,11 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from case_generator.datagen.eda_charts_business import generate_business_eda_charts
+from case_generator.datagen.eda_charts_business import (
+    _detect_period_grain,
+    _indexed_base_100,
+    generate_business_eda_charts,
+)
 
 CONTRACT = {"case_id": "test_case_business"}
 
@@ -542,3 +546,175 @@ def test_annotate_validate_emit_preserves_builder_caveat() -> None:
     assert notes.startswith("CAVEAT_BUILDER_FACTUAL")  # caveat íntegro y primero
     assert "NOTA_LLM" in notes  # la nota del LLM sobrevive (clampada)
     assert len(notes) <= 300
+
+
+# ─────────────────────────────────────────────────────────
+# financial_mirage — agregación temporal HONESTA para el display (Issue #297)
+#
+# Business genera 80–120 períodos MENSUALES → la línea de margen sale como sierra
+# ruidosa. Agregamos (media) a un grano más grueso SOLO para el display, antes de
+# indexar a base 100, y lo DECLARAMOS en el subtítulo. El dataset no cambia.
+#
+#   meses  →  grano       →  puntos        subtítulo
+#   ─────────────────────────────────────────────────────────
+#   > 48   →  anual        →  ~7–10         "... (promedio anual)"
+#   25–48  →  trimestral   →  ~9–16         "... (promedio trimestral)"
+#   ≤ 24   →  mensual      →  = nº meses    (sin sufijo)
+#   no "YYYY-MM" / mes inválido  →  crudo (fallback honesto, sin sufijo)
+# ─────────────────────────────────────────────────────────
+
+
+def _monthly_periods(n: int) -> list[str]:
+    """`n` períodos "YYYY-MM" consecutivos desde 2023-01 (igual que producción)."""
+    out = []
+    for i in range(n):
+        out.append(f"{2023 + i // 12}-{i % 12 + 1:02d}")
+    return out
+
+
+def _business_df_n(n_months: int, *, margin: list[float] | None = None) -> pd.DataFrame:
+    """DF business mínimo con `n_months` meses; revenue estrictamente creciente."""
+    revenue = [100_000 + i * 1_000 for i in range(n_months)]
+    if margin is None:
+        margin = [30.0] * n_months
+    return pd.DataFrame(
+        {"period": _monthly_periods(n_months), "revenue": revenue, "margin_pct": margin}
+    )
+
+
+def _fin(charts: list) -> dict:
+    return next(c for c in charts if c["id"] == "financial_mirage")
+
+
+# --- (a) > 48 meses → grano anual + nº de puntos reducido + subtítulo declara ---
+
+
+def test_financial_mirage_aggregates_annual_for_long_horizon() -> None:
+    df = _business_df_n(60)  # 5 años
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    assert "promedio anual" in fin["subtitle"]
+    rev = fin["traces"][0]
+    assert rev["name"] == "Ingresos (índice)"
+    assert len(rev["x"]) == 5  # 5 puntos anuales
+    assert len(rev["x"]) <= 10  # criterio: ≤ ~10 puntos
+    assert rev["y"][0] == 100.0  # base 100 preservada tras agregar
+    assert {t["name"] for t in fin["traces"]} == {
+        "Ingresos (índice)",
+        "Margen % (índice)",
+    }
+
+
+# --- (b) 25–48 meses → grano trimestral ---
+
+
+def test_financial_mirage_aggregates_quarterly_for_mid_horizon() -> None:
+    df = _business_df_n(36)  # 12 trimestres
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    assert "promedio trimestral" in fin["subtitle"]
+    assert len(fin["traces"][0]["x"]) == 12
+
+
+# --- (c) ≤ 24 meses → mensual sin agregar ---
+
+
+def test_financial_mirage_no_aggregation_at_24_months() -> None:
+    df = _business_df_n(24)
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    assert "promedio" not in fin["subtitle"]
+    assert len(fin["traces"][0]["x"]) == 24
+
+
+# --- (d) períodos no-"YYYY-MM" / mes inválido / mezcla → sin agregación ---
+
+
+def test_detect_period_grain_thresholds_and_fallbacks() -> None:
+    # Mensual: la escalera de grano por nº de meses.
+    assert _detect_period_grain(_monthly_periods(60)) == "annual"
+    assert _detect_period_grain(_monthly_periods(49)) == "annual"
+    assert _detect_period_grain(_monthly_periods(48)) == "quarterly"
+    assert _detect_period_grain(_monthly_periods(36)) == "quarterly"
+    assert _detect_period_grain(_monthly_periods(25)) == "quarterly"
+    assert _detect_period_grain(_monthly_periods(24)) is None
+    assert _detect_period_grain(_monthly_periods(12)) is None
+    assert _detect_period_grain([]) is None
+    # No mensual → fallback honesto (None).
+    assert _detect_period_grain([f"{2010 + i // 4}-Q{i % 4 + 1}" for i in range(60)]) is None
+    assert _detect_period_grain([str(2000 + i) for i in range(60)]) is None
+    assert _detect_period_grain([f"P{i + 1}" for i in range(60)]) is None
+    # Mes malformado "2030-13" (la regex exige 01–12) → None, no etiqueta Q5.
+    assert _detect_period_grain(_monthly_periods(59) + ["2030-13"]) is None
+    # Mezcla de formatos → None (all(), nunca any()).
+    mixed = _monthly_periods(50) + [f"2027-Q{i % 4 + 1}" for i in range(10)]
+    assert _detect_period_grain(mixed) is None
+
+
+def test_financial_mirage_non_monthly_periods_not_aggregated() -> None:
+    periods = [f"{2010 + i // 4}-Q{i % 4 + 1}" for i in range(60)]  # 60 trimestres
+    df = pd.DataFrame(
+        {
+            "period": periods,
+            "revenue": [100_000 + i * 1_000 for i in range(60)],
+            "margin_pct": [30.0] * 60,
+        }
+    )
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    assert "promedio" not in fin["subtitle"]  # no se declaró agregación
+    assert len(fin["traces"][0]["x"]) == 60  # graficado crudo
+
+
+# --- (e) la dirección de la tendencia se preserva al agregar ---
+
+
+def test_financial_mirage_aggregation_preserves_rising_trend() -> None:
+    df = _business_df_n(60)  # revenue estrictamente creciente
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    rev_y = fin["traces"][0]["y"]  # traza de ingresos (primera)
+    assert rev_y[-1] > rev_y[0]  # índice agregado creciente
+    assert all(rev_y[i] <= rev_y[i + 1] for i in range(len(rev_y) - 1))  # monótono
+
+
+# --- (f) la sierra del margen desaparece: varianza período-a-período cae ---
+
+
+def test_financial_mirage_aggregation_reduces_margin_sawtooth() -> None:
+    # Sierra: alterna ±8 alrededor de 30 cada mes (ruido por fila, sin señal).
+    margin = [30.0 + (8.0 if i % 2 == 0 else -8.0) for i in range(60)]
+    df = _business_df_n(60, margin=margin)
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    agg_y = next(t for t in fin["traces"] if "Margen" in t["name"])["y"]
+    max_agg_jump = max(abs(agg_y[i + 1] - agg_y[i]) for i in range(len(agg_y) - 1))
+
+    # Contrafactual: el MISMO margen sin agregar (índice base 100) salta fuerte.
+    raw_idx = _indexed_base_100(pd.Series(margin))
+    assert raw_idx is not None
+    max_raw_jump = max(abs(raw_idx[i + 1] - raw_idx[i]) for i in range(len(raw_idx) - 1))
+
+    assert max_raw_jump > 20  # la sierra cruda es ruidosa de verdad
+    assert max_agg_jump < max_raw_jump / 4  # agregar la aplana
+
+
+# --- (g) si el margen AGREGADO cruza ≤ 0, se omite con nota (guarda intacta) ---
+
+
+def test_financial_mirage_aggregated_margin_nonpositive_is_omitted() -> None:
+    # El promedio ANUAL del margen decae y cruza a ≤ 0 en años posteriores.
+    margin = [20.0 - (i // 12) * 8.0 for i in range(60)]  # años: 20,12,4,-4,-12
+    df = _business_df_n(60, margin=margin)
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    names = [t.get("name") for t in fin["traces"]]
+    assert "Ingresos (índice)" in names  # revenue positivo → presente
+    assert "Margen % (índice)" not in names  # margen anual cruza ≤0 → omitido
+    assert "no positivos" in fin["notes"]
+    assert "promedio anual" in fin["subtitle"]  # la agregación igual se declaró
+
+
+# --- guarda de fallo crítico: agregar sin margin_pct no tira el chart entero ---
+
+
+def test_financial_mirage_aggregation_without_margin_keeps_revenue() -> None:
+    df = _business_df_n(60).drop(columns=["margin_pct"])
+    fin = _fin(generate_business_eda_charts(df, "churn_rate", {}, CONTRACT))
+    names = [t.get("name") for t in fin["traces"]]
+    assert "Ingresos (índice)" in names  # solo revenue, pero no se cae el chart
+    assert "promedio anual" in fin["subtitle"]
+    assert len(fin["traces"][0]["x"]) == 5


### PR DESCRIPTION
## Context

PR #296 replaced the business-profile M2 EDA charts with a Python-deterministic builder. The
`financial_mirage` chart indexes revenue and margin to **base 100 on a single axis** (killed the
misleading dual-axis — that honesty is preserved here). Business datasets carry **80–120 monthly
periods**, and `margin_pct` has high per-row variance (`costs` `noise_factor: 0.12` + the
`(rev-cost)/rev` recompute), so the margin trace rendered as a noisy **sawtooth** (~65↔148/month) that
buried the "mirage" narrative (revenue rises while margin stalls/diverges).

This is **legibility only**, per Issue #297.

## What changed

Display-only **honest temporal aggregation** inside `_build_financial_mirage`, applied **before**
base-100 indexing. The dataset is untouched — cohorts, correlations, other charts, and ml_ds are
byte-identical. The aggregation is **declared in the subtitle**.

- Two new pure, unit-testable helpers in `eda_charts_business.py`:
  - `_detect_period_grain(periods)` — grain ladder: `>48mo → annual`, `>24mo → quarterly`,
    `≤24mo → monthly (raw)`. Returns `None` (plot raw) unless **all** periods are monthly `YYYY-MM`.
  - `_aggregate_by_grain(d, value_cols, grain)` — mean per grain key (`"YYYY"` / `"YYYY-Qn"`),
    deterministic chronological order, aggregating **only the columns present**.
- Per-period regex validates month `01–12`, so a malformed month (`"2023-13"`) falls to the honest
  no-aggregation fallback instead of producing a `Q5`/`Q0` label.
- A missing `margin_pct` never drops the whole chart (revenue trace is kept).
- `_indexed_base_100` honesty guards (`base ≤ 0` / any `≤ 0` → omit + note) are **untouched** and
  applied to the aggregated series.
- `EDAChartSpec` contract unchanged → **zero frontend changes**.

In production (business is always monthly, 80–120 rows) this always lands on **annual** (~7–10 points).
The quarterly branch is defensive (25–48 months) and covered by test.

## Tests

`backend/tests/test_eda_charts_business.py` — deterministic, no LLM:
- grain selection: >48 → annual (point count + subtitle), 25–48 → quarterly, ≤24 → monthly (no suffix)
- non-`YYYY-MM` / malformed-month / mixed-format → no aggregation (helper + integration)
- rising-trend preservation through aggregation
- **de-sawtoothing**: aggregated margin period-to-period variance ≪ raw monthly (the headline criterion)
- aggregated margin crossing `≤ 0` → trace omitted + note (honesty guard survives aggregation)
- missing `margin_pct` during aggregation → revenue trace still emitted

## Validation

- `uv run --directory backend pytest -q` → **1002 passed, 16 skipped**
- `uv run --directory backend mypy src` → **clean (80 files)**
- No frontend touched.

## Deferred

`TODOS.md` → **TODO-297-A**: the de-sawtooth is presentation-only; the root-cause per-row margin
variance is intact, and the quarterly grain branch is currently unreachable in production.

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
