### PR TITLE
feat(business): deterministic binary domain target for business+classification M2 (#301 PR1)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1445,3 +1445,97 @@ emparejarlo con [TODO-294-A] una vez confirmada la ruta de escritura de `data_ga
 
 **Depends on / blocked by:** Confirmar cómo se persiste `data_gap_warnings` desde el nodo de EDA.
 Idealmente junto con [TODO-294-A].
+
+---
+
+## TODO-301-A: Aplicar el guard `_ensure_both_classes` también a `categoria` (ml_ds)
+
+**What:** Extender el guard anti-degeneración de clases `_ensure_both_classes` (hoy
+business-only, en el branch int dependiente de `_generate_dataset_from_schema`) al target
+binario `categoria` de ml_ds + clasificación.
+
+**Why:** El guard se introdujo en Issue #301 gateado a `profile == "business"` para no
+alterar el output de ml_ds (invariante "ml_ds intacto / golden sin cambios"). Pero
+`categoria` tiene el MISMO riesgo probabilístico de colapsar a una sola clase
+(`round(parent_norm + noise)` con `churn_rate` sesgado), lo que produciría un notebook M3
+con AUC indefinido sin aviso.
+
+**Pros:** Cierra el bug latente en el perfil de alto valor; un solo guard en todas partes.
+
+**Cons:** Cambia el output de `categoria` en el seed degenerado → exige re-baseline del
+golden/snapshot de ml_ds, que el invariante de #301 prohíbe tocar ahora.
+
+**Context:** El guard vive junto a `_generate_dataset_from_schema` en `graph.py`; `categoria`
+se define inline en `_build_fallback_schema` (~L2018-2027). Aplicarlo a ml_ds requiere mover
+el gate y regenerar el golden en un PR dedicado.
+
+**Depends on / blocked by:** PR1 de Issue #301 (el guard) mergeado. Re-baseline del golden ml_ds.
+
+---
+
+## TODO-301-B: Eliminar la duplicación verbatim de `CASE_ARCHITECT_PROMPT`
+
+**What:** Extraer el cuerpo genérico de `CASE_ARCHITECT_PROMPT` a una constante compartida y
+componer `CASE_ARCHITECT_PROMPT_CLASSIFICATION = _BASE + _ANCHOR`, eliminando la copia
+verbatim en `prompts/clasificacion/M1_clasificacion/architect.py` (L67-276).
+
+**Why:** Hoy cada cambio al prompt base debe replicarse a mano en dos archivos (el header del
+módulo lo admite explícitamente). El test de sincronización de #301 PR2 DETECTA el drift pero
+no lo previene; este refactor lo elimina en la raíz.
+
+**Pros:** DRY real; futuros edits del architect tocan un solo lugar; el test guard se vuelve
+redundante.
+
+**Cons:** Reestructura el módulo sensible de ensamblaje de prompts; riesgo de romper variables
+`.format()`; fuera del alcance de #301.
+
+**Context:** Detectado en la plan-eng-review de Issue #301 (issue 5, opción 5B diferida).
+Depende de que PR2 (condicionamiento de la "regla 7" por perfil) aterrice primero para partir
+del texto corregido. Requiere snapshot de prompts para verificar.
+
+**Depends on / blocked by:** PR2 de Issue #301 mergeado.
+
+---
+
+## TODO-301-C: Consumir `min_signal_strength` en el umbral del chart + validador suave
+
+**What:** Cablear `min_signal_strength` del contrato al umbral "sin driver fuerte" de
+`churn_drivers` (`_DRIVERS_MIN_ABS_CORR`, hoy fijo en 0.10) y añadir un validador SUAVE que
+avise (no falle el job) cuando `|corr|` alcanzada < `min_signal_strength`.
+
+**Why:** #301 PR1 usa `min_signal_strength` solo como objetivo de síntesis (deriva el
+`noise_factor` del driver). Leerlo también en display + validación lo vuelve un campo del
+contrato totalmente load-bearing en vez de medio decorativo.
+
+**Pros:** El campo pasa a ser la única fuente de verdad para "señal suficiente"; umbral
+ajustable por caso.
+
+**Cons:** Acopla el display del chart al contrato; un validador DURO podría fallar casos de
+señal débil honestos (por eso 8A lo difirió).
+
+**Context:** Detectado en la plan-eng-review de Issue #301 (issue 8, opción 8B diferida).
+Toca `eda_charts_business.py` (`_DRIVERS_MIN_ABS_CORR`) + un validador en `graph.py`.
+
+**Depends on / blocked by:** PR1 de Issue #301 mergeado.
+
+---
+
+## TODO-301-D: Chart 3 dedicado para clasificación (tasa de evento / balance en el tiempo)
+
+**What:** Construir un tercer chart hecho a medida para casos de clasificación binaria — p. ej.
+tasa del evento por período, o balance de clases en el tiempo — en vez del `class_balance`
+(barra de conteo) que #301 PR1 reutiliza en el slot de cohorte.
+
+**Why:** 4A reutiliza el slot de cohorte con una barra simple de balance de clases (diff
+mínimo). Un chart dedicado podría contar una historia pedagógica más rica para un target
+binario (tendencia de la tasa del evento, desglose por segmento).
+
+**Pros:** Mejor pedagogía del M2 para clasificación no-churn; completa la familia de charts
+business.
+
+**Cons:** Nuevo builder + dispatch + tests en el módulo datagen sensible; requiere diseño.
+
+**Context:** Detectado en la plan-eng-review de Issue #301 (issue 4, opción 4B diferida).
+`eda_charts_business.py` + dispatch en `eda_chart_generator`.
+
+**Depends on / blocked by:** PR1 de Issue #301 (títulos/fallback) mergeado.

--- a/backend/src/case_generator/datagen/eda_charts_business.py
+++ b/backend/src/case_generator/datagen/eda_charts_business.py
@@ -59,6 +59,19 @@ logger = logging.getLogger("adam.graph")
 _DRIVERS_TOP_K = 8
 _DRIVERS_MIN_ABS_CORR = 0.10
 
+# Issue #301 — el título del chart de drivers no debe asumir "abandono"/churn cuando el
+# caso no es de retención. Si el target pertenece a la familia retención usamos el título
+# clásico; en cualquier otro dominio (logística, fraude, crédito…) usamos uno neutro.
+_RETENTION_TITLE_TOKENS = ("churn", "retention", "renewal", "attrition", "loyalty", "abandon")
+
+
+def _drivers_title(target_col: str) -> str:
+    """Título de `churn_drivers` derivado del target real (no asume churn/retención)."""
+    t = (target_col or "").lower()
+    if any(tok in t for tok in _RETENTION_TITLE_TOKENS):
+        return "Factores asociados al abandono"
+    return "Factores asociados al objetivo"
+
 # Período mensual válido "YYYY-MM" con mes 01–12. Validar el mes (no solo \d{2})
 # hace que un mes malformado (p. ej. "2023-13") caiga al fallback honesto sin
 # agregación, en vez de producir una etiqueta de trimestre absurda (Q5/Q0).
@@ -340,11 +353,12 @@ def _build_churn_drivers(
     respaldaban. El eje fijo [0, 1] impide exagerar correlaciones pequeñas, y si
     ninguna supera el umbral lo decimos en `notes` en vez de sugerir un driver.
     """
+    title = _drivers_title(target_col)
     corrs = _target_correlations(df, target_col, precalculated_metrics)
     if not corrs:
         return empty_chart(
             "churn_drivers",
-            "Factores asociados al abandono",
+            title,
             "Sin correlaciones calculables con el objetivo",
             "bar",
             source,
@@ -365,7 +379,7 @@ def _build_churn_drivers(
     target_label = target_col or "objetivo"
     return {
         "id": "churn_drivers",
-        "title": "Factores asociados al abandono",
+        "title": title,
         "subtitle": f"Correlación absoluta de cada variable con {target_label} (mayor = más asociada)",
         "library": "plotly",
         "chart_type": "bar",
@@ -434,10 +448,46 @@ def _build_cohort_collapse(
             "data_source": "python_builder",
         }
 
-    # Fallback: distribución del objetivo (sin cohortes que graficar).
+    # Fallback (sin cohortes de retención que graficar — caso NO-retención, Issue #301).
     if target_col in df.columns and pd.api.types.is_numeric_dtype(df[target_col]):
-        vals = pd.to_numeric(df[target_col], errors="coerce").dropna().tolist()
-        if vals:
+        s = pd.to_numeric(df[target_col], errors="coerce").dropna()
+        if not s.empty:
+            # Target binario {0,1}: una caja es inútil (masa en dos puntos). Mostramos el
+            # balance de clases (conteo por clase) → la tasa del evento objetivo, honesta.
+            uniq = {float(v) for v in s.unique()}
+            is_binary = uniq == {0.0, 1.0}
+            if is_binary:
+                counts = s.astype(int).value_counts().sort_index()
+                labels = [str(int(k)) for k in counts.index]
+                vals_count = [int(v) for v in counts.values]
+                return {
+                    "id": "class_balance",
+                    "title": f"Balance de clases del objetivo ({target_col})",
+                    "subtitle": "Número de casos por clase del evento objetivo (0 = no ocurre, 1 = ocurre)",
+                    "library": "plotly",
+                    "chart_type": "bar",
+                    "traces": [
+                        {
+                            "type": "bar",
+                            "x": labels,
+                            "y": vals_count,
+                            "name": "casos",
+                            "text": [str(v) for v in vals_count],
+                            "textposition": "outside",
+                        }
+                    ],
+                    "layout": {
+                        "template": "plotly_white",
+                        "xaxis": {"title": "Clase del objetivo", "type": "category"},
+                        "yaxis": {"title": "Número de casos"},
+                        "showlegend": False,
+                    },
+                    "source": source,
+                    "description": "",
+                    "notes": "",
+                    "data_source": "python_builder",
+                }
+            # Target continuo: caja de distribución (comportamiento previo).
             return {
                 "id": "target_distribution",
                 "title": f"Distribución de {target_col}",
@@ -447,7 +497,7 @@ def _build_cohort_collapse(
                 "traces": [
                     {
                         "type": "box",
-                        "y": vals,
+                        "y": s.tolist(),
                         "name": target_col,
                         "boxpoints": "outliers",
                     }

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2599,24 +2599,28 @@ def _is_retention_target_name(name: str, role: str = "") -> bool:
     return (role or "").strip().lower() == "forecasting_target" and "retention" in n
 
 
-def _select_driver_feature(contract: dict | None) -> tuple[str, dict | None]:
+def _select_driver_feature(
+    contract: dict | None, *, target_name: str | None = None
+) -> tuple[str, dict | None]:
     """Elige la feature de dominio que el target binario usará como driver (#298 absorbido).
 
     Regla (7A): primera ``feature_columns`` con ``is_leakage_risk=False`` y dtype numérico
     (un driver de leakage haría que el modelo 'haga trampa'). Si no hay ninguna usable,
     sintetiza un driver numérico neutro para que exista UNA señal real GENERADA en los
     datos (no afirmada en prosa). El chart conserva el aviso 'sin driver fuerte' si la
-    señal resultante igual es débil.
+    señal resultante igual es débil. ``target_name`` (si se pasa) se excluye para que el
+    target nunca dependa de sí mismo (contrato malformado que lista el target como feature).
 
     Devuelve ``(driver_name, synth_column_or_None)``.
     """
     for feat in (contract or {}).get("feature_columns") or []:
         if feat.get("is_leakage_risk"):
             continue
-        if feat.get("dtype") in ("int", "float"):
-            fname = (feat.get("name") or "").strip()
-            if fname:
-                return fname, None
+        fname = (feat.get("name") or "").strip()
+        if target_name and fname == target_name:
+            continue  # L-6: el target no puede ser su propio driver
+        if feat.get("dtype") in ("int", "float") and fname:
+            return fname, None
     synth = {
         "name": "domain_driver_score",
         "type": "float",
@@ -2660,25 +2664,35 @@ def _binary_target_column(
 
 def _enforce_business_classification_schema(
     schema: dict, contract: dict | None, *, profile: str, primary_family: str | None
-) -> tuple[dict, list[str]]:
+) -> tuple[dict, list[str], str | None]:
     """Garantiza un dataset coherente con el dilema para business + clasificación (#301).
 
     Determinista, 0 tokens LLM, business-only (gate ``profile == "business"`` +
     ``primary_family == "clasificacion"``). NO toca el dict de entrada ni ml_ds.
-    Devuelve ``(schema, notes)`` — ``notes`` alimenta ``data_gap_warnings``.
+    Devuelve ``(schema, notes, target_name)``: ``notes`` alimenta ``data_gap_warnings`` y
+    ``target_name`` es el nombre del target binario garantizado (``None`` fuera del gate) —
+    schema_designer lo propaga al contrato para que la selección downstream lo elija
+    (Issue #301 H-1).
     """
     notes: list[str] = []
     if profile != "business" or primary_family != "clasificacion":
-        return schema, notes
+        return schema, notes, None
 
     contract = contract or {}
     target_spec = contract.get("target_column") or {}
     role = (target_spec.get("role") or "").strip().lower()
     cname = (target_spec.get("name") or "").strip()
     cdesc = (target_spec.get("description") or "").strip()
+    cdtype = (target_spec.get("dtype") or "").strip().lower()
 
     if role == "classification_target" and cname:
         target_name = cname
+        if cdtype and cdtype != "int":
+            # L-5 — el dtype declarado se coerciona a binario {0,1}; avisar al docente.
+            notes.append(
+                f"target '{cname}' declarado dtype='{cdtype}' coercido a binario {{0,1}} (int) "
+                "para clasificación business."
+            )
     else:
         # 3A — síntesis determinista honesta cuando no hay contrato de clasificación.
         target_name = "target_event_flag"
@@ -2690,7 +2704,7 @@ def _enforce_business_classification_schema(
 
     is_retention = _is_retention_target_name(target_name, role)
     min_signal = float(contract.get("min_signal_strength") or 0.15)
-    driver_name, synth_driver = _select_driver_feature(contract)
+    driver_name, synth_driver = _select_driver_feature(contract, target_name=target_name)
 
     new_schema = dict(schema)
     columns = [dict(c) for c in new_schema.get("columns", [])]
@@ -2721,10 +2735,11 @@ def _enforce_business_classification_schema(
         existing.add(target_name)
 
     # 4. Cobertura de domain_features_required (8A): añade una columna por categoría no
-    #    cubierta por nombre (el contrato deja el nombre concreto a schema_designer).
+    #    cubierta (L-2: match EXACTO de nombre — `in` por substring saltaba una categoría
+    #    'rate' por ser substring de 'churn_rate' y la dejaba sin cubrir).
     for cat in contract.get("domain_features_required") or []:
         cat_name = str(cat).strip()
-        if not cat_name or any(cat_name in n for n in existing):
+        if not cat_name or cat_name in existing:
             continue
         columns.append({
             "name": cat_name,
@@ -2739,7 +2754,29 @@ def _enforce_business_classification_schema(
         existing.add(cat_name)
 
     new_schema["columns"] = columns
-    return new_schema, notes
+    return new_schema, notes, target_name
+
+
+def _contract_with_enforced_target(contract: dict | None, target_name: str | None) -> dict | None:
+    """Reescribe ``target_column`` del contrato al target binario que el spine garantizó.
+
+    Issue #301 H-1: ``_build_metadata``/``_identify_target_variable`` eligen el target vía
+    ``contract.target_column.name``. Cuando el architect emitió un target CONTINUO
+    (p. ej. ``margin_pct``, role regresión) o ninguno, el spine sintetiza un binario, pero
+    el contrato seguía nombrando la columna continua → la selección downstream graficaba el
+    target equivocado (el síntoma de #301 desplazado). Propagar el target binario al
+    contrato cierra el bucle de forma determinista. Devuelve ``None`` si no aplica.
+    """
+    if not target_name:
+        return None
+    updated = dict(contract or {})
+    tcol = dict(updated.get("target_column") or {})
+    prev_desc = (tcol.get("description") or "").strip()
+    tcol.update({"name": target_name, "role": "classification_target", "dtype": "int"})
+    if not prev_desc:
+        tcol["description"] = "Variable objetivo binaria del caso (0/1)"
+    updated["target_column"] = tcol
+    return updated
 
 
 # ─────────────────────────────────────────────────────────
@@ -2894,7 +2931,7 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
             # Issue #301 — spine determinista business+clasificación: garantiza un target
             # binario de dominio + driver (no el template fijo de churn). Business-only;
             # no toca ml_ds. Corre tras el augment para sobrescribir el target int genérico.
-            schema_result, biz_notes = _enforce_business_classification_schema(
+            schema_result, biz_notes, biz_target = _enforce_business_classification_schema(
                 schema_result, contract, profile=profile, primary_family=primary_family
             )
             missing, leakage = _validate_schema_against_contract(schema_result, contract)
@@ -2908,10 +2945,17 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
                 warnings_payload.extend(leakage)
             if biz_notes:
                 warnings_payload.extend(biz_notes)
-            return {
+            node_out: dict[str, Any] = {
                 "dataset_schema": schema_result,
                 "data_gap_warnings": warnings_payload,
             }
+            # Issue #301 H-1 — si el spine sintetizó/forzó el target binario, propágalo al
+            # contrato para que _build_metadata/_identify_target_variable lo elijan (y no un
+            # target de contrato continuo). Solo cuando realmente cambia algo.
+            updated_contract = _contract_with_enforced_target(contract, biz_target)
+            if updated_contract is not None and updated_contract != (contract or {}):
+                node_out["dataset_schema_required"] = updated_contract
+            return node_out
         except (ValidationError, Exception) as e:
             logger.error("[schema_designer] %s ERROR: %s", model_label, e, exc_info=True)
 
@@ -2923,7 +2967,7 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
     contract = state.get("dataset_schema_required")
     fallback_schema = _augment_schema_with_contract(fallback_schema, contract)
     # Issue #301 — el spine determinista también aplica en fallback (red de seguridad).
-    fallback_schema, biz_notes = _enforce_business_classification_schema(
+    fallback_schema, biz_notes, biz_target = _enforce_business_classification_schema(
         fallback_schema, contract, profile=profile, primary_family=primary_family
     )
     missing, leakage = _validate_schema_against_contract(fallback_schema, contract)
@@ -2935,10 +2979,15 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
         warnings_payload.extend(leakage)
     if biz_notes:
         warnings_payload.extend(biz_notes)
-    return {
+    node_out = {
         "dataset_schema": fallback_schema,
         "data_gap_warnings": warnings_payload,
     }
+    # Issue #301 H-1 — propaga el target binario garantizado al contrato (ver call-site happy).
+    updated_contract = _contract_with_enforced_target(contract, biz_target)
+    if updated_contract is not None and updated_contract != (contract or {}):
+        node_out["dataset_schema_required"] = updated_contract
+    return node_out
 
 
 # ─────────────────────────────────────────────────────────
@@ -3277,6 +3326,15 @@ def _generate_dataset_from_schema(schema: dict, profile: str = "business") -> li
         and not (
             profile == "business"
             and any(tok in c["name"].lower() for tok in _financial_tokens)
+        )
+        # N-7 (Issue #301): nunca inyectes el outlier en el target binario {0,1} de
+        # business — un ×3.5 capado lo convertiría en float 0.0/1.0 (dtype mixto en una
+        # columna de clasificación). Se excluye toda columna int declarada en [0,1].
+        and not (
+            profile == "business"
+            and c["type"] == "int"
+            and c.get("range_min") == 0
+            and c.get("range_max") == 1
         )
     ]
     if numeric_non_revenue and n_rows >= 50:

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2570,6 +2570,179 @@ def _augment_schema_with_contract(schema: dict, contract: dict | None) -> dict:
 
 
 # ─────────────────────────────────────────────────────────
+# HELPER — Spine determinista business + clasificación (Issue #301)
+# ─────────────────────────────────────────────────────────
+#
+#   business + clasificacion ?
+#     ├─ contrato con target_column.role == "classification_target"
+#     │     → target binario de dominio + driver de dominio + features del contrato
+#     │       (set financiero mínimo; churn/retention SOLO si el dilema es de retención)
+#     ├─ sin contrato / target continuo
+#     │     → síntesis determinista: target_event_flag {0,1} + 1 driver + aviso honesto
+#     └─ dilema de retención → conserva el template churn/SaaS  (NO-REGRESIÓN)
+#
+# 0 tokens LLM, business-only. NO toca ml_ds (usa prompts por familia + `categoria`).
+
+# Columnas del template churn/SaaS que SOLO pertenecen a un dilema de retención.
+# En un caso business+clasificación NO-retención se eliminan para que el dataset
+# hable del dominio del caso (logística, fraude, crédito…) en vez de churn.
+_CHURN_TEMPLATE_COLUMNS: frozenset[str] = frozenset({
+    "churn_rate", "nps", "retention_m1", "retention_m3", "retention_m6", "retention_m12",
+})
+
+
+def _is_retention_target_name(name: str, role: str = "") -> bool:
+    """True si el target pertenece a la familia retención/churn (por nombre o rol)."""
+    n = (name or "").lower()
+    if any(tok in n for tok in _RETENTION_TARGET_NAME_TOKENS):
+        return True
+    return (role or "").strip().lower() == "forecasting_target" and "retention" in n
+
+
+def _select_driver_feature(contract: dict | None) -> tuple[str, dict | None]:
+    """Elige la feature de dominio que el target binario usará como driver (#298 absorbido).
+
+    Regla (7A): primera ``feature_columns`` con ``is_leakage_risk=False`` y dtype numérico
+    (un driver de leakage haría que el modelo 'haga trampa'). Si no hay ninguna usable,
+    sintetiza un driver numérico neutro para que exista UNA señal real GENERADA en los
+    datos (no afirmada en prosa). El chart conserva el aviso 'sin driver fuerte' si la
+    señal resultante igual es débil.
+
+    Devuelve ``(driver_name, synth_column_or_None)``.
+    """
+    for feat in (contract or {}).get("feature_columns") or []:
+        if feat.get("is_leakage_risk"):
+            continue
+        if feat.get("dtype") in ("int", "float"):
+            fname = (feat.get("name") or "").strip()
+            if fname:
+                return fname, None
+    synth = {
+        "name": "domain_driver_score",
+        "type": "float",
+        "description": "Driver de dominio sintetizado correlado con el objetivo del caso",
+        "range_min": 0.0,
+        "range_max": 1.0,
+        "nullable": False,
+        "trend": None,
+        "dependency": None,
+    }
+    return "domain_driver_score", synth
+
+
+def _binary_target_column(
+    name: str, *, depends_on: str, description: str, min_signal_strength: float = 0.15
+) -> dict:
+    """Construye una columna target binaria {0,1} con señal correlada a ``depends_on``.
+
+    Mismo patrón estructural que la columna ``categoria`` de ml_ds (int, range[0,1],
+    dependency lineal), extraído para no duplicar la definición (6A). ``noise_factor``
+    se deriva de ``min_signal_strength``: a mayor señal requerida, menor ruido (mayor
+    correlación). La ``description`` incluye 'objetivo' para que
+    ``_identify_target_variable`` la capture aun sin metadata (belt-and-suspenders).
+    """
+    noise_factor = max(0.08, min(0.30, 0.30 - float(min_signal_strength)))
+    return {
+        "name": name,
+        "type": "int",
+        "description": f"Variable objetivo binaria del caso (0/1): {description}".strip(),
+        "range_min": 0,
+        "range_max": 1,
+        "nullable": False,
+        "trend": None,
+        "dependency": {
+            "depends_on": depends_on,
+            "relationship": "linear",
+            "noise_factor": round(noise_factor, 3),
+        },
+    }
+
+
+def _enforce_business_classification_schema(
+    schema: dict, contract: dict | None, *, profile: str, primary_family: str | None
+) -> tuple[dict, list[str]]:
+    """Garantiza un dataset coherente con el dilema para business + clasificación (#301).
+
+    Determinista, 0 tokens LLM, business-only (gate ``profile == "business"`` +
+    ``primary_family == "clasificacion"``). NO toca el dict de entrada ni ml_ds.
+    Devuelve ``(schema, notes)`` — ``notes`` alimenta ``data_gap_warnings``.
+    """
+    notes: list[str] = []
+    if profile != "business" or primary_family != "clasificacion":
+        return schema, notes
+
+    contract = contract or {}
+    target_spec = contract.get("target_column") or {}
+    role = (target_spec.get("role") or "").strip().lower()
+    cname = (target_spec.get("name") or "").strip()
+    cdesc = (target_spec.get("description") or "").strip()
+
+    if role == "classification_target" and cname:
+        target_name = cname
+    else:
+        # 3A — síntesis determinista honesta cuando no hay contrato de clasificación.
+        target_name = "target_event_flag"
+        notes.append(
+            "target sintetizado sin contrato de dominio (business+clasificación): se generó "
+            "un objetivo binario y un driver para mantener la coherencia M1↔M2; revisar que "
+            "refleje el dilema del caso."
+        )
+
+    is_retention = _is_retention_target_name(target_name, role)
+    min_signal = float(contract.get("min_signal_strength") or 0.15)
+    driver_name, synth_driver = _select_driver_feature(contract)
+
+    new_schema = dict(schema)
+    columns = [dict(c) for c in new_schema.get("columns", [])]
+
+    # 1. En dilemas NO-retención, eliminar el template churn/SaaS (deja financiero mínimo).
+    if not is_retention:
+        columns = [c for c in columns if c.get("name") not in _CHURN_TEMPLATE_COLUMNS]
+
+    existing = {c.get("name", "") for c in columns}
+
+    # 2. Asegurar el driver (synth solo si no hay feature numérica usable en el contrato).
+    if synth_driver is not None and driver_name not in existing:
+        columns.append(synth_driver)
+        existing.add(driver_name)
+
+    # 3. Construir/forzar el target binario (override aunque exista, p. ej. tras augment,
+    #    que lo habría inyectado con range[0,100] en vez de {0,1}).
+    binary_target = _binary_target_column(
+        target_name,
+        depends_on=driver_name,
+        description=cdesc or "evento objetivo del dilema",
+        min_signal_strength=min_signal,
+    )
+    if target_name in existing:
+        columns = [binary_target if c.get("name") == target_name else c for c in columns]
+    else:
+        columns.append(binary_target)
+        existing.add(target_name)
+
+    # 4. Cobertura de domain_features_required (8A): añade una columna por categoría no
+    #    cubierta por nombre (el contrato deja el nombre concreto a schema_designer).
+    for cat in contract.get("domain_features_required") or []:
+        cat_name = str(cat).strip()
+        if not cat_name or any(cat_name in n for n in existing):
+            continue
+        columns.append({
+            "name": cat_name,
+            "type": "float",
+            "description": f"Feature de dominio requerida por el contrato ({cat_name})",
+            "range_min": 0.0,
+            "range_max": 1.0,
+            "nullable": False,
+            "trend": None,
+            "dependency": None,
+        })
+        existing.add(cat_name)
+
+    new_schema["columns"] = columns
+    return new_schema, notes
+
+
+# ─────────────────────────────────────────────────────────
 # NODO 1 — SCHEMA DESIGNER (Pro, thinking activo, output pequeño)
 # ─────────────────────────────────────────────────────────
 
@@ -2604,7 +2777,11 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
     # business: always "" → generic schema prompt, regardless of primary_family.
     # The classification and future family-specific prompts contain ml_ds-only sections
     # (18-col contract, GridSearchCV row counts) that should never reach business cases.
-    # The generic prompt handles both profiles via its existing 10-col / 14-col rules.
+    # The generic prompt seeds the financial base; for business+clasificacion the
+    # deterministic spine `_enforce_business_classification_schema` (Issue #301) then
+    # OWNS the target/feature columns (binary domain target + driver), replacing the
+    # rigid churn template when the dilemma is not about retention. `primary_family`
+    # (the resolved family, not "") gates that spine.
     _effective_family = (primary_family or "clasificacion") if profile == "ml_ds" else ""
 
     # ml_ds+clasificacion: 600 filas (Issue #240 cascade: 600 ≤ 2000 → full GridSearchCV).
@@ -2714,6 +2891,12 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
             #      como data_gap_warnings que M2 EDA y M3 notebook leerán.
             contract = state.get("dataset_schema_required")
             schema_result = _augment_schema_with_contract(schema_result, contract)
+            # Issue #301 — spine determinista business+clasificación: garantiza un target
+            # binario de dominio + driver (no el template fijo de churn). Business-only;
+            # no toca ml_ds. Corre tras el augment para sobrescribir el target int genérico.
+            schema_result, biz_notes = _enforce_business_classification_schema(
+                schema_result, contract, profile=profile, primary_family=primary_family
+            )
             missing, leakage = _validate_schema_against_contract(schema_result, contract)
             # Issue #228 — preserva semillas de data_gap_warnings emitidas por
             # case_architect (ej: target_semantic_mismatch). LangGraph reemplaza
@@ -2723,6 +2906,8 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
                 warnings_payload.extend(missing)
             if leakage:
                 warnings_payload.extend(leakage)
+            if biz_notes:
+                warnings_payload.extend(biz_notes)
             return {
                 "dataset_schema": schema_result,
                 "data_gap_warnings": warnings_payload,
@@ -2737,6 +2922,10 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
     # Issue #225 — incluso en fallback respetamos el contrato del architect.
     contract = state.get("dataset_schema_required")
     fallback_schema = _augment_schema_with_contract(fallback_schema, contract)
+    # Issue #301 — el spine determinista también aplica en fallback (red de seguridad).
+    fallback_schema, biz_notes = _enforce_business_classification_schema(
+        fallback_schema, contract, profile=profile, primary_family=primary_family
+    )
     missing, leakage = _validate_schema_against_contract(fallback_schema, contract)
     # Issue #228 — preserva warnings sembrados por case_architect.
     warnings_payload = list(state.get("data_gap_warnings") or [])
@@ -2744,6 +2933,8 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
         warnings_payload.extend(missing)
     if leakage:
         warnings_payload.extend(leakage)
+    if biz_notes:
+        warnings_payload.extend(biz_notes)
     return {
         "dataset_schema": fallback_schema,
         "data_gap_warnings": warnings_payload,
@@ -2821,6 +3012,42 @@ def _generate_independent_values(
         base = np.full(n_rows, center)
 
     return np.clip(base + rng.normal(0, (high - low) * 0.10, n_rows), low, high)
+
+
+# Fracción mínima de clase minoritaria que inyecta el guard cuando un target binario
+# degenera a una sola clase (Issue #301). 15% deja una clase aprendible por LR sin
+# sobre-balancear (no es un balanceador, es una red de seguridad anti-degeneración).
+_BINARY_MIN_MINORITY_FRACTION = 0.15
+
+
+def _ensure_both_classes(values: "np.ndarray") -> "np.ndarray":
+    """Garantiza que una serie continua en [0,1] redondee a AMBAS clases {0,1}.
+
+        round(values) tiene 2 clases ?  ── sí ──►  passthrough (sin tocar la señal)
+                       └─ no (degenerado) ──►  voltea las k filas más cercanas a 0.5
+                                               hacia la clase ausente (mínimo daño)
+
+    Determinista (orden estable por distancia a 0.5). Red de seguridad business-only
+    (Issue #301): un target de una sola clase deja corr indefinida y una LR sin sentido,
+    y se enviaría SILENCIOSAMENTE. Opera sobre los valores continuos PRE-redondeo para
+    elegir las filas más ambiguas. Si tras forzar el balance la señal queda débil, el
+    chart conserva el aviso 'sin driver fuerte' (honestidad #296/#298).
+    """
+    import numpy as np
+
+    if values.size == 0:
+        return values
+    rounded = np.rint(values)
+    if np.unique(rounded).size >= 2:
+        return values
+    only_class = float(rounded.flat[0])
+    k = max(1, int(round(_BINARY_MIN_MINORITY_FRACTION * values.size)))
+    order = np.argsort(np.abs(values - 0.5), kind="stable")
+    flip_idx = order[:k]
+    out = values.astype(float).copy()
+    # 0.4 redondea a 0; 0.6 redondea a 1 → introduce la clase ausente con mínimo desvío.
+    out[flip_idx] = 0.4 if only_class == 1.0 else 0.6
+    return out
 
 
 # ─────────────────────────────────────────────────────────
@@ -2967,6 +3194,11 @@ def _generate_dataset_from_schema(schema: dict, profile: str = "business") -> li
         if col_type == "float":
             result = [None if null_mask[i] else round(float(values[i]), 2) for i in range(n_rows)]
         else:
+            # Issue #301 — guard anti-degeneración del target binario de dominio (business).
+            # Un target dependiente declarado en [0,1] es el target sintetizado/de contrato;
+            # garantizar ambas clases evita una LR sin sentido por una sola clase.
+            if profile == "business" and low == 0.0 and high == 1.0:
+                values = _ensure_both_classes(np.asarray(values, dtype=float))
             result = [None if null_mask[i] else int(round(float(values[i]))) for i in range(n_rows)]
         df_data[name] = result
 

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -553,6 +553,12 @@ REGLAS DE COBERTURA DEL CONTRATO (cuando NO esté vacío):
   (CRÍTICO: Las columnas retention_mX representan el % de usuarios de esa cohorte
   retenidos en el mes X. Son obligatorias para el heatmap de análisis de cohortes.
   Asegúrate de que range_min/max respeten: retention_m1 > retention_m3 > retention_m6 > retention_m12.)
+  NOTA: este set de 10 columnas es el BASELINE de retención. Cuando el dilema del caso
+  es de CLASIFICACIÓN y NO trata de retención/churn (p. ej. incumplimiento logístico,
+  fraude, aprobación de crédito), el pipeline reemplaza determinísticamente las columnas
+  churn/retención por el target binario de dominio + sus features. Mantén SIEMPRE el set
+  financiero base (period, revenue, costs, margin_pct); las columnas churn_rate/nps/
+  retention_mX solo se conservan cuando el dilema ES de retención.
 
   DEPENDENCIAS OBLIGATORIAS (business) — para que el Módulo 2 muestre relaciones
   REALES y verificables (no correlaciones inventadas) y un margen financiero legible:

--- a/backend/tests/test_eda_charts_business.py
+++ b/backend/tests/test_eda_charts_business.py
@@ -781,3 +781,72 @@ def test_aggregate_by_grain_uneven_buckets_use_mean_not_sum() -> None:
     periods, series = _aggregate_by_grain(df, ["revenue"], "annual")
     assert periods == ["2023", "2024"]
     assert series["revenue"].tolist() == [105_500.0, 112_000.0]  # media, no suma
+
+
+# ─────────────────────────────────────────────────────────
+# Issue #301 — títulos sin asumir churn + barra de balance de clases
+# ─────────────────────────────────────────────────────────
+
+
+def _df_business_binary() -> pd.DataFrame:
+    """Caso NO-retención (logística): target binario, sin columnas de retención."""
+    periods = [f"2023-{m:02d}" for m in range(1, 13)]
+    driver = [i / 11 for i in range(12)]  # 0..1, correlado con el target
+    return pd.DataFrame(
+        {
+            "period": periods,
+            "revenue": [100_000 + i * 2_000 for i in range(12)],
+            "costs": [70_000 + i * 1_000 for i in range(12)],
+            "margin_pct": [30.0] * 12,
+            "partner_history_score": driver,
+            "late_partner_flag": [0 if d < 0.5 else 1 for d in driver],
+        }
+    )
+
+
+def test_drivers_title_non_churn_target_is_neutral() -> None:
+    """Un caso de logística no debe titular el chart de drivers como 'abandono'."""
+    df = _df_business_binary()
+    charts = generate_business_eda_charts(df, "late_partner_flag", {}, CONTRACT)
+    drivers = next(c for c in charts if c["id"] == "churn_drivers")
+    assert drivers["title"] == "Factores asociados al objetivo"
+    assert "abandono" not in drivers["title"].lower()
+    assert "late_partner_flag" in drivers["subtitle"]  # subtítulo nombra el target real
+
+
+def test_drivers_title_retention_target_keeps_abandono() -> None:
+    """No-regresión: un target de churn conserva el título clásico."""
+    df = _df_business_binary().rename(columns={"late_partner_flag": "churn_flag"})
+    charts = generate_business_eda_charts(df, "churn_flag", {}, CONTRACT)
+    drivers = next(c for c in charts if c["id"] == "churn_drivers")
+    assert drivers["title"] == "Factores asociados al abandono"
+
+
+def test_cohort_fallback_binary_target_uses_class_balance_bar() -> None:
+    """Sin cohortes + target binario → barra de balance de clases (no una caja inútil)."""
+    df = _df_business_binary()
+    charts = generate_business_eda_charts(df, "late_partner_flag", {}, CONTRACT)
+    third = charts[2]
+    assert third["id"] == "class_balance"
+    assert third["chart_type"] == "bar"
+    assert "late_partner_flag" in third["title"]
+    assert "Retención" not in third["title"]
+    # cuenta de cada clase {0,1}
+    assert sorted(third["traces"][0]["x"]) == ["0", "1"]
+
+
+def test_churn_business_non_regression_three_retention_charts(
+    df_business, precalc_with_cohort
+) -> None:
+    """No-regresión business churn/SaaS: 3 charts con cohorte de retención + eje [0,1]."""
+    charts = generate_business_eda_charts(
+        df_business, "churn_rate", precalc_with_cohort, CONTRACT
+    )
+    ids = [c["id"] for c in charts]
+    assert ids == ["financial_mirage", "churn_drivers", "cohort_collapse"]
+    cohort = next(c for c in charts if c["id"] == "cohort_collapse")
+    assert cohort["chart_type"] == "heatmap"  # matriz de retención intacta
+    assert "Retención de Cohortes" in cohort["title"]
+    drivers = next(c for c in charts if c["id"] == "churn_drivers")
+    assert drivers["title"] == "Factores asociados al abandono"
+    assert drivers["layout"]["xaxis"]["range"] == [0, 1]  # honestidad #296

--- a/backend/tests/test_issue301_business_classification_spine.py
+++ b/backend/tests/test_issue301_business_classification_spine.py
@@ -18,6 +18,7 @@ from case_generator.graph import (
     _augment_schema_with_contract,
     _binary_target_column,
     _build_fallback_schema,
+    _contract_with_enforced_target,
     _ensure_both_classes,
     _enforce_business_classification_schema,
     _generate_dataset_from_schema,
@@ -60,7 +61,7 @@ def _enforced_schema(contract: dict | None) -> dict:
     """Replica el orden real del pipeline: fallback base → augment → enforce."""
     base = _build_fallback_schema(_business_state(), 100, "business", primary_family="clasificacion")
     base = _augment_schema_with_contract(base, contract)
-    schema, _notes = _enforce_business_classification_schema(
+    schema, _notes, _target = _enforce_business_classification_schema(
         base, contract, profile="business", primary_family="clasificacion"
     )
     return schema
@@ -174,9 +175,10 @@ def test_enforce_with_contract_builds_binary_domain_target() -> None:
 
 def test_enforce_no_contract_synthesizes_target_with_note() -> None:
     base = _build_fallback_schema(_business_state(), 100, "business", primary_family="clasificacion")
-    schema, notes = _enforce_business_classification_schema(
+    schema, notes, target_name = _enforce_business_classification_schema(
         base, None, profile="business", primary_family="clasificacion"
     )
+    assert target_name == "target_event_flag"
     target = _col(schema, "target_event_flag")
     assert target is not None and target["range_min"] == 0 and target["range_max"] == 1
     assert _col(schema, "domain_driver_score") is not None  # driver sintetizado
@@ -204,20 +206,22 @@ def test_enforce_noop_for_ml_ds() -> None:
         primary_family="clasificacion",
     )
     before = [c["name"] for c in base["columns"]]
-    schema, notes = _enforce_business_classification_schema(
+    schema, notes, target_name = _enforce_business_classification_schema(
         base, _LOGISTICS_CONTRACT, profile="ml_ds", primary_family="clasificacion"
     )
-    assert [c["name"] for c in schema["columns"]] == before  # ml_ds intacto
-    assert notes == []
+    assert schema is base  # ml_ds: mismo objeto, intacto
+    assert [c["name"] for c in schema["columns"]] == before
+    assert notes == [] and target_name is None
 
 
 def test_enforce_noop_for_business_non_classification() -> None:
     base = _build_fallback_schema(_business_state(), 100, "business", primary_family="regresion")
     before = [c["name"] for c in base["columns"]]
-    schema, _notes = _enforce_business_classification_schema(
+    schema, _notes, target_name = _enforce_business_classification_schema(
         base, _LOGISTICS_CONTRACT, profile="business", primary_family="regresion"
     )
     assert [c["name"] for c in schema["columns"]] == before
+    assert target_name is None
 
 
 # ─────────────────────────────────────────────────────────
@@ -278,3 +282,116 @@ def test_ml_ds_fallback_categoria_unchanged() -> None:
     assert cat["type"] == "int" and cat["range_min"] == 0 and cat["range_max"] == 1
     assert cat["dependency"]["depends_on"] == "churn_rate"
     assert cat["dependency"]["noise_factor"] == 0.30  # literal inline preservado
+
+
+# ─────────────────────────────────────────────────────────
+# H-1 (audit) — contrato CONTINUO: la selección debe elegir el binario sintetizado,
+# no el target continuo del contrato (síntoma de #301 desplazado a margin_pct)
+# ─────────────────────────────────────────────────────────
+
+_CONTINUOUS_CONTRACT = {
+    "target_column": {"name": "margin_pct", "role": "regression_target",
+                      "dtype": "float", "description": "margen objetivo continuo"},
+    "feature_columns": [{"name": "ops_score", "role": "feature", "dtype": "float",
+                        "is_leakage_risk": False, "description": "score operativo"}],
+}
+
+
+def test_continuous_contract_synthesizes_binary_and_rewrites_contract_target() -> None:
+    base = _build_fallback_schema(_business_state(), 100, "business", primary_family="clasificacion")
+    base = _augment_schema_with_contract(base, _CONTINUOUS_CONTRACT)
+    schema, _notes, target_name = _enforce_business_classification_schema(
+        base, _CONTINUOUS_CONTRACT, profile="business", primary_family="clasificacion"
+    )
+    # spine sintetiza un binario, NO usa margin_pct (continuo) como target
+    assert target_name == "target_event_flag"
+    assert _col(schema, "target_event_flag")["range_max"] == 1
+    # H-1: el contrato propagado apunta al binario → _build_metadata elegirá el correcto
+    updated = _contract_with_enforced_target(_CONTINUOUS_CONTRACT, target_name)
+    assert updated["target_column"]["name"] == "target_event_flag"
+    assert updated["target_column"]["role"] == "classification_target"
+    assert updated["target_column"]["dtype"] == "int"
+
+
+def test_continuous_contract_identify_picks_binary_not_continuous() -> None:
+    base = _build_fallback_schema(_business_state(), 100, "business", primary_family="clasificacion")
+    base = _augment_schema_with_contract(base, _CONTINUOUS_CONTRACT)
+    schema, _notes, target_name = _enforce_business_classification_schema(
+        base, _CONTINUOUS_CONTRACT, profile="business", primary_family="clasificacion"
+    )
+    rows = _generate_dataset_from_schema(schema, profile="business")
+    df = pd.DataFrame(rows)
+    # metadata = lo que _build_metadata produce desde el contrato propagado
+    updated = _contract_with_enforced_target(_CONTINUOUS_CONTRACT, target_name)
+    state = {
+        "dataset_metadata": {"target_variable": updated["target_column"]["name"]},
+        "dataset_schema": schema,
+    }
+    picked = _identify_target_variable(state, df)
+    assert picked == "target_event_flag"
+    assert picked != "margin_pct"  # ya NO se grafica el target continuo (síntoma cerrado)
+    assert {int(v) for v in df[picked].dropna().unique()} == {0, 1}
+
+
+def test_contract_with_enforced_target_noop_when_no_target() -> None:
+    assert _contract_with_enforced_target(_LOGISTICS_CONTRACT, None) is None
+
+
+# ─────────────────────────────────────────────────────────
+# L-2 / L-5 / L-6 / N-7 (audit) — hardening de correctitud
+# ─────────────────────────────────────────────────────────
+
+
+def test_l2_domain_feature_substring_of_existing_is_still_added() -> None:
+    """'rate' NO debe saltarse por ser substring de 'churn_rate' (match exacto)."""
+    contract = {
+        "target_column": {"name": "churn_flag", "role": "classification_target",
+                          "dtype": "int", "description": "abandona"},
+        "feature_columns": [{"name": "tenure_months", "dtype": "float",
+                            "is_leakage_risk": False, "description": "x"}],
+        "domain_features_required": ["rate"],  # substring de churn_rate (retención → se mantiene)
+    }
+    schema = _enforced_schema(contract)
+    assert _col(schema, "churn_rate") is not None  # retención conserva el template
+    assert _col(schema, "rate") is not None  # y 'rate' SÍ se añade (no se saltó)
+
+
+def test_l5_str_dtype_target_emits_coercion_note() -> None:
+    contract = {
+        "target_column": {"name": "weird_cat", "role": "classification_target",
+                          "dtype": "str", "description": "categoría rara"},
+        "feature_columns": [{"name": "ops_score", "dtype": "float",
+                            "is_leakage_risk": False, "description": "x"}],
+    }
+    base = _build_fallback_schema(_business_state(), 100, "business", primary_family="clasificacion")
+    base = _augment_schema_with_contract(base, contract)
+    schema, notes, _t = _enforce_business_classification_schema(
+        base, contract, profile="business", primary_family="clasificacion"
+    )
+    assert _col(schema, "weird_cat")["type"] == "int"  # coercido a binario
+    assert any("coercido a binario" in n for n in notes)  # avisado
+
+
+def test_l6_driver_never_equals_target() -> None:
+    """Contrato malformado que lista el target dentro de feature_columns → driver != target."""
+    contract = {
+        "target_column": {"name": "flag", "role": "classification_target",
+                          "dtype": "int", "description": "evento"},
+        "feature_columns": [
+            {"name": "flag", "dtype": "int", "is_leakage_risk": False, "description": "dup"},
+            {"name": "real_driver", "dtype": "float", "is_leakage_risk": False, "description": "x"},
+        ],
+    }
+    name, _synth = _select_driver_feature(contract, target_name="flag")
+    assert name == "real_driver"  # saltó el target duplicado
+    schema = _enforced_schema(contract)
+    assert _col(schema, "flag")["dependency"]["depends_on"] != "flag"
+
+
+def test_n7_binary_target_stays_pure_int_no_outlier_float() -> None:
+    """El outlier B-05 no debe tocar el target binario (evita dtype mixto int/float)."""
+    schema = _enforced_schema(_LOGISTICS_CONTRACT)
+    rows = _generate_dataset_from_schema(schema, profile="business")
+    vals = [r["late_partner_flag"] for r in rows if r.get("late_partner_flag") is not None]
+    assert all(isinstance(v, int) for v in vals)  # ningún 0.0/1.0 float del outlier
+    assert set(vals) == {0, 1}

--- a/backend/tests/test_issue301_business_classification_spine.py
+++ b/backend/tests/test_issue301_business_classification_spine.py
@@ -1,0 +1,280 @@
+"""Issue #301 — spine determinista business + clasificación.
+
+Garantiza, SIN LLM, que un caso business de clasificación produzca un dataset
+coherente con el dilema: un target binario {0,1} de dominio (no el template fijo
+de churn) con un driver real, y que las salvaguardas no toquen ml_ds.
+
+Aserciones por PROPIEDAD donde el seed de `_generate_dataset_from_schema` deriva de
+`hash(...)` (aleatorizado entre procesos); las propiedades estructurales valen con
+cualquier seed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from case_generator.graph import (
+    _augment_schema_with_contract,
+    _binary_target_column,
+    _build_fallback_schema,
+    _ensure_both_classes,
+    _enforce_business_classification_schema,
+    _generate_dataset_from_schema,
+    _identify_target_variable,
+    _select_driver_feature,
+)
+
+# ─────────────────────────────────────────────────────────
+# Fixtures / helpers
+# ─────────────────────────────────────────────────────────
+
+_LOGISTICS_CONTRACT = {
+    "target_column": {
+        "name": "late_partner_flag",
+        "role": "classification_target",
+        "dtype": "int",
+        "description": "socio logístico incumple el SLA de entrega",
+    },
+    "feature_columns": [
+        # leakage primero a propósito: el selector debe saltarlo (7A).
+        {"name": "delivery_outcome_post", "role": "feature", "dtype": "float",
+         "is_leakage_risk": True, "description": "se conoce DESPUÉS del target"},
+        {"name": "partner_history_score", "role": "feature", "dtype": "float",
+         "is_leakage_risk": False, "description": "historial del socio"},
+    ],
+    "domain_features_required": ["route_complexity"],
+    "min_signal_strength": 0.15,
+}
+
+
+def _business_state() -> dict:
+    return {
+        "studentProfile": "business",
+        "doc1_anexo_financiero": "Ingresos: $12M anuales.",
+        "algoritmos": ["Logistic Regression"],
+    }
+
+
+def _enforced_schema(contract: dict | None) -> dict:
+    """Replica el orden real del pipeline: fallback base → augment → enforce."""
+    base = _build_fallback_schema(_business_state(), 100, "business", primary_family="clasificacion")
+    base = _augment_schema_with_contract(base, contract)
+    schema, _notes = _enforce_business_classification_schema(
+        base, contract, profile="business", primary_family="clasificacion"
+    )
+    return schema
+
+
+def _col(schema: dict, name: str) -> dict | None:
+    return next((c for c in schema["columns"] if c.get("name") == name), None)
+
+
+# ─────────────────────────────────────────────────────────
+# 9A — _ensure_both_classes (unit, determinista)
+# ─────────────────────────────────────────────────────────
+
+
+def test_ensure_both_classes_all_zeros_injects_minority() -> None:
+    out = _ensure_both_classes(np.zeros(100, dtype=float))
+    classes = set(int(round(v)) for v in out)
+    assert classes == {0, 1}  # ambas clases presentes tras el guard
+
+
+def test_ensure_both_classes_all_ones_injects_minority() -> None:
+    out = _ensure_both_classes(np.ones(100, dtype=float))
+    classes = set(int(round(v)) for v in out)
+    assert classes == {0, 1}
+
+
+def test_ensure_both_classes_balanced_is_passthrough() -> None:
+    vals = np.array([0.1, 0.2, 0.8, 0.9] * 25, dtype=float)
+    out = _ensure_both_classes(vals)
+    assert np.array_equal(out, vals)  # ya hay 2 clases → no toca la señal
+
+
+def test_ensure_both_classes_is_deterministic() -> None:
+    a = _ensure_both_classes(np.zeros(80, dtype=float))
+    b = _ensure_both_classes(np.zeros(80, dtype=float))
+    assert np.array_equal(a, b)
+
+
+def test_ensure_both_classes_minimal_flip_count() -> None:
+    out = _ensure_both_classes(np.zeros(100, dtype=float))
+    minority = sum(1 for v in out if int(round(v)) == 1)
+    # 15% objetivo: deja una clase aprendible sin sobre-balancear.
+    assert 1 <= minority <= 20
+
+
+def test_ensure_both_classes_empty() -> None:
+    out = _ensure_both_classes(np.array([], dtype=float))
+    assert out.size == 0
+
+
+# ─────────────────────────────────────────────────────────
+# 7A — selección de driver
+# ─────────────────────────────────────────────────────────
+
+
+def test_driver_selection_skips_leakage_and_picks_numeric() -> None:
+    name, synth = _select_driver_feature(_LOGISTICS_CONTRACT)
+    assert name == "partner_history_score"  # saltó la feature de leakage
+    assert synth is None
+
+
+def test_driver_selection_synthesizes_when_none_usable() -> None:
+    contract = {"feature_columns": [
+        {"name": "note", "dtype": "str", "is_leakage_risk": False},
+        {"name": "leaky", "dtype": "float", "is_leakage_risk": True},
+    ]}
+    name, synth = _select_driver_feature(contract)
+    assert name == "domain_driver_score"
+    assert synth is not None and synth["type"] == "float"
+
+
+# ─────────────────────────────────────────────────────────
+# _binary_target_column
+# ─────────────────────────────────────────────────────────
+
+
+def test_binary_target_column_shape() -> None:
+    col = _binary_target_column("x_flag", depends_on="d", description="evento", min_signal_strength=0.15)
+    assert col["type"] == "int"
+    assert col["range_min"] == 0 and col["range_max"] == 1
+    assert col["dependency"]["depends_on"] == "d"
+    assert "objetivo" in col["description"].lower()  # capturable por _identify_target_variable
+
+
+def test_binary_target_noise_decreases_with_signal_strength() -> None:
+    weak = _binary_target_column("a", depends_on="d", description="x", min_signal_strength=0.05)
+    strong = _binary_target_column("b", depends_on="d", description="x", min_signal_strength=0.30)
+    assert strong["dependency"]["noise_factor"] <= weak["dependency"]["noise_factor"]
+
+
+# ─────────────────────────────────────────────────────────
+# 1A/3A — enforcement del schema
+# ─────────────────────────────────────────────────────────
+
+
+def test_enforce_with_contract_builds_binary_domain_target() -> None:
+    schema = _enforced_schema(_LOGISTICS_CONTRACT)
+    target = _col(schema, "late_partner_flag")
+    assert target is not None
+    assert target["type"] == "int" and target["range_min"] == 0 and target["range_max"] == 1
+    assert target["dependency"]["depends_on"] == "partner_history_score"
+    # churn template eliminado (dilema NO de retención)
+    assert _col(schema, "churn_rate") is None
+    assert _col(schema, "retention_m1") is None
+    # set financiero mínimo conservado
+    for fin in ("period", "revenue", "costs", "margin_pct"):
+        assert _col(schema, fin) is not None
+    # cobertura de domain_features_required
+    assert _col(schema, "route_complexity") is not None
+
+
+def test_enforce_no_contract_synthesizes_target_with_note() -> None:
+    base = _build_fallback_schema(_business_state(), 100, "business", primary_family="clasificacion")
+    schema, notes = _enforce_business_classification_schema(
+        base, None, profile="business", primary_family="clasificacion"
+    )
+    target = _col(schema, "target_event_flag")
+    assert target is not None and target["range_min"] == 0 and target["range_max"] == 1
+    assert _col(schema, "domain_driver_score") is not None  # driver sintetizado
+    assert any("sintetizado" in n for n in notes)  # aviso honesto
+
+
+def test_enforce_retention_keeps_churn_template() -> None:
+    contract = {
+        "target_column": {"name": "churn_flag", "role": "classification_target",
+                          "dtype": "int", "description": "cliente abandona"},
+        "feature_columns": [{"name": "tenure_months", "role": "feature", "dtype": "float",
+                            "is_leakage_risk": False, "description": "antigüedad"}],
+    }
+    schema = _enforced_schema(contract)
+    # dilema de retención → churn/retention columns conservadas
+    assert _col(schema, "churn_rate") is not None
+    assert _col(schema, "retention_m1") is not None
+    target = _col(schema, "churn_flag")
+    assert target is not None and target["range_min"] == 0 and target["range_max"] == 1
+
+
+def test_enforce_noop_for_ml_ds() -> None:
+    base = _build_fallback_schema(
+        {"studentProfile": "ml_ds", "doc1_anexo_financiero": "$10M"}, 600, "ml_ds",
+        primary_family="clasificacion",
+    )
+    before = [c["name"] for c in base["columns"]]
+    schema, notes = _enforce_business_classification_schema(
+        base, _LOGISTICS_CONTRACT, profile="ml_ds", primary_family="clasificacion"
+    )
+    assert [c["name"] for c in schema["columns"]] == before  # ml_ds intacto
+    assert notes == []
+
+
+def test_enforce_noop_for_business_non_classification() -> None:
+    base = _build_fallback_schema(_business_state(), 100, "business", primary_family="regresion")
+    before = [c["name"] for c in base["columns"]]
+    schema, _notes = _enforce_business_classification_schema(
+        base, _LOGISTICS_CONTRACT, profile="business", primary_family="regresion"
+    )
+    assert [c["name"] for c in schema["columns"]] == before
+
+
+# ─────────────────────────────────────────────────────────
+# Integración — dataset generado + identify + señal
+# ─────────────────────────────────────────────────────────
+
+
+def test_generated_business_dataset_has_binary_target_both_classes_and_signal() -> None:
+    schema = _enforced_schema(_LOGISTICS_CONTRACT)
+    rows = _generate_dataset_from_schema(schema, profile="business")
+    df = pd.DataFrame(rows)
+
+    # target binario {0,1} con ambas clases (guard 2A)
+    target_vals = {int(v) for v in df["late_partner_flag"].dropna().unique()}
+    assert target_vals == {0, 1}
+
+    # driver de dominio con señal real ≥ ~0.3 (o, en su defecto, NO inventada)
+    corr = abs(df["partner_history_score"].corr(df["late_partner_flag"]))
+    assert corr >= 0.3, f"driver corr={corr:.3f} — esperaba señal fuerte generada"
+
+    # churn_rate ausente del dataset (dilema no-retención)
+    assert "churn_rate" not in df.columns
+
+
+def test_identify_target_variable_picks_contract_target_not_churn() -> None:
+    df = pd.DataFrame({
+        "period": ["2023-01", "2023-02"],
+        "churn_rate": [0.1, 0.2],
+        "late_partner_flag": [0, 1],
+    })
+    state = {"dataset_metadata": {"target_variable": "late_partner_flag"}}
+    assert _identify_target_variable(state, df) == "late_partner_flag"
+
+
+def test_identify_target_variable_uses_description_objetivo() -> None:
+    df = pd.DataFrame({"period": ["2023-01"], "x_flag": [1], "churn_rate": [0.1]})
+    state = {
+        "dataset_metadata": {},
+        "dataset_schema": {"columns": [
+            {"name": "x_flag", "description": "Variable objetivo binaria del caso"},
+        ]},
+    }
+    assert _identify_target_variable(state, df) == "x_flag"
+
+
+# ─────────────────────────────────────────────────────────
+# No-regresión ml_ds — categoria sigue siendo el target binario fijo
+# ─────────────────────────────────────────────────────────
+
+
+def test_ml_ds_fallback_categoria_unchanged() -> None:
+    schema = _build_fallback_schema(
+        {"studentProfile": "ml_ds", "doc1_anexo_financiero": "$10M"}, 600, "ml_ds",
+        primary_family="clasificacion",
+    )
+    cat = _col(schema, "categoria")
+    assert cat is not None
+    assert cat["type"] == "int" and cat["range_min"] == 0 and cat["range_max"] == 1
+    assert cat["dependency"]["depends_on"] == "churn_rate"
+    assert cat["dependency"]["noise_factor"] == 0.30  # literal inline preservado


### PR DESCRIPTION
## Context

Para un caso **business + clasificación** (Harvard+EDA con Logistic Regression), el dataset del M2 se generaba desde un **template fijo de 10 columnas churn/SaaS** en vez del **target binario de dominio del dilema** → incoherencia M1↔M2 (caso de logística/incumplimiento con datos de churn) y un chart de drivers que correlaciona contra `churn_rate` (continuo), no contra el objetivo real.

Esta es la **PR1** de #301 — el **spine determinista** (garantía en Python, no dependiente del LLM). Aprobada en plan-eng-review (BIG CHANGE, full scope). Absorbe #298.

## Cambios (business-only; no toca ml_ds)

- **`schema_designer` → `_enforce_business_classification_schema`** (corre tras el augment del contrato, en happy + fallback): para business+clasificación construye en Python el set financiero mínimo (`period, revenue, costs, margin_pct`) + **target binario {0,1} de dominio** + features del contrato + cobertura de `domain_features_required`. Las columnas churn/retención se conservan **solo** si el dilema es de retención.
- **Sin contrato / target continuo:** síntesis determinista de `target_event_flag` {0,1} + driver + **aviso honesto** (sin keyword-inference).
- **#298 absorbido:** el target depende de la **primera feature numérica no-leakage** (sintetizada si no hay) → driver real **generado en los datos**, no afirmado en prosa; el chart conserva el aviso "sin driver fuerte".
- **`_ensure_both_classes`:** guard determinista (boundary-flip) en el branch int-dependiente del generador, **business-gated** — un target de una sola clase enviaría una LR rota silenciosamente. ml_ds `categoria` queda **byte-idéntico** (el builder `_binary_target_column` se comparte en espíritu; `categoria` permanece inline para preservar el golden ml_ds).
- **`eda_charts_business`:** el título de drivers deriva del target real (no "abandono" en casos no-retención); el slot de cohorte renderiza una **barra de balance de clases** para target binario en vez de una caja inútil. `financial_mirage`, la ruta de cohorte de retención y la honestidad de #296 (eje fijo `[0,1]`, guardas base-100) quedan intactos.
- **`SCHEMA_DESIGNER_PROMPT`:** el template de 10 columnas se documenta como baseline de retención; el spine determinista gobierna clasificación no-retención.

`_identify_target_variable` **no requiere cambio** — `_build_metadata` ya prioriza el target del contrato y la prioridad-1 lo devuelve una vez la columna existe.

## Criterios de aceptación cubiertos por PR1
- [x] business+clasificación: dataset M2 con target **binario {0,1}** (no `churn_rate`).
- [x] `_identify_target_variable` devuelve el target del contrato, no `churn_rate`.
- [x] drivers correlaciona contra el target del dilema; ≥1 feature `|corr| ≥ 0.3` **o** aviso honesto.
- [x] títulos/subtítulos no asumen churn/retención cuando el caso no es de retención; fallbacks honestos.
- [x] mismatch/target ausente/continuo → **síntesis determinista** (no solo warning).
- [x] **no-regresión business churn** y **ml_ds+clasificación intacto**.

(Enforcement del architect/regla-7 + golden multi-dominio → PR2/PR3.)

## Validación
- `uv run --directory backend pytest -q` → **1030 passed, 16 skipped**
- `uv run --directory backend mypy src` → **clean (80 files)**
- `uv run --directory backend pytest -q tests/test_eda_charts_business.py` → verde

## Diferido (TODOS.md)
`TODO-301-A` guard a ml_ds · `TODO-301-B` refactor dup de prompt · `TODO-301-C` consumo pleno de `min_signal_strength` · `TODO-301-D` chart 3 dedicado de clasificación.

Refs #301
Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)