### PR TITLE
fix(eda): scope class-balance guard to resolved target + spare binary financial targets (#301 PR2a)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1539,3 +1539,31 @@ business.
 `eda_charts_business.py` + dispatch en `eda_chart_generator`.
 
 **Depends on / blocked by:** PR1 de Issue #301 (títulos/fallback) mergeado.
+
+---
+
+## TODO-301-PR2a-A: Anunciar el flip legítimo del target en `data_gap_warnings`
+
+**What:** Cuando `_ensure_both_classes` balancea un target binario degenerado en
+`_generate_dataset_from_schema` (`backend/src/case_generator/graph.py`), emitir una nota en
+`data_gap_warnings` con el conteo de filas volteadas (p. ej. "target binario degenerado:
+N filas sintéticas inyectadas para garantizar ambas clases").
+
+**Why:** Honestidad #296/#298 — un flip sintético sobre el target hoy es SILENCIOSO. PR2a
+detuvo los flips sobre features no-target (Fix 1), pero el flip legítimo del target sigue sin
+anunciarse. El docente debería ver que el dataset tuvo intervención determinista.
+
+**Pros:** Cierra el último flip silencioso del generador; coherente con el resto de avisos de
+honestidad que ya alimentan M2/M3.
+
+**Cons:** `_generate_dataset_from_schema` hoy devuelve solo `rows`; los warnings se ensamblan
+aguas arriba en `schema_designer` (graph.py:2941-2947, 2975-2981). Anunciar el flip exige
+cambiar la forma de retorno (p. ej. `(rows, notes)`) y enhebrarlo por `data_generator`
+(graph.py:3383) → fuera de la "tajada segura" de PR2a.
+
+**Context:** Detectado en la verificación adversarial de PR #302 ("8 filas volteadas, flip
+sintético no anunciado") y registrado en la plan-eng-review de PR2a. `_ensure_both_classes`
+(graph.py) ya conoce cuántas filas voltea (`k`); solo falta propagar esa señal.
+
+**Depends on / blocked by:** Empareja naturalmente con PR2b (que ya toca el camino del target
+y del architect). Independiente del resto de PR2b — puede hacerse en su propio PR de honestidad.

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2654,6 +2654,10 @@ def _binary_target_column(
         "range_max": 1,
         "nullable": False,
         "trend": None,
+        # Issue #301 PR2a — marca el target de dominio resuelto por el spine. El guard
+        # anti-degeneración (_ensure_both_classes) honra ESTA bandera en vez de asumir que
+        # cualquier binaria {0,1} dependiente es el target (rompía con varias binarias).
+        "is_domain_target": True,
         "dependency": {
             "depends_on": depends_on,
             "relationship": "linear",
@@ -3099,6 +3103,20 @@ def _ensure_both_classes(values: "np.ndarray") -> "np.ndarray":
     return out
 
 
+def _is_declared_binary_int(col: dict) -> bool:
+    """Una columna declarada como binaria {0,1} (int, rango [0,1]) — target o feature.
+
+    Predicado único (Issue #301 PR2a): lo comparten el guard N-7 del outlier (no inyectar
+    atípicos en una binaria) y el recompute financiero (no pisar un target binario nombrado
+    ``margin_pct``/``ebitda``). Una sola fuente de verdad evita que las dos reglas deriven.
+    """
+    return (
+        col.get("type") == "int"
+        and col.get("range_min") == 0
+        and col.get("range_max") == 1
+    )
+
+
 # ─────────────────────────────────────────────────────────
 # HELPER — _generate_dataset_from_schema (Python puro, 0 tokens LLM)
 # ─────────────────────────────────────────────────────────
@@ -3244,9 +3262,17 @@ def _generate_dataset_from_schema(schema: dict, profile: str = "business") -> li
             result = [None if null_mask[i] else round(float(values[i]), 2) for i in range(n_rows)]
         else:
             # Issue #301 — guard anti-degeneración del target binario de dominio (business).
-            # Un target dependiente declarado en [0,1] es el target sintetizado/de contrato;
-            # garantizar ambas clases evita una LR sin sentido por una sola clase.
-            if profile == "business" and low == 0.0 and high == 1.0:
+            # SOLO el target que el spine etiquetó con ``is_domain_target`` se balancea;
+            # las demás binarias {0,1} (features no-target emitidas por el LLM, p. ej.
+            # compliance_flag/late_flag) se dejan EXACTAMENTE como se generaron — no se
+            # voltean filas sintéticas no anunciadas (PR2a). Garantizar ambas clases en el
+            # target evita una LR sin sentido por una sola clase.
+            if (
+                profile == "business"
+                and low == 0.0
+                and high == 1.0
+                and col.get("is_domain_target")
+            ):
                 values = _ensure_both_classes(np.asarray(values, dtype=float))
             result = [None if null_mask[i] else int(round(float(values[i]))) for i in range(n_rows)]
         df_data[name] = result
@@ -3285,12 +3311,20 @@ def _generate_dataset_from_schema(schema: dict, profile: str = "business") -> li
         (c["name"] for c in columns if "cost" in c["name"].lower()),
         None
     )
+    # Issue #301 PR2a — si el case_architect nombró un classification_target literal
+    # ``margin_pct``/``ebitda``, el spine lo marcó binario int [0,1] (correcto). NO lo
+    # recalcules a continuo: ello degradaba el 3er chart M2 a box. Simetría con el guard
+    # N-7. Se resuelve UNA vez desde el spec (no por fila); business-gated → ml_ds intacto.
+    binary_int_names = {
+        c["name"] for c in columns
+        if profile == "business" and _is_declared_binary_int(c)
+    }
     for row in rows:
         rev  = float(row.get(revenue_col, 0) or 0)
         cost = float(row.get(cost_col_name, 0) or 0) if cost_col_name else 0
-        if "ebitda" in row:
+        if "ebitda" in row and "ebitda" not in binary_int_names:
             row["ebitda"] = round(rev - cost, 2)
-        if "margin_pct" in row:
+        if "margin_pct" in row and "margin_pct" not in binary_int_names:
             row["margin_pct"] = round(((rev - cost) / rev * 100), 2) if rev > 0 else 0.0
 
     # ── Enforcement retenciones: m1 >= m3 >= m6 >= m12 por fila ──
@@ -3330,12 +3364,7 @@ def _generate_dataset_from_schema(schema: dict, profile: str = "business") -> li
         # N-7 (Issue #301): nunca inyectes el outlier en el target binario {0,1} de
         # business — un ×3.5 capado lo convertiría en float 0.0/1.0 (dtype mixto en una
         # columna de clasificación). Se excluye toda columna int declarada en [0,1].
-        and not (
-            profile == "business"
-            and c["type"] == "int"
-            and c.get("range_min") == 0
-            and c.get("range_max") == 1
-        )
+        and not (profile == "business" and _is_declared_binary_int(c))
     ]
     if numeric_non_revenue and n_rows >= 50:
         target_col_def = numeric_non_revenue[0]

--- a/backend/tests/test_issue301_business_classification_spine.py
+++ b/backend/tests/test_issue301_business_classification_spine.py
@@ -395,3 +395,159 @@ def test_n7_binary_target_stays_pure_int_no_outlier_float() -> None:
     vals = [r["late_partner_flag"] for r in rows if r.get("late_partner_flag") is not None]
     assert all(isinstance(v, int) for v in vals)  # ningún 0.0/1.0 float del outlier
     assert set(vals) == {0, 1}
+
+
+# ─────────────────────────────────────────────────────────
+# PR2a — Fix 1: el guard anti-degeneración balancea SOLO el target etiquetado
+#               por el spine, no features binarias no-target.
+# ─────────────────────────────────────────────────────────
+
+
+def test_pr2a_binary_target_column_is_tagged_domain_target() -> None:
+    """El único constructor del target de dominio lo etiqueta con ``is_domain_target``."""
+    col = _binary_target_column("evento_flag", depends_on="driver_x", description="evento")
+    assert col["is_domain_target"] is True
+    assert col["type"] == "int" and col["range_min"] == 0 and col["range_max"] == 1
+
+
+def _append_non_target_binary(schema: dict, name: str, depends_on: str) -> None:
+    """Añade una feature binaria {0,1} int dependiente SIN etiqueta de target.
+
+    Reproduce las binarias no-target que el LLM emite (p. ej. compliance_flag/late_flag):
+    int en [0,1], dependientes → caen en el mismo loop+branch que dispara el guard.
+    """
+    schema["columns"].append({
+        "name": name, "type": "int", "range_min": 0, "range_max": 1,
+        "nullable": False, "trend": None,
+        "dependency": {"depends_on": depends_on, "relationship": "linear", "noise_factor": 0.1},
+    })
+
+
+def test_pr2a_guard_balances_only_tagged_target_not_other_binaries(monkeypatch) -> None:
+    """Spy determinista: con el target etiquetado + 2 binarias no-target, el guard
+    (`_ensure_both_classes`) se invoca EXACTAMENTE una vez (solo el target).
+    Antes del fix se invocaba 3× (una por cada binaria {0,1} dependiente).
+    """
+    import case_generator.graph as g
+
+    real = g._ensure_both_classes
+    calls: list[int] = []
+
+    def _spy(values):
+        calls.append(1)
+        return real(values)
+
+    monkeypatch.setattr(g, "_ensure_both_classes", _spy)
+
+    schema = _enforced_schema(_LOGISTICS_CONTRACT)  # target late_partner_flag → etiquetado
+    _append_non_target_binary(schema, "compliance_flag", "partner_history_score")
+    _append_non_target_binary(schema, "late_flag", "partner_history_score")
+
+    rows = g._generate_dataset_from_schema(schema, profile="business")
+
+    assert len(calls) == 1, f"el guard tocó {len(calls)} columnas — debe ser solo el target"
+    df = pd.DataFrame(rows)
+    # el target etiquetado sí queda con ambas clases
+    assert {int(v) for v in df["late_partner_flag"].dropna().unique()} == {0, 1}
+    # las features no-target conservan sus valores binarios (no se mutaron silenciosamente)
+    for nm in ("compliance_flag", "late_flag"):
+        assert set(int(v) for v in df[nm].dropna().unique()).issubset({0, 1})
+
+
+def test_pr2a_guard_never_runs_for_ml_ds(monkeypatch) -> None:
+    """ml_ds tiene `categoria` binaria {0,1} dependiente, pero el gate ``profile==business``
+    impide que el guard corra: `_ensure_both_classes` no se invoca (0 veces)."""
+    import case_generator.graph as g
+
+    calls: list[int] = []
+
+    def _spy(values):
+        calls.append(1)
+        return values
+
+    monkeypatch.setattr(g, "_ensure_both_classes", _spy)
+
+    schema = g._build_fallback_schema(
+        {"studentProfile": "ml_ds", "doc1_anexo_financiero": "$10M"}, 600, "ml_ds",
+        primary_family="clasificacion",
+    )
+    g._generate_dataset_from_schema(schema, profile="ml_ds")
+    assert calls == []  # gate de perfil: el guard nunca corre en ml_ds
+
+
+# ─────────────────────────────────────────────────────────
+# PR2a — Fix 2: el recompute financiero no pisa un target binario nombrado
+#               margin_pct/ebitda; los financieros float normales se recomputan igual.
+# ─────────────────────────────────────────────────────────
+
+_MARGIN_BINARY_CONTRACT = {
+    "target_column": {"name": "margin_pct", "role": "classification_target",
+                      "dtype": "int", "description": "el margen cae bajo el umbral (evento)"},
+    "feature_columns": [{"name": "ops_score", "role": "feature", "dtype": "float",
+                        "is_leakage_risk": False, "description": "score operativo del período"}],
+}
+
+
+def test_pr2a_binary_int_margin_target_stays_binary_and_chart_not_box() -> None:
+    """Edge: un classification_target nombrado literal ``margin_pct`` marcado int [0,1]
+    sigue binario {0,1} tras la generación (el recompute NO lo devolvió a continuo) y el
+    3er chart M2 NO degrada a una caja de distribución."""
+    schema = _enforced_schema(_MARGIN_BINARY_CONTRACT)
+    mp = _col(schema, "margin_pct")
+    assert mp is not None
+    assert mp["type"] == "int" and mp["range_min"] == 0 and mp["range_max"] == 1
+    assert mp.get("is_domain_target") is True
+
+    rows = _generate_dataset_from_schema(schema, profile="business")
+    df = pd.DataFrame(rows)
+    # Fix 2: el recompute financiero NO lo pisó a continuo.
+    assert {int(v) for v in df["margin_pct"].dropna().unique()} == {0, 1}
+
+    # symptom cerrado: 3er chart = balance de clases, NO target_distribution/box.
+    from case_generator.datagen.eda_charts_business import generate_business_eda_charts
+
+    charts = generate_business_eda_charts(df, "margin_pct", {}, {"case_id": "pr2a"})
+    assert any(c["id"] == "class_balance" for c in charts)
+    assert not any(c.get("id") == "target_distribution" for c in charts)
+
+
+def test_pr2a_normal_float_financials_still_recomputed_business_and_ml_ds() -> None:
+    """No-regresión (crítico): margin_pct/ebitda float continuos se recomputan EXACTAMENTE
+    como hoy (ebitda = revenue - costs; margin = (rev-cost)/rev*100). Idéntico en business
+    y ml_ds — Fix 2 solo cambia el camino de una columna declarada binaria int [0,1]."""
+    schema = {
+        # n_rows < 50 desactiva la inyección de outliers (B-05), que en ml_ds infla `costs`
+        # DESPUÉS del recompute (comportamiento pre-existente, ajeno a Fix 2) y rompería la
+        # igualdad exacta ebitda == rev - cost. Así aislamos el recompute que Fix 2 toca.
+        "n_rows": 40,
+        "time_granularity": "monthly",
+        "columns": [
+            {"name": "period", "type": "str", "range_min": None, "range_max": None,
+             "nullable": False, "trend": None, "dependency": None},
+            {"name": "revenue", "type": "float", "range_min": 80_000, "range_max": 120_000,
+             "nullable": False, "trend": "up", "dependency": None},
+            {"name": "costs", "type": "float", "range_min": 50_000, "range_max": 90_000,
+             "nullable": False, "trend": None,
+             "dependency": {"depends_on": "revenue", "relationship": "linear", "noise_factor": 0.12}},
+            {"name": "margin_pct", "type": "float", "range_min": 0, "range_max": 100,
+             "nullable": False, "trend": None, "dependency": None},
+            {"name": "ebitda", "type": "float", "range_min": 0, "range_max": 50_000,
+             "nullable": False, "trend": None, "dependency": None},
+        ],
+        "constraints": {
+            "revenue_annual_total": 1_200_000, "cost_annual_total": 800_000,
+            "revenue_column": "revenue", "tolerance_pct": 0.05,
+        },
+    }
+    for profile in ("business", "ml_ds"):
+        rows = _generate_dataset_from_schema(schema, profile=profile)
+        for r in rows:
+            assert r["ebitda"] == round(r["revenue"] - r["costs"], 2)
+            expected_margin = (
+                round((r["revenue"] - r["costs"]) / r["revenue"] * 100, 2)
+                if r["revenue"] > 0 else 0.0
+            )
+            assert r["margin_pct"] == expected_margin
+        # margin_pct quedó continuo (NO degenerado a {0,1}) → el recompute corrió.
+        df = pd.DataFrame(rows)
+        assert not set(int(v) for v in df["margin_pct"]).issubset({0, 1})


### PR DESCRIPTION
## Safe slice of #301 PR2

This is the **safe slice** of PR2: two deterministic, **business-effect-only** fixes in `_generate_dataset_from_schema` (`backend/src/case_generator/graph.py`). **No prompt edits, no `case_architect` changes.** Source: the adversarial execution-based verification on [#302](https://github.com/4Tech-Labs/ADAM-EDU/pull/302) + umbrella issue #301.

`Refs #301` — the umbrella stays **open**. Deferred to **PR2b** (with evals): conditioning "rule 7", `case_architect` contract synthesis, and retention-token work (`_is_retention_target_name` substring + the `abandon` divergence).

### Fix 1 — guard only the resolved target
The anti-degeneration guard (`_ensure_both_classes`) fired on **any** business binary `{0,1}` int **dependent** column, silently flipping rows in non-target features the LLM emits (e.g. `compliance_flag`/`late_flag`) — an unannounced synthetic flip. The spine (the single place that *determines* the target) now tags it via `_binary_target_column(is_domain_target=True)`; the guard honors that tag, so **only the target is balanced** and other binaries are left exactly as generated. No signature change, no state plumbing — the flag rides in the schema dict `data_generator` already reads (validation at graph.py:2902 runs *before* the spine, so the flag survives untouched).

### Fix 2 — don't clobber a binary target named `margin_pct`/`ebitda`
The unconditional financial recompute forced a `classification_target` literally named `margin_pct`/`ebitda` back to **continuous** → the 3rd M2 chart degraded to `target_distribution`/box. **Pre-existing** (blame `31f14e1`), not a PR1 regression. The recompute now skips a column whose declared spec is binary int `[0,1]`, via a shared `_is_declared_binary_int` predicate **also used by the N-7 outlier guard** (DRY). Business-gated and resolved **once** from the spec (not per row) → normal float financials and ml_ds are **provably unchanged**.

### Tests (deterministic) — `test_issue301_business_classification_spine.py`
- **Fix 1 core:** spy on `_ensure_both_classes` — fires **exactly once** on the tagged target with 2 extra non-target binaries present (pre-fix: 3×); non-target binaries untouched.
- **Fix 1 ml_ds:** spy fires **0×** (profile gate) despite `categoria` being binary `{0,1}`.
- **Fix 2 edge:** target named `margin_pct` marked int `[0,1]` stays `{0,1}` after generation; `generate_business_eda_charts` 3rd chart is `class_balance`/bar, **not** `target_distribution`/box.
- **Fix 2 no-regression (critical):** normal float `margin_pct`/`ebitda` recompute exactly as today (`ebitda = rev − cost`, `margin = (rev−cost)/rev*100`) for **business and ml_ds**.

### Validation
- `uv run --directory backend pytest -q` → **1042 passed, 16 skipped**
- `uv run --directory backend mypy src` → **clean (80 files)**
- targeted: `test_issue301_business_classification_spine.py` + `test_eda_charts_business.py` → **71 passed**

### Follow-up
`TODO-301-PR2a-A` added: announce the legit target flip in `data_gap_warnings` (needs a return-shape change → PR2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)