### PR TITLE
fix(ui): topbar de ancho completo en portales docente, estudiante y admin

### DIFF
--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
@@ -499,7 +499,7 @@ export function AdminDashboardPage() {
     return (
         <div className="min-h-screen bg-[#f0f4f8] text-slate-800" data-testid="admin-dashboard-shell">
             <header className="border-b-[3px] border-[#0144a0] bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800" data-testid="admin-dashboard-header">
-                <div className="mx-auto flex h-20 w-full max-w-7xl items-center justify-between gap-5 px-6">
+                <div className="flex h-20 w-full items-center justify-between gap-5 px-6">
                     <div className="flex items-center gap-3.5">
                         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-600 shadow-lg">
                             <BarChart3 className="h-5 w-5 text-white" strokeWidth={2.2} />

--- a/frontend/src/features/student-layout/StudentUserHeader.tsx
+++ b/frontend/src/features/student-layout/StudentUserHeader.tsx
@@ -24,7 +24,7 @@ export function StudentUserHeader() {
             className="w-full"
             style={{ background: "linear-gradient(135deg, #0144a0 0%, #0255c5 100%)" }}
         >
-            <div className={`mx-auto flex ${PORTAL_HEADER_HEIGHT_CLASSNAME} max-w-6xl items-center justify-between gap-4 px-6`}>
+            <div className={`flex ${PORTAL_HEADER_HEIGHT_CLASSNAME} items-center justify-between gap-4 px-6`}>
                 <div className="flex min-w-0 items-center gap-3.5">
                     <Link
                         to="/student/dashboard"

--- a/frontend/src/features/teacher-layout/TeacherUserHeader.tsx
+++ b/frontend/src/features/teacher-layout/TeacherUserHeader.tsx
@@ -23,7 +23,7 @@ export function TeacherUserHeader() {
             className="w-full"
             style={{ background: "linear-gradient(135deg, #0144a0 0%, #0255c5 100%)" }}
         >
-            <div className={`mx-auto flex ${PORTAL_HEADER_HEIGHT_CLASSNAME} max-w-6xl items-center justify-between gap-4 px-6`}>
+            <div className={`flex ${PORTAL_HEADER_HEIGHT_CLASSNAME} items-center justify-between gap-4 px-6`}>
                 <div className="flex min-w-0 items-center gap-3.5">
                     <Link
                         to="/teacher/dashboard"


### PR DESCRIPTION
## Qué

Los topbars de los portales **Docente**, **Estudiante** y **Administrador** mostraban su contenido agrupado en el centro de la pantalla, dejando un gran espacio vacío a izquierda y derecha en monitores anchos.

La causa: el contenedor interno de cada header usaba `mx-auto ... max-w-{6,7}xl`, que limita el ancho y centra el bloque. Como el `<header>` ya es `w-full` y el contenedor usa `justify-between`, basta con quitar el tope de ancho y el centrado para que el logo quede pegado a la izquierda y las acciones a la derecha.

## Cambios

Se eliminan únicamente las clases `mx-auto` y `max-w-{6,7}xl` del contenedor interno en:

- `frontend/src/features/teacher-layout/TeacherUserHeader.tsx`
- `frontend/src/features/student-layout/StudentUserHeader.tsx`
- `frontend/src/features/admin-dashboard/AdminDashboardPage.tsx` (header inline)

Se conservan `flex`, altura, `items-center`, `justify-between`, `gap` y `px-6` (margen cómodo de ~24px desde cada borde, confirmado con el usuario). Solo cambios de clases Tailwind: sin cambios de lógica, props, textos ni estructura.

## Verificación

- ✅ `npm --prefix frontend run lint` — limpio
- ✅ `npm --prefix frontend run build` — exitoso (3663 módulos)
- ✅ `npm --prefix frontend run test` (3 componentes) — 42 tests pasan

🤖 Generated with [Claude Code](https://claude.com/claude-code)