### PR TITLE
fix(ui): dashboards fluidos de ancho completo en portales estudiante, docente y admin

### DIFF
--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.tsx
@@ -46,6 +46,7 @@ import { ApiError, api } from "@/shared/api";
 import { copyToClipboard } from "@/shared/clipboard";
 import { queryKeys, type CourseFilters } from "@/shared/queryKeys";
 import { useToast } from "@/shared/toast-context";
+import { PORTAL_CONTENT_SHELL_CLASSNAME } from "@/shared/ui/layout";
 import {
     Select,
     SelectContent,
@@ -499,7 +500,7 @@ export function AdminDashboardPage() {
     return (
         <div className="min-h-screen bg-[#f0f4f8] text-slate-800" data-testid="admin-dashboard-shell">
             <header className="border-b-[3px] border-[#0144a0] bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800" data-testid="admin-dashboard-header">
-                <div className="flex h-20 w-full items-center justify-between gap-5 px-6">
+                <div className={`${PORTAL_CONTENT_SHELL_CLASSNAME} flex h-20 items-center justify-between gap-5`}>
                     <div className="flex items-center gap-3.5">
                         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-600 shadow-lg">
                             <BarChart3 className="h-5 w-5 text-white" strokeWidth={2.2} />
@@ -527,7 +528,7 @@ export function AdminDashboardPage() {
                 </div>
             </header>
 
-            <main className="mx-auto w-full max-w-7xl px-6 py-8">
+            <main className={`${PORTAL_CONTENT_SHELL_CLASSNAME} py-8`}>
                 {!hasDashboardData && (summaryQuery.isPending || coursesQuery.isPending) ? (
                     <DashboardLoadingState />
                 ) : !hasDashboardData && pageError ? (

--- a/frontend/src/features/student-dashboard/StudentDashboardPage.tsx
+++ b/frontend/src/features/student-dashboard/StudentDashboardPage.tsx
@@ -15,6 +15,7 @@ import {
     matchesStudentCourseSearch,
 } from "./studentDashboardModel";
 import { StudentUserHeader } from "@/features/student-layout/StudentUserHeader";
+import { PORTAL_CONTENT_SHELL_CLASSNAME } from "@/shared/ui/layout";
 import { useStudentCases, useStudentCourses } from "./useStudentDashboard";
 
 const EMPTY_STUDENT_COURSES: StudentCourseItem[] = [];
@@ -328,7 +329,7 @@ export function StudentDashboardPage() {
         <div className="min-h-screen bg-[#F0F4F8]" data-testid="student-dashboard-page">
             <StudentUserHeader />
 
-            <main className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-9">
+            <main className={`${PORTAL_CONTENT_SHELL_CLASSNAME} flex flex-col gap-8 py-9`}>
                 {initialError ? (
                     <ErrorState message={resolveErrorMessage(initialError)} onRetry={handleRetry} />
                 ) : (
@@ -379,7 +380,7 @@ export function StudentDashboardPage() {
                             ) : coursesInitialLoading ? (
                                 <LoadingState />
                             ) : filteredCourses.length ? (
-                                <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                                <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
                                     {filteredCourses.map((course) => (
                                         <StudentCourseCard key={course.id} course={course} />
                                     ))}

--- a/frontend/src/features/student-layout/StudentUserHeader.tsx
+++ b/frontend/src/features/student-layout/StudentUserHeader.tsx
@@ -2,7 +2,10 @@ import { Bell, GraduationCap } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { useAuth } from "@/app/auth/useAuth";
-import { PORTAL_HEADER_HEIGHT_CLASSNAME } from "@/shared/ui/layout";
+import {
+    PORTAL_CONTENT_SHELL_CLASSNAME,
+    PORTAL_HEADER_HEIGHT_CLASSNAME,
+} from "@/shared/ui/layout";
 
 const STUDENT_NAME_FALLBACK = "Estudiante";
 const STUDENT_SUBTITLE = "Portal Estudiante";
@@ -24,7 +27,7 @@ export function StudentUserHeader() {
             className="w-full"
             style={{ background: "linear-gradient(135deg, #0144a0 0%, #0255c5 100%)" }}
         >
-            <div className={`flex ${PORTAL_HEADER_HEIGHT_CLASSNAME} items-center justify-between gap-4 px-6`}>
+            <div className={`${PORTAL_CONTENT_SHELL_CLASSNAME} flex ${PORTAL_HEADER_HEIGHT_CLASSNAME} items-center justify-between gap-4`}>
                 <div className="flex min-w-0 items-center gap-3.5">
                     <Link
                         to="/student/dashboard"

--- a/frontend/src/features/teacher-dashboard/CursosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CursosActivosSection.test.tsx
@@ -66,7 +66,7 @@ describe("CursosActivosSection", () => {
         expect(screen.getByRole("searchbox", { name: "Buscar curso" })).toBeTruthy();
     });
 
-    it("shows two skeleton cards while loading", () => {
+    it("shows skeleton cards while loading", () => {
         useTeacherCourses.mockReturnValue({
             data: undefined,
             isLoading: true,
@@ -75,7 +75,7 @@ describe("CursosActivosSection", () => {
 
         const { container } = renderWithProviders(<CursosActivosSection />);
 
-        expect(container.querySelectorAll(".animate-pulse")).toHaveLength(2);
+        expect(container.querySelectorAll(".animate-pulse")).toHaveLength(3);
     });
 
     it("shows an error message when the query fails", () => {

--- a/frontend/src/features/teacher-dashboard/CursosActivosSection.tsx
+++ b/frontend/src/features/teacher-dashboard/CursosActivosSection.tsx
@@ -234,7 +234,8 @@ export function CursosActivosSection() {
             </div>
 
             {isLoading ? (
-                <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+                    <CourseCardSkeleton />
                     <CourseCardSkeleton />
                     <CourseCardSkeleton />
                 </div>
@@ -255,7 +256,7 @@ export function CursosActivosSection() {
             ) : null}
 
             {!isLoading && !isError && filteredCourses.length > 0 ? (
-                <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
                     {filteredCourses.map((course, index) => (
                         <div
                             key={course.id}

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.test.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.test.tsx
@@ -57,7 +57,8 @@ describe("TeacherDashboardPage", () => {
         expect(teacherLayoutSpy).toHaveBeenCalledWith(
             expect.objectContaining({
                 testId: "teacher-dashboard-page",
-                contentClassName: "mx-auto max-w-6xl space-y-10 px-6 py-9",
+                contentClassName:
+                    "mx-auto w-full max-w-[2400px] px-4 sm:px-6 lg:px-8 space-y-10 py-9",
             }),
         );
         expect(quickActionsSectionSpy).toHaveBeenCalledWith(

--- a/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
+++ b/frontend/src/features/teacher-dashboard/TeacherDashboardPage.tsx
@@ -1,4 +1,5 @@
 import { TeacherLayout } from "@/features/teacher-layout/TeacherLayout";
+import { PORTAL_CONTENT_SHELL_CLASSNAME } from "@/shared/ui/layout";
 
 import { CasosActivosSection } from "./CasosActivosSection";
 import { CursosActivosSection } from "./CursosActivosSection";
@@ -8,7 +9,7 @@ export function TeacherDashboardPage() {
     return (
         <TeacherLayout
             testId="teacher-dashboard-page"
-            contentClassName="mx-auto max-w-6xl space-y-10 px-6 py-9"
+            contentClassName={`${PORTAL_CONTENT_SHELL_CLASSNAME} space-y-10 py-9`}
         >
                 <QuickActionsSection />
                 <CursosActivosSection />

--- a/frontend/src/features/teacher-layout/TeacherLayout.tsx
+++ b/frontend/src/features/teacher-layout/TeacherLayout.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { PORTAL_CONTENT_SHELL_CLASSNAME } from "@/shared/ui/layout";
+
 import { TeacherUserHeader } from "./TeacherUserHeader";
 
 interface TeacherLayoutProps {
@@ -10,7 +12,7 @@ interface TeacherLayoutProps {
 
 export function TeacherLayout({
     children,
-    contentClassName = "mx-auto w-full max-w-6xl px-6 py-9",
+    contentClassName = `${PORTAL_CONTENT_SHELL_CLASSNAME} py-9`,
     testId,
 }: TeacherLayoutProps) {
     return (

--- a/frontend/src/features/teacher-layout/TeacherUserHeader.tsx
+++ b/frontend/src/features/teacher-layout/TeacherUserHeader.tsx
@@ -2,7 +2,10 @@ import { Bell, GraduationCap } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { useAuth } from "@/app/auth/useAuth";
-import { PORTAL_HEADER_HEIGHT_CLASSNAME } from "@/shared/ui/layout";
+import {
+    PORTAL_CONTENT_SHELL_CLASSNAME,
+    PORTAL_HEADER_HEIGHT_CLASSNAME,
+} from "@/shared/ui/layout";
 
 const FACULTY_SUBTITLE = "Portal Docente";
 
@@ -23,7 +26,7 @@ export function TeacherUserHeader() {
             className="w-full"
             style={{ background: "linear-gradient(135deg, #0144a0 0%, #0255c5 100%)" }}
         >
-            <div className={`flex ${PORTAL_HEADER_HEIGHT_CLASSNAME} items-center justify-between gap-4 px-6`}>
+            <div className={`${PORTAL_CONTENT_SHELL_CLASSNAME} flex ${PORTAL_HEADER_HEIGHT_CLASSNAME} items-center justify-between gap-4`}>
                 <div className="flex min-w-0 items-center gap-3.5">
                     <Link
                         to="/teacher/dashboard"

--- a/frontend/src/shared/ui/layout.ts
+++ b/frontend/src/shared/ui/layout.ts
@@ -2,3 +2,15 @@ export const PORTAL_HEADER_HEIGHT_PX = 80;
 export const PORTAL_HEADER_HEIGHT_CLASSNAME = "h-20";
 export const PORTAL_SHELL_HEIGHT_DVH = `calc(100dvh - ${PORTAL_HEADER_HEIGHT_PX}px)`;
 export const PORTAL_SHELL_HEIGHT_VH_CLASSNAME = "h-[calc(100vh-80px)]";
+
+// Safety cap that only engages on ultra-wide monitors; on normal monitors
+// (<=2400px) the portal content is effectively full-bleed.
+export const PORTAL_MAX_WIDTH_CLASSNAME = "max-w-[2400px]";
+// Responsive horizontal gutter shared by topbar rows and content, so their
+// left/right edges stay aligned at every width.
+export const PORTAL_GUTTER_X_CLASSNAME = "px-4 sm:px-6 lg:px-8";
+// Horizontal shell applied to each portal's <main> and to the inner row of its
+// topbar. Written as a full string literal (not interpolated) so the Tailwind
+// v4 source scanner generates every class.
+export const PORTAL_CONTENT_SHELL_CLASSNAME =
+    "mx-auto w-full max-w-[2400px] px-4 sm:px-6 lg:px-8";


### PR DESCRIPTION
## Problema

Tras el PR #309 los topbars quedaron de ancho completo, pero el contenido de los dashboards siguió topado y centrado (`max-w-6xl` ≈1024px en docente/estudiante, `max-w-7xl` ≈1280px en admin). En monitores anchos eso deja grandes márgenes vacíos a los lados — el contenido se ve "a la mitad". Se agrava porque las grillas de cursos topaban en 2 columnas, dejando un curso solitario encogido en la mitad izquierda.

## Solución

Se centraliza un **content shell** responsivo en `frontend/src/shared/ui/layout.ts` (`PORTAL_CONTENT_SHELL_CLASSNAME = "mx-auto w-full max-w-[2400px] px-4 sm:px-6 lg:px-8"`) y se reutiliza tanto en las filas internas de los topbars como en los `<main>` de los dashboards, de modo que **header y contenido comparten ancho/gutter y quedan alineados en todo ancho**:

- Full-bleed (borde a borde) en monitores normales; tope de seguridad simétrico solo a partir de ~2400px (ultra-anchos).
- Topbars docente/estudiante/admin: el fondo del gradiente sigue full-bleed; solo la fila interna usa el shell.
- Grillas de cursos → `md:grid-cols-2 xl:grid-cols-3`: llenan pantallas anchas y un curso único conserva un tamaño razonable (~1/3).
- Las páginas docente NO-dashboard (formularios/lectura) conservan su `max-w-6xl` propio, sin cambios.

## Archivos

`layout.ts` (token compartido), `TeacherLayout.tsx`, `TeacherUserHeader.tsx`, `StudentUserHeader.tsx`, `AdminDashboardPage.tsx`, `TeacherDashboardPage.tsx`, `StudentDashboardPage.tsx`, `CursosActivosSection.tsx` (+ 2 tests actualizados).

## Verificación

- ✅ `npm --prefix frontend run lint`
- ✅ `npm --prefix frontend run build` (type-check + Tailwind genera `max-w-[2400px]`)
- ✅ `npm --prefix frontend run test` — **444/444**
- ✅ Visual en navegador (CSS de build real) a 1366 / 1920 / 2560 px: a 1366 y 1920 el contenido llena el viewport alineado con el topbar; a 2560 topa y se centra simétricamente; la grilla refluye a 3 columnas.

Cambio de UI puro (Tailwind). Sin backend, migraciones ni `case_generator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)