### PR TITLE
fix(ui): quitar cursor not-allowed del select de Grupos Destino

### DIFF
--- a/frontend/src/features/teacher-authoring/GroupsCombobox.tsx
+++ b/frontend/src/features/teacher-authoring/GroupsCombobox.tsx
@@ -47,7 +47,7 @@ export function GroupsCombobox({ courses, value, onAdd, onRemove, hasError }: Gr
                         type="button"
                         aria-expanded={open}
                         className={cn(
-                            "input-base w-full flex items-center justify-between rounded-lg border bg-white px-3.5 py-2.5 text-sm text-left transition hover:border-[#0144a0]",
+                            "input-base w-full flex items-center justify-between rounded-lg border bg-white px-3.5 py-2.5 text-sm text-left transition cursor-pointer hover:border-[#0144a0]",
                             hasError ? "border-red-500 input-error" : "border-slate-200"
                         )}
                     >

--- a/frontend/src/features/teacher-authoring/authoringFormConfig.ts
+++ b/frontend/src/features/teacher-authoring/authoringFormConfig.ts
@@ -75,7 +75,7 @@ export const FORM_STYLES = `
 .teacher-form .input-base:hover:not(:focus):not(:disabled) {
   border-color: #94a3b8;
 }
-.teacher-form .input-base:read-only, .teacher-form .input-base:disabled {
+.teacher-form input.input-base:read-only, .teacher-form textarea.input-base:read-only, .teacher-form .input-base:disabled {
   background-color: #f8fafc;
   color: #64748b;
   cursor: not-allowed;


### PR DESCRIPTION
## Problema

Al pasar el mouse sobre el select **Grupos Destino** (placeholder "Seleccione grupos...") aparecía el cursor rojo 🚫 `not-allowed`, como si el control estuviera deshabilitado. El control es totalmente funcional —al hacer clic abre el popover de búsqueda de cursos—, así que el cursor confundía al docente.

## Causa raíz

El trigger es un `<button class="input-base">` en `GroupsCombobox.tsx` (es un trigger de **Popover** de Radix, no un Select). La regla compartida en `authoringFormConfig.ts`:

```css
.teacher-form .input-base:read-only, .teacher-form .input-base:disabled {
  cursor: not-allowed;
  ...
}
```

La pseudo-clase CSS `:read-only` **matchea todo elemento no editable, incluidos los `<button>`**. Por eso el botón heredaba `cursor: not-allowed` (y un fondo gris `#f8fafc`) aunque no está deshabilitado ni es read-only. Su especificidad `(0,3,0)` además ganaba sobre el `bg-white`/`cursor-*` del propio botón, por lo que un override local no bastaba.

Era el único `input-base` afectado: los demás selects son `<SelectTrigger>` de Radix (forzados a `cursor: pointer !important` vía `[data-slot="select-trigger"]` en `global.css`) y el campo "Nivel" es un `<input readOnly>` real que sí debe verse deshabilitado.

## Cambios

1. **`authoringFormConfig.ts`** — acota el selector `:read-only` a `input`/`textarea` (donde el estado read-only es real), dejando `:disabled` universal. El botón deja de matchear → adiós `not-allowed` + fondo gris; el campo "Nivel" y cualquier campo deshabilitado conservan su estilo.
2. **`GroupsCombobox.tsx`** — agrega `cursor-pointer` al trigger para que muestre la manito como los demás selects.

Cambio puro de CSS/className. Sin tocar backend, schema ni contratos.

## Verificación

- `npm --prefix frontend run lint` → limpio
- `npm --prefix frontend run test` → 444/444 pasan
- `npm --prefix frontend run build` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)