### PR TITLE
feat(architect): close #301 — rule-7 in-text + #228 enforcement + dedup (PR2c, Gates 1-3)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1473,7 +1473,7 @@ el gate y regenerar el golden en un PR dedicado.
 
 ---
 
-## TODO-301-B: Eliminar la duplicación verbatim de `CASE_ARCHITECT_PROMPT`
+## TODO-301-B: Eliminar la duplicación verbatim de `CASE_ARCHITECT_PROMPT` [RESUELTO por #305]
 
 **What:** Extraer el cuerpo genérico de `CASE_ARCHITECT_PROMPT` a una constante compartida y
 componer `CASE_ARCHITECT_PROMPT_CLASSIFICATION = _BASE + _ANCHOR`, eliminando la copia
@@ -1570,7 +1570,7 @@ y del architect). Independiente del resto de PR2b — puede hacerse en su propio
 
 ---
 
-## TODO-301-PR2b-A: Deduplicar el prompt del architect (copia verbatim base→clasificación)
+## TODO-301-PR2b-A: Deduplicar el prompt del architect (copia verbatim base→clasificación) [RESUELTO por #305]
 
 **What:** `CASE_ARCHITECT_PROMPT_CLASSIFICATION`
 (`backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py`) es una **copia
@@ -1596,7 +1596,7 @@ mantener el prompt ml_ds byte-idéntico. La deuda de duplicación queda intacta 
 
 ---
 
-## TODO-301-PR2b-B: Limpiar las líneas stale "business puede emitir null/continuo"
+## TODO-301-PR2b-B: Limpiar las líneas stale "business puede emitir null/continuo" [RESUELTO por #305]
 
 **What:** En el prompt de clasificación, la rule 7 (~L263-265) y la prosa de
 `## dataset_schema_required` (~L195-198) todavía dicen que business puede emitir `null` o un target
@@ -1619,3 +1619,52 @@ contradicción es cosmética hoy.
 
 **Depends on / blocked by:** TODO-301-PR2b-A (un prompt compuesto permite condicionar estas líneas
 sin duplicar la edición ni romper el snapshot ml_ds).
+
+---
+
+## TODO-305-A: Deduplicar `CASE_WRITER_PROMPT_CLASSIFICATION` / `CASE_QUESTIONS_PROMPT_CLASSIFICATION`
+
+**What:** Igual que el architect en #305: `CASE_WRITER_PROMPT_CLASSIFICATION`
+(`prompts/clasificacion/M1_clasificacion/writer.py`) y `CASE_QUESTIONS_PROMPT_CLASSIFICATION`
+(`.../questions.py`) son copias verbatim de sus bases (`CASE_WRITER_PROMPT` /
+`CASE_QUESTIONS_PROMPT` en `prompts/__init__.py`) + un ancla. Componerlas como `base + ancla`
+extrayendo las bases a módulos leaf (patrón `prompts/_architect_base.py` de #305).
+
+**Why:** Misma deuda de duplicación que el architect: cualquier edición a la base hay que
+replicarla a mano y el header del módulo declara una regla manual de "mirror changes".
+
+**Pros:** DRY consistente en las tres copias M1 de clasificación; un solo lugar por prompt base.
+
+**Cons:** No son auto-contradictorias hoy (a diferencia del architect), así que NO hay bug
+funcional — es limpieza. Cada copia es su propia superficie de snapshot; conviene un guard
+de identidad por prompt como el de #305 antes de tocar.
+
+**Context:** #305 dedupló SOLO el architect (era el único con la contradicción rule-7) y extrajo
+`CASE_ARCHITECT_PROMPT` a `prompts/_architect_base.py` para romper el ciclo de import. Usar ese
+PR como plantilla exacta: leaf module + import en `__init__.py` (bloque top, evita E402) + import
+en el módulo de familia + test de identidad `X_CLASSIFICATION == BASE + ANCHOR`.
+
+**Depends on / blocked by:** #305 mergeado (provee la plantilla de extracción + import ordering).
+
+---
+
+## TODO-305-B: Ampliar la cobertura de `_TITLE_TO_TARGET_TOKENS` (blind spots del detector de mismatch)
+
+**What:** Añadir keywords de dominio que el detector `_validate_target_semantic_coherence`
+(`graph.py`) no cubre hoy — p. ej. logística/incumplimiento/socios/SLA. El caso FastRoute que
+motivó #301 ni siquiera dispara el warning porque su título no matchea ningún keyword del mapa.
+
+**Why:** El enforcement de mismatch de #305 Gate 2 (reprompt) SOLO se dispara cuando la heurística
+detecta el mismatch. Los blind spots = passthrough silencioso de un target con nombre desalineado.
+
+**Pros:** Más casos business+clasificación reciben el reprompt de corrección de nombre.
+
+**Cons:** #301 de-enfatiza explícitamente el keyword-matching (no escala — por eso la síntesis
+determinista y el reprompt son la red). Más keywords también amplían la superficie de FALSOS
+positivos del detector, justo ahora que es accionable (reprompt). Prioridad baja.
+
+**Context:** El mapa `_TITLE_TO_TARGET_TOKENS` mapea sustantivos de título (es/en) a tokens
+esperados de target. El reprompt de #305 es false-positive-safe (acepta cualquier target de
+clasificación válido en el reprompt), así que ampliar tokens es seguro pero de bajo retorno.
+
+**Depends on / blocked by:** #305 mergeado (Gate 2 enforcement). Independiente por lo demás.

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -806,20 +806,55 @@ def _build_base_context(state: ADAMState) -> dict:
     }
 
 
+# #305 Gate 1b — Condiciona POR PERFIL la "regla 7" y la prosa de `dataset_schema_required`
+# en el texto ENSAMBLADO para business+clasificación. La base (compartida) permite `null`/
+# continuo, legítimo para ml_ds y para business en otras familias; aquí se NEUTRALIZA esa
+# permisión SOLO para business+clasificación, de modo que el prompt ya no se contradiga con
+# `M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK`. La sustitución corre ANTES de `.format()` (el
+# template aún tiene `{student_profile}` sin formatear) y los reemplazos NO introducen llaves
+# nuevas. Si la base deriva y un `old` deja de encontrarse, el `.replace` es no-op y el guard
+# test (permisivo ABSENT / restrictivo PRESENT) lo detecta en CI — nunca falla un job en runtime.
+_BUSINESS_CLF_PERMISSIVE_SUBSTITUTIONS: tuple[tuple[str, str], ...] = (
+    (
+        '**Obligatorio cuando {student_profile}="ml_ds"**. Para "business" puedes\n'
+        "emitir `null` (el pipeline mantiene el comportamiento heurístico previo).",
+        '**Obligatorio** (también para "business" en clasificación). En clasificación el '
+        "contrato de target es OBLIGATORIO y binario — NO `null`, NO continuo "
+        "(ver el bloque de target binario de dominio más abajo).",
+    ),
+    (
+        '7. Para "business" perfil puedes emitir `null` o un contrato simple con un único\n'
+        "   target gerencial (ej: `revenue`, `margin_pct`).",
+        '7. Para "business" en clasificación NO emitas `null` ni un target continuo '
+        "(`revenue`, `margin_pct`): el target es OBLIGATORIO y binario de dominio "
+        "(ver el bloque de target binario de dominio más abajo).",
+    ),
+)
+
+
 def _assemble_architect_prompt(context: dict) -> str:
     """Selecciona el prompt M1 por familia y lo formatea con el contexto.
 
-    Punto único de ensamblado del prompt del architect. El gate por perfil para
-    business+clasificación (#301 PR2b) vive AQUÍ, de modo que el prompt ensamblado para
-    ml_ds queda byte-idéntico (el snapshot de Item 4 lo vigila).
+    Punto único de ensamblado del prompt del architect. El gate por perfil (#301) vive AQUÍ,
+    de modo que el prompt ensamblado para ml_ds queda byte-idéntico (el snapshot de Item 4 /
+    Riesgo #1 lo vigila)::
+
+        family/profile
+          ├─ ml_ds + clasificación ──────► base+anchor, SIN cirugía  → byte-idéntico
+          ├─ business + clasificación ───► base+anchor
+          │       + cirugía: neutraliza regla 7 / prosa permisiva (#305 Gate 1b)
+          │       + M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK (PR2b)
+          └─ business/otros + otra fam ──► base, SIN cirugía  (null/continuo legítimo)
     """
     family = str(context.get("primary_family") or "")
     profile = str(context.get("student_profile") or "")
     template = CASE_ARCHITECT_PROMPT_BY_FAMILY.get(family, CASE_ARCHITECT_PROMPT)
-    # business + clasificación: exige un target binario de dominio (resuelve la
-    # contradicción rule 7 ↔ ancla). Gate por perfil → ml_ds queda byte-idéntico.
-    # El bloque no tiene placeholders, así que pasa intacto por `.format()`.
+    # business + clasificación: exige un target binario de dominio. Primero NEUTRALIZA la
+    # permisión `null`/continuo en el texto (Gate 1b) y luego añade el bloque obligatorio
+    # (PR2b). Gate por perfil → ml_ds queda byte-idéntico. El bloque no tiene placeholders.
     if profile == "business" and family == "clasificacion":
+        for old, new in _BUSINESS_CLF_PERMISSIVE_SUBSTITUTIONS:
+            template = template.replace(old, new)
         template = template + M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK
     return template.format(**context)
 
@@ -900,6 +935,28 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
         contract_dict, target_enforced = _normalize_business_classification_target(
             contract_dict, profile=profile_resolved, family=family_resolved
         )
+
+        # Issue #301 #305 Gate 2 — enforcement de #228 por mismatch título↔target.
+        # Si la forma NO se tuvo que normalizar (target ya era un classification_target
+        # válido) pero su NOMBRE está semánticamente desalineado del título, reprompt UNA
+        # vez para que el LLM lo renombre. Se acepta cualquier nombre de clasificación
+        # válido sin re-juzgarlo con la heurística (a prueba de falsos positivos); el
+        # re-_normalize garantiza la forma binaria pase lo que pase. Nunca falla el job.
+        if (
+            not target_enforced
+            and profile_resolved == "business"
+            and family_resolved == "clasificacion"
+            and any(w.startswith("target_semantic_mismatch") for w in coherence_warnings)
+        ):
+            contract_dict, mismatch_note = _reprompt_business_target_on_mismatch(
+                llm=llm, prompt=prompt, contract=contract_dict, title=result.titulo
+            )
+            contract_dict = _infer_leakage_risk_from_naming(contract_dict)
+            contract_dict, _ = _normalize_business_classification_target(
+                contract_dict, profile=profile_resolved, family=family_resolved
+            )
+            if mismatch_note:
+                coherence_warnings = list(coherence_warnings) + [mismatch_note]
 
         # Issue #238/#242 — valida matriz de costos con la misma resolución de
         # familia que usan los dispatchers downstream.
@@ -2373,6 +2430,64 @@ def _normalize_business_classification_target(
     new_contract = dict(src)
     new_contract["target_column"] = new_target
     return new_contract, True
+
+
+def _reprompt_business_target_on_mismatch(
+    *, llm: Any, prompt: str, contract: dict | None, title: str | None
+) -> tuple[dict | None, str | None]:
+    """#305 Gate 2 — reprompt-once enforcement for a title↔target NAME mismatch.
+
+    Precondition (checked by the caller): business+clasificación, a
+    ``target_semantic_mismatch`` warning is present, and the target is a *valid* binary
+    classification target whose NAME is semantically misaligned with the título. The shape
+    is fine; only the LLM can rename it to the domain event (deterministic title-slugging
+    was rejected — 3B). So we reprompt ONCE and let the caller re-run
+    ``_normalize_business_classification_target`` to guarantee the binary shape regardless::
+
+        reprompt ONCE (wrapped — any exception is swallowed)
+          ├─ usable classification target returned ─► swap it in (NOT re-judged by the
+          │                                            heuristic → false-positive-safe)
+          ├─ null / unusable target returned ───────► keep original (still valid) + note
+          └─ LLM call raises ───────────────────────► keep original (still valid) + note
+
+    Returns ``(contract, note)``. NEVER raises — a mismatch was only a warning before, so
+    enforcement must not regress reliability by failing the job.
+    """
+    correction = (
+        prompt
+        + "\n\n# CORRECCIÓN OBLIGATORIA DE COHERENCIA TÍTULO↔TARGET (#228/#301)\n"
+        + f'El título del caso es: "{title}". Tu `dataset_schema_required.target_column.name` '
+        + "anterior NO refleja el evento central de ese título. Reescribe la respuesta "
+        + "COMPLETA respetando el schema, manteniendo `role`=`classification_target` y "
+        + "`dtype`=`int` binario, pero renombrando `target_column.name` (snake_case inglés) "
+        + "para que nombre el EVENTO binario del título (p. ej. incumplimiento→`late_partner_flag`, "
+        + "fraude→`fraud_flag`, mora→`default_60d`, abandono→`churn_flag`). No menciones Python, "
+        + "notebooks, AUC ni hiperparámetros."
+    )
+    try:
+        structured_llm = llm.with_structured_output(CaseArchitectOutput)
+        result: CaseArchitectOutput = structured_llm.invoke(correction)
+    except Exception as e:  # noqa: BLE001 — best-effort; never fail the job on a reprompt
+        logger.warning("[case_architect] reprompt #305 Gate2 falló: %s", e)
+        return contract, (
+            "target_semantic_mismatch no corregido (reprompt falló): se conserva el target "
+            "original válido; revisar coherencia título↔target."
+        )
+
+    new_contract = (
+        result.dataset_schema_required.model_dump()
+        if result.dataset_schema_required is not None
+        else None
+    )
+    if not new_contract or not ((new_contract.get("target_column") or {}).get("name") or "").strip():
+        return contract, (
+            "reprompt no produjo un target de clasificación usable: se conserva el target "
+            "original válido; revisar coherencia título↔target."
+        )
+    return new_contract, (
+        "target_column corregido vía reprompt (#305 Gate 2) para alinear el nombre con el "
+        "evento del título."
+    )
 
 
 def _validate_business_cost_matrix(

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -53,6 +53,7 @@ Resiliencia (v9):
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -3351,8 +3352,13 @@ def _generate_dataset_from_schema(schema: dict, profile: str = "business") -> li
     constraints = schema.get("constraints", {})
 
     # Seed determinista: mismo schema → mismo dataset siempre.
+    # hashlib (no el builtin hash()) porque hash() de un str está aleatorizado por
+    # proceso (PYTHONHASHSEED), lo que rompía la reproducibilidad entre corridas.
     # RNG local (no global) para evitar race conditions con usuarios concurrentes.
-    case_seed = hash(json.dumps(schema, sort_keys=True)) % (2**31)
+    case_seed = (
+        int(hashlib.sha256(json.dumps(schema, sort_keys=True).encode()).hexdigest(), 16)
+        % (2**31)
+    )
     rng = np.random.default_rng(case_seed)       # numpy — thread-safe (instancia local)
     rng_std = random.Random(case_seed)            # stdlib — thread-safe (instancia local)
 

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -15,6 +15,7 @@ VARIABLES GLOBALES NUEVAS AÑADIDAS:
   {industry_cagr_range} → CAGR histórico del sector (ej: "5-8%"). Default: "5-8%"
 """
 
+from case_generator.prompts._architect_base import CASE_ARCHITECT_PROMPT
 from case_generator.prompts._shared import (
     M3_EXPERIMENT_ENGINEER_PROMPT,
     M3_EXPERIMENT_PROMPT,
@@ -25,17 +26,16 @@ from case_generator.prompts._shared import (
 )
 from case_generator.prompts.clasificacion import (
     CASE_ARCHITECT_PROMPT_CLASSIFICATION,
-    M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK,
     CASE_QUESTIONS_PROMPT_CLASSIFICATION,
     CASE_WRITER_PROMPT_CLASSIFICATION,
     CLASSIFICATION_NOTEBOOK_PROMPT_BY_VARIANT,
     CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY,
     CLASSIFICATION_NOTEBOOK_VARIANT_LR_RF_CONTRAST,
     CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY,
-    ClassificationNotebookVariant,
     EDA_ANNOTATE_ONLY_PROMPT_CLASSIFICATION,
     EDA_QUESTIONS_GENERATOR_PROMPT_CLASSIFICATION,
     EDA_TEXT_ANALYST_PROMPT_CLASSIFICATION,
+    M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK,
     M3_CLASSIFICATION_QUESTIONS_BY_VARIANT,
     M3_CLASSIFICATION_QUESTIONS_PROMPT_LR_ONLY,
     M3_CLASSIFICATION_QUESTIONS_PROMPT_LR_RF_CONTRAST,
@@ -57,225 +57,12 @@ from case_generator.prompts.clasificacion import (
     M5_QUESTIONS_PROMPT_CLASSIFICATION,
     SCHEMA_DESIGNER_PROMPT_CLASSIFICATION,
     TOC_MARKDOWN_CELL_BY_VARIANT,
+    ClassificationNotebookVariant,
 )
-
-
 
 # ══════════════════════════════════════════════════════════════════════════════
 # MÓDULO 1 — COMPRENSIÓN DEL CASO (Case Reader / Problem Framer)
 # ══════════════════════════════════════════════════════════════════════════════
-
-# `teacher_input` is injected as delimited case data and must remain sanitized/bounded upstream.
-CASE_ARCHITECT_PROMPT = """\
-# Your Identity
-Eres el Case Architect de ADAM, un estratega senior en negocios y finanzas con 20 años de experiencia diseñando casos Harvard. Diseñas los cimientos estructurales: empresa ficticia, dilema real sin solución obvia, exhibits numéricos consistentes.
-
-# Your Mission
-Generar los CIMIENTOS estructurales y numéricos del caso (Pre-M1 / Narrativa Maestra) que alimentarán a todos los demás agentes del sistema, garantizando coherencia matemática absoluta entre todos los campos generados.
-
-# Schema de Referencia (campos esperados — NO incluir claves extra)
-# Mantén este schema sincronizado con el modelo Pydantic en graph.py:
-# {{
-#   "titulo": str,
-#   "industria": str,               ← CAMPO OBLIGATORIO para dataset_generator
-#   "company_profile": str,
-#   "dilema_brief": str,
-#   "instrucciones_estudiante": str,
-#   "pregunta_eje": str|null,        ← Issue #242 — solo ml_ds + clasificacion
-#   "anexo_financiero": str,
-#   "anexo_operativo": str,
-#   "anexo_stakeholders": str,
-#   "dataset_schema_required": object|null  ← Issue #225 — contrato dataset↔dilema
-# }}
-# Si graph.py añade o elimina un campo, actualizar este bloque.
-
-# How You Work (Workflow)
-Sigue estos pasos SECUENCIALMENTE:
-1. **Diseña:** Define un revenue anual realista para la industria y tamaño de la empresa.
-2. **Proyecta:** Define inversión propuesta y métricas financieras/operativas base.
-   - REGLA DE INVERSIÓN: Inversión Propuesta ≤ {max_investment_pct}% del Revenue Anual.
-   - Si el sector requiere inversiones mayores (manufactura pesada, farmacéutica, energía),
-     {max_investment_pct} habrá sido ajustado por graph.py antes de este prompt.
-3. **Ejecuta Code Execution (OBLIGATORIO):** Escribe y ejecuta Python para:
-   - Validar Inversión Propuesta ≤ {max_investment_pct}% del Revenue Anual.
-   - Validar Ingresos - Costos = EBITDA con margen correcto (tolerancia ±0.5%).
-   - Validar coherencia proporcional entre Exhibit 1 y Exhibit 2.
-   - Validar que el campo `industria` está presente y no vacío.
-4. **Verifica:** Lee la salida del código. MAX_RETRIES = 3.
-   - Si falla en el intento 1: corrige el error específico y re-ejecuta.
-   - Si falla en el intento 2: simplifica las métricas y re-ejecuta.
-   - Si falla en el intento 3: genera una versión conservadora con datos mínimos
-     y añade una nota `"_validation_warning": "Validación parcial — revisar manualmente"`.
-5. **Genera:** SOLO cuando el código confirme consistencia (o tras 3 intentos), genera los campos finales.
-
-## Tool Selection
-- Usa `code_execution` SIEMPRE antes de generar la respuesta final. Es obligatorio, no opcional.
-
-# Your Boundaries
-- Responde SOLO con los campos del schema definido arriba. Empresa y personas 100% ficticias.
-- `pregunta_eje`: emitir SOLO si {student_profile}="ml_ds" y {primary_family}="clasificacion".
-  Debe ser una pregunta directiva gerencial, no técnica, que conecte M1→M5.
-  Ejemplo correcto: "¿Debe la empresa priorizar retención selectiva aunque aumente el riesgo operativo?"
-  Ejemplo prohibido: "¿Qué modelo tiene mayor AUC?". Para otros perfiles/familias, emitir `null`.
-- **REGLA DE BALANCE DE OPCIONES A/B/C:**
-  Las 3 opciones deben ser IGUALMENTE PRESENTABLES ante un comité directivo, pero NO
-  igualmente óptimas. Cada opción debe tener una dimensión donde supera a las demás
-  (ej: A=mayor ROI, B=menor riesgo, C=mayor velocidad). El docente y M5 elegirán A/B/C
-  según los datos de M2. Esto garantiza que la decisión requiera análisis, no sea obvia.
-- En campos visibles al estudiante: NUNCA menciones Python, SQL, ML. Para "ml_ds"
-  puedes decir "modelos predictivos" o "infraestructura de datos" a nivel gerencial.
-- Markdown limpio. PROHIBIDO usar bloques de código (triple backtick) en cualquier campo
-  de texto visible al estudiante. Solo tablas y listas.
-- Tablas con exactamente 3 guiones por columna (`|---|---|`).
-- CAMPO `industria`: debe ser un sustantivo específico (ej: "retail B2B", "fintech latinoamericana",
-  "manufactura automotriz"). NO usar descripciones largas. dataset_generator lo consume directamente.
-- **Idioma de salida: {output_language}**
-
-# Perfil del estudiante: {student_profile}
-- Si es "business":
-  Dilema centrado en impacto financiero, flujo de caja, mapa de poder de stakeholders.
-  Exhibits estándar: financiero + operativo.
-- Si es "ml_ds":
-  Dilema de negocio central + fricción técnica documentada (silos de datos, deuda técnica,
-  inconsistencia de fuentes, incertidumbre de información cuantificable).
-  Protagonista sigue siendo directivo, no técnico.
-  En Exhibit 2 (Operativo): añadir al menos 2 métricas de calidad de datos
-  (ej: "% registros con ID duplicado", "Lag promedio de actualización de datos en horas").
-  Esto le da a dataset_generator material para generar variables técnicas realistas.
-
-# Nivel del curso: {course_level}
-- "undergrad": dilemas de complejidad media, máximo 4 stakeholders, 2 opciones estratégicas claras.
-- "grad": dilemas de alta complejidad, 5-6 stakeholders, 3 opciones con trade-offs no obvios.
-- "executive": dilemas de alta complejidad + restricciones políticas internas + presión regulatoria.
-
-# Campos a Generar (Expected Output)
-
-## titulo
-Una línea: nombre empresa ficticia + problema central.
-Ejemplo: "NovaTech Solutions — Crisis de retención en B2B SaaS"
-
-## industria
-Una frase corta y específica (usada por dataset_generator).
-Ejemplo: "SaaS B2B para PYMES latinoamericanas"
-
-## company_profile (300-500 palabras)
-Nombre, industria, tamaño. Protagonista decisor (nombre, cargo, presiones, estilo de decisión).
-4-6 hitos clave. 3-5 bullets de contexto competitivo.
-
-## dilema_brief (400-600 palabras)
-- **Problema central:** Qué decisión inminente. Separar "lo que sabemos" vs "lo que no sabemos".
-- **Restricciones:** 4-6 bullets (tiempo, caja, regulación, capacidad, reputación).
-- **Opciones A, B, C:** Para cada una:
-  · Qué implica / Beneficio principal / Riesgo principal / Señal de éxito a 90 días
-  · Dimensión donde supera a las demás (explícito, para que M5 pueda argumentar)
-
-## instrucciones_estudiante (máx 100 palabras)
-Rol del estudiante y recordatorio de responder preguntas en plataforma.
-
-## pregunta_eje
-Pregunta directiva central del caso. SOLO para {student_profile}="ml_ds" y
-{primary_family}="clasificacion"; en cualquier otro caso debe ser `null`.
-Debe obligar a una decisión ejecutiva defendible con evidencia M2/M3/M4 y matriz de costos.
-No mencionar Python, notebooks, AUC, F1 ni hiperparámetros.
-
-## anexo_financiero
-Encabezado: `### Exhibit 1 — Datos Financieros`
-Tabla: Métrica | Año N-1 | Año N (Estimado)
-Mínimo: Ingresos, Costos, EBITDA, Margen %, Caja, Inversión (con % sobre revenue).
-
-## anexo_operativo
-Encabezado: `### Exhibit 2 — Indicadores Operativos`
-Tabla comparativa, mín 6 filas. Coherente con Exhibit 1.
-Si {student_profile}="ml_ds": incluir 2 métricas de calidad de datos como filas adicionales.
-
-## anexo_stakeholders
-Encabezado: `### Exhibit 3 — Mapa de Stakeholders`
-Tabla: Actor | Interés | Incentivo | Riesgo | Postura (A/B/C)
-Mín 6 actores (mín 4 para "undergrad").
-
-## dataset_schema_required
-Objeto que declara qué dataset necesita el caso para que el dilema sea respondible
-con datos. **Obligatorio cuando {student_profile}="ml_ds"**. Para "business" puedes
-emitir `null` (el pipeline mantiene el comportamiento heurístico previo).
-
-Forma exacta del objeto (snake_case en inglés en todos los `name`):
-
-{{
-  "target_column": {{
-    "name": "<columna objetivo del dilema>",
-    "role": "classification_target|regression_target|clustering_target|anomaly_target|ranking_target|forecasting_target",
-    "dtype": "int|float|str|date",
-    "description": "qué representa la columna en negocio"
-  }},
-  "feature_columns": [
-    {{
-      "name": "<feature snake_case>",
-      "role": "feature|weak_feature|control",
-      "dtype": "int|float|str|date",
-      "description": "por qué importa al dilema",
-      "temporal_offset_months": 0,
-      "is_leakage_risk": false
-    }}
-    // 3-8 features que el dilema referencia explícitamente
-  ],
-  "domain_features_required": ["<categoria_semantica_1>", "<categoria_semantica_2>"],
-  "min_signal_strength": 0.15,
-  "notes": null
-}}
-
-Reglas duras:
-1. `target_column.name` DEBE coincidir conceptualmente con la decisión del `dilema_brief`.
-   Ej: si el dilema es "decidir cómo retener clientes", el target NO puede ser un
-   código aleatorio sin relación causal. Debe ser una variable medible y observable
-   en producción (ej: `churn_flag`, `delivery_delay_minutes`, `default_60d`).
-1bis. **Coherencia título↔target**: el `name` y el `role` del target
-   deben reflejar el sustantivo central del `titulo`. Mapeo de referencia
-   (no exhaustivo — adapta al caso, pero respeta la familia):
-     - título habla de "retención"/"churn"/"abandono"/"fidelización" → target
-       en familia retención: `churn_flag`, `retention_rate`, `renewal_flag`,
-       con role `classification_target` o `regression_target`. **NO** uses
-       `delay_flag`, `defect_count`, etc.
-     - título habla de "retraso"/"demora"/"entrega" → target operativo:
-       `delivery_delay_minutes`, `late_delivery_flag`.
-     - título habla de "fraude" → `fraud_flag`, role `anomaly_target` o
-       `classification_target`.
-     - título habla de "ventas"/"demanda"/"ingresos" → `units_sold`, `revenue`,
-       role `regression_target` o `forecasting_target`.
-     - título habla de "calidad"/"defectos" → `defect_count`, `reject_rate`.
-   Si el dilema requiere combinar dos familias, prioriza el sustantivo del título.
-2. **Anti-leakage**: marca `is_leakage_risk=true` y/o `temporal_offset_months>0`
-   en cualquier feature que en operación real se conoce DESPUÉS del target.
-   Ej: al predecir `churn_flag` del mes 0, las columnas `retention_m3`, `retention_m6`,
-   `retention_m12` son leakage por construcción → marcarlas siempre.
-2bis. **Naming patterns que SIEMPRE son leakage cuando el target NO es de
-   familia retención**: `retention_*`, `churn_*`, `nps`, `csat`,
-   `customer_ltv`, `complaint_*`, `cancellation_*`, `*_post_event`. Si tu
-   target es operativo (delay/defecto/fraude/ventas) y declaras alguna de
-   estas como feature, marca `is_leakage_risk=true` SIEMPRE — el pipeline
-   downstream las excluirá del entrenamiento. (El validador determinista
-   las marcará automáticamente si lo olvidas, pero declararlas correctamente
-   evita el warning visible en logs.)
-3. `feature_columns` debe contener entre 3 y 8 entradas. Mínimo 2 features con
-   `is_leakage_risk=false` para garantizar señal aprendible.
-4. `domain_features_required` lista categorías semánticas que `schema_designer` debe
-   cubrir aunque elija nombres específicos (ej: "delivery_time", "customer_segment",
-   "transaction_volume"). 0-5 entradas.
-5. `min_signal_strength` queda en 0.15 salvo justificación pedagógica explícita.
-6. NUNCA incluyas en `feature_columns` la misma `name` que `target_column.name`.
-7. Para "business" perfil puedes emitir `null` o un contrato simple con un único
-   target gerencial (ej: `revenue`, `margin_pct`).
-
-# Context — Datos del profesor
-{teacher_input}
-
-# Metadatos del sistema (no mostrar al estudiante)
-case_id: {case_id}
-output_language: {output_language}
-course_level: {course_level}
-max_investment_pct: {max_investment_pct}
-primary_family: {primary_family}
-"""
-
 
 # `architect_output` arrives as sanitized, bounded case data from an upstream hop.
 CASE_WRITER_PROMPT = """\

--- a/backend/src/case_generator/prompts/_architect_base.py
+++ b/backend/src/case_generator/prompts/_architect_base.py
@@ -1,0 +1,218 @@
+"""Generic Case Architect base prompt - single source of truth.
+
+Shared verbatim by the generic M1 path (``case_generator.prompts``) and the
+classification family (``CASE_ARCHITECT_PROMPT_CLASSIFICATION = base + anchor``).
+Kept as a leaf module (no intra-package imports) to avoid a circular import
+between ``prompts/__init__.py`` and the ``clasificacion`` subpackage.
+"""
+
+# `teacher_input` is injected as delimited case data and must remain sanitized/bounded upstream.
+CASE_ARCHITECT_PROMPT = """\
+# Your Identity
+Eres el Case Architect de ADAM, un estratega senior en negocios y finanzas con 20 años de experiencia diseñando casos Harvard. Diseñas los cimientos estructurales: empresa ficticia, dilema real sin solución obvia, exhibits numéricos consistentes.
+
+# Your Mission
+Generar los CIMIENTOS estructurales y numéricos del caso (Pre-M1 / Narrativa Maestra) que alimentarán a todos los demás agentes del sistema, garantizando coherencia matemática absoluta entre todos los campos generados.
+
+# Schema de Referencia (campos esperados — NO incluir claves extra)
+# Mantén este schema sincronizado con el modelo Pydantic en graph.py:
+# {{
+#   "titulo": str,
+#   "industria": str,               ← CAMPO OBLIGATORIO para dataset_generator
+#   "company_profile": str,
+#   "dilema_brief": str,
+#   "instrucciones_estudiante": str,
+#   "pregunta_eje": str|null,        ← Issue #242 — solo ml_ds + clasificacion
+#   "anexo_financiero": str,
+#   "anexo_operativo": str,
+#   "anexo_stakeholders": str,
+#   "dataset_schema_required": object|null  ← Issue #225 — contrato dataset↔dilema
+# }}
+# Si graph.py añade o elimina un campo, actualizar este bloque.
+
+# How You Work (Workflow)
+Sigue estos pasos SECUENCIALMENTE:
+1. **Diseña:** Define un revenue anual realista para la industria y tamaño de la empresa.
+2. **Proyecta:** Define inversión propuesta y métricas financieras/operativas base.
+   - REGLA DE INVERSIÓN: Inversión Propuesta ≤ {max_investment_pct}% del Revenue Anual.
+   - Si el sector requiere inversiones mayores (manufactura pesada, farmacéutica, energía),
+     {max_investment_pct} habrá sido ajustado por graph.py antes de este prompt.
+3. **Ejecuta Code Execution (OBLIGATORIO):** Escribe y ejecuta Python para:
+   - Validar Inversión Propuesta ≤ {max_investment_pct}% del Revenue Anual.
+   - Validar Ingresos - Costos = EBITDA con margen correcto (tolerancia ±0.5%).
+   - Validar coherencia proporcional entre Exhibit 1 y Exhibit 2.
+   - Validar que el campo `industria` está presente y no vacío.
+4. **Verifica:** Lee la salida del código. MAX_RETRIES = 3.
+   - Si falla en el intento 1: corrige el error específico y re-ejecuta.
+   - Si falla en el intento 2: simplifica las métricas y re-ejecuta.
+   - Si falla en el intento 3: genera una versión conservadora con datos mínimos
+     y añade una nota `"_validation_warning": "Validación parcial — revisar manualmente"`.
+5. **Genera:** SOLO cuando el código confirme consistencia (o tras 3 intentos), genera los campos finales.
+
+## Tool Selection
+- Usa `code_execution` SIEMPRE antes de generar la respuesta final. Es obligatorio, no opcional.
+
+# Your Boundaries
+- Responde SOLO con los campos del schema definido arriba. Empresa y personas 100% ficticias.
+- `pregunta_eje`: emitir SOLO si {student_profile}="ml_ds" y {primary_family}="clasificacion".
+  Debe ser una pregunta directiva gerencial, no técnica, que conecte M1→M5.
+  Ejemplo correcto: "¿Debe la empresa priorizar retención selectiva aunque aumente el riesgo operativo?"
+  Ejemplo prohibido: "¿Qué modelo tiene mayor AUC?". Para otros perfiles/familias, emitir `null`.
+- **REGLA DE BALANCE DE OPCIONES A/B/C:**
+  Las 3 opciones deben ser IGUALMENTE PRESENTABLES ante un comité directivo, pero NO
+  igualmente óptimas. Cada opción debe tener una dimensión donde supera a las demás
+  (ej: A=mayor ROI, B=menor riesgo, C=mayor velocidad). El docente y M5 elegirán A/B/C
+  según los datos de M2. Esto garantiza que la decisión requiera análisis, no sea obvia.
+- En campos visibles al estudiante: NUNCA menciones Python, SQL, ML. Para "ml_ds"
+  puedes decir "modelos predictivos" o "infraestructura de datos" a nivel gerencial.
+- Markdown limpio. PROHIBIDO usar bloques de código (triple backtick) en cualquier campo
+  de texto visible al estudiante. Solo tablas y listas.
+- Tablas con exactamente 3 guiones por columna (`|---|---|`).
+- CAMPO `industria`: debe ser un sustantivo específico (ej: "retail B2B", "fintech latinoamericana",
+  "manufactura automotriz"). NO usar descripciones largas. dataset_generator lo consume directamente.
+- **Idioma de salida: {output_language}**
+
+# Perfil del estudiante: {student_profile}
+- Si es "business":
+  Dilema centrado en impacto financiero, flujo de caja, mapa de poder de stakeholders.
+  Exhibits estándar: financiero + operativo.
+- Si es "ml_ds":
+  Dilema de negocio central + fricción técnica documentada (silos de datos, deuda técnica,
+  inconsistencia de fuentes, incertidumbre de información cuantificable).
+  Protagonista sigue siendo directivo, no técnico.
+  En Exhibit 2 (Operativo): añadir al menos 2 métricas de calidad de datos
+  (ej: "% registros con ID duplicado", "Lag promedio de actualización de datos en horas").
+  Esto le da a dataset_generator material para generar variables técnicas realistas.
+
+# Nivel del curso: {course_level}
+- "undergrad": dilemas de complejidad media, máximo 4 stakeholders, 2 opciones estratégicas claras.
+- "grad": dilemas de alta complejidad, 5-6 stakeholders, 3 opciones con trade-offs no obvios.
+- "executive": dilemas de alta complejidad + restricciones políticas internas + presión regulatoria.
+
+# Campos a Generar (Expected Output)
+
+## titulo
+Una línea: nombre empresa ficticia + problema central.
+Ejemplo: "NovaTech Solutions — Crisis de retención en B2B SaaS"
+
+## industria
+Una frase corta y específica (usada por dataset_generator).
+Ejemplo: "SaaS B2B para PYMES latinoamericanas"
+
+## company_profile (300-500 palabras)
+Nombre, industria, tamaño. Protagonista decisor (nombre, cargo, presiones, estilo de decisión).
+4-6 hitos clave. 3-5 bullets de contexto competitivo.
+
+## dilema_brief (400-600 palabras)
+- **Problema central:** Qué decisión inminente. Separar "lo que sabemos" vs "lo que no sabemos".
+- **Restricciones:** 4-6 bullets (tiempo, caja, regulación, capacidad, reputación).
+- **Opciones A, B, C:** Para cada una:
+  · Qué implica / Beneficio principal / Riesgo principal / Señal de éxito a 90 días
+  · Dimensión donde supera a las demás (explícito, para que M5 pueda argumentar)
+
+## instrucciones_estudiante (máx 100 palabras)
+Rol del estudiante y recordatorio de responder preguntas en plataforma.
+
+## pregunta_eje
+Pregunta directiva central del caso. SOLO para {student_profile}="ml_ds" y
+{primary_family}="clasificacion"; en cualquier otro caso debe ser `null`.
+Debe obligar a una decisión ejecutiva defendible con evidencia M2/M3/M4 y matriz de costos.
+No mencionar Python, notebooks, AUC, F1 ni hiperparámetros.
+
+## anexo_financiero
+Encabezado: `### Exhibit 1 — Datos Financieros`
+Tabla: Métrica | Año N-1 | Año N (Estimado)
+Mínimo: Ingresos, Costos, EBITDA, Margen %, Caja, Inversión (con % sobre revenue).
+
+## anexo_operativo
+Encabezado: `### Exhibit 2 — Indicadores Operativos`
+Tabla comparativa, mín 6 filas. Coherente con Exhibit 1.
+Si {student_profile}="ml_ds": incluir 2 métricas de calidad de datos como filas adicionales.
+
+## anexo_stakeholders
+Encabezado: `### Exhibit 3 — Mapa de Stakeholders`
+Tabla: Actor | Interés | Incentivo | Riesgo | Postura (A/B/C)
+Mín 6 actores (mín 4 para "undergrad").
+
+## dataset_schema_required
+Objeto que declara qué dataset necesita el caso para que el dilema sea respondible
+con datos. **Obligatorio cuando {student_profile}="ml_ds"**. Para "business" puedes
+emitir `null` (el pipeline mantiene el comportamiento heurístico previo).
+
+Forma exacta del objeto (snake_case en inglés en todos los `name`):
+
+{{
+  "target_column": {{
+    "name": "<columna objetivo del dilema>",
+    "role": "classification_target|regression_target|clustering_target|anomaly_target|ranking_target|forecasting_target",
+    "dtype": "int|float|str|date",
+    "description": "qué representa la columna en negocio"
+  }},
+  "feature_columns": [
+    {{
+      "name": "<feature snake_case>",
+      "role": "feature|weak_feature|control",
+      "dtype": "int|float|str|date",
+      "description": "por qué importa al dilema",
+      "temporal_offset_months": 0,
+      "is_leakage_risk": false
+    }}
+    // 3-8 features que el dilema referencia explícitamente
+  ],
+  "domain_features_required": ["<categoria_semantica_1>", "<categoria_semantica_2>"],
+  "min_signal_strength": 0.15,
+  "notes": null
+}}
+
+Reglas duras:
+1. `target_column.name` DEBE coincidir conceptualmente con la decisión del `dilema_brief`.
+   Ej: si el dilema es "decidir cómo retener clientes", el target NO puede ser un
+   código aleatorio sin relación causal. Debe ser una variable medible y observable
+   en producción (ej: `churn_flag`, `delivery_delay_minutes`, `default_60d`).
+1bis. **Coherencia título↔target**: el `name` y el `role` del target
+   deben reflejar el sustantivo central del `titulo`. Mapeo de referencia
+   (no exhaustivo — adapta al caso, pero respeta la familia):
+     - título habla de "retención"/"churn"/"abandono"/"fidelización" → target
+       en familia retención: `churn_flag`, `retention_rate`, `renewal_flag`,
+       con role `classification_target` o `regression_target`. **NO** uses
+       `delay_flag`, `defect_count`, etc.
+     - título habla de "retraso"/"demora"/"entrega" → target operativo:
+       `delivery_delay_minutes`, `late_delivery_flag`.
+     - título habla de "fraude" → `fraud_flag`, role `anomaly_target` o
+       `classification_target`.
+     - título habla de "ventas"/"demanda"/"ingresos" → `units_sold`, `revenue`,
+       role `regression_target` o `forecasting_target`.
+     - título habla de "calidad"/"defectos" → `defect_count`, `reject_rate`.
+   Si el dilema requiere combinar dos familias, prioriza el sustantivo del título.
+2. **Anti-leakage**: marca `is_leakage_risk=true` y/o `temporal_offset_months>0`
+   en cualquier feature que en operación real se conoce DESPUÉS del target.
+   Ej: al predecir `churn_flag` del mes 0, las columnas `retention_m3`, `retention_m6`,
+   `retention_m12` son leakage por construcción → marcarlas siempre.
+2bis. **Naming patterns que SIEMPRE son leakage cuando el target NO es de
+   familia retención**: `retention_*`, `churn_*`, `nps`, `csat`,
+   `customer_ltv`, `complaint_*`, `cancellation_*`, `*_post_event`. Si tu
+   target es operativo (delay/defecto/fraude/ventas) y declaras alguna de
+   estas como feature, marca `is_leakage_risk=true` SIEMPRE — el pipeline
+   downstream las excluirá del entrenamiento. (El validador determinista
+   las marcará automáticamente si lo olvidas, pero declararlas correctamente
+   evita el warning visible en logs.)
+3. `feature_columns` debe contener entre 3 y 8 entradas. Mínimo 2 features con
+   `is_leakage_risk=false` para garantizar señal aprendible.
+4. `domain_features_required` lista categorías semánticas que `schema_designer` debe
+   cubrir aunque elija nombres específicos (ej: "delivery_time", "customer_segment",
+   "transaction_volume"). 0-5 entradas.
+5. `min_signal_strength` queda en 0.15 salvo justificación pedagógica explícita.
+6. NUNCA incluyas en `feature_columns` la misma `name` que `target_column.name`.
+7. Para "business" perfil puedes emitir `null` o un contrato simple con un único
+   target gerencial (ej: `revenue`, `margin_pct`).
+
+# Context — Datos del profesor
+{teacher_input}
+
+# Metadatos del sistema (no mostrar al estudiante)
+case_id: {case_id}
+output_language: {output_language}
+course_level: {course_level}
+max_investment_pct: {max_investment_pct}
+primary_family: {primary_family}
+"""

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
@@ -1,18 +1,18 @@
-"""M1 Case Architect prompt — clasificación family.
+"""M1 Case Architect prompt - clasificacion family.
 
-Base: verbatim copy of ``CASE_ARCHITECT_PROMPT`` from ``prompts/__init__.py``.
-Addition: ``_M1_CLASSIFICATION_ANCHOR_ARCHITECT`` appended at the end.
+``CASE_ARCHITECT_PROMPT_CLASSIFICATION`` is assembled as the single-source generic
+base (``CASE_ARCHITECT_PROMPT`` from ``case_generator.prompts._architect_base``) plus
+``_M1_CLASSIFICATION_ANCHOR_ARCHITECT``. No verbatim copy of the base is kept in sync -
+editing the base in ``_architect_base.py`` propagates here automatically.
 
 The anchor block uses ONLY variables confirmed to be present in ``_build_base_context()``:
   {student_profile}, {primary_family}, {output_language}, {course_level},
   {max_investment_pct}, {case_id}, {urgency_frame}
 and the context injected by ``case_architect`` itself:
   {teacher_input}
-
-Maintenance rule: when the generic ``CASE_ARCHITECT_PROMPT`` changes, mirror those
-changes here and in the classification anchor accordingly.  Stale divergence is worse
-than no divergence.
 """
+
+from case_generator.prompts._architect_base import CASE_ARCHITECT_PROMPT
 
 # ── Classification-specific anchor ────────────────────────────────────────────
 # This block is appended after the generic case architect instructions.
@@ -97,212 +97,4 @@ M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK = """
 
 
 # ── Full prompt: generic base + classification anchor ─────────────────────────
-CASE_ARCHITECT_PROMPT_CLASSIFICATION = """\
-# Your Identity
-Eres el Case Architect de ADAM, un estratega senior en negocios y finanzas con 20 años de experiencia diseñando casos Harvard. Diseñas los cimientos estructurales: empresa ficticia, dilema real sin solución obvia, exhibits numéricos consistentes.
-
-# Your Mission
-Generar los CIMIENTOS estructurales y numéricos del caso (Pre-M1 / Narrativa Maestra) que alimentarán a todos los demás agentes del sistema, garantizando coherencia matemática absoluta entre todos los campos generados.
-
-# Schema de Referencia (campos esperados — NO incluir claves extra)
-# Mantén este schema sincronizado con el modelo Pydantic en graph.py:
-# {{
-#   "titulo": str,
-#   "industria": str,               ← CAMPO OBLIGATORIO para dataset_generator
-#   "company_profile": str,
-#   "dilema_brief": str,
-#   "instrucciones_estudiante": str,
-#   "pregunta_eje": str|null,        ← Issue #242 — solo ml_ds + clasificacion
-#   "anexo_financiero": str,
-#   "anexo_operativo": str,
-#   "anexo_stakeholders": str,
-#   "dataset_schema_required": object|null  ← Issue #225 — contrato dataset↔dilema
-# }}
-# Si graph.py añade o elimina un campo, actualizar este bloque.
-
-# How You Work (Workflow)
-Sigue estos pasos SECUENCIALMENTE:
-1. **Diseña:** Define un revenue anual realista para la industria y tamaño de la empresa.
-2. **Proyecta:** Define inversión propuesta y métricas financieras/operativas base.
-   - REGLA DE INVERSIÓN: Inversión Propuesta ≤ {max_investment_pct}% del Revenue Anual.
-   - Si el sector requiere inversiones mayores (manufactura pesada, farmacéutica, energía),
-     {max_investment_pct} habrá sido ajustado por graph.py antes de este prompt.
-3. **Ejecuta Code Execution (OBLIGATORIO):** Escribe y ejecuta Python para:
-   - Validar Inversión Propuesta ≤ {max_investment_pct}% del Revenue Anual.
-   - Validar Ingresos - Costos = EBITDA con margen correcto (tolerancia ±0.5%).
-   - Validar coherencia proporcional entre Exhibit 1 y Exhibit 2.
-   - Validar que el campo `industria` está presente y no vacío.
-4. **Verifica:** Lee la salida del código. MAX_RETRIES = 3.
-   - Si falla en el intento 1: corrige el error específico y re-ejecuta.
-   - Si falla en el intento 2: simplifica las métricas y re-ejecuta.
-   - Si falla en el intento 3: genera una versión conservadora con datos mínimos
-     y añade una nota `"_validation_warning": "Validación parcial — revisar manualmente"`.
-5. **Genera:** SOLO cuando el código confirme consistencia (o tras 3 intentos), genera los campos finales.
-
-## Tool Selection
-- Usa `code_execution` SIEMPRE antes de generar la respuesta final. Es obligatorio, no opcional.
-
-# Your Boundaries
-- Responde SOLO con los campos del schema definido arriba. Empresa y personas 100% ficticias.
-- `pregunta_eje`: emitir SOLO si {student_profile}="ml_ds" y {primary_family}="clasificacion".
-  Debe ser una pregunta directiva gerencial, no técnica, que conecte M1→M5.
-  Ejemplo correcto: "¿Debe la empresa priorizar retención selectiva aunque aumente el riesgo operativo?"
-  Ejemplo prohibido: "¿Qué modelo tiene mayor AUC?". Para otros perfiles/familias, emitir `null`.
-- **REGLA DE BALANCE DE OPCIONES A/B/C:**
-  Las 3 opciones deben ser IGUALMENTE PRESENTABLES ante un comité directivo, pero NO
-  igualmente óptimas. Cada opción debe tener una dimensión donde supera a las demás
-  (ej: A=mayor ROI, B=menor riesgo, C=mayor velocidad). El docente y M5 elegirán A/B/C
-  según los datos de M2. Esto garantiza que la decisión requiera análisis, no sea obvia.
-- En campos visibles al estudiante: NUNCA menciones Python, SQL, ML. Para "ml_ds"
-  puedes decir "modelos predictivos" o "infraestructura de datos" a nivel gerencial.
-- Markdown limpio. PROHIBIDO usar bloques de código (triple backtick) en cualquier campo
-  de texto visible al estudiante. Solo tablas y listas.
-- Tablas con exactamente 3 guiones por columna (`|---|---|`).
-- CAMPO `industria`: debe ser un sustantivo específico (ej: "retail B2B", "fintech latinoamericana",
-  "manufactura automotriz"). NO usar descripciones largas. dataset_generator lo consume directamente.
-- **Idioma de salida: {output_language}**
-
-# Perfil del estudiante: {student_profile}
-- Si es "business":
-  Dilema centrado en impacto financiero, flujo de caja, mapa de poder de stakeholders.
-  Exhibits estándar: financiero + operativo.
-- Si es "ml_ds":
-  Dilema de negocio central + fricción técnica documentada (silos de datos, deuda técnica,
-  inconsistencia de fuentes, incertidumbre de información cuantificable).
-  Protagonista sigue siendo directivo, no técnico.
-  En Exhibit 2 (Operativo): añadir al menos 2 métricas de calidad de datos
-  (ej: "% registros con ID duplicado", "Lag promedio de actualización de datos en horas").
-  Esto le da a dataset_generator material para generar variables técnicas realistas.
-
-# Nivel del curso: {course_level}
-- "undergrad": dilemas de complejidad media, máximo 4 stakeholders, 2 opciones estratégicas claras.
-- "grad": dilemas de alta complejidad, 5-6 stakeholders, 3 opciones con trade-offs no obvios.
-- "executive": dilemas de alta complejidad + restricciones políticas internas + presión regulatoria.
-
-# Campos a Generar (Expected Output)
-
-## titulo
-Una línea: nombre empresa ficticia + problema central.
-Ejemplo: "NovaTech Solutions — Crisis de retención en B2B SaaS"
-
-## industria
-Una frase corta y específica (usada por dataset_generator).
-Ejemplo: "SaaS B2B para PYMES latinoamericanas"
-
-## company_profile (300-500 palabras)
-Nombre, industria, tamaño. Protagonista decisor (nombre, cargo, presiones, estilo de decisión).
-4-6 hitos clave. 3-5 bullets de contexto competitivo.
-
-## dilema_brief (400-600 palabras)
-- **Problema central:** Qué decisión inminente. Separar "lo que sabemos" vs "lo que no sabemos".
-- **Restricciones:** 4-6 bullets (tiempo, caja, regulación, capacidad, reputación).
-- **Opciones A, B, C:** Para cada una:
-  · Qué implica / Beneficio principal / Riesgo principal / Señal de éxito a 90 días
-  · Dimensión donde supera a las demás (explícito, para que M5 pueda argumentar)
-
-## instrucciones_estudiante (máx 100 palabras)
-Rol del estudiante y recordatorio de responder preguntas en plataforma.
-
-## pregunta_eje
-Pregunta directiva central del caso. SOLO para {student_profile}="ml_ds" y
-{primary_family}="clasificacion"; en cualquier otro caso debe ser `null`.
-Debe obligar a una decisión ejecutiva defendible con evidencia M2/M3/M4 y matriz de costos.
-No mencionar Python, notebooks, AUC, F1 ni hiperparámetros.
-
-## anexo_financiero
-Encabezado: `### Exhibit 1 — Datos Financieros`
-Tabla: Métrica | Año N-1 | Año N (Estimado)
-Mínimo: Ingresos, Costos, EBITDA, Margen %, Caja, Inversión (con % sobre revenue).
-
-## anexo_operativo
-Encabezado: `### Exhibit 2 — Indicadores Operativos`
-Tabla comparativa, mín 6 filas. Coherente con Exhibit 1.
-Si {student_profile}="ml_ds": incluir 2 métricas de calidad de datos como filas adicionales.
-
-## anexo_stakeholders
-Encabezado: `### Exhibit 3 — Mapa de Stakeholders`
-Tabla: Actor | Interés | Incentivo | Riesgo | Postura (A/B/C)
-Mín 6 actores (mín 4 para "undergrad").
-
-## dataset_schema_required
-Objeto que declara qué dataset necesita el caso para que el dilema sea respondible
-con datos. **Obligatorio cuando {student_profile}="ml_ds"**. Para "business" puedes
-emitir `null` (el pipeline mantiene el comportamiento heurístico previo).
-
-Forma exacta del objeto (snake_case en inglés en todos los `name`):
-
-{{
-  "target_column": {{
-    "name": "<columna objetivo del dilema>",
-    "role": "classification_target|regression_target|clustering_target|anomaly_target|ranking_target|forecasting_target",
-    "dtype": "int|float|str|date",
-    "description": "qué representa la columna en negocio"
-  }},
-  "feature_columns": [
-    {{
-      "name": "<feature snake_case>",
-      "role": "feature|weak_feature|control",
-      "dtype": "int|float|str|date",
-      "description": "por qué importa al dilema",
-      "temporal_offset_months": 0,
-      "is_leakage_risk": false
-    }}
-    // 3-8 features que el dilema referencia explícitamente
-  ],
-  "domain_features_required": ["<categoria_semantica_1>", "<categoria_semantica_2>"],
-  "min_signal_strength": 0.15,
-  "notes": null
-}}
-
-Reglas duras:
-1. `target_column.name` DEBE coincidir conceptualmente con la decisión del `dilema_brief`.
-   Ej: si el dilema es "decidir cómo retener clientes", el target NO puede ser un
-   código aleatorio sin relación causal. Debe ser una variable medible y observable
-   en producción (ej: `churn_flag`, `delivery_delay_minutes`, `default_60d`).
-1bis. **Coherencia título↔target**: el `name` y el `role` del target
-   deben reflejar el sustantivo central del `titulo`. Mapeo de referencia
-   (no exhaustivo — adapta al caso, pero respeta la familia):
-     - título habla de "retención"/"churn"/"abandono"/"fidelización" → target
-       en familia retención: `churn_flag`, `retention_rate`, `renewal_flag`,
-       con role `classification_target` o `regression_target`. **NO** uses
-       `delay_flag`, `defect_count`, etc.
-     - título habla de "retraso"/"demora"/"entrega" → target operativo:
-       `delivery_delay_minutes`, `late_delivery_flag`.
-     - título habla de "fraude" → `fraud_flag`, role `anomaly_target` o
-       `classification_target`.
-     - título habla de "ventas"/"demanda"/"ingresos" → `units_sold`, `revenue`,
-       role `regression_target` o `forecasting_target`.
-     - título habla de "calidad"/"defectos" → `defect_count`, `reject_rate`.
-   Si el dilema requiere combinar dos familias, prioriza el sustantivo del título.
-2. **Anti-leakage**: marca `is_leakage_risk=true` y/o `temporal_offset_months>0`
-   en cualquier feature que en operación real se conoce DESPUÉS del target.
-   Ej: al predecir `churn_flag` del mes 0, las columnas `retention_m3`, `retention_m6`,
-   `retention_m12` son leakage por construcción → marcarlas siempre.
-2bis. **Naming patterns que SIEMPRE son leakage cuando el target NO es de
-   familia retención**: `retention_*`, `churn_*`, `nps`, `csat`,
-   `customer_ltv`, `complaint_*`, `cancellation_*`, `*_post_event`. Si tu
-   target es operativo (delay/defecto/fraude/ventas) y declaras alguna de
-   estas como feature, marca `is_leakage_risk=true` SIEMPRE — el pipeline
-   downstream las excluirá del entrenamiento. (El validador determinista
-   las marcará automáticamente si lo olvidas, pero declararlas correctamente
-   evita el warning visible en logs.)
-3. `feature_columns` debe contener entre 3 y 8 entradas. Mínimo 2 features con
-   `is_leakage_risk=false` para garantizar señal aprendible.
-4. `domain_features_required` lista categorías semánticas que `schema_designer` debe
-   cubrir aunque elija nombres específicos (ej: "delivery_time", "customer_segment",
-   "transaction_volume"). 0-5 entradas.
-5. `min_signal_strength` queda en 0.15 salvo justificación pedagógica explícita.
-6. NUNCA incluyas en `feature_columns` la misma `name` que `target_column.name`.
-7. Para "business" perfil puedes emitir `null` o un contrato simple con un único
-   target gerencial (ej: `revenue`, `margin_pct`).
-
-# Context — Datos del profesor
-{teacher_input}
-
-# Metadatos del sistema (no mostrar al estudiante)
-case_id: {case_id}
-output_language: {output_language}
-course_level: {course_level}
-max_investment_pct: {max_investment_pct}
-primary_family: {primary_family}
-""" + _M1_CLASSIFICATION_ANCHOR_ARCHITECT
+CASE_ARCHITECT_PROMPT_CLASSIFICATION = CASE_ARCHITECT_PROMPT + _M1_CLASSIFICATION_ANCHOR_ARCHITECT

--- a/backend/tests/test_issue301_pr2b_architect.py
+++ b/backend/tests/test_issue301_pr2b_architect.py
@@ -25,12 +25,17 @@ import hashlib
 import pytest
 
 from case_generator.graph import (
+    _BUSINESS_CLF_PERMISSIVE_SUBSTITUTIONS,
     _assemble_architect_prompt,
     _normalize_business_classification_target,
 )
 from case_generator.prompts import (
+    CASE_ARCHITECT_PROMPT,
     CASE_ARCHITECT_PROMPT_CLASSIFICATION,
     M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK,
+)
+from case_generator.prompts.clasificacion.M1_clasificacion.architect import (
+    _M1_CLASSIFICATION_ANCHOR_ARCHITECT,
 )
 
 # Full format context (union of _build_base_context keys + per-node injections), mirroring
@@ -97,6 +102,18 @@ def test_mlds_architect_prompt_frozen_hash() -> None:
     )
 
 
+# ── 1b. dedup identity (#305 Gate 1a) ─────────────────────────────────────────
+
+def test_classification_prompt_is_base_plus_anchor_not_a_copy() -> None:
+    """#305 Gate 1a: the classification prompt is assembled from the single-source
+    base + anchor, NOT a verbatim ~200-line copy. This is the DRY guard — if someone
+    reintroduces a literal copy that drifts from the base, this fails."""
+    assert (
+        CASE_ARCHITECT_PROMPT_CLASSIFICATION
+        == CASE_ARCHITECT_PROMPT + _M1_CLASSIFICATION_ANCHOR_ARCHITECT
+    )
+
+
 # ── 2. business gate fires for business+clf ───────────────────────────────────
 
 def test_business_clf_prompt_includes_target_block() -> None:
@@ -109,6 +126,51 @@ def test_business_regresion_prompt_excludes_target_block() -> None:
     ctx["primary_family"] = "regresion"
     assembled = _assemble_architect_prompt(ctx)
     assert M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK.strip() not in assembled
+
+
+# ── 2b. in-text rule-7 surgery (#305 Gate 1b) ─────────────────────────────────
+# Placeholder-free fragments unique to the PERMISSIVE rule 7 / dataset_schema_required
+# prose. (`{student_profile}` is gone post-format, so we assert on these stable phrases.)
+_PERMISSIVE_PROSE = "el pipeline mantiene el comportamiento heurístico previo"
+_PERMISSIVE_RULE7_NULL = 'puedes emitir `null` o un contrato simple'
+_PERMISSIVE_RULE7_CONT = "target gerencial (ej: `revenue`, `margin_pct`)"
+_RESTRICTIVE_RULE7 = "el target es OBLIGATORIO y binario de dominio"
+
+
+def test_business_clf_prompt_drops_permissive_null_continuous() -> None:
+    """The assembled business+clf prompt must NOT permit null/continuous (no contradiction)."""
+    assembled = _assemble_architect_prompt(_business_ctx())
+    assert _PERMISSIVE_PROSE not in assembled
+    assert _PERMISSIVE_RULE7_NULL not in assembled
+    assert _PERMISSIVE_RULE7_CONT not in assembled
+    # restrictive replacement + obligatory block both present
+    assert _RESTRICTIVE_RULE7 in assembled
+    assert M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK.strip() in assembled
+
+
+def test_business_regresion_keeps_permissive_text_no_overreach() -> None:
+    """Surgery is gated to clasificación: business+regresión keeps the permissive base."""
+    ctx = _business_ctx()
+    ctx["primary_family"] = "regresion"
+    assembled = _assemble_architect_prompt(ctx)
+    assert _PERMISSIVE_PROSE in assembled
+    assert _PERMISSIVE_RULE7_CONT in assembled
+
+
+def test_mlds_clf_keeps_permissive_text_no_overreach() -> None:
+    """Surgery is gated to business: ml_ds+clf keeps the permissive base (byte-identical)."""
+    assembled = _assemble_architect_prompt(dict(_MLDS_CTX))
+    assert _PERMISSIVE_PROSE in assembled
+    assert _PERMISSIVE_RULE7_NULL in assembled
+
+
+def test_permissive_substitution_targets_still_match_raw_template() -> None:
+    """Drift guard: if the base prompt wording changes, the .replace() would silently
+    no-op and the contradiction would return. Assert each `old` still matches the raw
+    (un-surgered) assembled template so any drift fails loudly in CI."""
+    raw = CASE_ARCHITECT_PROMPT_CLASSIFICATION + M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK
+    for old, _new in _BUSINESS_CLF_PERMISSIVE_SUBSTITUTIONS:
+        assert old in raw, f"surgery target drifted, would no-op: {old[:50]!r}"
 
 
 # ── 3. contract normalization (A1/A4) ─────────────────────────────────────────

--- a/backend/tests/test_issue305_mismatch_enforcement.py
+++ b/backend/tests/test_issue305_mismatch_enforcement.py
@@ -1,0 +1,178 @@
+"""Issue #305 Gate 2 — title↔target mismatch enforcement (reprompt-once).
+
+``_reprompt_business_target_on_mismatch`` turns the #228 ``target_semantic_mismatch``
+warning into ACTION for business+clasificación, WITHOUT regressing reliability: a mismatch
+used to be a pure warning, so the reprompt must never fail the job.
+
+Three codepaths (mirrors the helper's decision tree)::
+
+    reprompt corrects ─► swap in the LLM's domain name (not re-judged → fp-safe)
+    reprompt unusable ─► keep original valid target + note
+    reprompt raises   ─► keep original valid target + note   (NEVER raises)
+
+Plus the composition guarantee: helper → ``_normalize_business_classification_target``
+always yields a binary classification_target shape, preserving a domain name when present.
+No LLM, no DB — the LLM is a fake whose ``.invoke`` returns/raises a scripted result.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from case_generator.graph import (
+    _normalize_business_classification_target,
+    _reprompt_business_target_on_mismatch,
+)
+
+# ── Fakes: a structured LLM whose .invoke() returns a scripted result or raises ───
+
+
+class _FakeContract:
+    def __init__(self, d: dict | None) -> None:
+        self._d = d
+
+    def model_dump(self) -> dict | None:
+        return self._d
+
+
+class _FakeResult:
+    def __init__(self, contract: dict | None) -> None:
+        self.dataset_schema_required = _FakeContract(contract) if contract is not None else None
+
+
+class _FakeStructured:
+    def __init__(self, result_or_exc: object) -> None:
+        self._r = result_or_exc
+
+    def invoke(self, _prompt: str) -> object:
+        if isinstance(self._r, Exception):
+            raise self._r
+        return self._r
+
+
+class _FakeLLM:
+    """Stands in for the Gemini client: .with_structured_output(...).invoke(prompt)."""
+
+    def __init__(self, result_or_exc: object) -> None:
+        self._r = result_or_exc
+
+    def with_structured_output(self, _schema: object) -> _FakeStructured:
+        return _FakeStructured(self._r)
+
+
+# A valid-but-misnamed target: churn_flag on a fraud-titled case.
+def _mislabeled_contract() -> dict:
+    return {
+        "target_column": {
+            "name": "churn_flag",
+            "role": "classification_target",
+            "dtype": "int",
+            "description": "evento binario",
+        },
+        "feature_columns": [
+            {"name": "tx_velocity", "role": "feature", "dtype": "float"},
+        ],
+    }
+
+
+_FRAUD_TITLE = "PayShield — Detección de transacciones fraudulentas"
+
+
+# ── 1. reprompt corrects the name ─────────────────────────────────────────────
+
+def test_reprompt_corrects_target_name() -> None:
+    corrected = {
+        "target_column": {
+            "name": "fraud_flag",
+            "role": "classification_target",
+            "dtype": "int",
+            "description": "transacción fraudulenta",
+        },
+        "feature_columns": [{"name": "tx_velocity", "role": "feature", "dtype": "float"}],
+    }
+    llm = _FakeLLM(_FakeResult(corrected))
+    out, note = _reprompt_business_target_on_mismatch(
+        llm=llm, prompt="<prompt>", contract=_mislabeled_contract(), title=_FRAUD_TITLE
+    )
+    assert out is not None
+    assert out["target_column"]["name"] == "fraud_flag"
+    assert note and "corregido" in note
+
+
+def test_reprompt_correction_is_not_re_judged_false_positive_safe() -> None:
+    """If the LLM re-affirms a valid classification target, we accept it verbatim —
+    the heuristic must not override the LLM's domain judgment (false-positive safety)."""
+    reaffirmed = {
+        "target_column": {
+            "name": "high_value_lead_flag",  # heuristic might still 'mismatch' this
+            "role": "classification_target",
+            "dtype": "int",
+        },
+        "feature_columns": [{"name": "engagement_score", "role": "feature", "dtype": "float"}],
+    }
+    llm = _FakeLLM(_FakeResult(reaffirmed))
+    out, _note = _reprompt_business_target_on_mismatch(
+        llm=llm, prompt="<prompt>", contract=_mislabeled_contract(), title="Ventas B2B"
+    )
+    assert out is not None
+    assert out["target_column"]["name"] == "high_value_lead_flag"
+
+
+# ── 2. reprompt unusable → keep original valid target ─────────────────────────
+
+@pytest.mark.parametrize(
+    "bad",
+    [None, {"target_column": None}, {"target_column": {"name": "", "role": "classification_target"}}],
+    ids=["null_contract", "null_target", "empty_name"],
+)
+def test_reprompt_unusable_keeps_original(bad: dict | None) -> None:
+    original = _mislabeled_contract()
+    llm = _FakeLLM(_FakeResult(bad))
+    out, note = _reprompt_business_target_on_mismatch(
+        llm=llm, prompt="<prompt>", contract=original, title=_FRAUD_TITLE
+    )
+    # original valid target preserved (no destructive genericization on an unusable reprompt)
+    assert out is not None
+    assert out["target_column"]["name"] == "churn_flag"
+    assert note and "no produjo" in note
+
+
+# ── 3. reprompt raises → keep original, NEVER fail the job ─────────────────────
+
+def test_reprompt_raises_keeps_original_and_never_raises() -> None:
+    original = _mislabeled_contract()
+    llm = _FakeLLM(RuntimeError("gemini 503"))
+    # must not raise — a mismatch was only a warning before; enforcement can't regress that
+    out, note = _reprompt_business_target_on_mismatch(
+        llm=llm, prompt="<prompt>", contract=original, title=_FRAUD_TITLE
+    )
+    assert out is not None
+    assert out["target_column"]["name"] == "churn_flag"
+    assert note and "reprompt falló" in note
+
+
+# ── 4. composition: helper → _normalize guarantees binary shape ───────────────
+
+def test_reprompt_then_normalize_preserves_domain_name_and_fixes_shape() -> None:
+    """A corrected target with a non-int dtype is shape-fixed by the subsequent
+    _normalize while keeping the domain name (role is classification-adjacent)."""
+    corrected_float = {
+        "target_column": {
+            "name": "fraud_flag",
+            "role": "classification_target",
+            "dtype": "float",  # wrong dtype on purpose
+        },
+        "feature_columns": [{"name": "tx_velocity", "role": "feature", "dtype": "float"}],
+    }
+    llm = _FakeLLM(_FakeResult(corrected_float))
+    out, _note = _reprompt_business_target_on_mismatch(
+        llm=llm, prompt="<prompt>", contract=_mislabeled_contract(), title=_FRAUD_TITLE
+    )
+    normalized, changed = _normalize_business_classification_target(
+        out, profile="business", family="clasificacion"
+    )
+    t = (normalized or {}).get("target_column") or {}
+    assert t["name"] == "fraud_flag"          # domain name preserved
+    assert t["role"] == "classification_target"
+    assert t["dtype"] == "int"                # shape guaranteed binary
+    assert changed is True


### PR DESCRIPTION
Closes #301. Implements #305 — the 3 residual gates from the #304 execution-based audit (Fases 2+4). PR1 (#302), PR2a (#303), PR2b (#304) already merged.

## Gate 1 — dedup + rule-7 conditioned in-text
- **1a (DRY):** extracted the generic `CASE_ARCHITECT_PROMPT` to a leaf module `prompts/_architect_base.py` and composed `CASE_ARCHITECT_PROMPT_CLASSIFICATION = base + anchor`, removing the ~200-line verbatim copy. The leaf module breaks the circular import between `prompts/__init__.py` and the `clasificacion` subpackage (reordering would trip E402). Resolves `TODO-301-B` / `TODO-301-PR2b-A`.
- **1b (no contradiction):** `_assemble_architect_prompt` now neutralizes the permissive "business puede emitir `null`/continuo" lines (rule 7 + `dataset_schema_required` prose) **only on the `business`+`clasificacion` branch**, so the assembled prompt no longer contradicts `M1_CLASSIFICATION_BUSINESS_TARGET_BLOCK`. `ml_ds` and other families keep the permissive base. Resolves `TODO-301-PR2b-B`.
- **Risk #1 protected:** the `ml_ds` assembled prompt is **byte-identical** — frozen sha256 `2cb71906…` unchanged. Guard tests assert permissive text ABSENT / restrictive PRESENT for business+clf, present for business+regresión and ml_ds (no over-reach), plus a drift guard that fails loudly if the base wording changes (so the `.replace()` can't silently no-op).

## Gate 2 — #228 enforcement on title↔target mismatch
A title↔target **name** mismatch (valid binary shape, semantically wrong name) for business+clasificación now triggers `_reprompt_business_target_on_mismatch`: reprompt **once** for a domain-correct name, **accept any valid classification target without re-judging** with the heuristic (false-positive safe), and fall back to deterministic synthesis on an unusable/raised reprompt. The subsequent `_normalize_business_classification_target` guarantees the binary shape regardless. **Never fails the job** — a mismatch was only a warning before, so enforcement must not regress reliability.

## Gate 3 — live multi-domain evals (5A)
`RUN_LIVE_LLM_TESTS=1` over 4 business+LR domains (logística / fraude / crédito / churn): every domain emitted a domain-named binary `classification_target` (not generic `target_event_flag`), and the de-contradicted prompt did not hinder cooperation (no raised failure rate). 4 passed in ~3.5 min.

## Validation
- `uv run --directory backend pytest -q` → **1100 passed, 20 skipped**. (The single `test_issue110` Makefile failure is a pre-existing local working-tree edit, unrelated to this PR and not part of the diff.)
- `uv run --directory backend mypy src` → clean.
- Targeted: `test_issue301_pr2b_architect.py`, `test_issue301_multidomain_evals.py`, `test_issue301_business_classification_spine.py`, new `test_issue305_mismatch_enforcement.py` all green.

## Follow-ups (added to TODOS.md)
- `TODO-305-A`: dedup `CASE_WRITER/QUESTIONS_PROMPT_CLASSIFICATION` (same copy-paste smell; not contradictory, out of scope here).
- `TODO-305-B`: widen `_TITLE_TO_TARGET_TOKENS` coverage (detector blind spots; #301 de-emphasizes keyword matching).

## Invariants honored
business-only behavior; `ml_ds` byte-identical; deterministic synthesis remains the safety net; no LLM-JSON business path reintroduced; no secrets; absolute imports; no new buses/SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
