### PR TITLE
refactor(architect): polish #305 PR2c per pre-landing review (4 findings)

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -931,8 +931,9 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
         # Issue #301 PR2b (A1/A4) — convierte la detección de #228 en ACCIÓN para
         # business+clasificación: null/continuo/rol no-clasificación → classification_target
         # int binario. El spine downstream construye la columna; el nombre de dominio es
-        # LLM-primario (lo empuja el bloque del prompt). NO reescribe por mismatch
-        # título↔target (eso permanece como warning de coherencia, arriba).
+        # LLM-primario (lo empuja el bloque del prompt). Esta normalización solo corrige la
+        # FORMA; el mismatch título↔target (nombre válido pero desalineado) lo maneja el
+        # bloque Gate 2 de más abajo (#305), no esta función.
         contract_dict, target_enforced = _normalize_business_classification_target(
             contract_dict, profile=profile_resolved, family=family_resolved
         )
@@ -943,11 +944,11 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
         # vez para que el LLM lo renombre. Se acepta cualquier nombre de clasificación
         # válido sin re-juzgarlo con la heurística (a prueba de falsos positivos); el
         # re-_normalize garantiza la forma binaria pase lo que pase. Nunca falla el job.
-        if (
-            not target_enforced
-            and profile_resolved == "business"
-            and family_resolved == "clasificacion"
-            and any(w.startswith("target_semantic_mismatch") for w in coherence_warnings)
+        if _should_reprompt_on_target_mismatch(
+            target_enforced=target_enforced,
+            profile=profile_resolved,
+            family=family_resolved,
+            warnings=coherence_warnings,
         ):
             contract_dict, mismatch_note = _reprompt_business_target_on_mismatch(
                 llm=llm, prompt=prompt, contract=contract_dict, title=result.titulo
@@ -2272,6 +2273,12 @@ _LEAKAGE_NAMING_PATTERN = re.compile(
 # Se usa para no inferir leakage por naming cuando el propio objetivo pertenece a esa
 # familia (las retention_* features podrían ser lags válidos de auditoría temporal).
 
+# Token único del warning de mismatch título↔target. Lo EMITE
+# `_validate_target_semantic_coherence` y lo CONSUME `_should_reprompt_on_target_mismatch`
+# (#305 Gate 2). Constante compartida para que productor y consumidor no se acoplen por un
+# string literal duplicado.
+_TARGET_SEMANTIC_MISMATCH_TOKEN = "target_semantic_mismatch"
+
 
 def _validate_target_semantic_coherence(
     case_title: str | None, target_spec: dict | None
@@ -2309,7 +2316,7 @@ def _validate_target_semantic_coherence(
     expected_str = ", ".join(sorted(expected_tokens))
     matched_str = ", ".join(sorted(set(matched_keys)))
     return [
-        f"target_semantic_mismatch: el título sugiere [{matched_str}] "
+        f"{_TARGET_SEMANTIC_MISMATCH_TOKEN}: el título sugiere [{matched_str}] "
         f"(tokens esperados: {expected_str}) pero target_column.name='{target_name}' "
         f"(role={target_role or 'n/a'}). Revisa que el dataset y el dilema "
         f"resuelvan la misma pregunta de negocio."
@@ -2433,6 +2440,19 @@ def _normalize_business_classification_target(
     return new_contract, True
 
 
+def _should_reprompt_on_target_mismatch(
+    *, target_enforced: bool, profile: str, family: str | None, warnings: list[str]
+) -> bool:
+    """#305 Gate 2 — gate the mismatch reprompt. True only when the shape was NOT
+    normalized (``target_enforced`` is False → the target is already a valid binary
+    classification target) for business+clasificación AND a ``target_semantic_mismatch``
+    warning is present (valid shape, wrong NAME). Extracted from ``case_architect`` so the
+    exact condition is unit-testable in isolation."""
+    if target_enforced or profile != "business" or family != "clasificacion":
+        return False
+    return any(w.startswith(_TARGET_SEMANTIC_MISMATCH_TOKEN) for w in warnings)
+
+
 def _reprompt_business_target_on_mismatch(
     *, llm: Any, prompt: str, contract: dict | None, title: str | None
 ) -> tuple[dict | None, str | None]:
@@ -2486,8 +2506,8 @@ def _reprompt_business_target_on_mismatch(
             "original válido; revisar coherencia título↔target."
         )
     return new_contract, (
-        "target_column corregido vía reprompt (#305 Gate 2) para alinear el nombre con el "
-        "evento del título."
+        "target_column reemplazado por la respuesta del reprompt (#305 Gate 2): se solicitó "
+        "alinear el nombre con el evento del título; aceptado sin re-juzgar."
     )
 
 

--- a/backend/tests/test_issue305_mismatch_enforcement.py
+++ b/backend/tests/test_issue305_mismatch_enforcement.py
@@ -22,6 +22,7 @@ import pytest
 from case_generator.graph import (
     _normalize_business_classification_target,
     _reprompt_business_target_on_mismatch,
+    _should_reprompt_on_target_mismatch,
 )
 
 # ── Fakes: a structured LLM whose .invoke() returns a scripted result or raises ───
@@ -78,9 +79,11 @@ def _mislabeled_contract() -> dict:
 _FRAUD_TITLE = "PayShield — Detección de transacciones fraudulentas"
 
 
-# ── 1. reprompt corrects the name ─────────────────────────────────────────────
+# ── 1. reprompt replaces the name ─────────────────────────────────────────────
+# (the helper reprompts and accepts the LLM's replacement WITHOUT verifying alignment —
+#  see fix #2: the note says "reemplazado ... aceptado sin re-juzgar", not "corregido")
 
-def test_reprompt_corrects_target_name() -> None:
+def test_reprompt_replaces_target_name() -> None:
     corrected = {
         "target_column": {
             "name": "fraud_flag",
@@ -96,7 +99,7 @@ def test_reprompt_corrects_target_name() -> None:
     )
     assert out is not None
     assert out["target_column"]["name"] == "fraud_flag"
-    assert note and "corregido" in note
+    assert note and "reemplazado" in note
 
 
 def test_reprompt_correction_is_not_re_judged_false_positive_safe() -> None:
@@ -176,3 +179,53 @@ def test_reprompt_then_normalize_preserves_domain_name_and_fixes_shape() -> None
     assert t["role"] == "classification_target"
     assert t["dtype"] == "int"                # shape guaranteed binary
     assert changed is True
+
+
+# ── 5. gating predicate (the case_architect wiring condition) ─────────────────
+
+_MISMATCH_W = ["target_semantic_mismatch: el título sugiere [...] pero target_column.name='x'"]
+
+
+def test_predicate_fires_for_business_clf_mismatch_unenforced() -> None:
+    """The positive case: valid-shape (not enforced) business+clf with a mismatch warning."""
+    assert _should_reprompt_on_target_mismatch(
+        target_enforced=False, profile="business", family="clasificacion", warnings=_MISMATCH_W
+    ) is True
+
+
+@pytest.mark.parametrize(
+    "target_enforced,profile,family,warnings,why",
+    [
+        (True, "business", "clasificacion", _MISMATCH_W, "shape was already enforced (null/continuo)"),
+        (False, "ml_ds", "clasificacion", _MISMATCH_W, "ml_ds is out of scope"),
+        (False, "business", "regresion", _MISMATCH_W, "non-classification family"),
+        (False, "business", None, _MISMATCH_W, "unresolved family"),
+        (False, "business", "clasificacion", [], "no mismatch warning"),
+        (False, "business", "clasificacion", ["data_gap: foo"], "unrelated warning only"),
+        (False, "business", "clasificacion", ["prefix target_semantic_mismatch: x"],
+         "token mid-string, not a line prefix — pins startswith vs in"),
+    ],
+    ids=["enforced", "ml_ds", "regresion", "no_family", "no_warning", "other_warning",
+         "token_not_prefix"],
+)
+def test_predicate_does_not_fire(target_enforced, profile, family, warnings, why) -> None:
+    """Every negative branch must gate the reprompt OFF — no wasted LLM call, and (for the
+    'enforced' / 'no_warning' cases) no destructive action on a fine contract."""
+    assert _should_reprompt_on_target_mismatch(
+        target_enforced=target_enforced, profile=profile, family=family, warnings=warnings
+    ) is False, why
+
+
+def test_predicate_token_matches_real_validator_output() -> None:
+    """Coupling guard: the predicate matches the SAME token the validator emits, so the two
+    can't drift. Drive the real validator and assert its warning trips the predicate."""
+    from case_generator.graph import _validate_target_semantic_coherence
+
+    warnings = _validate_target_semantic_coherence(
+        "Estrategia de retención de clientes",  # title keyword 'retencion'
+        {"name": "fraud_flag", "role": "classification_target"},  # unrelated target
+    )
+    assert warnings, "expected the validator to emit a mismatch warning for this pair"
+    assert _should_reprompt_on_target_mismatch(
+        target_enforced=False, profile="business", family="clasificacion", warnings=warnings
+    ) is True

--- a/backend/tests/test_issue305_seed_determinism.py
+++ b/backend/tests/test_issue305_seed_determinism.py
@@ -1,0 +1,87 @@
+"""Issue #305 — regression guard for the dataset-seed determinism fix.
+
+`_generate_dataset_from_schema` derives its RNG seed from the schema. It used the builtin
+`hash(json.dumps(schema))`, but `hash()` of a `str` is salted per-process by `PYTHONHASHSEED`,
+so the seed — and thus the whole generated dataset — varied between runs/processes, breaking
+the "same schema → same dataset" contract. The fix switched to `hashlib.sha256`, which is
+stable across processes.
+
+This guard runs generation in independent subprocesses with different `PYTHONHASHSEED` and
+asserts byte-identical output. It FAILS on the pre-fix `hash()` code and PASSES after — i.e.
+it actually pins the bug, not just the symptom. Pure stdlib; spawns short-lived subprocesses.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import subprocess
+import sys
+
+# Runs in a fresh interpreter (own PYTHONHASHSEED). Prints a marker-prefixed digest so the
+# parent can ignore any import-time stdout noise.
+_SNIPPET = """
+import json, hashlib
+from case_generator.graph import _generate_dataset_from_schema
+
+schema = {
+    "columns": [
+        {"name": "period", "type": "date"},
+        {"name": "revenue", "type": "float"},
+        {"name": "driver_score", "type": "float"},
+        {"name": "event_flag", "type": "int", "range_min": 0, "range_max": 1,
+         "dependency": {"depends_on": "driver_score", "relationship": "linear", "noise_factor": 0.3}},
+    ],
+    "n_rows": 24,
+    "time_granularity": "monthly",
+    "constraints": {},
+}
+rows = _generate_dataset_from_schema(schema, profile="business")
+digest = hashlib.sha256(json.dumps(rows, sort_keys=True, default=str).encode()).hexdigest()
+print("ADAM_SEED_DIGEST=" + digest)
+"""
+
+
+def _digest_with_hashseed(seed: str) -> str:
+    env = {**os.environ, "PYTHONHASHSEED": seed}
+    proc = subprocess.run(
+        [sys.executable, "-c", _SNIPPET],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180,
+    )
+    assert proc.returncode == 0, f"subprocess (PYTHONHASHSEED={seed}) failed:\n{proc.stderr[-2000:]}"
+    lines = [ln for ln in proc.stdout.splitlines() if ln.startswith("ADAM_SEED_DIGEST=")]
+    assert lines, f"no digest emitted (PYTHONHASHSEED={seed}); stdout tail:\n{proc.stdout[-1000:]}"
+    return lines[-1].split("=", 1)[1].strip()
+
+
+def test_dataset_generation_reproducible_across_process_hash_seeds() -> None:
+    digests = {seed: _digest_with_hashseed(seed) for seed in ("0", "1", "12345")}
+    unique = set(digests.values())
+    assert len(unique) == 1, (
+        "dataset generation is NOT reproducible across PYTHONHASHSEED values "
+        f"(builtin hash() leaked into the seed?): {digests}"
+    )
+
+
+def test_seed_derivation_does_not_use_builtin_hash() -> None:
+    """White-box backstop: the seed must derive from hashlib, not the process-salted builtin
+    hash(). The subprocess test above is the real guard; this pins the in-file form so a silent
+    revert is caught regardless of what expression gets hashed. Robust against two weak spots:
+    comment-only lines are stripped (so a stale comment can't satisfy the positive assert), and
+    the negative match catches ANY builtin ``hash(...)`` call, not just the exact prior literal."""
+    from case_generator import graph
+
+    # Drop comment-only lines so neither assertion can be satisfied/tripped by a comment.
+    code = "\n".join(
+        ln for ln in inspect.getsource(graph._generate_dataset_from_schema).splitlines()
+        if not ln.lstrip().startswith("#")
+    )
+    assert "hashlib.sha256" in code, "seed must be derived via hashlib.sha256 (in code, not a comment)"
+    # `hash(` NOT preceded by a word char or dot → the builtin, never `hashlib.`/`.sha256(`.
+    assert re.search(r"(?<![\w.])hash\s*\(", code) is None, (
+        "builtin hash() reintroduced — seed would be process-salted again"
+    )


### PR DESCRIPTION
Follow-up to **#312** (PR2c, already merged) — applies the 4 findings from a pre-landing `/review` plus an adversarial multi-agent verification pass. All changes are **test/quality polish; zero behavior change** to the merged Gate 1/2/3 logic. `Refs #301` (the umbrella is already closed by #312).

## Findings fixed
1. **Stale comment.** The note above `_normalize_business_classification_target` claimed a title↔target mismatch "permanece como warning" — now corrected to point at the Gate 2 block below (#305), which enforces on mismatch.
2. **Honest log wording.** The reprompt success-note changed from `"corregido"` (overclaimed a *verified* correction) to `"reemplazado … aceptado sin re-juzgar"` — we swap in the LLM's response and accept it without re-judging (false-positive-safe). Test assertion + section/name updated in lockstep.
3. **Unit-testable predicate + de-coupled token.** Extracted the inline Gate 2 gating condition into `_should_reprompt_on_target_mismatch(...)`, and routed **both** the producer (`_validate_target_semantic_coherence`) and the consumer through a shared `_TARGET_SEMANTIC_MISMATCH_TOKEN` constant (removes string coupling). New tests cover the positive case + all 6 negative branches, and pin `startswith` (prefix) vs `in` semantics.
4. **Seed-determinism regression guard.** New subprocess test proving `_generate_dataset_from_schema` is reproducible across `PYTHONHASHSEED` (the `hash()`→`hashlib.sha256` fix that shipped in #312) — **empirically confirmed to FAIL on the pre-fix `hash()` code**. The white-box backstop now strips comment lines (no false-pass) and matches *any* builtin `hash(...)` call, not just the prior literal.

## Verification
- 18 `#305` tests green; full backend suite **1110 passed, 20 skipped** (the lone failure, `test_issue109_db_resilience::test_intake_maps_connection_saturation_to_503`, is a pre-existing order-dependent flake — passes in isolation, untouched by this diff).
- `mypy src` clean; ruff clean on changed files.
- **Adversarial multi-agent verification: 0 confirmed issues.** Behavior-preservation reviewer brute-forced 700 input combinations and found `_should_reprompt_on_target_mismatch` is exactly equivalent to the old inline condition; checklist-regression scan found nothing introduced. The 6 raw findings were all nits — 3 "no change needed" verifications, 3 polish items applied here.

## Diff
`backend/src/case_generator/graph.py` (comment/wording/predicate/constant), `backend/tests/test_issue305_mismatch_enforcement.py` (predicate + prefix-semantics tests), `backend/tests/test_issue305_seed_determinism.py` (new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
