### PR TITLE
feat(ui): badges de publicación/disponibilidad en Casos Activos

### DIFF
--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx
@@ -169,6 +169,49 @@ describe("CasosActivosSection", () => {
         expect(normal.className).toContain("bg-[#e8f0fe]");
     });
 
+    it("renders 'Publicado' badge when available_from is null or in the past", () => {
+        useTeacherCases.mockReturnValue({
+            data: {
+                cases: [
+                    createCase(1, { available_from: null }),
+                    createCase(2, { available_from: "2020-01-01T00:00:00Z" }),
+                ],
+                total: 2,
+            },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CasosActivosSection />);
+
+        const badges = screen.getAllByText("Publicado");
+        expect(badges).toHaveLength(2);
+        expect(badges[0].className).toContain("bg-[#dcfce7]");
+        expect(screen.queryByText(/Disponible desde:/)).toBeNull();
+    });
+
+    it("renders 'Disponible desde' badge with formatted date when available_from is in the future", () => {
+        const futureAvailableFrom = "2099-01-01T12:00:00Z";
+        useTeacherCases.mockReturnValue({
+            data: {
+                cases: [createCase(1, { available_from: futureAvailableFrom })],
+                total: 1,
+            },
+            isLoading: false,
+            isError: false,
+        });
+
+        renderWithProviders(<CasosActivosSection />);
+
+        const expectedDate = formatDeadline(futureAvailableFrom);
+        const badge = screen.getByText(
+            (content) =>
+                normalizeText(content) === normalizeText(`Disponible desde: ${expectedDate}`),
+        );
+        expect(badge.className).toContain("bg-amber-50");
+        expect(screen.queryByText("Publicado")).toBeNull();
+    });
+
     it("click 'Ver Caso' navigates to /teacher/cases/:id", () => {
         useTeacherCases.mockReturnValue({
             data: { cases: [createCase(1)], total: 1 },

--- a/frontend/src/features/teacher-dashboard/CasosActivosSection.tsx
+++ b/frontend/src/features/teacher-dashboard/CasosActivosSection.tsx
@@ -51,6 +51,26 @@ function DeadlineBadge({ days }: { days: number | null }) {
     );
 }
 
+function PublicationBadge({ availableFrom }: { availableFrom?: string | null }) {
+    const parsed = availableFrom ? new Date(availableFrom) : null;
+    const isScheduled =
+        parsed !== null && !Number.isNaN(parsed.getTime()) && parsed.getTime() > Date.now();
+
+    if (isScheduled) {
+        return (
+            <span className="inline-flex items-center rounded-[7px] border border-amber-100 bg-amber-50 px-[10px] py-1 text-[11.5px] font-semibold text-amber-700 whitespace-nowrap">
+                Disponible desde: {SPANISH_DEADLINE_FORMATTER.format(parsed)}
+            </span>
+        );
+    }
+
+    return (
+        <span className="inline-flex items-center rounded-[7px] border border-green-100 bg-[#dcfce7] px-[10px] py-1 text-[11.5px] font-semibold text-[#15803d] whitespace-nowrap">
+            Publicado
+        </span>
+    );
+}
+
 function formatDeadline(deadline: string | null): string | null {
     if (!deadline) {
         return null;
@@ -76,7 +96,9 @@ function CasoRow({ caso, onEdit }: CasoRowProps) {
         <tr className="group transition-colors hover:bg-slate-50">
             <td className="px-6 py-5 align-middle">
                 <div className="text-[15px] font-bold text-slate-900">{caso.title}</div>
-                <div className="mt-1 text-[12.5px] text-slate-400">{caso.status}</div>
+                <div className="mt-1.5">
+                    <PublicationBadge availableFrom={caso.available_from} />
+                </div>
             </td>
             <td className="px-6 py-5 align-middle">
                 {caso.course_codes.length > 0 ? (


### PR DESCRIPTION
## Qué

En la tabla **Casos Activos** del dashboard del docente, reemplaza el texto crudo `published` (en inglés y minúsculas) que aparecía bajo el título de cada caso por una **badge** que distingue dos estados según `available_from`:

- **Verde "Publicado"** cuando la disponibilidad ya pasó o no está definida (disponible de inmediato).
- **Ámbar "Disponible desde: {fecha y hora}"** cuando la disponibilidad está programada a futuro.

El formato de fecha reutiliza el formateador `es-CO` / `America/Bogota` existente (idéntico a la columna *Deadline*).

## Por qué

`published` en crudo no comunicaba si el caso ya estaba visible para los estudiantes o si su disponibilidad era a futuro. Un caso publicado con `available_from` a futuro **sí** aparece en "Casos Activos" (el predicado no filtra por `available_from`), así que la nueva badge cubre exactamente ese caso.

## Alcance

**Solo frontend.** `available_from` ya viaja de extremo a extremo: lo popula `list_teacher_active_cases` (con fallback legacy), lo expone `TeacherCaseItemResponse`, y el tipo `TeacherCaseItem` ya lo incluía. Sin cambios de backend, esquema ni tipos.

## Cambios

- `frontend/src/features/teacher-dashboard/CasosActivosSection.tsx`: nuevo componente `PublicationBadge` + reemplazo del texto de estado bajo el título.
- `frontend/src/features/teacher-dashboard/CasosActivosSection.test.tsx`: pruebas para ambos estados (nulo/pasado → "Publicado" verde; futuro → "Disponible desde" ámbar).

## Verificación

- `npm --prefix frontend run test` → ✅ 12/12 (10 existentes + 2 nuevas)
- `npm --prefix frontend run lint` → ✅ limpio
- `npm --prefix frontend run build` → ✅ OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)