### PR TITLE
feat(business): conectar probabilidad LR ↔ impacto financiero en M4/M5 (#306)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -743,28 +743,53 @@ implementar de forma independiente en un PR posterior de bajo riesgo.
 
 ---
 
-## TODO-LR-M4M5: Conectar probabilidad LR ↔ impacto financiero en M4/M5 (business)
+## TODO-LR-GATE-UNIFY: Unificar el gate business+clasificación de M3 con el helper de M4/M5
 
-**What:** Hacer que M4 (impacto económico) y M5 (resolución) del perfil business referencien
-explícitamente la decisión apoyada en regresión logística (probabilidad de abandono × valor del
-cliente en riesgo), en lenguaje gerencial. Hoy M4/M5 business caen al prompt default sin esa conexión.
+**What:** Refactorizar el gate inline de `m3_content_generator` (`graph.py`, inyección de
+`M3_AUDIT_LR_BUSINESS_BLOCK` vía `context["lr_business_block"]`) para que comparta el mismo origen
+de verdad que `_maybe_business_classification_prompt` (Issue #306), de modo que la condición
+`profile=="business" AND family=="clasificacion"` se defina UNA sola vez para M3/M4/M5.
 
-**Why:** La pregunta guía del caso ya pide priorizar "basándose en la probabilidad de abandono
-estimada por el modelo y el impacto financiero". El bloque LR de M3 (Issue 3A) abrió el arco; M4/M5
-aún no lo cierran.
+**Why:** Hoy la condición del gate está duplicada: inline en M3 y dentro del helper para M4/M5.
+Tres copias del mismo predicado de negocio derivan con el tiempo (p. ej. al añadir una familia o
+cambiar la normalización de `profile`).
 
-**Pros:** Coherencia narrativa completa del caso business+LR (M2→M3→M4→M5 alrededor del mismo modelo).
+**Pros:** Una única definición del gate business-LR en los tres módulos del arco.
 
-**Cons:** Cruza el umbral de complejidad del cambio original; toca M4/M5 (área sensible) y posiblemente
-un dispatch business por familia; sube el riesgo cerca de entregas.
+**Cons:** Toca `m3_content_generator` (código ya mergeado, área sensible) para un refactor no
+funcional; además los MECANISMOS de inyección difieren — M3 rellena un placeholder
+(`{lr_business_block}`) mientras M4/M5 sustituyen el prompt completo (variante por concatenación),
+así que un helper único probablemente necesite una segunda forma. La CONDICIÓN es idéntica; el
+mecanismo no.
 
-**Context:** `_resolve_family_prompt` solo despacha para ml_ds; business usa el prompt default. La
-inserción debe ser análoga al bloque LR de M3 (gate `profile==business AND family==clasificacion`),
-empezando por `M4_CONTENT_GENERATOR_PROMPT` / `M5_CONTENT_GENERATOR_PROMPT` en `prompts/__init__.py`.
-Mantener lenguaje gerendial plano, sin jerga DS (igual que `M3_AUDIT_LR_BUSINESS_BLOCK`).
+**Context:** Introducido en Issue #306. `_maybe_business_classification_prompt` vive junto a
+`_resolve_generation_focus` en `graph.py`. M3 usa el idiom placeholder; M4/M5 usan swap de prompt.
 
-**Depends on / blocked by:** Patrón de gate business+clasificacion introducido en el PR de
-"business LR + gráficos M2" (rama feature/business-lr-m2-charts).
+**Depends on / blocked by:** Issue #306 mergeado (este PR).
+
+---
+
+## TODO-MLDS-M4M5-FROZEN-HASH: Frozen-hash invariante para los prompts ml_ds de M4/M5
+
+**What:** Añadir tests con digest SHA256 congelado para los prompts ml_ds ensamblados de M4/M5,
+espejo de `_MLDS_ARCHITECT_PROMPT_SHA256` en `tests/test_issue301_pr2b_architect.py`.
+
+**Why:** Hoy solo el prompt ml_ds del ARQUITECTO está congelado por hash. Los prompts ml_ds de
+M4/M5 no tienen guard byte-level, así que una futura edición del lado business podría filtrarse al
+path ml_ds y solo lo detectarían los tests de ausencia-de-sentinela (más débiles).
+
+**Pros:** Tripwire explícito y fuerte de que el output ml_ds de M4/M5 nunca deriva por un cambio
+del lado business.
+
+**Cons:** Los hashes congelados son fricción de mantenimiento — toda edición intencional del prompt
+ml_ds de M4/M5 debe actualizar el digest; alcance más amplio que #306.
+
+**Context:** El approach 1B de Issue #306 ya mantiene el base byte-idéntico y el test
+`test_lr_business_block_m4m5_absent_from_ml_ds_prompts` cubre el riesgo inmediato de filtración. El
+frozen-hash es defensa-en-profundidad para cambios FUTUROS. Referencia:
+`tests/test_issue301_pr2b_architect.py:71-102`.
+
+**Depends on / blocked by:** Ninguno (hardening independiente).
 
 ---
 

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -129,10 +129,12 @@ from case_generator.prompts import (
     PROMPT_BY_FAMILY,
     M4_PROMPT_BY_FAMILY,
     M4_CONTENT_GENERATOR_PROMPT,
+    M4_BUSINESS_PROMPT_CLASSIFICATION,
     M4_CHART_GENERATOR_PROMPT,
     M4_CHARTS_PROMPT_BY_FAMILY,
     M5_PROMPT_BY_FAMILY,
     M5_CONTENT_GENERATOR_PROMPT,
+    M5_BUSINESS_PROMPT_CLASSIFICATION,
     TEACHING_NOTE_PART1_PROMPT,
     TEACHING_NOTE_PART2_PROMPT,
     SCHEMA_DESIGNER_PROMPT,
@@ -4146,6 +4148,22 @@ def _resolve_generation_focus(
     return profile, family
 
 
+def _maybe_business_classification_prompt(
+    state: ADAMState, default_prompt: str, business_clasif_prompt: str
+) -> str:
+    """Swap to the business+classification LR prompt variant; else keep ``default_prompt``.
+
+    Issue #306 — shared gate for M4/M5 (DRY): only business + family==clasificacion gets the
+    LR-business block (mirrors the M3 gate of ``M3_AUDIT_LR_BUSINESS_BLOCK``). ml_ds and
+    business non-classification keep their original prompt untouched. The variant is purely
+    additive (base + block), so ``.format(**context)`` is unaffected — no new placeholder.
+    """
+    profile, family = _resolve_generation_focus(state)
+    if profile == "business" and family == "clasificacion":
+        return business_clasif_prompt
+    return default_prompt
+
+
 def _is_ml_ds_classification(
     state: ADAMState,
     *,
@@ -5447,6 +5465,11 @@ def m4_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
                 M4_CONTENT_GENERATOR_PROMPT,
             )
         )
+        # Issue #306 — business+clasificación cierra el arco LR (probabilidad × valor en riesgo).
+        # No-op para ml_ds y para business no-clasificación.
+        prompt_template = _maybe_business_classification_prompt(
+            state, prompt_template, M4_BUSINESS_PROMPT_CLASSIFICATION
+        )
         context["computed_metrics_block"] = metrics_block
 
         m4 = _invoke_narrative_with_grounding(
@@ -5612,6 +5635,11 @@ def m5_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
                 M5_PROMPT_BY_FAMILY,
                 M5_CONTENT_GENERATOR_PROMPT,
             )
+        )
+        # Issue #306 — business+clasificación prioriza por el ranking de riesgo del modelo.
+        # No-op para ml_ds y para business no-clasificación.
+        prompt_template = _maybe_business_classification_prompt(
+            state, prompt_template, M5_BUSINESS_PROMPT_CLASSIFICATION
         )
         context["computed_metrics_block"] = metrics_block
 

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -1149,6 +1149,66 @@ M5_PROMPT_BY_FAMILY: dict[str, str] = {
     "serie_temporal": M5_CONTENT_GENERATOR_PROMPT,
 }
 
+
+# ── Bloques LR-business para M4/M5 (Issue #306, follow-up de #301; cierra el arco
+# M2→M3→M4→M5 alrededor del modelo de clasificación). Gated en graph.py por
+# profile==business AND family==clasificacion (espejo del gate de M3_AUDIT_LR_BUSINESS_BLOCK).
+#
+# IMPORTANTE — por qué VARIANTE por concatenación y NO placeholder (a diferencia de M3):
+# en M3 el prompt business (M3_AUDIT_PROMPT) es DISJUNTO del de ml_ds (M3_EXPERIMENT_PROMPT),
+# así que un placeholder solo toca business. En M4/M5 el base M{4,5}_CONTENT_GENERATOR_PROMPT
+# es COMPARTIDO con ml_ds (M{4,5}_PROMPT_CLASSIFICATION = base + grounding). Añadir un
+# placeholder al base lo inyectaría también en el template ml_ds. Por eso se ensambla una
+# VARIANTE aditiva (base + bloque) que graph.py despacha SOLO para business+clasificación: el
+# base queda byte-idéntico y ml_ds intacto, y .format() no puede romper (no hay placeholder nuevo).
+#
+# Texto ESTÁTICO (cero placeholders .format()), SIN {computed_metrics_block} ni grounding
+# (business nunca ejecuta notebook). Lenguaje gerencial PLANO — la jerga DS (coeficientes,
+# log-odds, AUC, umbrales) solo se NOMBRA para prohibirla al lector directivo, igual que en M3.
+M4_LR_BUSINESS_BLOCK = """
+# Enfoque del caso: impacto económico apoyado en probabilidad de evento
+La decisión de este caso se apoya en un modelo que estima, para cada cliente u operación, una
+**probabilidad de evento** (abandono, incumplimiento, impago…), un número entre 0% y 100%. NO
+expliques matemática ni términos técnicos (coeficientes, log-odds, AUC, umbrales estadísticos):
+el lector es un directivo, no un científico de datos. Cuantifica el impacto económico en lenguaje
+gerencial, integrando estos puntos en las secciones 4.1–4.5 ya existentes (NO agregues secciones
+nuevas):
+- **Dónde se concentra el valor (4.1–4.2):** lo que está en juego por cliente u operación es su
+  **probabilidad de evento × el valor en riesgo** de ese cliente u operación (ingreso, saldo o
+  contrato expuesto). El presupuesto de intervención se prioriza hacia los de mayor
+  probabilidad × valor, no por igual entre todos.
+- **Costo de intervenir vs valor protegido (4.3):** contrasta el **costo de la intervención**
+  (retención, revisión, garantía) con el **valor que se protege** al evitar el evento. Intervenir
+  solo conviene cuando el valor protegido esperado supera su costo.
+- **Riesgo de la priorización (4.4):** si las relaciones del M2 no se sostienen, priorizar por
+  probabilidad puede dirigir el presupuesto al lugar equivocado; nómbralo como riesgo de ejecución.
+- **Honestidad (4.5):** usa únicamente cifras del caso (Exhibits, M2, M4). NO inventes
+  probabilidades, tasas ni valores nuevos; razona sobre la lógica de priorización, no sobre métricas.
+"""
+
+M5_LR_BUSINESS_BLOCK = """
+# Enfoque del caso: resolución apoyada en el ranking de riesgo del modelo
+La decisión de este caso se apoya en un modelo que ordena a los clientes u operaciones por su
+**probabilidad de evento** (abandono, incumplimiento, impago…). NO uses términos técnicos
+(coeficientes, log-odds, AUC, umbrales): el lector es la Junta Directiva. Integra esta lógica en
+las Secciones 1–3 ya existentes (NO agregues secciones nuevas):
+- **Cómo se prioriza la acción (Secciones 1–2):** la recomendación atiende primero a quienes
+  concentran mayor **probabilidad de evento × valor en riesgo**, no a todos por igual; el modelo
+  ordena la acción, no dicta una verdad.
+- **El trade-off directivo (El Dilema Directivo):** plantea la tensión entre **falsas alarmas**
+  (intervenir sobre quien no iba a tener el evento → gasto desperdiciado) y **eventos no evitados**
+  (no intervenir sobre quien sí lo tiene → valor perdido), coherente con la auditoría del M3.
+- **Costo vs valor protegido (Sección 2):** la mitigación pondera el costo de intervenir contra el
+  valor en riesgo que se protege; exprésalo en lenguaje de negocio.
+- **Honestidad:** usa solo cifras del caso (M2, Exhibits, M4); NO inventes probabilidades ni
+  métricas. Refiérete a la decisión apoyada por el modelo, no a su matemática.
+"""
+
+# Variantes business+clasificación: aditivas sobre el base (ensambladas en import). El gate vive
+# en graph.py::_maybe_business_classification_prompt; aquí solo se declara la composición.
+M4_BUSINESS_PROMPT_CLASSIFICATION = M4_CONTENT_GENERATOR_PROMPT + M4_LR_BUSINESS_BLOCK
+M5_BUSINESS_PROMPT_CLASSIFICATION = M5_CONTENT_GENERATOR_PROMPT + M5_LR_BUSINESS_BLOCK
+
 # ── SCHEMA_DESIGNER_PROMPT_BY_FAMILY — dispatch table consumed by
 # graph.py::schema_designer.  Keys MUST match values returned by
 # ``family_of(name)`` / ``resolve_legacy_family(name)`` in suggest_service.py.
@@ -2270,17 +2330,21 @@ __all__ = [
   "M3_NOTEBOOK_ALGO_PROMPT_TIMESERIES",
   "M3_NOTEBOOK_BASE_TEMPLATE",
   "M3_QUESTIONS_GENERATOR_PROMPT",
+  "M4_BUSINESS_PROMPT_CLASSIFICATION",
   "M4_CHART_GENERATOR_PROMPT",
   "M4_CHART_PROMPT_CLASSIFICATION",
   "M4_CHARTS_PROMPT_BY_FAMILY",
   "M4_CONTENT_GENERATOR_PROMPT",
+  "M4_LR_BUSINESS_BLOCK",
   "M4_NARRATIVE_PROMPT_CLASSIFICATION",
   "M4_PROMPT_BY_FAMILY",
   "M4_PROMPT_CLASSIFICATION",
   "M4_QUESTIONS_GENERATOR_PROMPT",
   "M4_QUESTIONS_PROMPT_CLASSIFICATION",
   "M4_QUESTIONS_PROMPT_BY_FAMILY",
+  "M5_BUSINESS_PROMPT_CLASSIFICATION",
   "M5_CONTENT_GENERATOR_PROMPT",
+  "M5_LR_BUSINESS_BLOCK",
   "M5_NARRATIVE_PROMPT_CLASSIFICATION",
   "M5_PROMPT_BY_FAMILY",
   "M5_PROMPT_CLASSIFICATION",

--- a/backend/tests/test_eda_charts_business.py
+++ b/backend/tests/test_eda_charts_business.py
@@ -410,6 +410,158 @@ def test_lr_business_block_absent_from_ml_ds_prompts() -> None:
 
 
 # ─────────────────────────────────────────────────────────
+# M4/M5 LR-business — cierre del arco (Issue #306)
+#
+# Gate: business + clasificación → la variante por concatenación (base + bloque LR) se despacha;
+# business + clustering / ml_ds → prompt base intacto. Sentinelas de heading (únicas por módulo):
+_M4_SENTINEL = "impacto económico apoyado en probabilidad de evento"
+_M5_SENTINEL = "resolución apoyada en el ranking de riesgo del modelo"
+# ─────────────────────────────────────────────────────────
+
+
+def test_m4m5_business_classification_prompt_is_additive() -> None:
+    """La variante business+clasif es PURAMENTE aditiva (base + bloque): garantiza que el base
+    compartido con ml_ds queda byte-idéntico. Los bloques son gerenciales (sin jerga DS al lector).
+    """
+    from case_generator.prompts import (
+        M4_BUSINESS_PROMPT_CLASSIFICATION,
+        M4_CONTENT_GENERATOR_PROMPT,
+        M4_LR_BUSINESS_BLOCK,
+        M5_BUSINESS_PROMPT_CLASSIFICATION,
+        M5_CONTENT_GENERATOR_PROMPT,
+        M5_LR_BUSINESS_BLOCK,
+    )
+
+    # Aditivo ⇒ base intacto (ml_ds usa el mismo base; no puede contaminarse).
+    assert (
+        M4_BUSINESS_PROMPT_CLASSIFICATION
+        == M4_CONTENT_GENERATOR_PROMPT + M4_LR_BUSINESS_BLOCK
+    )
+    assert (
+        M5_BUSINESS_PROMPT_CLASSIFICATION
+        == M5_CONTENT_GENERATOR_PROMPT + M5_LR_BUSINESS_BLOCK
+    )
+
+    # Lenguaje gerencial: "valor en riesgo" presente; el bloque enmarca al lector como directivo
+    # (la jerga DS solo se nombra para prohibirla, igual que en M3 — no se asserta su ausencia).
+    assert "valor en riesgo" in M4_LR_BUSINESS_BLOCK
+    assert "directivo" in M4_LR_BUSINESS_BLOCK
+    assert "valor en riesgo" in M5_LR_BUSINESS_BLOCK
+    assert "Junta Directiva" in M5_LR_BUSINESS_BLOCK
+
+    # Sin placeholders .format() nuevos en los bloques (no pueden romper el formateo).
+    for block in (M4_LR_BUSINESS_BLOCK, M5_LR_BUSINESS_BLOCK):
+        assert "{" not in block and "}" not in block
+
+
+def test_m4_lr_block_gate_business_classification() -> None:
+    """business + Logistic Regression → el prompt M4 lleva el bloque LR;
+    business + clustering → no lo lleva.
+    """
+    from case_generator.graph import m4_content_generator
+
+    captured: dict[str, str] = {}
+
+    def _capture(*, node_name, llm, prompt, metrics_block, grounding_enabled):
+        captured["prompt"] = prompt
+        return "m4 content"
+
+    base_state = {
+        "doc1_narrativa": "n",
+        "doc2_eda": "eda report",
+        "studentProfile": "business",
+        "case_id": "c1",
+    }
+
+    with patch("case_generator.graph._invoke_narrative_with_grounding", _capture), patch(
+        "case_generator.graph.Configuration.from_runnable_config",
+        return_value=MagicMock(
+            writer_model="gemini-2.5-flash",
+            architect_model="gemini-pro",
+            node_model_overrides={},
+        ),
+    ), patch("case_generator.graph._get_m4_llm", return_value=MagicMock()):
+        m4_content_generator(
+            {**base_state, "task_payload": {"algoritmos": ["Logistic Regression"]}},
+            config=None,
+        )
+        assert _M4_SENTINEL in captured["prompt"]
+
+        m4_content_generator(
+            {**base_state, "task_payload": {"algoritmos": ["K-Means"]}},
+            config=None,
+        )
+        assert _M4_SENTINEL not in captured["prompt"]
+
+
+def test_m5_lr_block_gate_business_classification() -> None:
+    """business + Logistic Regression → el prompt M5 lleva el bloque LR;
+    business + clustering → no lo lleva. (M5 enruta vía _invoke_m5_content_with_contract,
+    que delega en _invoke_narrative_with_grounding — el mismo punto de captura.)
+    """
+    from case_generator.graph import m5_content_generator
+
+    captured: dict[str, str] = {}
+
+    def _capture(*, node_name, llm, prompt, metrics_block, grounding_enabled):
+        captured["prompt"] = prompt
+        return "m5 content"
+
+    base_state = {
+        "doc1_narrativa": "n",
+        "doc2_eda": "eda report",
+        "studentProfile": "business",
+        "case_id": "c1",
+    }
+
+    with patch("case_generator.graph._invoke_narrative_with_grounding", _capture), patch(
+        "case_generator.graph.Configuration.from_runnable_config",
+        return_value=MagicMock(
+            writer_model="gemini-2.5-flash",
+            architect_model="gemini-pro",
+            node_model_overrides={},
+        ),
+    ), patch("case_generator.graph._get_m5_llm", return_value=MagicMock()):
+        m5_content_generator(
+            {**base_state, "task_payload": {"algoritmos": ["Logistic Regression"]}},
+            config=None,
+        )
+        assert _M5_SENTINEL in captured["prompt"]
+
+        m5_content_generator(
+            {**base_state, "task_payload": {"algoritmos": ["K-Means"]}},
+            config=None,
+        )
+        assert _M5_SENTINEL not in captured["prompt"]
+
+
+def test_lr_business_block_m4m5_absent_from_ml_ds_prompts() -> None:
+    """Invariante 'ml_ds intacto': el bloque LR-business de M4/M5 vive SOLO en la variante
+    business; no está horneado en el base compartido ni en ningún prompt ml_ds (por familia).
+    """
+    from case_generator.prompts import (
+        M4_CONTENT_GENERATOR_PROMPT,
+        M4_PROMPT_BY_FAMILY,
+        M4_PROMPT_CLASSIFICATION,
+        M5_CONTENT_GENERATOR_PROMPT,
+        M5_PROMPT_BY_FAMILY,
+        M5_PROMPT_CLASSIFICATION,
+    )
+
+    # Base compartido y prompt ml_ds de clasificación: sin sentinela.
+    assert _M4_SENTINEL not in M4_CONTENT_GENERATOR_PROMPT
+    assert _M4_SENTINEL not in M4_PROMPT_CLASSIFICATION
+    assert _M5_SENTINEL not in M5_CONTENT_GENERATOR_PROMPT
+    assert _M5_SENTINEL not in M5_PROMPT_CLASSIFICATION
+
+    # Toda la tabla de dispatch ml_ds (cualquier familia): sin sentinela.
+    for family_prompt in M4_PROMPT_BY_FAMILY.values():
+        assert _M4_SENTINEL not in family_prompt
+    for family_prompt in M5_PROMPT_BY_FAMILY.values():
+        assert _M5_SENTINEL not in family_prompt
+
+
+# ─────────────────────────────────────────────────────────
 # financial_mirage — honestidad ante márgenes no positivos (anti-inversión)
 # ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Qué

Cierra el arco narrativo **business + Logistic Regression**: M4 (impacto económico) y M5 (resolución) ahora referencian explícitamente la decisión apoyada en el modelo — *probabilidad de evento × valor en riesgo* — en **lenguaje gerencial plano**, coherente con el bloque LR de M3 (#301). Antes caían al prompt genérico y perdían el hilo del modelo del que hablan M2/M3.

## Por qué

La pregunta guía de los casos business+LR ya pide priorizar "basándose en la probabilidad estimada por el modelo y el impacto financiero". El bloque LR de M3 (#301, decisión 3A) abrió el arco; este PR lo cierra en M4/M5. Cierra `TODO-LR-M4M5`.

## Approach — 1B (variante por concatenación, NO placeholder)

A diferencia de M3, los prompts base de M4/M5 son **compartidos** con ml_ds (`M{4,5}_PROMPT_CLASSIFICATION = base + grounding`). Un placeholder en el base habría tocado el template ml_ds. En su lugar:

- Se ensamblan variantes **aditivas** `M{4,5}_BUSINESS_PROMPT_CLASSIFICATION = base + M{4,5}_LR_BUSINESS_BLOCK`.
- `graph.py` las despacha **solo** para `profile=="business" AND family=="clasificacion"` vía el helper compartido `_maybe_business_classification_prompt` (DRY entre M4 y M5).
- El base queda **byte-idéntico** ⇒ ml_ds provablemente intacto y `.format()` no puede romper (sin placeholder nuevo).

```
        m4/m5_content_generator → _maybe_business_classification_prompt(state, default, biz_clasif)
                                              │  profile, family = _resolve_generation_focus(state)
   ┌───────────────────────────┼──────────────────────────────┐
business + clasificacion   business + clustering/regresion    ml_ds (cualquier familia)
→ variante LR (base+bloque)  → base intacto                  → base intacto
```

## Invariantes respetadas

- **business + clasificación únicamente.** ml_ds usa `M{4,5}_PROMPT_BY_FAMILY` — no se toca.
- **Lenguaje gerencial, sin jerga DS** (la jerga solo se nombra para prohibirla al lector directivo, igual que M3).
- **Sin notebook, sin métricas, sin grounding** (business nunca ejecuta): los bloques son texto estático, sin `{computed_metrics_block}`.
- **Honestidad:** referenciar la decisión apoyada por el modelo, sin inventar cifras (usar Exhibits/M2/M4).

## Tests (`tests/test_eda_charts_business.py`)

- Gate determinista para **M4 y M5**: business+`Logistic Regression` → bloque presente; business+`K-Means` → ausente.
- Aditividad: `M{4,5}_BUSINESS_PROMPT_CLASSIFICATION == base + bloque` (prueba que el base no se contamina).
- Invariante ml_ds: la sentinela no está en el base ni en ningún valor de `M{4,5}_PROMPT_BY_FAMILY`.

## Validación

- `uv run --directory backend pytest -q` → **1116 passed, 20 skipped**
- `uv run --directory backend mypy src` → **Success: no issues found in 82 source files**

## Follow-ups diferidos (TODOS.md)

- `TODO-LR-GATE-UNIFY`: unificar el gate inline de M3 con el helper de M4/M5 (la condición se repite; el mecanismo de inyección difiere).
- `TODO-MLDS-M4M5-FROZEN-HASH`: frozen-hash invariante para los prompts ml_ds de M4/M5 (defensa-en-profundidad).

Closes #306
Refs #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)