### PR TITLE
fix(business): codificar el signo de la asociación en el chart de drivers de M2 (#320)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1718,3 +1718,31 @@ superficie de test en `backend/tests/test_eda_charts_business.py` y
 exacto de #306/#319: bloque estático placeholder-free + `_maybe_business_classification_prompt`.
 
 **Depends on / blocked by:** Independiente de #319.
+
+---
+
+## TODO-320-A: Test de snapshot/regresión visual frontend para el chart de drivers divergente
+
+**What:** Añadir un test automatizado de frontend que cubra el render del chart `churn_drivers`
+divergente de M2 business: que el encoding con signo (x ∈ [-1,1]), el `marker.color` por barra y
+el `xaxis.range=[-1,1]` sobreviven a `sanitizeTraces` y llegan intactos a Plotly.
+
+**Why:** Hoy **no existe ninguna cobertura de test de frontend** para estos charts Plotly; el fix de
+#320 se apoya en verificación manual del JSON de la traza (e inspección visual) para confirmar que
+`sanitizeTraces` no descarta `marker` ni recorta valores negativos. Un cambio futuro en
+`sanitizeTraces`/`buildLayout` podría romper el encoding direccional sin que ningún test lo detecte.
+
+**Pros:** Cierra el gap de cero cobertura FE para los charts EDA; bloquea regresiones silenciosas del
+encoding con signo y del color por barra (modo de fallo F2 del plan-eng-review de #320).
+
+**Cons:** No existe aún harness de test para componentes de chart en `frontend/` — es infraestructura
+net-new (Vitest/RTL + setup de Plotly mock). Mayor que un test puntual.
+
+**Context:** Render en `frontend/src/shared/case-viewer/PlotlyChartsRenderer.tsx` +
+`plotlyChartUtils.ts` (`sanitizeTraces`, `buildLayout`). Verificado en #320 que `sanitizeTraces` solo
+normaliza heatmaps y `null→0` en x/y (no toca `marker`, no recorta negativos) y que el tipo TS
+`Data`/`PlotMarker` ya admite `Color[]`. Punto de partida sugerido: un snapshot de la salida de
+`sanitizeTraces` para una spec de barra divergente con `marker.color` por barra y x con signo.
+
+**Depends on / blocked by:** Ninguno. El fix backend de #320 es independiente; este TODO es hardening
+de cobertura FE.

--- a/backend/src/case_generator/datagen/eda_charts_business.py
+++ b/backend/src/case_generator/datagen/eda_charts_business.py
@@ -60,6 +60,12 @@ logger = logging.getLogger("adam.graph")
 _DRIVERS_TOP_K = 8
 _DRIVERS_MIN_ABS_CORR = 0.10
 
+# Issue #320 — color por dirección de la asociación (mismo eje rojo↔azul que el
+# heatmap RdBu de correlación): rojo = la variable *aumenta* el evento (corr > 0);
+# azul = lo *reduce* / protege (corr < 0). Tonos distinguibles para daltonismo.
+_DRIVER_COLOR_RISK = "#d6604d"  # aumenta el evento
+_DRIVER_COLOR_PROTECT = "#4393c3"  # reduce el evento
+
 # Issue #301 — el título del chart de drivers no debe asumir "abandono"/churn cuando el
 # caso no es de retención. El match de retención vive en el vocab único
 # `retention_tokens.is_retention_match` (mismo usado por el spine en graph.py), que además
@@ -188,7 +194,11 @@ def _indexed_base_100(series: pd.Series) -> list[float | None] | None:
 def _target_correlations(
     df: pd.DataFrame, target_col: str, precalculated_metrics: dict | None
 ) -> dict[str, float]:
-    """``{feature: |corr con el objetivo|}``.
+    """``{feature: corr con signo con el objetivo}`` (r ∈ [-1, 1]).
+
+    Conserva el signo (Issue #320): el consumidor distingue factores que
+    *aumentan* el evento (corr > 0) de los que lo *reducen* (corr < 0). Quien
+    necesite magnitud aplica ``abs()`` en el call site.
 
     Prefiere la ``correlation_matrix`` ya calculada (consistencia con otras
     vistas y exclusión de columnas constantes ya aplicada). Si no está
@@ -206,7 +216,7 @@ def _target_correlations(
                 if name == target_col:
                     continue
                 try:
-                    out[name] = abs(float(z[ti][j]))
+                    out[name] = float(z[ti][j])
                 except (TypeError, ValueError, IndexError):
                     continue
             if out:
@@ -224,7 +234,7 @@ def _target_correlations(
             continue
         corr = numeric[name].corr(numeric[target_col])
         if pd.notna(corr):
-            out[name] = abs(float(corr))
+            out[name] = float(corr)
     return out
 
 
@@ -345,11 +355,16 @@ def _build_financial_mirage(df: pd.DataFrame, source: str) -> dict[str, Any]:
 def _build_churn_drivers(
     df: pd.DataFrame, target_col: str, precalculated_metrics: dict | None, source: str
 ) -> dict[str, Any]:
-    """Barra horizontal de |correlación| real de cada variable con el objetivo.
+    """Barra horizontal divergente: dirección + fuerza de cada variable vs. el objetivo.
 
-    Reemplaza el scatter+recta que afirmaba un –0.89 que los puntos no
-    respaldaban. El eje fijo [0, 1] impide exagerar correlaciones pequeñas, y si
-    ninguna supera el umbral lo decimos en `notes` en vez de sugerir un driver.
+    Issue #320 — antes mostrábamos solo la magnitud (|correlación|), así que un
+    factor protector (corr < 0) y uno de riesgo (corr > 0) se veían idénticos. Ahora
+    el signo se codifica espacialmente: a la derecha = *aumenta* el evento, a la
+    izquierda = lo *reduce*; el color refuerza la dirección. El eje simétrico [-1, 1]
+    conserva la propiedad anti-exageración (una asociación pequeña sigue siendo una
+    barra corta). La etiqueta numérica muestra la *fuerza* (valor absoluto, 0–1) para
+    que un número nunca se lea como "peor". El orden sigue por fuerza (mayor |r| arriba)
+    y, si ninguna la supera, lo decimos en `notes` en vez de sugerir un driver.
     """
     title = _drivers_title(target_col)
     corrs = _target_correlations(df, target_col, precalculated_metrics)
@@ -357,19 +372,25 @@ def _build_churn_drivers(
         return empty_chart(
             "churn_drivers",
             title,
-            "Sin correlaciones calculables con el objetivo",
+            "Sin asociaciones calculables con el objetivo",
             "bar",
             source,
-            notes="No se pudieron calcular correlaciones con la variable objetivo.",
+            notes="No se pudo medir la relación de las variables con la variable objetivo.",
         )
 
-    pairs = sorted(corrs.items(), key=lambda kv: kv[1], reverse=True)[:_DRIVERS_TOP_K]
+    # Orden por fuerza (|r|): la asociación más marcada queda arriba, sin importar
+    # si aumenta o reduce el evento.
+    pairs = sorted(corrs.items(), key=lambda kv: abs(kv[1]), reverse=True)[:_DRIVERS_TOP_K]
     feats = [p[0] for p in pairs]
-    vals = [round(p[1], 3) for p in pairs]
-    strongest = vals[0] if vals else 0.0
+    vals = [round(p[1], 3) for p in pairs]  # con signo
+    # Color derivado del MISMO `vals` → len(colors) == len(x) siempre (evita que
+    # Plotly recicle colores y pinte la barra equivocada). r == 0 → PROTECT; es
+    # inofensivo porque |0| < 0.10 dispara el aviso de driver débil de abajo.
+    colors = [_DRIVER_COLOR_RISK if v > 0 else _DRIVER_COLOR_PROTECT for v in vals]
+    strongest = abs(vals[0]) if vals else 0.0
     note = (
-        "Ninguna variable supera |correlación| ≥ 0.10 con el objetivo: no hay un "
-        "driver lineal fuerte en estos datos; interpretar con cautela."
+        "Ninguna variable muestra una asociación fuerte con el objetivo en estos "
+        "datos: no hay un factor claro que lo aumente o lo reduzca; interpretar con cautela."
         if strongest < _DRIVERS_MIN_ABS_CORR
         else ""
     )
@@ -378,24 +399,33 @@ def _build_churn_drivers(
     return {
         "id": "churn_drivers",
         "title": title,
-        "subtitle": f"Correlación absoluta de cada variable con {target_label} (mayor = más asociada)",
+        "subtitle": (
+            f"Asociación de cada variable con {target_label}: "
+            "a la derecha aumenta el evento, a la izquierda lo reduce"
+        ),
         "library": "plotly",
         "chart_type": "bar",
         "traces": [
             {
                 "type": "bar",
-                "x": vals,
+                "x": vals,  # con signo: posición izq/der = reduce/aumenta
                 "y": feats,
                 "orientation": "h",
-                "name": "|correlación|",
-                "text": [f"{v:.2f}" for v in vals],
+                "name": "asociación",
+                # La etiqueta muestra la fuerza (0–1); la dirección la dan posición y color.
+                "text": [f"{abs(v):.2f}" for v in vals],
                 "textposition": "outside",
+                "marker": {"color": colors},
             }
         ],
         "layout": {
             "template": "plotly_white",
-            # Eje fijo [0,1]: |corr| siempre cae aquí → no exagera magnitudes.
-            "xaxis": {"title": f"|correlación| con {target_label}", "range": [0, 1]},
+            # Eje simétrico [-1,1]: conserva el anti-exageración y deja ver el lado
+            # (izquierda reduce, derecha aumenta).
+            "xaxis": {
+                "title": f"Relación con {target_label}  (← reduce · aumenta →)",
+                "range": [-1, 1],
+            },
             "yaxis": {"title": "Variable", "autorange": "reversed"},
             "showlegend": False,
         },

--- a/backend/tests/test_eda_charts_business.py
+++ b/backend/tests/test_eda_charts_business.py
@@ -24,6 +24,8 @@ import pandas as pd
 import pytest
 
 from case_generator.datagen.eda_charts_business import (
+    _DRIVER_COLOR_PROTECT,
+    _DRIVER_COLOR_RISK,
     _aggregate_by_grain,
     _detect_period_grain,
     _indexed_base_100,
@@ -40,13 +42,18 @@ CONTRACT = {"case_id": "test_case_business"}
 
 @pytest.fixture
 def df_business() -> pd.DataFrame:
-    """12 meses; revenue sube, churn baja, nps sube (→ nps↔churn negativo)."""
+    """12 meses; revenue sube, churn baja, nps sube (→ nps↔churn negativo).
+
+    `payment_failures` baja junto con churn (ambos descienden) → correlación
+    POSITIVA con el objetivo: un factor que *aumenta* el evento (Issue #320).
+    """
     periods = [f"2023-{m:02d}" for m in range(1, 13)]
     revenue = [100_000 + i * 2_000 for i in range(12)]
     costs = [round(r * 0.7, 2) for r in revenue]
     margin_pct = [round((r - c) / r * 100, 2) for r, c in zip(revenue, costs)]
     churn = [round(0.20 - i * 0.005, 4) for i in range(12)]
     nps = [30 + i * 2 for i in range(12)]
+    payment_failures = [60 - i * 4 for i in range(12)]  # baja con churn → corr > 0
     return pd.DataFrame(
         {
             "period": periods,
@@ -55,6 +62,7 @@ def df_business() -> pd.DataFrame:
             "margin_pct": margin_pct,
             "churn_rate": churn,
             "nps": nps,
+            "payment_failures": payment_failures,
             "retention_m1": [0.90] * 12,
             "retention_m3": [0.70] * 12,
             "retention_m6": [0.50] * 12,
@@ -68,13 +76,15 @@ def precalc_with_cohort() -> dict:
     """Métricas precalculadas con matriz de correlación + cohortes (forma real)."""
     return {
         "correlation_matrix": {
-            "x": ["revenue", "costs", "churn_rate", "nps"],
-            "y": ["revenue", "costs", "churn_rate", "nps"],
+            # payment_failures (corr +0.6 con churn) prueba un driver POSITIVo (#320).
+            "x": ["revenue", "costs", "churn_rate", "nps", "payment_failures"],
+            "y": ["revenue", "costs", "churn_rate", "nps", "payment_failures"],
             "z": [
-                [1.0, 0.8, -0.9, 0.7],
-                [0.8, 1.0, -0.5, 0.4],
-                [-0.9, -0.5, 1.0, -0.85],  # fila del target churn_rate
-                [0.7, 0.4, -0.85, 1.0],
+                [1.0, 0.8, -0.9, 0.7, -0.6],
+                [0.8, 1.0, -0.5, 0.4, -0.3],
+                [-0.9, -0.5, 1.0, -0.85, 0.6],  # fila del target churn_rate
+                [0.7, 0.4, -0.85, 1.0, -0.5],
+                [-0.6, -0.3, 0.6, -0.5, 1.0],
             ],
         },
         "cohort_matrix": {
@@ -147,8 +157,8 @@ def test_financial_mirage_missing_revenue_degrades(df_business) -> None:
 def test_churn_drivers_values_come_from_precalculated_corr(
     df_business, precalc_with_cohort
 ) -> None:
-    """Las magnitudes mostradas == |corr| reales de la matriz precalculada,
-    ordenadas desc. NO números inventados por el LLM.
+    """Los valores mostrados == corr CON SIGNO reales de la matriz precalculada,
+    ordenados por fuerza (|r|) desc. NO números inventados por el LLM (#320).
     """
     charts = generate_business_eda_charts(
         df_business, "churn_rate", precalc_with_cohort, CONTRACT
@@ -157,21 +167,27 @@ def test_churn_drivers_values_come_from_precalculated_corr(
     trace = drivers["traces"][0]
     assert drivers["chart_type"] == "bar"
     assert trace["orientation"] == "h"
-    # |corr| de churn_rate vs {revenue:0.9, nps:0.85, costs:0.5} → orden desc
-    assert trace["y"] == ["revenue", "nps", "costs"]
-    assert trace["x"] == [0.9, 0.85, 0.5]
-    # Eje fijo [0,1] impide exagerar magnitudes pequeñas.
-    assert drivers["layout"]["xaxis"]["range"] == [0, 1]
+    # corr de churn_rate: revenue -0.9, nps -0.85, payment_failures +0.6, costs -0.5
+    # → orden por |r| desc; el signo se CONSERVA en x.
+    assert trace["y"] == ["revenue", "nps", "payment_failures", "costs"]
+    assert trace["x"] == [-0.9, -0.85, 0.6, -0.5]
+    # La etiqueta muestra la fuerza (valor absoluto, 0–1), sin el signo.
+    assert trace["text"] == ["0.90", "0.85", "0.60", "0.50"]
+    # Eje simétrico [-1,1]: conserva el anti-exageración y muestra la dirección.
+    assert drivers["layout"]["xaxis"]["range"] == [-1, 1]
 
 
 def test_churn_drivers_fallback_computes_from_df(df_business) -> None:
-    """Sin correlation_matrix precalculada, computa |corr| del df (no se rinde)."""
+    """Sin correlation_matrix precalculada, computa corr CON SIGNO del df (no se rinde)."""
     charts = generate_business_eda_charts(df_business, "churn_rate", {}, CONTRACT)
     drivers = next(c for c in charts if c["id"] == "churn_drivers")
     trace = drivers["traces"][0]
-    # nps sube y churn baja → |corr| alto y real.
+    # nps sube y churn baja → corr fuerte y NEGATIVA (reduce el evento).
     nps_idx = trace["y"].index("nps")
-    assert trace["x"][nps_idx] > 0.8
+    assert trace["x"][nps_idx] < -0.8
+    # payment_failures baja con churn → corr POSITIVA (aumenta el evento).
+    pf_idx = trace["y"].index("payment_failures")
+    assert trace["x"][pf_idx] > 0.8
 
 
 def test_churn_drivers_no_computable_correlations_returns_empty() -> None:
@@ -212,9 +228,67 @@ def test_churn_drivers_weak_but_present_correlation_is_flagged() -> None:
     charts = generate_business_eda_charts(df, "churn_rate", precalc, CONTRACT)
     drivers = next(c for c in charts if c["id"] == "churn_drivers")
     assert drivers["traces"] != []  # hay barra real
-    assert drivers["traces"][0]["x"] == [0.05]
-    assert "0.10" in drivers["notes"]  # nota de cautela explícita
-    assert drivers["layout"]["xaxis"]["range"] == [0, 1]  # eje fijo anti-exageración
+    assert drivers["traces"][0]["x"] == [0.05]  # signo conservado (aquí positivo y débil)
+    assert "cautela" in drivers["notes"]  # nota de cautela explícita
+    assert drivers["layout"]["xaxis"]["range"] == [-1, 1]  # eje simétrico anti-exageración
+
+
+def test_churn_drivers_encodes_direction_with_sign_and_color(
+    df_business, precalc_with_cohort
+) -> None:
+    """Issue #320: el signo distingue factor de riesgo (aumenta) de protector (reduce).
+
+    Un driver con corr negativa → x < 0 y color PROTECT; uno con corr positiva →
+    x > 0 y color RISK. La etiqueta numérica nunca lleva signo (es la fuerza).
+    """
+    charts = generate_business_eda_charts(
+        df_business, "churn_rate", precalc_with_cohort, CONTRACT
+    )
+    trace = next(c for c in charts if c["id"] == "churn_drivers")["traces"][0]
+    colors = trace["marker"]["color"]
+
+    nps_idx = trace["y"].index("nps")  # corr -0.85 → reduce el evento
+    assert trace["x"][nps_idx] < 0
+    assert colors[nps_idx] == _DRIVER_COLOR_PROTECT
+
+    pf_idx = trace["y"].index("payment_failures")  # corr +0.6 → aumenta el evento
+    assert trace["x"][pf_idx] > 0
+    assert colors[pf_idx] == _DRIVER_COLOR_RISK
+
+    # La fuerza se muestra sin signo (un "-0.85" se leería como "peor").
+    assert all(not t.startswith("-") for t in trace["text"])
+
+
+def test_churn_drivers_marker_color_length_matches_x(
+    df_business, precalc_with_cohort
+) -> None:
+    """Guard anti-mis-render (F2): si len(color) != len(x), Plotly recicla colores
+    y pinta la barra equivocada. Deben coincidir siempre."""
+    charts = generate_business_eda_charts(
+        df_business, "churn_rate", precalc_with_cohort, CONTRACT
+    )
+    trace = next(c for c in charts if c["id"] == "churn_drivers")["traces"][0]
+    assert len(trace["marker"]["color"]) == len(trace["x"])
+
+
+def test_churn_drivers_has_no_ds_jargon(df_business, precalc_with_cohort) -> None:
+    """La dirección se comunica en lenguaje de negocio, sin jerga DS (#320)."""
+    charts = generate_business_eda_charts(
+        df_business, "churn_rate", precalc_with_cohort, CONTRACT
+    )
+    drivers = next(c for c in charts if c["id"] == "churn_drivers")
+    trace = drivers["traces"][0]
+    surfaces = " ".join(
+        [
+            drivers["subtitle"],
+            drivers["notes"],
+            trace["name"],
+            drivers["layout"]["xaxis"]["title"],
+            *trace["text"],
+        ]
+    ).lower()
+    for jargon in ("pearson", "coeficiente", "r=", "|correlación|", "absoluta"):
+        assert jargon not in surfaces
 
 
 # ─────────────────────────────────────────────────────────
@@ -990,7 +1064,7 @@ def test_cohort_fallback_binary_target_uses_class_balance_bar() -> None:
 def test_churn_business_non_regression_three_retention_charts(
     df_business, precalc_with_cohort
 ) -> None:
-    """No-regresión business churn/SaaS: 3 charts con cohorte de retención + eje [0,1]."""
+    """No-regresión business churn/SaaS: 3 charts con cohorte de retención + eje [-1,1]."""
     charts = generate_business_eda_charts(
         df_business, "churn_rate", precalc_with_cohort, CONTRACT
     )
@@ -1001,4 +1075,5 @@ def test_churn_business_non_regression_three_retention_charts(
     assert "Retención de Cohortes" in cohort["title"]
     drivers = next(c for c in charts if c["id"] == "churn_drivers")
     assert drivers["title"] == "Factores asociados al abandono"
-    assert drivers["layout"]["xaxis"]["range"] == [0, 1]  # honestidad #296
+    # Eje simétrico [-1,1] (#320): conserva el anti-exageración de #296 y muestra dirección.
+    assert drivers["layout"]["xaxis"]["range"] == [-1, 1]


### PR DESCRIPTION
## Contexto (#320)

En el perfil **business** + **clasificación**, el chart de M2 "Factores asociados al…"
ordenaba las variables por correlación **absoluta** y descartaba el signo. Resultado: un
factor **protector** (corr<0, p. ej. NPS↑ → menos abandono) y uno de **riesgo** (corr>0, p. ej.
fallos de pago↑ → más abandono) se renderizaban como barras **idénticas**. Un directivo no podía
distinguir "qué reduce el evento" de "qué lo aumenta" — justo la lectura accionable.

## Qué cambió

Todo en el builder Python determinista (`backend/src/case_generator/datagen/eda_charts_business.py`),
no en un prompt — el paso de anotación LLM tiene prohibido tocar `traces`/`layout`/números.

- **`_target_correlations`** conserva el signo: se quita `abs()` en las **dos** rutas (matriz
  precalculada y fallback pandas). Tiene un **único llamador**, así que el cambio es seguro.
- **`_build_churn_drivers`** pasa a **barra divergente**:
  - `x` con **signo** en eje **simétrico `[-1, 1]`** (conserva la propiedad anti-exageración de #296).
  - **color por barra** vía `marker.color` (rojo = aumenta el evento / azul = reduce, mismo eje
    rojo↔azul que el heatmap RdBu de correlación).
  - la **etiqueta numérica muestra la fuerza** (`|valor|`, 0–1) para que un número nunca se lea
    como "peor"; la dirección la dan la posición (izq/der) y el color.
  - el **orden sigue por fuerza** (mayor `|r|` arriba) y el **aviso de driver débil** se mantiene
    (`|r| < 0.10`).
  - el color se construye desde la **misma** lista que los valores → `len(marker.color) == len(x)`
    siempre (guard anti-mis-render, modo de fallo F2 del plan-eng-review).
- **Cero jerga DS:** se de-jergoniza subtítulo, título de eje, nombre de traza y la nota de driver
  débil (fuera `|correlación|` / "absoluta"; ahora "asociación/relación", "aumenta/reduce").

## ml_ds intacto

ml_ds usa otro builder (`eda_charts_classification.py`) que **no tiene** chart de drivers; no se
toca, ni el `empty_chart()` compartido. El **frontend no necesita cambios**: `sanitizeTraces` no
toca `marker` ni recorta negativos, y el tipo TS `Data`/`PlotMarker` ya admite `Color[]`.

## Tests

- Se añade un driver **positivo** (`payment_failures`) a **ambos** fixtures (`precalc_with_cohort`
  y `df_business`) para cubrir la dirección "aumenta el evento" en la ruta precalculada **y** en el
  fallback.
- Se actualizan las aserciones existentes al encoding con signo (`x` con signo, `xaxis.range==[-1,1]`,
  etiqueta = magnitud) y se añaden tests nuevos: dirección+color por barra, `len(marker.color)==len(x)`,
  y ausencia de jerga DS ("pearson"/"coeficiente"/"r="/"|correlación|"/"absoluta").

### Evidencia

- `uv run --directory backend pytest -q tests/test_eda_charts_business.py` → **47 passed**
- `uv run --directory backend pytest -q` → **1134 passed, 20 skipped** (ml_ds/classification verdes)
- `uv run --directory backend mypy src` → **Success: no issues found in 82 source files**
- `uv run --directory backend ruff check src/case_generator/datagen/eda_charts_business.py` → **All checks passed!**

## Follow-up

Se difiere a `TODOS.md` (TODO-320-A) un test de snapshot/regresión visual de frontend para el chart
divergente — hoy no hay cobertura FE de estos charts Plotly.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)