### PR TITLE
fix(business): el chart class_balance de M2 marca el desbalance severo (#321)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1746,3 +1746,55 @@ normaliza heatmaps y `null→0` en x/y (no toca `marker`, no recorta negativos) 
 
 **Depends on / blocked by:** Ninguno. El fix backend de #320 es independiente; este TODO es hardening
 de cobertura FE.
+
+---
+
+## TODO-321-A: Paridad de aviso de desbalance en el chart ml_ds `class_distribution`
+
+**What:** Añadir una nota condicional de desbalance al chart ml_ds `_build_class_distribution`
+(`backend/src/case_generator/datagen/eda_charts_classification.py`, id `class_distribution`,
+hoy `notes=''`), espejando el patrón conditional-notes que #321 introdujo en el chart business
+`class_balance`.
+
+**Why:** Tras #321, el chart **business** marca el desbalance severo en el propio gráfico, pero
+el **ml_ds** sigue mostrando solo conteos+`pct` sin aviso, pese a que su prompt M2 ml_ds ya avisa
+(`prompts/clasificacion/M2_clasificacion/eda_text.py:51,77`). Esa asimetría la introduce #321.
+
+**Pros:** Restaura consistencia cross-perfil; el chart ml_ds ya computa `pct` y `total`, así que el
+follow-up es pequeño y aditivo.
+
+**Cons:** No es copy-paste: el registro ml_ds admite jerga DS (Accuracy Paradox, AUC-ROC, ratio
+N:1), a diferencia del registro gerencial sin jerga de business. Requiere redactar la nota ml_ds y
+decidir si usa el umbral 20% (clasificación binaria) o el 4:1 que ya cita el prompt ml_ds.
+
+**Context:** `_build_class_distribution` es un code path separado, sin cross-import con
+`eda_charts_business.py`. Punto de partida: replicar la rama condicional `notes = WARN if
+minority_share < THRESHOLD else ''` usando los `pct`/`total` ya calculados. NO hacerlo dentro de
+#321 (rompe el invariante business-only de ese PR).
+
+**Depends on / blocked by:** Independiente de #321. Building now NO — viola el scope business-only.
+
+---
+
+## TODO-321-B: Single-source-of-truth del umbral de desbalance (low priority)
+
+**What:** Unificar el umbral de desbalance severo (clase minoritaria < 20% ⇔ ratio > 4:1) que hoy
+vive en tres lugares: el prompt M2 business (`eda_text.py`, "menos del 20%"), el prompt M2 ml_ds
+(`eda_text.py:51,77`, 20% y 4:1) y la constante `_CLASS_BALANCE_MINORITY_WARN = 0.20` que #321
+añadió en `eda_charts_business.py`.
+
+**Why:** Esta superficie está en churn activo (#318/#319/#320/#321); con tres copias del umbral, un
+3.º consumidor o un cambio de política puede divergir en silencio.
+
+**Pros:** Una sola fuente de verdad numérica para los builders; menos riesgo de drift.
+
+**Cons:** Los prompts son prosa y no consumen trivialmente una constante numérica, así que la
+unificación es parcial (los prompts seguirían diciendo "20%" en texto) → payoff limitado hoy.
+
+**Context:** Decisión #321 (plan-eng-review 2A): se aceptó la duplicación con un comentario
+cross-ref en la constante. Disparador para actuar: aparece un 3.º consumidor en código o se pide
+cambiar el umbral → extraer un módulo `imbalance_thresholds` que importen los builders business y
+ml_ds; los prompts permanecen como prosa.
+
+**Depends on / blocked by:** Un 3.º consumidor de código del umbral o una solicitud de cambio del
+valor. No bloquea nada.

--- a/backend/src/case_generator/datagen/eda_charts_business.py
+++ b/backend/src/case_generator/datagen/eda_charts_business.py
@@ -60,6 +60,11 @@ logger = logging.getLogger("adam.graph")
 _DRIVERS_TOP_K = 8
 _DRIVERS_MIN_ABS_CORR = 0.10
 
+# Issue #321 — desbalance severo: clase minoritaria < 20% del total (⇔ ratio > 4:1).
+# El mismo umbral vive como prosa en el prompt M2 business (prompts/clasificacion/
+# M2_clasificacion/eda_text.py, "menos del 20%") — mantener ambos en sync.
+_CLASS_BALANCE_MINORITY_WARN = 0.20
+
 # Issue #320 — color por dirección de la asociación (mismo eje rojo↔azul que el
 # heatmap RdBu de correlación): rojo = la variable *aumenta* el evento (corr > 0);
 # azul = lo *reduce* / protege (corr < 0). Tonos distinguibles para daltonismo.
@@ -488,6 +493,25 @@ def _build_cohort_collapse(
                 counts = s.astype(int).value_counts().sort_index()
                 labels = [str(int(k)) for k in counts.index]
                 vals_count = [int(v) for v in counts.values]
+                # Issue #321 — marca el desbalance en el propio gráfico: % por barra
+                # (siempre) + nota gerencial sin jerga DS cuando la clase minoritaria
+                # es poco frecuente. Guard total==0 defensivo (is_binary ya implica
+                # total>=2; el builder corre en un try-except que omite el chart si lanza).
+                total = sum(vals_count)
+                bar_text = (
+                    [f"{v} ({v / total:.0%})" for v in vals_count]
+                    if total
+                    else [str(v) for v in vals_count]
+                )
+                minority_share = (min(vals_count) / total) if total else 1.0
+                imbalance_note = (
+                    "El evento es poco frecuente (solo "
+                    f"{minority_share:.0%} de los casos). Un análisis que asumiera que "
+                    "casi nunca ocurre parecería acertar casi siempre sin aportar valor; "
+                    "lo importante es anticipar los pocos casos en que sí ocurre."
+                    if minority_share < _CLASS_BALANCE_MINORITY_WARN
+                    else ""
+                )
                 return {
                     "id": "class_balance",
                     "title": f"Balance de clases del objetivo ({target_col})",
@@ -500,7 +524,7 @@ def _build_cohort_collapse(
                             "x": labels,
                             "y": vals_count,
                             "name": "casos",
-                            "text": [str(v) for v in vals_count],
+                            "text": bar_text,
                             "textposition": "outside",
                         }
                     ],
@@ -512,7 +536,7 @@ def _build_cohort_collapse(
                     },
                     "source": source,
                     "description": "",
-                    "notes": "",
+                    "notes": imbalance_note,
                     "data_source": "python_builder",
                 }
             # Target continuo: caja de distribución (comportamiento previo).

--- a/backend/tests/test_eda_charts_business.py
+++ b/backend/tests/test_eda_charts_business.py
@@ -1030,6 +1030,23 @@ def _df_business_binary() -> pd.DataFrame:
     )
 
 
+def _df_business_binary_with_flags(flags: list[int]) -> pd.DataFrame:
+    """Variante de `_df_business_binary` con una distribución de clases controlada
+    (Issue #321). Conserva las columnas business y reemplaza el flag objetivo para
+    forzar balance/desbalance/borde sin cohort_matrix."""
+    n = len(flags)
+    return pd.DataFrame(
+        {
+            "period": [f"2023-{(m % 12) + 1:02d}" for m in range(n)],
+            "revenue": [100_000 + i * 2_000 for i in range(n)],
+            "costs": [70_000 + i * 1_000 for i in range(n)],
+            "margin_pct": [30.0] * n,
+            "partner_history_score": [i / max(n - 1, 1) for i in range(n)],
+            "late_partner_flag": list(flags),
+        }
+    )
+
+
 def test_drivers_title_non_churn_target_is_neutral() -> None:
     """Un caso de logística no debe titular el chart de drivers como 'abandono'."""
     df = _df_business_binary()
@@ -1059,6 +1076,45 @@ def test_cohort_fallback_binary_target_uses_class_balance_bar() -> None:
     assert "Retención" not in third["title"]
     # cuenta de cada clase {0,1}
     assert sorted(third["traces"][0]["x"]) == ["0", "1"]
+    # Issue #321 — balanceado (6/6 = 50%): el % se muestra siempre, sin aviso de desbalance.
+    assert third["notes"] == ""
+    assert "(50%)" in third["traces"][0]["text"][0]
+
+
+def test_class_balance_severe_imbalance_emits_managerial_note() -> None:
+    """Issue #321 — minoría < 20% ⇒ el propio gráfico marca el desbalance (% + nota gerencial)."""
+    df = _df_business_binary_with_flags([0] * 11 + [1])  # minoría 1/12 ≈ 8%
+    charts = generate_business_eda_charts(df, "late_partner_flag", {}, CONTRACT)
+    chart = next(c for c in charts if c["id"] == "class_balance")
+    notes = chart["notes"]
+    assert "poco frecuente" in notes
+    assert "8%" in notes  # % real de la minoría, en la nota
+    # % también visible en las barras, sin leer la nota
+    text = chart["traces"][0]["text"]
+    assert "1 (8%)" in text
+    assert "11 (92%)" in text
+    # registro gerencial — sin jerga DS
+    for jargon in (
+        "Accuracy Paradox",
+        "AUC-ROC",
+        "matriz de confusión",
+        "F1",
+        "precision",
+        "recall",
+    ):
+        assert jargon not in notes
+    # la nota cabe íntegra en el presupuesto de _annotate_validate_emit (300 chars)
+    assert len(notes) <= 300
+
+
+def test_class_balance_boundary_exactly_20pct_does_not_warn() -> None:
+    """Issue #321 — 20% exacto NO dispara (umbral estricto `<`, alinea 'menos del 20%')."""
+    df = _df_business_binary_with_flags([0] * 8 + [1] * 2)  # minoría 2/10 = 20%
+    charts = generate_business_eda_charts(df, "late_partner_flag", {}, CONTRACT)
+    chart = next(c for c in charts if c["id"] == "class_balance")
+    assert chart["notes"] == ""
+    # el % sigue presente en las barras aunque no haya aviso
+    assert "2 (20%)" in chart["traces"][0]["text"]
 
 
 def test_churn_business_non_regression_three_retention_charts(


### PR DESCRIPTION
## Contexto (#321)

En perfil **business + clasificación**, el gráfico de M2 `class_balance` (rama binaria de `_build_cohort_collapse`) mostraba los conteos por clase pero **no avisaba** cuando el desbalance era severo (clase minoritaria < 20% del total ⇔ ratio > 4:1). Un lector que solo miraba el gráfico subestimaba el problema: el aviso vivía únicamente en el texto de M2 (`eda_text.py`) y en la auditoría de M3. Este PR hace que **el propio gráfico** marque el desbalance, en lenguaje gerencial sin jerga DS (mismo registro que el bloque business post-#318).

## Qué cambió

`backend/src/case_generator/datagen/eda_charts_business.py` (rama `class_balance`):

- **% por barra (siempre):** `text = f"{n} ({n/total:.0%})"` — el desbalance es visible sin leer la nota.
- **Constante de módulo** `_CLASS_BALANCE_MINORITY_WARN = 0.20` (espejando `_DRIVERS_MIN_ABS_CORR`), con comentario cross-ref al umbral "menos del 20%" del prompt M2 business.
- **Nota gerencial condicional** (incluye el % real) **solo** cuando `minority_share < 0.20`; balanceado deja `notes=''` (mismo patrón condicional que `_build_churn_drivers`). Prohibido jerga DS (Accuracy Paradox / AUC-ROC / matriz de confusión / precision/recall/F1).
- **Defensivo:** guard `total == 0` (aunque `is_binary` ya implica `total ≥ 2`); el builder corre en try-except que omite el chart si lanza.

Se preservan `id='class_balance'`, `chart_type='bar'`, `data_source='python_builder'` y la detección binaria `{0.0,1.0}`. La nota (~209 chars) cabe íntegra en el presupuesto de 300 chars de `_annotate_validate_emit` (`graph.py`), así que sobrevive sin clip.

## ml_ds queda intacto

El homólogo ml_ds `_build_class_distribution` (`eda_charts_classification.py`, id `class_distribution`) es un code path **separado, sin cross-import** — no se toca. Tampoco se toca `empty_chart()` / `eda_charts_common.py`. Suite completa verde confirma no-regresión.

## Tests (`backend/tests/test_eda_charts_business.py`)

- **Balanceado** (6/6, fixture existente extendido): `notes == ''` + `(50%)` en barras.
- **Desbalance severo** (1/12 ≈ 8%): nota contiene "poco frecuente" + `8%`; barras `1 (8%)` y `11 (92%)`; sin jerga; `len(notes) <= 300` (invariante no-clip).
- **Borde 20% exacto** (2/10): `notes == ''` (umbral estricto `<`, alinea "menos del 20%").
- Helper DRY `_df_business_binary_with_flags(flags)` para distribuciones controladas.

## Evidencia

- `pytest -q tests/test_eda_charts_business.py` → **49 passed**
- `pytest -q` (suite completa) → **1136 passed, 20 skipped** (ml_ds/`eda_charts_classification` verdes)
- `mypy src` → **Success, no issues** (82 files)
- `ruff check` (archivos tocados) → **All checks passed**

## Follow-ups (en `TODOS.md`)

- **TODO-321-A:** paridad de aviso en el chart ml_ds `class_distribution` (registro ml_ds, jerga permitida).
- **TODO-321-B:** single-source-of-truth del umbral 20%/4:1 (hoy en 2 prompts + 1 constante; low priority).

Closes #321