### PR TITLE
fix(business): gatear el heatmap de cohortes M2 por retención del target (#322)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1811,6 +1811,10 @@ pero no existe código que lo haga (grep no encontró `drop`/`exclude`/`filter` 
 tipo de caso; `_enforce_business_classification_schema` solo fuerza el decaimiento m1≥m3≥m6≥m12 en
 graph.py:3579, nunca elimina columnas). Gatear el cómputo (o eliminar las columnas de retención del
 schema) para casos business NO-retención, y reconciliar la promesa del prompt con la realidad.
+Además, el path LLM-JSON legacy (`EDA_CHART_GENERATOR_PROMPT`, `prompts/__init__.py:576-590`,
+vivo para business+familias-no-clasificación y ml_ds) tiene la MISMA selección de heatmap
+"de Retención" gateada solo por la existencia de `cohort_matrix` (CASO A, línea 578), sin mirar
+si el target es de retención — mismo bug que #322 fuera del path determinista. Gatearlo ahí también.
 
 **Why:** Cierra la causa raíz que #322 solo mitigó en la SELECCIÓN del chart. Hoy se computa y se
 pasa una matriz de cohortes que el builder ya ignora para casos NO-retención (artefacto fantasma +

--- a/TODOS.md
+++ b/TODOS.md
@@ -1798,3 +1798,39 @@ ml_ds; los prompts permanecen como prosa.
 
 **Depends on / blocked by:** Un 3.º consumidor de código del umbral o una solicitud de cambio del
 valor. No bloquea nada.
+
+---
+
+## TODO-COHORT-PRECOMPUTE-322: gatear el cómputo de `cohort_matrix` por retención (y reconciliar el prompt)
+
+**What:** `_calculate_eda_regressions` en `backend/src/case_generator/graph.py` (líneas 1309-1333)
+computa `cohort_matrix` para CUALQUIER dataset con `retention_m*` (≥2) + `period`, sin mirar si el
+objetivo del caso es de retención. Además, el prompt (`prompts/__init__.py:345-350`) promete que para
+clasificación NO-retención el pipeline "reemplaza determinísticamente las columnas churn/retención",
+pero no existe código que lo haga (grep no encontró `drop`/`exclude`/`filter` de `retention_m*` por
+tipo de caso; `_enforce_business_classification_schema` solo fuerza el decaimiento m1≥m3≥m6≥m12 en
+graph.py:3579, nunca elimina columnas). Gatear el cómputo (o eliminar las columnas de retención del
+schema) para casos business NO-retención, y reconciliar la promesa del prompt con la realidad.
+
+**Why:** Cierra la causa raíz que #322 solo mitigó en la SELECCIÓN del chart. Hoy se computa y se
+pasa una matriz de cohortes que el builder ya ignora para casos NO-retención (artefacto fantasma +
+cómputo desperdiciado), y el prompt afirma un paso que no se ejecuta (límite engañoso).
+
+**Pros:** Elimina el artefacto fantasma y el cómputo desperdiciado; defensa en profundidad detrás del
+gate del builder; el prompt deja de mentir sobre un paso inexistente.
+
+**Cons:** Toca el precompute de `graph.py` + el schema/datagen (la parte MÁS sensible del repo, mayor
+blast radius); requiere primero investigar si el reemplazo prometido vive en otro punto antes de
+escribirlo. Mayor superficie de tests/mypy.
+
+**Context:** Bug #322. El gate del builder (`eda_charts_business._build_cohort_collapse`, PR de #322)
+ya deja el OUTPUT correcto. Empezar por `graph.py:1309-1333` (cómputo incondicional) y
+`prompts/__init__.py:345-350` (promesa). El default del schema business siembra siempre
+`retention_m1/m3/m6/m12` (graph.py:2111-2114), así que un caso NO-retención los arrastra salvo que el
+case_architect los reemplace. Decidir: (a) gatear el cómputo por `is_retention_match` del target, o
+(b) eliminar `retention_m*` del schema en casos NO-retención e implementar de verdad la promesa del
+prompt. CLAUDE.md marca `case_generator/**` como sensible y `graph.py`/`prompts` sin ediciones
+cosméticas → requiere cuidado extra y tests.
+
+**Depends on / blocked by:** PR del gate de #322 mergeado primero (este deja el output correcto sin
+tocar el precompute).

--- a/backend/src/case_generator/datagen/eda_charts_business.py
+++ b/backend/src/case_generator/datagen/eda_charts_business.py
@@ -21,8 +21,8 @@ Pipeline (no LLM calls; pandas only):
    │                                             para el display; lo declara)      │
    │  2. churn_drivers      (bar horizontal)    |corr| reales con el objetivo,    │
    │                                            eje fijo [0,1] → sin exagerar      │
-   │  3. cohort_collapse    (heatmap)           retención por cohorte             │
-   │                                            (reusa precalculated cohort_matrix)│
+   │  3. cohort_collapse    (heatmap/bar/box)   retención por cohorte si el target │
+   │                                            es churn; si no, balance/box (#322) │
    └────────────────────────────────────────────────────────────────────────────┘
                                         ▼
             list[EDAChartSpec]  (data_source="python_builder",
@@ -444,14 +444,33 @@ def _build_churn_drivers(
 def _build_cohort_collapse(
     df: pd.DataFrame, target_col: str, precalculated_metrics: dict | None, source: str
 ) -> dict[str, Any]:
-    """Heatmap de retención por cohorte (reusa la matriz ya row-capped).
+    """3er chart M2 business — heatmap de retención SOLO si el target es de retención.
 
-    Si no hay matriz de cohortes, cae a una caja (box) de la distribución del
-    objetivo — nunca falsea una cohorte inexistente.
+    `cohort_matrix` se computa siempre en graph.py para cualquier dataset con
+    `retention_m*`+`period`, sin mirar el objetivo del caso (Issue #322). Por eso aquí
+    se gatea por `is_retention_match(target_col)`: un caso binario NO-retención (fraude,
+    impago, entrega tardía) que arrastre columnas de retención NO debe rotular un heatmap
+    "de Retención" — cae al chart relevante. Nunca falsea una cohorte inexistente.
+
+        cohort dict AND cohort["z"] AND is_retention ?        ◀━ gate (#322)
+          ├─ YES ─▶ [HEATMAP] "Retención de Cohortes"
+          └─ NO  ─▶ target in df AND numérico ?
+                      ├─ SÍ ─▶ binario {0,1} ? ─ SÍ ─▶ [CLASS_BALANCE bar]
+                      │                         └ NO ─▶ [BOX target_distribution]
+                      └─ NO ─▶ [EMPTY_CHART] título retention-aware (sin "Retención"
+                                             cuando is_retention es False)
     """
     pm = precalculated_metrics or {}
     cohort = pm.get("cohort_matrix")
-    if isinstance(cohort, dict) and cohort.get("z"):
+    # `is_retention_match` ya acepta str|None y vetea compuestos de gobernanza/RR.HH.
+    # (mismo predicado que `_drivers_title`); se computa una vez y se reutiliza en el
+    # gate del heatmap y en el título del empty_chart.
+    is_retention = is_retention_match(target_col)
+    # Issue #322 — el heatmap "de Retención" solo gana si el target ES de retención.
+    # Trade-off aceptado: un caso de churn con target de nombre genérico (p. ej.
+    # `categoria`) que el vocab no detecte cae a class_balance/box en vez de heatmap —
+    # seguro y relevante, y preferible a un heatmap "de Retención" en un caso de fraude.
+    if isinstance(cohort, dict) and cohort.get("z") and is_retention:
         return {
             "id": "cohort_collapse",
             "title": "El colapso del valor (Retención de Cohortes)",
@@ -565,13 +584,24 @@ def _build_cohort_collapse(
                 "data_source": "python_builder",
             }
 
+    # Issue #322 — título retention-aware: no rotular "Retención" cuando el caso no es
+    # de retención (mismo gate que el heatmap, vía `is_retention`).
+    if is_retention:
+        return empty_chart(
+            "cohort_collapse",
+            "El colapso del valor (Retención de Cohortes)",
+            "Sin columnas de retención ni objetivo numérico",
+            "heatmap",
+            source,
+            notes="No hay matriz de cohortes ni objetivo numérico para graficar.",
+        )
     return empty_chart(
         "cohort_collapse",
-        "El colapso del valor (Retención de Cohortes)",
-        "Sin columnas de retención ni objetivo numérico",
+        "El objetivo del caso",
+        "Sin objetivo numérico para graficar",
         "heatmap",
         source,
-        notes="No hay matriz de cohortes ni objetivo numérico para graficar.",
+        notes="No hay un objetivo numérico del caso para graficar.",
     )
 
 

--- a/backend/tests/test_eda_charts_business.py
+++ b/backend/tests/test_eda_charts_business.py
@@ -1133,3 +1133,86 @@ def test_churn_business_non_regression_three_retention_charts(
     assert drivers["title"] == "Factores asociados al abandono"
     # Eje simétrico [-1,1] (#320): conserva el anti-exageración de #296 y muestra dirección.
     assert drivers["layout"]["xaxis"]["range"] == [-1, 1]
+
+
+# ─────────────────────────────────────────────────────────
+# Issue #322 — el heatmap de cohortes se gatea por retención del target
+#
+# `cohort_matrix` se computa en graph.py para CUALQUIER dataset con retention_m*+period,
+# sin mirar el objetivo. Aquí inyectamos esa matriz en casos NO-retención para probar que
+# el 3er chart YA NO la usa para rotular un heatmap "de Retención", y que un caso de churn
+# sí lo conserva.
+# ─────────────────────────────────────────────────────────
+
+
+def test_cohort_non_retention_binary_with_cohort_uses_class_balance(
+    precalc_with_cohort,
+) -> None:
+    """Caso binario NO-retención que arrastra cohort_matrix → barra de balance de clases,
+    NO un heatmap "de Retención". Sin el gate este test fallaría (rendiría heatmap)."""
+    df = _df_business_binary()  # target NO-retención `late_partner_flag` {0,1}
+    charts = generate_business_eda_charts(
+        df,
+        "late_partner_flag",
+        {"cohort_matrix": precalc_with_cohort["cohort_matrix"]},
+        CONTRACT,
+    )
+    third = charts[2]
+    assert third["id"] == "class_balance"
+    assert third["chart_type"] == "bar"
+    assert "Retención" not in third["title"]
+
+
+def test_cohort_retention_binary_with_cohort_keeps_heatmap(precalc_with_cohort) -> None:
+    """No-regresión: un target de churn binario {0,1} con cohort presente sigue rindiendo
+    el heatmap de retención (el gate aprueba por el token 'churn')."""
+    df = _df_business_binary().rename(columns={"late_partner_flag": "churn_flag"})
+    charts = generate_business_eda_charts(
+        df,
+        "churn_flag",
+        {"cohort_matrix": precalc_with_cohort["cohort_matrix"]},
+        CONTRACT,
+    )
+    third = charts[2]
+    assert third["id"] == "cohort_collapse"
+    assert third["chart_type"] == "heatmap"
+    assert "Retención de Cohortes" in third["title"]
+
+
+def test_cohort_non_retention_continuous_with_cohort_falls_to_box(
+    precalc_with_cohort,
+) -> None:
+    """Target continuo NO-retención con cohort presente → caja de distribución (no heatmap).
+    Cubre la 3ra combinación nueva creada por el gate (continuo × cohort presente)."""
+    df = _df_business_binary()  # `partner_history_score` es continuo y NO-retención
+    charts = generate_business_eda_charts(
+        df,
+        "partner_history_score",
+        {"cohort_matrix": precalc_with_cohort["cohort_matrix"]},
+        CONTRACT,
+    )
+    third = charts[2]
+    assert third["id"] == "target_distribution"
+    assert third["chart_type"] == "box"
+    assert "Retención" not in third["title"]
+
+
+def test_cohort_empty_fallback_title_is_retention_aware() -> None:
+    """Sin cohort y sin objetivo numérico en el df, el empty_chart no debe rotular
+    "Retención" para un caso NO-retención; un caso de retención sí conserva el título."""
+    df = _df_business_binary()  # no contiene las columnas objetivo que pasamos abajo
+    # NO-retención: target ausente del df + sin cohort → empty, título neutro.
+    non_ret = next(
+        c
+        for c in generate_business_eda_charts(df, "fraud_target", {}, CONTRACT)
+        if c["id"] == "cohort_collapse"
+    )
+    assert "Retención" not in non_ret["title"]
+    assert "Retención" not in non_ret["subtitle"]
+    # Retención: target de churn ausente + sin cohort → empty, conserva el título clásico.
+    ret = next(
+        c
+        for c in generate_business_eda_charts(df, "churn_flag", {}, CONTRACT)
+        if c["id"] == "cohort_collapse"
+    )
+    assert "Retención de Cohortes" in ret["title"]


### PR DESCRIPTION
## Contexto (#322)

En **business + clasificación**, el 3er chart de M2 (`_build_cohort_collapse`) elegía la rama de **heatmap de retención** con solo comprobar que existía `cohort_matrix`, **sin verificar que el objetivo del caso fuera de retención/churn**, y **antes** de la rama `class_balance`. Un caso binario **NO-retención** (fraude, impago, entrega tardía) cuyo dataset arrastrara columnas `retention_m*`+`period` rendía un heatmap rotulado *"El colapso del valor (Retención de Cohortes)" / "% de usuarios retenidos…"* en vez del `class_balance` relevante.

**Corrige el cuerpo original de la issue: es una ruta normal sin gating, NO una corrupción.** `cohort_matrix` se computa **incondicionalmente** en `_calculate_eda_regressions` (`graph.py:1314`) para cualquier dataset con `retention_m*` (≥2) + `period`, **fresco por caso** (sin caché). El bug es la falta de gate en la SELECCIÓN del chart.

## Qué cambió (business-only)

- **Gate del heatmap** por `is_retention_match(target_col)` en `_build_cohort_collapse` — predicado ya importado y usado por `_drivers_title`; se computa **una vez** y se reutiliza. Resultado:
  - target de retención (`churn_*`) + cohort → **heatmap** (sin cambio)
  - binario NO-retención (`late_partner_flag`, `fraud_flag`) + cohort → **class_balance** (la corrección)
  - continuo NO-retención + cohort → **box**
- **empty_chart retention-aware:** ya no rotula "Retención" cuando el caso no es de retención (cierra el último camino del mismo síntoma).
- **Diagrama de decisión ASCII** en el docstring + resumen del módulo actualizado.

No se tocó `eda_charts_classification.py` (ml_ds), el helper compartido `empty_chart()`, ni el cómputo de `cohort_matrix` en `graph.py`.

## Trade-off documentado

Un caso de churn con target de nombre **genérico** (p. ej. `categoria`) que `is_retention_match` no detecte caería a `class_balance`/`box` en vez de heatmap. Es aceptable y seguro (siguen siendo charts relevantes para ese objetivo) y preferible a un heatmap "de Retención" en un caso de fraude. Anotado en comentario.

## Tests (`backend/tests/test_eda_charts_business.py`)

4 nuevos:
- **binario NO-retención + cohort presente → `class_balance` bar** (la regresión clave; sin el gate rendiría heatmap)
- **churn binario + cohort presente → heatmap** (no-regresión)
- **continuo NO-retención + cohort presente → box** (3ra combinación nueva creada por el gate)
- **empty_chart con título retention-aware** (sin "Retención" para NO-retención; lo conserva para churn)

Se mantienen verdes `test_cohort_collapse_uses_precalculated_matrix`, `test_cohort_collapse_fallback_to_box`, `test_cohort_fallback_binary_target_uses_class_balance_bar`.

## Evidencia

- `uv run --directory backend pytest -q tests/test_eda_charts_business.py` → **53 passed**
- `uv run --directory backend pytest -q` → **1140 passed, 20 skipped** (ml_ds/`eda_charts_classification` verdes)
- `uv run --directory backend mypy src` → **Success: no issues found in 82 source files**
- `uv run --directory backend ruff check src/case_generator/datagen/eda_charts_business.py` → **All checks passed!**

## Seguimiento (fuera de alcance — anotado en `TODOS.md`)

`TODO-COHORT-PRECOMPUTE-322`: el cómputo de `cohort_matrix` ocurre para **cualquier** dataset con `retention_m*`+`period` (`graph.py:1309-1333`), y la promesa del prompt (`prompts/__init__.py:345-350`) de "reemplazo determinístico" de columnas de retención para casos NO-retención **no está implementada** en código. Mayor blast radius (precompute + schema, módulo sensible). Este PR deja el **output** correcto sin meterse ahí.

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)
