### PR TITLE
fix(business): gate cohort_matrix computation by retention (#326)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1801,40 +1801,54 @@ valor. No bloquea nada.
 
 ---
 
-## TODO-COHORT-PRECOMPUTE-322: gatear el cómputo de `cohort_matrix` por retención (y reconciliar el prompt)
+## TODO-COHORT-PRECOMPUTE-322: gatear el cómputo de `cohort_matrix` por retención — ✅ RESUELTO (#326)
 
-**What:** `_calculate_eda_regressions` en `backend/src/case_generator/graph.py` (líneas 1309-1333)
-computa `cohort_matrix` para CUALQUIER dataset con `retention_m*` (≥2) + `period`, sin mirar si el
-objetivo del caso es de retención. Además, el prompt (`prompts/__init__.py:345-350`) promete que para
-clasificación NO-retención el pipeline "reemplaza determinísticamente las columnas churn/retención",
-pero no existe código que lo haga (grep no encontró `drop`/`exclude`/`filter` de `retention_m*` por
-tipo de caso; `_enforce_business_classification_schema` solo fuerza el decaimiento m1≥m3≥m6≥m12 en
-graph.py:3579, nunca elimina columnas). Gatear el cómputo (o eliminar las columnas de retención del
-schema) para casos business NO-retención, y reconciliar la promesa del prompt con la realidad.
-Además, el path LLM-JSON legacy (`EDA_CHART_GENERATOR_PROMPT`, `prompts/__init__.py:576-590`,
-vivo para business+familias-no-clasificación y ml_ds) tiene la MISMA selección de heatmap
-"de Retención" gateada solo por la existencia de `cohort_matrix` (CASO A, línea 578), sin mirar
-si el target es de retención — mismo bug que #322 fuera del path determinista. Gatearlo ahí también.
+**Estado:** RESUELTO por Issue #326 (`fix/issue-326-cohort-precompute-gate`). El cómputo de
+`cohort_matrix` en `_calculate_eda_regressions` (`graph.py`) ahora se gatea con
+`profile != "ml_ds" and is_retention_match(target_col)` — el MISMO predicado que la selección
+determinista business (`eda_charts_business.py`), así computar ⟺ seleccionar. Para casos
+NO-retención el artefacto desaparece de `precalculated_metrics`, por lo que el path LLM-JSON legacy
+(`EDA_CHART_GENERATOR_PROMPT`, CASO A "si existe la clave cohort_matrix") cae naturalmente a CASO B
+(box/violin) sin tocar el prompt. ml_ds nunca computa el artefacto (su panel determinista no
+renderiza cohort heatmap). #322 no se regresa: business churn sigue mostrando el heatmap.
 
-**Why:** Cierra la causa raíz que #322 solo mitigó en la SELECCIÓN del chart. Hoy se computa y se
-pasa una matriz de cohortes que el builder ya ignora para casos NO-retención (artefacto fantasma +
-cómputo desperdiciado), y el prompt afirma un paso que no se ejecuta (límite engañoso).
+**Corrección de premisa (el cuerpo original de este TODO y el de #326 eran incorrectos en un
+punto):** SÍ existe código que reemplaza determinísticamente las columnas churn/retención para
+business clasificación NO-retención — `_enforce_business_classification_schema` elimina
+`_CHURN_TEMPLATE_COLUMNS = {churn_rate, nps, retention_m1/m3/m6/m12}` en `graph.py:2962`, gateado por
+`profile=="business" AND family=="clasificacion"` y por `_is_retention_target_name(target)`. El grep
+original falló porque buscaba `drop`/`filter`/`retention_m`, pero el código usa un frozenset nombrado.
+La promesa del prompt (`prompts/__init__.py:345-350`) por tanto NO mentía para business. El residual
+real era (a) el cómputo incondicional del artefacto y (b) ml_ds, que conserva `retention_m*` en su
+schema fijo de 18 columnas → ambos cerrados por el gate del cómputo. Ver TODO-ML-DS-RETENTION-AWARE
+para el stripping del schema ml_ds (gated por ADR).
 
-**Pros:** Elimina el artefacto fantasma y el cómputo desperdiciado; defensa en profundidad detrás del
-gate del builder; el prompt deja de mentir sobre un paso inexistente.
+---
 
-**Cons:** Toca el precompute de `graph.py` + el schema/datagen (la parte MÁS sensible del repo, mayor
-blast radius); requiere primero investigar si el reemplazo prometido vive en otro punto antes de
-escribirlo. Mayor superficie de tests/mypy.
+## TODO-ML-DS-RETENTION-AWARE: ml_ds retention-awareness (stripping de schema + cohort heatmap) — ADR
 
-**Context:** Bug #322. El gate del builder (`eda_charts_business._build_cohort_collapse`, PR de #322)
-ya deja el OUTPUT correcto. Empezar por `graph.py:1309-1333` (cómputo incondicional) y
-`prompts/__init__.py:345-350` (promesa). El default del schema business siembra siempre
-`retention_m1/m3/m6/m12` (graph.py:2111-2114), así que un caso NO-retención los arrastra salvo que el
-case_architect los reemplace. Decidir: (a) gatear el cómputo por `is_retention_match` del target, o
-(b) eliminar `retention_m*` del schema en casos NO-retención e implementar de verdad la promesa del
-prompt. CLAUDE.md marca `case_generator/**` como sensible y `graph.py`/`prompts` sin ediciones
-cosméticas → requiere cuidado extra y tests.
+**What:** Hacer el perfil **ml_ds** clasificación consciente de retención, en simetría con business:
+(1) eliminar las columnas plantilla churn/retención (`retention_m*`, `churn_rate`, `nps`) del schema
+fijo de 18 columnas en casos NO-retención (hoy se conservan siempre); y (2) opcionalmente renderizar
+un cohort heatmap en el panel determinista ml_ds para casos de churn legítimos (la brecha de feature
+que deja la decisión 1A de #326: ml_ds nunca muestra cohort heatmap).
 
-**Depends on / blocked by:** PR del gate de #322 mergeado primero (este deja el output correcto sin
-tocar el precompute).
+**Why:** #326 elimina el ARTEFACTO fantasma (`cohort_matrix`) sin tocar el schema, pero un caso ml_ds
+de fraude/crédito/logística sigue arrastrando columnas `retention_m*`/`churn_rate`/`nps` fantasma en
+el dataset. Cerrar del todo la causa raíz exige cambiar el schema ml_ds.
+
+**Pros:** El dataset habla del dominio real del caso (sin columnas churn en un caso de fraude);
+elimina el último fantasma; simetría con el path business.
+
+**Cons:** Cambia el contrato documentado del schema ml_ds (18 columnas exactas en
+`prompts/clasificacion/M2_clasificacion/dataset.py:88-107`). CLAUDE.md trata el schema como contrato
+→ **requiere un ADR** + actualizaciones coordinadas backend/frontend/docs. Mayor blast radius, zona
+más sensible del repo.
+
+**Context:** Carved out de TODO-COHORT-PRECOMPUTE-322 al resolver #326. El gate del cómputo (#326) ya
+deja el output correcto sin tocar el schema. La señal de retención para ml_ds es no trivial: el target
+es siempre `categoria` e `is_retention_match` es English-only (no matchea prosa española "retención"),
+así que el ADR debe definir la señal (p. ej. `target_column.description`/`is_leakage_risk` del
+contrato, o un detector de tema bilingüe) antes de implementar.
+
+**Depends on / blocked by:** ADR aprobado; PR de #326 mergeado primero.

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -1266,10 +1266,12 @@ def _identify_target_variable(state: ADAMState, df: 'pd.DataFrame') -> str:
 def _calculate_eda_regressions(state: ADAMState, dataset: list[dict]) -> dict:
     """Calcula métricas precalculadas para el EDA Chart Generator.
 
-    Siempre computa correlation_matrix y cohort_matrix cuando hay datos
-    suficientes — independientemente de si se identifica un target_col.
-    Las regresiones lineales (target_vs_X) son opcionales y se omiten
-    sin early-return cuando target_col no está disponible.
+    Siempre computa correlation_matrix cuando hay datos suficientes. cohort_matrix
+    (artefacto de retención) SOLO se computa en casos de retención — Issue #326:
+    business con target de retención (mismo predicado que la selección determinista,
+    eda_charts_business.py); nunca para ml_ds (su panel determinista no renderiza
+    cohort heatmap). Las regresiones lineales (target_vs_X) son opcionales y se
+    omiten sin early-return cuando target_col no está disponible.
 
     Fix v8.2: el early-return previo en "target_col not found" dejaba
     precalculated_metrics = {} y el LLM no tenía matriz para heatmaps.
@@ -1306,12 +1308,27 @@ def _calculate_eda_regressions(state: ADAMState, dataset: list[dict]) -> dict:
                 "z": corr_matrix.values.tolist(),
             }
 
-        # ── 2. Cohort matrix (siempre, si las columnas existen) ───────────────
+        # ── 2. Cohort matrix (SOLO en casos de RETENCIÓN — Issue #326) ────────
+        # El heatmap de cohortes es un artefacto de retención. Antes se computaba
+        # para CUALQUIER dataset con retention_m* (≥2) + period, dejando un
+        # artefacto fantasma en casos NO-retención. Lo gateamos con el MISMO
+        # predicado que la selección determinista business (is_retention_match,
+        # eda_charts_business.py:473), así computar ⟺ seleccionar: nunca queda un
+        # fantasma ni se suprime un heatmap legítimo de #322.
+        #
+        #   business + target de retención → cohort COMPUTADO  (preserva #322)
+        #   business + target NO-retención → cohort AUSENTE     (builder→box; LLM-JSON→CASO B)
+        #   ml_ds (cualquier tema)         → cohort AUSENTE     (el panel determinista
+        #                                                        ml_ds no renderiza cohort heatmap)
+        target_col = _identify_target_variable(state, df)
+        profile = state.get("studentProfile", "business")
+        is_retention_case = profile != "ml_ds" and is_retention_match(target_col)
+
         retention_cols = sorted(
             [c for c in df.columns if c.startswith("retention_m")],
             key=lambda x: int(x.split("_m")[1])
         )
-        if len(retention_cols) >= 2 and "period" in df.columns:
+        if is_retention_case and len(retention_cols) >= 2 and "period" in df.columns:
             # Limita a las primeras MAX_COHORT_ROWS cohortes: legibles, todas
             # históricas (empiezan en 2023-01 → sin fechas futuras) y las más
             # observadas a M12. Sin recorte, las 80-120 filas del dataset business
@@ -1333,8 +1350,7 @@ def _calculate_eda_regressions(state: ADAMState, dataset: list[dict]) -> dict:
             }
 
         # ── 3. Regresiones lineales (opcional — requiere target_col) ──────────
-        target_col = _identify_target_variable(state, df)
-
+        # target_col ya se identificó arriba (gate de cohort) — se reutiliza aquí.
         if not target_col or target_col not in df.columns:
             # No target → skip regressions, but still return matrices above
             return results

--- a/backend/tests/test_cohort_heatmap_row_cap.py
+++ b/backend/tests/test_cohort_heatmap_row_cap.py
@@ -1,4 +1,4 @@
-"""Tests for the business cohort-retention heatmap row cap.
+"""Tests for the cohort-retention heatmap: row cap + retention gate (Issue #326).
 
 Surface tested:
   - _calculate_eda_regressions caps cohort_matrix to the first MAX_COHORT_ROWS (12)
@@ -7,6 +7,12 @@ Surface tested:
   - The cap preserves chronological order (first 12 ascending periods) and the
     retention column axis (M1/M3/M6/M12), and z stays row-aligned with y.
   - Datasets with fewer than 12 cohorts are returned uncapped.
+  - Issue #326 — cohort_matrix is a RETENTION artifact: it is computed ONLY when the
+    case is about retention, using the same `is_retention_match(target_col)` predicate
+    as the deterministic business chart selection (eda_charts_business.py). Business +
+    non-retention target → absent; ml_ds (any theme) → absent (its deterministic panel
+    never renders a cohort heatmap). The row-cap tests therefore pass a retention
+    target so the gate opens and the cap behavior is still exercised.
 
 Cero LLMs, cero red, cero DB. Tests puros y rápidos.
 """
@@ -15,12 +21,17 @@ from __future__ import annotations
 
 from case_generator.graph import _calculate_eda_regressions
 
+# A retention target opens the cohort gate (is_retention_match("churn_rate") is True),
+# so the row-cap behavior below is exercised exactly as before the gate landed.
+_RETENTION_STATE: dict = {"dataset_metadata": {"target_variable": "churn_rate"}}
+
 
 def _make_cohort_dataset(n_rows: int) -> list[dict]:
     """Build a synthetic business cohort dataset with ascending monthly periods.
 
     Mirrors the deterministic generator: period 'YYYY-MM' ascending from 2023-01,
-    plus the four retention columns the M2 dataset contract defines.
+    plus churn_rate (the retention target) and the four retention columns the M2
+    dataset contract defines.
     """
     rows: list[dict] = []
     for i in range(n_rows):
@@ -40,11 +51,26 @@ def _make_cohort_dataset(n_rows: int) -> list[dict]:
     return rows
 
 
+def _make_non_retention_dataset(n_rows: int) -> list[dict]:
+    """Cohort-shaped dataset whose target is NON-retention (fraud).
+
+    retention_m* + period are present (the phantom scenario the gate guards against),
+    but the case is about fraud — so cohort_matrix must NOT be computed.
+    """
+    rows = _make_cohort_dataset(n_rows)
+    for i, row in enumerate(rows):
+        row["fraud_flag"] = i % 2
+    return rows
+
+
+# ── Row-cap behavior (retention case — gate open) ─────────────────────────────
+
+
 def test_cohort_matrix_is_capped_to_twelve_rows() -> None:
     """A 30-cohort dataset must yield exactly 12 rows in the heatmap matrix."""
     dataset = _make_cohort_dataset(30)
 
-    result = _calculate_eda_regressions(state={}, dataset=dataset)
+    result = _calculate_eda_regressions(state=_RETENTION_STATE, dataset=dataset)
 
     assert "cohort_matrix" in result
     cohort = result["cohort_matrix"]
@@ -58,7 +84,7 @@ def test_cohort_matrix_keeps_first_twelve_chronological_cohorts() -> None:
     """The cap selects the 12 earliest cohorts (chronological order preserved)."""
     dataset = _make_cohort_dataset(30)
 
-    cohort = _calculate_eda_regressions(state={}, dataset=dataset)["cohort_matrix"]
+    cohort = _calculate_eda_regressions(state=_RETENTION_STATE, dataset=dataset)["cohort_matrix"]
 
     expected_periods = [row["period"] for row in dataset[:12]]
     assert cohort["y"] == expected_periods
@@ -70,7 +96,7 @@ def test_cohort_matrix_axis_labels_are_retention_months() -> None:
     """x axis is the uppercased retention months (M1/M3/M6/M12)."""
     dataset = _make_cohort_dataset(15)
 
-    cohort = _calculate_eda_regressions(state={}, dataset=dataset)["cohort_matrix"]
+    cohort = _calculate_eda_regressions(state=_RETENTION_STATE, dataset=dataset)["cohort_matrix"]
 
     assert cohort["x"] == ["M1", "M3", "M6", "M12"]
 
@@ -79,7 +105,49 @@ def test_cohort_matrix_below_cap_is_not_truncated() -> None:
     """A dataset with fewer than 12 cohorts is returned in full."""
     dataset = _make_cohort_dataset(5)
 
-    cohort = _calculate_eda_regressions(state={}, dataset=dataset)["cohort_matrix"]
+    cohort = _calculate_eda_regressions(state=_RETENTION_STATE, dataset=dataset)["cohort_matrix"]
 
     assert len(cohort["y"]) == 5
     assert len(cohort["z"]) == 5
+
+
+# ── Retention gate (Issue #326) ───────────────────────────────────────────────
+
+
+def test_cohort_matrix_computed_for_business_retention_case() -> None:
+    """T1 — business + retention target: cohort_matrix IS computed (preserves #322)."""
+    result = _calculate_eda_regressions(
+        state=_RETENTION_STATE, dataset=_make_cohort_dataset(15)
+    )
+
+    assert "cohort_matrix" in result
+
+
+def test_cohort_matrix_absent_for_business_non_retention_case() -> None:
+    """T2 — business + non-retention target: cohort_matrix is NOT computed even though
+    retention_m* + period are present; correlation_matrix is still computed.
+
+    This absence is also what makes the legacy LLM-JSON EDA path fall to CASO B
+    (box/violin) instead of selecting the cohort heatmap (decision 2A/4A).
+    """
+    result = _calculate_eda_regressions(
+        state={"dataset_metadata": {"target_variable": "fraud_flag"}},
+        dataset=_make_non_retention_dataset(15),
+    )
+
+    assert "cohort_matrix" not in result
+    assert "correlation_matrix" in result
+
+
+def test_cohort_matrix_absent_for_ml_ds_even_when_retention_themed() -> None:
+    """T3 — ml_ds never computes cohort_matrix, even for a churn-themed case
+    (decision 1A: the ml_ds deterministic panel never renders a cohort heatmap)."""
+    result = _calculate_eda_regressions(
+        state={
+            "studentProfile": "ml_ds",
+            "dataset_metadata": {"target_variable": "churn_rate"},
+        },
+        dataset=_make_cohort_dataset(15),
+    )
+
+    assert "cohort_matrix" not in result


### PR DESCRIPTION
## Context

`_calculate_eda_regressions` computed `cohort_matrix` (a retention-cohort heatmap artifact) for **any** dataset with ≥2 `retention_m*` columns + a `period` column, **without checking whether the case is about retention** (`graph.py:1314`). Issue #322 (PR #327) gated only the *deterministic business chart selection* by `is_retention_match(target_col)`; the **root cause** — the artifact computation and the legacy LLM-JSON path that selects the cohort heatmap purely on `cohort_matrix` existence — stayed open.

## Premise correction (the #326 body and the TODO were wrong on one point)

For **business** classification, the churn/retention columns **are** stripped when the target is non-retention: `_enforce_business_classification_schema` removes `_CHURN_TEMPLATE_COLUMNS = {churn_rate, nps, retention_m1/m3/m6/m12}` at `graph.py:2962`, gated by `business AND clasificacion`. The TODO's *"no existe código que lo haga"* was false — the original grep looked for `drop`/`filter`/`retention_m`, but the code uses a named frozenset.

## The real residual

- **ml_ds** classification always ships the fixed 18-column schema *including* `retention_m*`, and its target is always `categoria` — so a non-retention ml_ds case (fraud/credit/logistics) **always** computed a phantom `cohort_matrix`.
- The ml_ds *deterministic* panel never renders a cohort heatmap at all, so for ml_ds the artifact was a pure phantom (only the rare LLM-JSON fallback could surface it).

## Approach (single lever)

Gate the **computation** with the **same predicate** the #322 business selection gate uses — `profile != "ml_ds" and is_retention_match(target_col)` (`eda_charts_business.py:473`). Now **compute ⟺ select**: no phantom, no suppressed legit heatmap.

Because non-retention cases no longer carry `cohort_matrix` in `precalculated_metrics`, the legacy LLM-JSON path (`EDA_CHART_GENERATOR_PROMPT`, CASO A *"si existe la clave cohort_matrix"*) **falls naturally to CASO B** (box/violin) — **no prompt edit needed**. ml_ds never computes the artifact (decision 1A).

### Changes
- **`graph.py`** — move `target_col` above the cohort block (dedup the later call), add the retention gate, refresh the now-stale docstring + inline comment.
- **`test_cohort_heatmap_row_cap.py`** — make the 4 row-cap tests retention-positive; add **T1** (business retention → present), **T2** (business non-retention → absent, correlation present — also the LLM-JSON CASO B input contract), **T3** (ml_ds → absent even when churn-themed).
- **`TODOS.md`** — mark `TODO-COHORT-PRECOMPUTE-322` resolved + correct the false stripping claim; carve out the ADR-gated `TODO-ML-DS-RETENTION-AWARE` (ml_ds schema stripping + optional ml_ds cohort heatmap).

## Invariants held
- **#322 not regressed** — business churn still shows the heatmap; the deterministic gate at `eda_charts_business.py:473` is untouched.
- `correlation_matrix`, the m1≥m3≥m6≥m12 decay, and the business stripping are **not** touched.

## Verification
- `uv run --directory backend pytest -q` → **1143 passed, 20 skipped**
- `uv run --directory backend mypy src` → Success, no issues (82 files)
- `uv run --directory backend ruff check src/case_generator/graph.py` → zero new errors (104 on both `main` and branch)

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)