### PR TITLE
fix(case_generator): unificar el scrub de seguridad en la validación de generación del notebook M3

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -163,6 +163,7 @@ from case_generator.m3_notebook_execution import (
     execute_m3_notebook,
     format_execution_failure_for_prompt,
     is_m3_quality_warning_blocking,
+    scrub_notebook_for_safe_execution,
 )
 from case_generator.tools_and_schemas import (
     CaseArchitectOutput,
@@ -5104,6 +5105,41 @@ def _validate_notebook_family_consistency(
     return violations
 
 
+def _detect_unsafe_constructs(code: str) -> list[str]:
+    """Return safety violations for a generated notebook, generation-side.
+
+    Reuses the AST-only ``scrub_notebook_for_safe_execution`` (no subprocess) so
+    the single denylist (``locals``/``globals``/``eval``/denied imports/…) is the
+    one source of truth shared with the execution-time scrub in
+    ``m3_notebook_executor``. The scrubber fails fast on the first offending cell,
+    so this returns at most one finding per call — enough to drive the
+    reprompt-once mechanism. The finding is prefixed with ``"INSEGURO: "`` so it
+    flows through the same ``violations`` list as ``FALTANTE:``/prohibited entries
+    in ``_invoke_m3_notebook_algo_section``.
+
+    Empty list = clean. Catching the unsafe construct here (before the notebook is
+    stored in state) lets the SAME reprompt that strips ``locals()`` also keep the
+    family-required APIs/sentinels intact, instead of the disjoint two-stage path
+    where the execution-time scrub triggers a blind full regeneration that can drop
+    a required artefact (Issue: M3 ml_ds clasificación ``locals()`` escalation).
+    """
+    try:
+        scrub_notebook_for_safe_execution(code)
+    except M3NotebookExecutionError as exc:
+        if exc.kind in ("unsafe_code", "syntax_error"):
+            return [f"INSEGURO: {exc}"]
+        return [f"INSEGURO: {exc.kind}"]
+    except Exception as exc:
+        # Defensivo: el detector NUNCA debe crashear el job. `ast.parse` puede
+        # lanzar RecursionError/ValueError (no SyntaxError) ante código patológico
+        # generado por el LLM (p. ej. una expresión plana de miles de términos).
+        # Cualquier fallo inesperado del scrubber se reporta como INSEGURO y se
+        # enruta por el reprompt-once → falla cerrada con mensaje claro, jamás
+        # como excepción opaca.
+        return [f"INSEGURO: scrub_error:{type(exc).__name__}"]
+    return []
+
+
 @dataclass(frozen=True)
 class _M3NotebookGenerationContext:
     llm: Any
@@ -5223,12 +5259,34 @@ def _build_m3_notebook_validation_correction(
     notebook_variant: str | None = None,
 ) -> str:
     missing = [v.removeprefix("FALTANTE: ") for v in violations if v.startswith("FALTANTE: ")]
-    prohibited_hits = [v for v in violations if not v.startswith("FALTANTE: ")]
+    unsafe_hits = [v.removeprefix("INSEGURO: ") for v in violations if v.startswith("INSEGURO: ")]
+    prohibited_hits = [
+        v
+        for v in violations
+        if not v.startswith("FALTANTE: ") and not v.startswith("INSEGURO: ")
+    ]
     corrective_blocks: list[str] = ["\n\n# CORRECCIÓN OBLIGATORIA"]
     if notebook_variant:
         corrective_blocks.append(
             f"# Variante de notebook requerida: {notebook_variant}. "
             "No agregues secciones, métricas ni imports de modelos fuera de esa variante."
+        )
+    if unsafe_hits:
+        bullet_list = "\n".join(f"#   - {tok}" for tok in unsafe_hits)
+        corrective_blocks.append(
+            "# Tu salida anterior usó introspección dinámica o un escape de runtime PROHIBIDO\n"
+            "# en una celda ejecutable (el kernel limpio la rechaza):\n"
+            f"{bullet_list}\n"
+            "# PROHIBIDO usar globals(), locals(), vars(), getattr(...), __builtins__,\n"
+            "# __import__, eval(...) o exec(...) en cualquier celda ejecutable.\n"
+            "# Si necesitas comprobar si una variable existe, usa try/except NameError.\n"
+            "# Ejemplo permitido:\n"
+            "# try:\n"
+            "#     X_train\n"
+            "#     y_train\n"
+            "# except NameError:\n"
+            "#     # recrear splits con train_test_split(...)\n"
+            "# Reescribe la salida COMPLETA conservando TODAS las sentinelas y APIs requeridas."
         )
     if prohibited_hits:
         corrective_blocks.append(
@@ -5265,14 +5323,28 @@ def _invoke_m3_notebook_algo_section(
     print(f"[{node_name}] Sección módulos LLM (1ª pasada): {len(algo_section)} chars")
 
     violations = _validate_notebook_family_consistency(family, algo_section, notebook_variant)
+    # Safety scrub is scoped to clasificacion — the ONLY family the executor runs
+    # and scrubs (graph.py m3_notebook_executor gate), the only family the bug
+    # occurred in, and the only one with a required-API contract. The other 3
+    # families' notebooks are never executed server-side, so applying the denylist
+    # there would be new policy with false-positive risk (e.g. dir()/getattr() in
+    # pedagogical code), not a bug fix. Keep blast radius == executor scope.
+    if family == "clasificacion":
+        violations += _detect_unsafe_constructs(algo_section)
     if not violations:
         return algo_section
 
     missing = [v.removeprefix("FALTANTE: ") for v in violations if v.startswith("FALTANTE: ")]
-    prohibited_hits = [v for v in violations if not v.startswith("FALTANTE: ")]
+    unsafe_hits = [v.removeprefix("INSEGURO: ") for v in violations if v.startswith("INSEGURO: ")]
+    prohibited_hits = [
+        v
+        for v in violations
+        if not v.startswith("FALTANTE: ") and not v.startswith("INSEGURO: ")
+    ]
     print(
-        f"[{node_name}] Violación de familia detectada (familia={family}, "
-        f"prohibited={prohibited_hits}, faltantes={missing}). Reprompt explícito (1/1)."
+        f"[{node_name}] Violación detectada (familia={family}, "
+        f"prohibited={prohibited_hits}, faltantes={missing}, inseguros={unsafe_hits}). "
+        "Reprompt explícito (1/1)."
     )
     reprompt = prompt_with_context + _build_m3_notebook_validation_correction(
         family,
@@ -5282,14 +5354,17 @@ def _invoke_m3_notebook_algo_section(
     response2 = llm.invoke(reprompt)
     algo_section = sanitize_markdown(_extract_text(response2))
     violations2 = _validate_notebook_family_consistency(family, algo_section, notebook_variant)
+    if family == "clasificacion":
+        violations2 += _detect_unsafe_constructs(algo_section)
     if violations2:
         logger.error(
             "[%s] Reprompt falló — familia=%s violations=%s",
             node_name, family, violations2,
         )
         raise RuntimeError(
-            f"M3 notebook generator no satisfizo la familia "
-            f"'{family}' incluso tras un reprompt: {violations2}. "
+            f"M3 notebook generator no satisfizo las validaciones de notebook "
+            f"(familia/seguridad) para '{family}' incluso tras un reprompt: "
+            f"{violations2}. "
             f"Job marcado como fallido para evitar shipping de notebook roto."
         )
     print(f"[{node_name}] Reprompt OK — familia={family}, chars={len(algo_section)}")

--- a/backend/tests/test_m3_notebook_unsafe_generation_guard.py
+++ b/backend/tests/test_m3_notebook_unsafe_generation_guard.py
@@ -1,0 +1,279 @@
+"""Regression: unify the AST safety scrub into the M3 notebook generation loop.
+
+Bug (ml_ds + clasificación): ``m3_notebook_generator`` (Flash) emitted a
+``locals()`` existence-guard into a code cell. The family-consistency validator
+does NOT check for unsafe builtins, so the notebook — otherwise complete, with
+``precision_recall_curve(`` and all sentinels — passed generation and was stored.
+At ``m3_notebook_executor`` the AST safety scrub correctly rejected ``locals()``,
+which then triggered a blind FULL regeneration of the algo section. That re-roll
+dropped ``precision_recall_curve(`` and the job died on a *different* axis with
+``RuntimeError ['FALTANTE: precision_recall_curve(']``.
+
+Root cause: the safety check and the family check ran at disjoint stages, so
+fixing one re-rolled the dice on the other. The fix routes unsafe-construct
+detection through the SAME generation-time reprompt-once loop that already
+enforces required APIs/sentinels, so one pass enforces both axes at once.
+
+Pure/unit coverage. No LLM, no DB, no network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from case_generator.graph import (
+    _build_m3_notebook_validation_correction,
+    _detect_unsafe_constructs,
+    _invoke_m3_notebook_algo_section,
+    _validate_notebook_family_consistency,
+)
+
+
+# A family-complete, valid-Python classification algo section: contains every
+# required sentinel + every required API call site, and zero unsafe constructs.
+# A guard assertion below proves it is actually complete, so this fixture fails
+# loudly (not silently) if the clasificación contract ever changes.
+_COMPLETE_CLASSIFICATION_ALGO = """# %%
+# === SECTION:dummy_baseline ===
+# === SECTION:pipeline_lr ===
+# === SECTION:pipeline_rf ===
+# === SECTION:cv_scores ===
+# === SECTION:roc_curves ===
+# === SECTION:pr_curves ===
+# === SECTION:comparison_table ===
+# === SECTION:confusion_matrix ===
+# === SECTION:cost_matrix ===
+# === SECTION:tuning_lr ===
+# === SECTION:tuning_rf ===
+# === SECTION:interp_lr ===
+# === SECTION:interp_rf ===
+# === SECTION:metrics_summary_json ===
+from sklearn.dummy import DummyClassifier
+from sklearn.compose import ColumnTransformer
+from sklearn.model_selection import (
+    StratifiedKFold,
+    cross_val_score,
+    train_test_split,
+    GridSearchCV,
+    RandomizedSearchCV,
+)
+from sklearn.inspection import permutation_importance, PartialDependenceDisplay
+from sklearn.metrics import (
+    roc_curve,
+    precision_recall_curve,
+    confusion_matrix,
+    ConfusionMatrixDisplay,
+)
+
+
+def _run(X, y, proba, preds, X_te, y_te):
+    model = DummyClassifier()
+    ct = ColumnTransformer([])
+    skf = StratifiedKFold()
+    scores = cross_val_score(model, X, y, cv=skf)
+    X_tr, X_te2, y_tr, y_te2 = train_test_split(X, y)
+    gs = GridSearchCV(model, {})
+    rs = RandomizedSearchCV(model, {}, n_iter=2)
+    perm = permutation_importance(model, X_te, y_te)
+    disp = PartialDependenceDisplay.from_estimator(model, X_te, [0])
+    fpr, tpr, _ = roc_curve(y_te, proba)
+    prec, rec, _ = precision_recall_curve(y_te, proba)
+    cm = confusion_matrix(y_te, preds)
+    ConfusionMatrixDisplay(cm).plot()
+    out = model.predict_proba(X_te)
+    return scores, ct, gs, rs, perm, disp, out
+"""
+
+# Same complete section, but with the forbidden existence-guard that the original
+# bug emitted. Family-complete, yet unsafe.
+_UNSAFE_CLASSIFICATION_ALGO = (
+    _COMPLETE_CLASSIFICATION_ALGO + '\nif "X_train" in locals():\n    pass\n'
+)
+
+# Safe (no locals) but drops the precision_recall_curve(...) CALL — reproduces the
+# axis the original blind regeneration failed on. The import name remains but has
+# no "(" so the validator (which requires "precision_recall_curve(") flags it.
+_MISSING_PR_CLASSIFICATION_ALGO = _COMPLETE_CLASSIFICATION_ALGO.replace(
+    "    prec, rec, _ = precision_recall_curve(y_te, proba)\n",
+    "    prec, rec = (0.0, 0.0)\n",
+)
+
+
+class _StubResponse:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _SequenceLLM:
+    """Returns canned responses in order; records every prompt it received."""
+
+    def __init__(self, contents: list[str]) -> None:
+        self._contents = list(contents)
+        self.prompts: list[str] = []
+
+    def invoke(self, prompt: str) -> _StubResponse:
+        self.prompts.append(prompt)
+        return _StubResponse(self._contents.pop(0))
+
+
+def test_fixture_is_actually_family_complete_and_safe() -> None:
+    """Guard: if the clasificación contract drifts, fail here with a clear name."""
+    assert _validate_notebook_family_consistency(
+        "clasificacion", _COMPLETE_CLASSIFICATION_ALGO, None
+    ) == []
+    assert _detect_unsafe_constructs(_COMPLETE_CLASSIFICATION_ALGO) == []
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _detect_unsafe_constructs — the new generation-side safety check
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_detect_unsafe_flags_locals_with_prefix() -> None:
+    findings = _detect_unsafe_constructs(_UNSAFE_CLASSIFICATION_ALGO)
+    assert len(findings) == 1
+    assert findings[0].startswith("INSEGURO: ")
+    assert "locals" in findings[0]
+
+
+def test_detect_unsafe_clean_code_returns_empty() -> None:
+    assert _detect_unsafe_constructs(_COMPLETE_CLASSIFICATION_ALGO) == []
+
+
+def test_detect_unsafe_flags_syntax_error() -> None:
+    findings = _detect_unsafe_constructs("# %%\ndef (:\n    pass\n")
+    assert findings and findings[0].startswith("INSEGURO: ")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _build_m3_notebook_validation_correction — INSEGURO branch
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_correction_block_unsafe_emits_safe_pattern_not_crossfamily() -> None:
+    block = _build_m3_notebook_validation_correction(
+        "clasificacion", ["INSEGURO: Denied call in generated notebook: locals"], None
+    )
+    assert "try/except NameError" in block
+    assert "globals()" in block
+    # An INSEGURO finding must NOT be mislabeled as cross-family leakage.
+    assert "OTRAS familias prohibidas" not in block
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _invoke_m3_notebook_algo_section — the unified loop (core regression)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_locals_caught_at_generation_then_reprompt_recovers() -> None:
+    """Headline regression: family-complete code that ALSO has locals() is now
+    caught at generation time; a clean reprompt recovers instead of escalating
+    to the executor's brittle full-regeneration that killed the job."""
+    llm = _SequenceLLM([_UNSAFE_CLASSIFICATION_ALGO, _COMPLETE_CLASSIFICATION_ALGO])
+
+    result = _invoke_m3_notebook_algo_section(
+        llm=llm,
+        prompt="PROMPT",
+        family="clasificacion",
+        notebook_variant=None,
+        node_name="test",
+    )
+
+    assert len(llm.prompts) == 2  # original + exactly one reprompt
+    assert "try/except NameError" in llm.prompts[1]  # concrete safe pattern given
+    assert "precision_recall_curve(" in result
+    assert "locals(" not in result
+
+
+def test_persistent_locals_fails_closed() -> None:
+    """If the model keeps emitting locals() on the reprompt, the job fails closed
+    (never ships unsafe code) with a security-aware message."""
+    llm = _SequenceLLM([_UNSAFE_CLASSIFICATION_ALGO, _UNSAFE_CLASSIFICATION_ALGO])
+
+    with pytest.raises(RuntimeError, match="seguridad"):
+        _invoke_m3_notebook_algo_section(
+            llm=llm,
+            prompt="PROMPT",
+            family="clasificacion",
+            notebook_variant=None,
+            node_name="test",
+        )
+
+
+def test_fixing_locals_but_dropping_required_api_is_caught_in_one_pass() -> None:
+    """Both axes are enforced in the SAME validation pass: a reprompt that strips
+    locals() but drops precision_recall_curve( is caught deterministically, not
+    silently shipped. This is exactly the original two-stage failure, now unified."""
+    llm = _SequenceLLM(
+        [_UNSAFE_CLASSIFICATION_ALGO, _MISSING_PR_CLASSIFICATION_ALGO]
+    )
+
+    with pytest.raises(RuntimeError, match="precision_recall_curve") as excinfo:
+        _invoke_m3_notebook_algo_section(
+            llm=llm,
+            prompt="PROMPT",
+            family="clasificacion",
+            notebook_variant=None,
+            node_name="test",
+        )
+    assert "FALTANTE: precision_recall_curve(" in str(excinfo.value)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Robustness: the detector must never crash the job, even on pathological code
+# (ast.parse raises RecursionError/ValueError — NOT SyntaxError — on a huge flat
+# expression an LLM can emit under the 24576-token cap).
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_detect_unsafe_is_defensive_on_pathological_recursion() -> None:
+    pathological = "# %%\nx = " + "+".join(["1"] * 4000) + "\n"
+    findings = _detect_unsafe_constructs(pathological)
+    # No exception escapes; the pathological input is funneled as an INSEGURO
+    # finding so the reprompt-once path handles it (fail-closed, not a crash).
+    assert findings and findings[0].startswith("INSEGURO: ")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Blast radius: the safety scrub is scoped to clasificación (the only family the
+# executor runs). Non-clasificación families must NOT gain the denylist at
+# generation time — their notebooks are never executed server-side.
+# ──────────────────────────────────────────────────────────────────────────────
+
+# A regresión-valid, valid-Python section that ALSO contains a locals() guard.
+# Regresión has no required sentinels/APIs, only a prohibited list — this fixture
+# avoids every prohibited token (guard assertion below), so family validation
+# passes and the ONLY thing that could flag it is the safety scrub.
+_REGRESION_ALGO_WITH_LOCALS = """# %%
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_squared_error, r2_score
+
+
+def _run(X, y):
+    model = LinearRegression().fit(X, y)
+    preds = model.predict(X)
+    if "X_train" in locals():
+        pass
+    return mean_squared_error(y, preds), r2_score(y, preds)
+"""
+
+
+def test_regresion_fixture_is_family_clean() -> None:
+    assert _validate_notebook_family_consistency(
+        "regresion", _REGRESION_ALGO_WITH_LOCALS, None
+    ) == []
+
+
+def test_unsafe_check_not_applied_to_non_classification_families() -> None:
+    """A regresión notebook with locals() must pass straight through — no reprompt,
+    no job failure. The denylist belongs to the executed (clasificación) path only."""
+    llm = _SequenceLLM([_REGRESION_ALGO_WITH_LOCALS])
+
+    result = _invoke_m3_notebook_algo_section(
+        llm=llm,
+        prompt="PROMPT",
+        family="regresion",
+        notebook_variant=None,
+        node_name="test",
+    )
+
+    assert len(llm.prompts) == 1  # no reprompt triggered
+    assert "locals(" in result  # locals() was NOT flagged for regresión

--- a/backend/tests/test_m3_notebook_unsafe_generation_guard.py
+++ b/backend/tests/test_m3_notebook_unsafe_generation_guard.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import pytest
 
+import case_generator.graph as graph_module
 from case_generator.graph import (
     _build_m3_notebook_validation_correction,
     _detect_unsafe_constructs,
@@ -224,12 +225,28 @@ def test_fixing_locals_but_dropping_required_api_is_caught_in_one_pass() -> None
 # expression an LLM can emit under the 24576-token cap).
 # ──────────────────────────────────────────────────────────────────────────────
 
-def test_detect_unsafe_is_defensive_on_pathological_recursion() -> None:
-    pathological = "# %%\nx = " + "+".join(["1"] * 4000) + "\n"
-    findings = _detect_unsafe_constructs(pathological)
-    # No exception escapes; the pathological input is funneled as an INSEGURO
-    # finding so the reprompt-once path handles it (fail-closed, not a crash).
-    assert findings and findings[0].startswith("INSEGURO: ")
+@pytest.mark.parametrize("exc", [RecursionError("deep"), ValueError("bad")])
+def test_detect_unsafe_is_defensive_against_unexpected_scrubber_errors(
+    monkeypatch: pytest.MonkeyPatch, exc: Exception
+) -> None:
+    """ast.parse can raise RecursionError/ValueError (NOT SyntaxError, NOT
+    M3NotebookExecutionError) on pathological LLM output. Whatever the scrubber
+    raises, the detector must funnel it as an INSEGURO finding — never let it
+    escape and crash the job.
+
+    The exact input that trips ast.parse's recursion limit is platform-dependent
+    (OS/stack size/recursion limit), so we inject the error deterministically
+    instead of relying on a giant expression that only overflows on some hosts.
+    """
+
+    def _boom(_code: str) -> None:
+        raise exc
+
+    monkeypatch.setattr(graph_module, "scrub_notebook_for_safe_execution", _boom)
+    findings = graph_module._detect_unsafe_constructs("# %%\nx = 1\n")
+    assert len(findings) == 1
+    assert findings[0].startswith("INSEGURO: ")
+    assert type(exc).__name__ in findings[0]
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problema

Un caso **ml_ds + clasificación + visual_plus_notebook** se caía con:

```
RuntimeError: M3 notebook generator no satisfizo la familia 'clasificacion'
incluso tras un reprompt: ['FALTANTE: precision_recall_curve(']
```

…pero el gatillo real (antes en el traceback) era:

```
M3NotebookExecutionError: Denied call in generated notebook: locals
```

## Causa raíz

Dos validaciones **disjuntas en etapas distintas**:
- **Familia** (exige `precision_recall_curve(` + sentinels) → al **generar**.
- **Scrub de seguridad AST** (bloquea `locals`/`globals`/`eval`/…) → al **ejecutar**.

Flash emitió `if "X_train" in locals():`. La validación de familia no mira `locals`, así que el notebook (completo) pasó y se guardó. El executor lo rechazó por `locals` y la recuperación **regeneró todo el algo-section desde cero**, perdiendo `precision_recall_curve(`. El único reprompt no lo recuperó → job muerto en un eje **distinto** al que intentaba arreglar.

## Fix

Enrutar la detección de construcciones inseguras por el **mismo loop de reprompt-once** de generación, reusando `scrub_notebook_for_safe_execution` (AST puro, sin subprocess). Una sola pasada exige **ambos** ejes: el reprompt que quita `locals()` está obligado a conservar `precision_recall_curve(` y los sentinels.

- `_detect_unsafe_constructs(code)`: reusa el denylist único (cero duplicación); prefijo `INSEGURO:` para fluir por la misma lista de `violations`.
- Merge en `_invoke_m3_notebook_algo_section` (1ª pasada + post-reprompt) + rama `INSEGURO` en `_build_m3_notebook_validation_correction` con ejemplo `try/except NameError` copiable.
- **Scoped a `family == "clasificacion"`** (la única que el executor scrubea y la única con contrato de APIs). Cero cambio de comportamiento para regresión/clustering/serie_temporal, cuyos notebooks no se ejecutan en servidor.
- **Detector defensivo**: cualquier fallo inesperado del scrubber (p. ej. `RecursionError` de `ast.parse` ante expresiones planas enormes) se reporta como `INSEGURO` y falla cerrada vía reprompt, jamás como excepción opaca.

El scrub de ejecución queda como red de defensa. **Sin cambios a contratos** (denylist, sentinels/APIs, wiring del grafo).

## Tests / verificación

- Nuevo: `backend/tests/test_m3_notebook_unsafe_generation_guard.py` (11 casos: detección, bloque de corrección, los 3 escenarios del loop unificado, robustez ante recursión patológica, y scoping a no-clasificación).
- Suite completa: **1154 passed, 20 skipped**.
- `mypy src`: limpio (82 archivos).

## Notas de review

Esta rama pasó una review adversarial ultra-profunda (2 agentes independientes). Encontró y se corrigieron 2 riesgos antes del merge: (1) `RecursionError`/`ValueError` de `ast.parse` escapaban el `except` estrecho; (2) el scrub se aplicaba a las 4 familias, ampliando el blast radius. Ambos resueltos y cubiertos por tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)