### PR TITLE
fix(case_generator): restore cost_matrix pedagogy in M3 classification variants (#334)

### DIFF
--- a/backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py
+++ b/backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py
@@ -487,6 +487,18 @@ COST_SECTIONS: dict[ClassificationNotebookVariant, str] = {
     "lr_only": """
 # %% [markdown]
 # ### 3.0.6 — Matriz de costos del negocio + threshold tuning
+# El threshold default 0.5 SOLO es óptimo si FP y FN cuestan igual. En la
+# mayoría de los problemas de negocio (churn, fraude, mantenimiento) los
+# costos son asimétricos. Esta celda lee la matriz de costos del contrato
+# (`dataset_schema_required.business_cost_matrix`), barre 100 thresholds
+# y elige el que minimiza el costo total esperado en el hold-out.
+#
+# **Cómo extraer los costos:**
+# Inspecciona el JSON del contrato del caso (bloque `dataset_contract_block`
+# que recibiste en el prompt). Si contiene `business_cost_matrix` con
+# `fp_cost`, `fn_cost`, `currency`, EMITE esos números literales en la celda.
+# Si NO está presente, usa el fallback `fp_cost=1.0`, `fn_cost=5.0`,
+# `currency="USD"` Y añade un `print` explicando que se usó fallback.
 
 # %%
 # === SECTION:cost_matrix ===
@@ -496,9 +508,17 @@ try:
   else:
     from sklearn.model_selection import train_test_split
     from sklearn.metrics import confusion_matrix
-    fp_cost = 1.0
-    fn_cost = 5.0
-    currency = "USD"
+    # Costos del negocio extraídos del contrato dataset_schema_required
+    # .business_cost_matrix. Si el contrato no los traía, fallback fp=1, fn=5.
+    # IMPORTANTE: emite los 3 valores como literales Python (NO leas un
+    # diccionario `dataset_schema_required` en runtime — el notebook se
+    # ejecuta standalone).
+    fp_cost = 1.0   # ← reemplaza por business_cost_matrix.fp_cost del contrato
+    fn_cost = 5.0   # ← reemplaza por business_cost_matrix.fn_cost del contrato
+    currency = "USD"  # ← reemplaza por business_cost_matrix.currency del contrato
+    # Si el contrato NO traía business_cost_matrix, deja los valores fallback
+    # de arriba y añade un print pedagógico explicando el fallback:
+    # print(f"⚠️ Sin matriz de costos en el contrato — usando fallback fp={{fp_cost}}, fn={{fn_cost}} {{currency}}")
     _Xtr_cm, _Xte_cm, _ytr_cm, _yte_cm = train_test_split(X_raw, y, test_size=0.2, random_state=42, stratify=y if y.value_counts().min() >= 2 else None)
     pipe_lr.fit(_Xtr_cm, _ytr_cm)
     proba = pipe_lr.predict_proba(_Xte_cm)[:, 1]
@@ -511,19 +531,54 @@ try:
       costs.append(fp * fp_cost + fn * fn_cost)
     costs = np.array(costs)
     optimal = float(thresholds[int(np.argmin(costs))])
+    cost_at_optimal = float(costs[int(np.argmin(costs))])
+    cost_at_default = float(costs[int(np.argmin(np.abs(thresholds - 0.5)))])
     plt.figure(figsize=(8, 5))
     plt.plot(thresholds, costs, label="Costo total esperado")
     plt.axvline(optimal, color="red", linestyle="-", label=f"Óptimo = {{optimal:.2f}}")
     plt.axvline(0.5, color="gray", linestyle="--", alpha=0.7, label="Default 0.5")
     plt.xlabel("Threshold de decisión"); plt.ylabel(f"Costo total ({{currency}})")
-    plt.title("Curva costo-vs-threshold — Logistic Regression")
+    plt.title(f"Curva costo-vs-threshold (LR) — fp={{fp_cost}} {{currency}}, fn={{fn_cost}} {{currency}}")
     plt.legend(loc="best"); plt.tight_layout(); plt.show()
+    # Pedagogía 3 ramas:
+    if optimal in (float(thresholds[0]), float(thresholds[-1])):
+      print(
+          f"⚠️ El threshold óptimo {{optimal:.2f}} está en el borde del barrido "
+          f"[0.05, 0.95]. Esto sugiere que la matriz de costos es muy desbalanceada "
+          f"o que el modelo no separa bien las clases — revisa fp/fn antes de productivizar."
+      )
+    elif abs(optimal - 0.5) < 0.05:
+      print(
+          f"El threshold óptimo {{optimal:.2f}} es prácticamente el default 0.5: "
+          f"para esta matriz de costos (fp={{fp_cost}}, fn={{fn_cost}} {{currency}}) "
+          f"el sesgo asimétrico no compensa mover el umbral."
+      )
+    else:
+      ahorro = cost_at_default - cost_at_optimal
+      print(
+          f"Threshold óptimo: {{optimal:.2f}} (vs default 0.5). "
+          f"Costo total: {{cost_at_optimal:,.0f}} {{currency}} (ahorro estimado vs 0.5: "
+          f"{{ahorro:,.0f}} {{currency}}). Productivizar este threshold puede traducirse "
+          f"directamente a un caso de negocio cuantificable."
+      )
 except Exception as e:
   print(f"⚠️ Cost matrix LR falló: {{e}}")
 """,
     "rf_only": """
 # %% [markdown]
 # ### 3.0.6 — Matriz de costos del negocio + threshold tuning
+# El threshold default 0.5 SOLO es óptimo si FP y FN cuestan igual. En la
+# mayoría de los problemas de negocio (churn, fraude, mantenimiento) los
+# costos son asimétricos. Esta celda lee la matriz de costos del contrato
+# (`dataset_schema_required.business_cost_matrix`), barre 100 thresholds
+# y elige el que minimiza el costo total esperado en el hold-out.
+#
+# **Cómo extraer los costos:**
+# Inspecciona el JSON del contrato del caso (bloque `dataset_contract_block`
+# que recibiste en el prompt). Si contiene `business_cost_matrix` con
+# `fp_cost`, `fn_cost`, `currency`, EMITE esos números literales en la celda.
+# Si NO está presente, usa el fallback `fp_cost=1.0`, `fn_cost=5.0`,
+# `currency="USD"` Y añade un `print` explicando que se usó fallback.
 
 # %%
 # === SECTION:cost_matrix ===
@@ -533,9 +588,17 @@ try:
   else:
     from sklearn.model_selection import train_test_split
     from sklearn.metrics import confusion_matrix
-    fp_cost = 1.0
-    fn_cost = 5.0
-    currency = "USD"
+    # Costos del negocio extraídos del contrato dataset_schema_required
+    # .business_cost_matrix. Si el contrato no los traía, fallback fp=1, fn=5.
+    # IMPORTANTE: emite los 3 valores como literales Python (NO leas un
+    # diccionario `dataset_schema_required` en runtime — el notebook se
+    # ejecuta standalone).
+    fp_cost = 1.0   # ← reemplaza por business_cost_matrix.fp_cost del contrato
+    fn_cost = 5.0   # ← reemplaza por business_cost_matrix.fn_cost del contrato
+    currency = "USD"  # ← reemplaza por business_cost_matrix.currency del contrato
+    # Si el contrato NO traía business_cost_matrix, deja los valores fallback
+    # de arriba y añade un print pedagógico explicando el fallback:
+    # print(f"⚠️ Sin matriz de costos en el contrato — usando fallback fp={{fp_cost}}, fn={{fn_cost}} {{currency}}")
     _Xtr_cm, _Xte_cm, _ytr_cm, _yte_cm = train_test_split(X_raw, y, test_size=0.2, random_state=42, stratify=y if y.value_counts().min() >= 2 else None)
     pipe_rf.fit(_Xtr_cm, _ytr_cm)
     proba = pipe_rf.predict_proba(_Xte_cm)[:, 1]
@@ -548,13 +611,36 @@ try:
       costs.append(fp * fp_cost + fn * fn_cost)
     costs = np.array(costs)
     optimal = float(thresholds[int(np.argmin(costs))])
+    cost_at_optimal = float(costs[int(np.argmin(costs))])
+    cost_at_default = float(costs[int(np.argmin(np.abs(thresholds - 0.5)))])
     plt.figure(figsize=(8, 5))
     plt.plot(thresholds, costs, label="Costo total esperado")
     plt.axvline(optimal, color="red", linestyle="-", label=f"Óptimo = {{optimal:.2f}}")
     plt.axvline(0.5, color="gray", linestyle="--", alpha=0.7, label="Default 0.5")
     plt.xlabel("Threshold de decisión"); plt.ylabel(f"Costo total ({{currency}})")
-    plt.title("Curva costo-vs-threshold — Random Forest")
+    plt.title(f"Curva costo-vs-threshold (RF) — fp={{fp_cost}} {{currency}}, fn={{fn_cost}} {{currency}}")
     plt.legend(loc="best"); plt.tight_layout(); plt.show()
+    # Pedagogía 3 ramas:
+    if optimal in (float(thresholds[0]), float(thresholds[-1])):
+      print(
+          f"⚠️ El threshold óptimo {{optimal:.2f}} está en el borde del barrido "
+          f"[0.05, 0.95]. Esto sugiere que la matriz de costos es muy desbalanceada "
+          f"o que el modelo no separa bien las clases — revisa fp/fn antes de productivizar."
+      )
+    elif abs(optimal - 0.5) < 0.05:
+      print(
+          f"El threshold óptimo {{optimal:.2f}} es prácticamente el default 0.5: "
+          f"para esta matriz de costos (fp={{fp_cost}}, fn={{fn_cost}} {{currency}}) "
+          f"el sesgo asimétrico no compensa mover el umbral."
+      )
+    else:
+      ahorro = cost_at_default - cost_at_optimal
+      print(
+          f"Threshold óptimo: {{optimal:.2f}} (vs default 0.5). "
+          f"Costo total: {{cost_at_optimal:,.0f}} {{currency}} (ahorro estimado vs 0.5: "
+          f"{{ahorro:,.0f}} {{currency}}). Productivizar este threshold puede traducirse "
+          f"directamente a un caso de negocio cuantificable."
+      )
 except Exception as e:
   print(f"⚠️ Cost matrix RF falló: {{e}}")
 """,
@@ -562,6 +648,18 @@ except Exception as e:
 # %% [markdown]
 # ### 3.0.6 — Matriz de costos del negocio + threshold tuning
 # En contraste usamos LR como soporte de threshold por interpretabilidad.
+# El threshold default 0.5 SOLO es óptimo si FP y FN cuestan igual. En la
+# mayoría de los problemas de negocio (churn, fraude, mantenimiento) los
+# costos son asimétricos. Esta celda lee la matriz de costos del contrato
+# (`dataset_schema_required.business_cost_matrix`), barre 100 thresholds
+# y elige el que minimiza el costo total esperado en el hold-out.
+#
+# **Cómo extraer los costos:**
+# Inspecciona el JSON del contrato del caso (bloque `dataset_contract_block`
+# que recibiste en el prompt). Si contiene `business_cost_matrix` con
+# `fp_cost`, `fn_cost`, `currency`, EMITE esos números literales en la celda.
+# Si NO está presente, usa el fallback `fp_cost=1.0`, `fn_cost=5.0`,
+# `currency="USD"` Y añade un `print` explicando que se usó fallback.
 
 # %%
 # === SECTION:cost_matrix ===
@@ -571,9 +669,17 @@ try:
   else:
     from sklearn.model_selection import train_test_split
     from sklearn.metrics import confusion_matrix
-    fp_cost = 1.0
-    fn_cost = 5.0
-    currency = "USD"
+    # Costos del negocio extraídos del contrato dataset_schema_required
+    # .business_cost_matrix. Si el contrato no los traía, fallback fp=1, fn=5.
+    # IMPORTANTE: emite los 3 valores como literales Python (NO leas un
+    # diccionario `dataset_schema_required` en runtime — el notebook se
+    # ejecuta standalone).
+    fp_cost = 1.0   # ← reemplaza por business_cost_matrix.fp_cost del contrato
+    fn_cost = 5.0   # ← reemplaza por business_cost_matrix.fn_cost del contrato
+    currency = "USD"  # ← reemplaza por business_cost_matrix.currency del contrato
+    # Si el contrato NO traía business_cost_matrix, deja los valores fallback
+    # de arriba y añade un print pedagógico explicando el fallback:
+    # print(f"⚠️ Sin matriz de costos en el contrato — usando fallback fp={{fp_cost}}, fn={{fn_cost}} {{currency}}")
     _Xtr_cm, _Xte_cm, _ytr_cm, _yte_cm = train_test_split(X_raw, y, test_size=0.2, random_state=42, stratify=y if y.value_counts().min() >= 2 else None)
     pipe_lr.fit(_Xtr_cm, _ytr_cm)
     proba = pipe_lr.predict_proba(_Xte_cm)[:, 1]
@@ -586,13 +692,36 @@ try:
       costs.append(fp * fp_cost + fn * fn_cost)
     costs = np.array(costs)
     optimal = float(thresholds[int(np.argmin(costs))])
+    cost_at_optimal = float(costs[int(np.argmin(costs))])
+    cost_at_default = float(costs[int(np.argmin(np.abs(thresholds - 0.5)))])
     plt.figure(figsize=(8, 5))
     plt.plot(thresholds, costs, label="Costo total esperado")
     plt.axvline(optimal, color="red", linestyle="-", label=f"Óptimo = {{optimal:.2f}}")
     plt.axvline(0.5, color="gray", linestyle="--", alpha=0.7, label="Default 0.5")
     plt.xlabel("Threshold de decisión"); plt.ylabel(f"Costo total ({{currency}})")
-    plt.title("Curva costo-vs-threshold — LR como baseline interpretable")
+    plt.title(f"Curva costo-vs-threshold (LR) — fp={{fp_cost}} {{currency}}, fn={{fn_cost}} {{currency}}")
     plt.legend(loc="best"); plt.tight_layout(); plt.show()
+    # Pedagogía 3 ramas:
+    if optimal in (float(thresholds[0]), float(thresholds[-1])):
+      print(
+          f"⚠️ El threshold óptimo {{optimal:.2f}} está en el borde del barrido "
+          f"[0.05, 0.95]. Esto sugiere que la matriz de costos es muy desbalanceada "
+          f"o que el modelo no separa bien las clases — revisa fp/fn antes de productivizar."
+      )
+    elif abs(optimal - 0.5) < 0.05:
+      print(
+          f"El threshold óptimo {{optimal:.2f}} es prácticamente el default 0.5: "
+          f"para esta matriz de costos (fp={{fp_cost}}, fn={{fn_cost}} {{currency}}) "
+          f"el sesgo asimétrico no compensa mover el umbral."
+      )
+    else:
+      ahorro = cost_at_default - cost_at_optimal
+      print(
+          f"Threshold óptimo: {{optimal:.2f}} (vs default 0.5). "
+          f"Costo total: {{cost_at_optimal:,.0f}} {{currency}} (ahorro estimado vs 0.5: "
+          f"{{ahorro:,.0f}} {{currency}}). Productivizar este threshold puede traducirse "
+          f"directamente a un caso de negocio cuantificable."
+      )
 except Exception as e:
   print(f"⚠️ Cost matrix contraste falló: {{e}}")
 """,

--- a/backend/tests/test_issue230_classification_notebook_variants.py
+++ b/backend/tests/test_issue230_classification_notebook_variants.py
@@ -154,6 +154,48 @@ def test_variant_prompts_keep_three_chart_budget(prompt: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("prompt", "model_tag"),
+    [
+        pytest.param(M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LR_ONLY, "(LR)", id="lr_only"),
+        pytest.param(M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_RF_ONLY, "(RF)", id="rf_only"),
+        pytest.param(
+            M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LR_RF_CONTRAST,
+            "(LR)",
+            id="lr_rf_contrast",
+        ),
+    ],
+)
+def test_variant_cost_cell_restores_legacy_pedagogy(prompt: str, model_tag: str) -> None:
+    """Issue #334: each variant's cost_matrix cell must keep parity with the
+    legacy rich cell — contract-extraction guide, cost_at_optimal/cost_at_default
+    scalars, an fp/fn-interpolated title carrying the correct model tag, and the
+    3-branch business interpretation (edge / near-default / savings). This guards
+    against the per-variant builder silently re-dropping the rich cell, which is
+    exactly how the original regression slipped in."""
+    start = prompt.index("# === SECTION:cost_matrix ===")
+    header_start = prompt.rindex("# %% [markdown]", 0, start)
+    nxt = prompt.index("# %% [markdown]", start)
+    header = prompt[header_start:start]
+    cell = prompt[start:nxt]
+
+    # A — contract-extraction guidance in the markdown header.
+    assert "extraer los costos" in header
+    assert "business_cost_matrix" in header
+    # D — savings scalars (without these the savings branch is uncomputable).
+    assert "cost_at_optimal" in cell
+    assert "cost_at_default" in cell
+    # E — fp/fn-interpolated title carrying the correct model tag.
+    assert ("Curva costo-vs-threshold " + model_tag) in cell
+    assert "fp={{fp_cost}} {{currency}}, fn={{fn_cost}} {{currency}}" in cell
+    # F — 3-branch interpretation: edge / near-default / savings.
+    assert "borde del barrido" in cell
+    assert "no compensa mover el umbral" in cell
+    assert "ahorro estimado vs 0.5" in cell
+    # Budget — the restored pedagogy is print-only: still exactly one render call.
+    assert cell.count("plt.show()") == 1
+
+
+@pytest.mark.parametrize(
     "prompt",
     [
         pytest.param(M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LR_ONLY, id="lr_only"),


### PR DESCRIPTION
Closes #334

## What & why

When the M3 classification notebook was split into per-teacher-intent variants
(`lr_only` / `rf_only` / `lr_rf_contrast`), the `cost_matrix` cell was reimplemented as three
thin strings in `COST_SECTIONS`. That rewrite dropped the rich behavior of the legacy cell:
`build_classification_notebook_prompt` splices `COST_SECTIONS[variant]` over the legacy rich
cell (`notebook.py:746-834`) via `_replace_section`, so **every** `ml_ds` + `clasificacion` +
LR/RF notebook shipped the impoverished cell — it stopped at the cost-optimal threshold and
never taught contract extraction nor printed the "ahorro estimado vs 0.5" business framing.

This is the pedagogical regression #334 reports.

## The fix (bounded scope)

Single edit site: the three string values of `COST_SECTIONS` in
`backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py`. Each variant now
restores parity with the legacy cell:

- **A** rich markdown header (why 0.5 is only optimal under symmetric costs; names
  `dataset_schema_required.business_cost_matrix`; "Cómo extraer los costos" guide)
- **B** contract-extraction comments + standalone-execution warning
- **C** commented fallback print template
- **D** `cost_at_optimal` / `cost_at_default` scalars (needed to compute the savings)
- **E** title with interpolated fp/fn and per-variant model tag: `(LR)` for lr_only &
  lr_rf_contrast, `(RF)` for rf_only
- **F** 3-branch interpretation print (edge / near-default / savings)

Functional, not cosmetic: the cell reads `business_cost_matrix` when present, falls back to
`fp=1/fn=5/USD` when absent, and prints the quantifiable business-case framing either way.

## Decision: `business_cost_matrix` population (out of scope)

This PR fixes the **cell** (the #334 ask). Making the matrix reliably **populated** is a
separate, larger change: the schema, validator, normalization, warnings, and prompt injection
are all real and tested, but no prompt instructs the architect to *emit* the field, so it's
almost always `None` and M3 uses the fp=1/fn=5 fallback by design. That belongs in the
**architect** prompt, not `schema_designer`. Tracked in #340 and intentionally not bundled
here.

## Contracts preserved

- `# === SECTION:cost_matrix ===` sentinel stays first executable line
- exactly one `plt.show()` per cost cell → 3-figure budget intact
- `confusion_matrix(` / `predict_proba(` / `threshold` kept executable
- single-model purity (rf_only cost cell: 0 hits of `pipe_lr`/`LogisticRegression`/
  `LinearRegression`/`GridSearchCV(`/`auc_lr`)
- `lr_rf_contrast` still does `fit`/`predict_proba` on **`pipe_lr`** (LR-only cost analysis by
  design); no second RF curve
- clean `.format()` escaping; sentinel/API counts unchanged (14 / 14)

**No operational rule changed → AGENTS.md / CLAUDE.md untouched.**

## Evidence

- Focused suite: `132 passed` (incl. `test_variant_prompts_are_exported_and_render`,
  `test_variant_prompts_keep_three_chart_budget`,
  `test_single_model_prompts_do_not_seed_unselected_model_text`,
  `test_classification_notebook_prompt_has_no_issue_references`,
  `test_rendered_variants_pass_executor_scrubber`, `test_prompt_declares_quick_mode_thresholds`)
- Full backend suite: `1180 passed, 20 skipped`
- `mypy src`: `Success: no issues found in 82 source files`
- Manual render (`prompt.format(**SHARED_FORMAT_KEYS)`), per variant:

| variant | plt.show() in cell | cost_at_optimal/default | "ahorro estimado vs 0.5" | extraction guide | title tag | next section intact |
|---|---|---|---|---|---|---|
| lr_only | 1 | ✓ | ✓ | ✓ | (LR) | 3.0.7 LR tuning |
| rf_only | 1 | ✓ | ✓ | ✓ | (RF) | 3.0.8 RF tuning |
| lr_rf_contrast | 1 | ✓ | ✓ | ✓ | (LR) | 3.0.7 LR tuning |

Rendered 3-branch + extraction snippet (lr_only):

```python
    # Costos del negocio extraídos del contrato dataset_schema_required
    # .business_cost_matrix. Si el contrato no los traía, fallback fp=1, fn=5.
    fp_cost = 1.0   # ← reemplaza por business_cost_matrix.fp_cost del contrato
    fn_cost = 5.0   # ← reemplaza por business_cost_matrix.fn_cost del contrato
    currency = "USD"  # ← reemplaza por business_cost_matrix.currency del contrato
    ...
    cost_at_optimal = float(costs[int(np.argmin(costs))])
    cost_at_default = float(costs[int(np.argmin(np.abs(thresholds - 0.5)))])
    ...
    plt.title(f"Curva costo-vs-threshold (LR) — fp={fp_cost} {currency}, fn={fn_cost} {currency}")
    ...
    # Pedagogía 3 ramas: borde / cerca-default / ahorro
    else:
      ahorro = cost_at_default - cost_at_optimal
      print(f"Threshold óptimo: {optimal:.2f} (vs default 0.5). "
            f"Costo total: {cost_at_optimal:,.0f} {currency} (ahorro estimado vs 0.5: "
            f"{ahorro:,.0f} {currency}). ...")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)