### PR TITLE
fix(case_generator): instruct architect to emit business_cost_matrix (#340)

### DIFF
--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
@@ -61,6 +61,47 @@ _M1_CLASSIFICATION_ANCHOR_ARCHITECT = """
    - Completitud de campos críticos (ej: "% registros con campo contractual sin dato: 12 %").
    Sin estas filas el `schema_designer` downstream no puede modelar el desbalance de
    clases real del caso, comprometiendo la coherencia pedagógica del notebook M3.
+
+## Matriz de costos de negocio (`business_cost_matrix`) — opcional, condicional
+
+Emite `business_cost_matrix` SOLO para el perfil ml_ds con target binario (matriz de
+confusión 2×2). Para el perfil business, target multiclase, u otras familias: NO la
+emitas (déjala ausente / `null`).
+
+Esta clave CUANTIFICA los dos errores de decisión que la regla 3 ya te obligó a narrar
+en el dilema:
+- `fp_cost` = costo del error de comisión (intervenir/actuar donde NO hacía falta).
+- `fn_cost` = costo del error de omisión (NO actuar donde la pérdida era evitable).
+Deriva ambos números del `dilema_brief` y de los Exhibits financieros (Exhibit 1/2):
+deben ser TRAZABLES al caso, NUNCA inventados. Anclaje típico: `fn_cost` ≈ pérdida de
+no detectar el evento (LTV del cliente perdido, monto del fraude no bloqueado);
+`fp_cost` ≈ costo de la acción innecesaria (retención/descuento regalado, revisión
+manual sin causa).
+
+Condición de emisión (si NO se cumple, deja la clave ausente / `null`):
+- SOLO cuando los costos de mala clasificación sean genuinamente ASIMÉTRICOS y
+  derivables del caso. Si son simétricos o no inferibles → `null` (no fabriques una
+  asimetría).
+
+Valores VÁLIDOS o el pipeline la descarta en silencio:
+- `fp_cost` y `fn_cost` ambos > 0 y finitos; cada uno ≤ 1e9.
+- ratio max(fp,fn)/min(fp,fn) ≤ 1000:1 (en cualquier dirección).
+- `currency` en MAYÚSCULAS dentro de {{USD, EUR, GBP, COP, MXN, BRL, CLP, PEN, ARS}}
+  (default "USD"); elige la moneda coherente con los Exhibits del caso.
+
+Ubicación EXACTA: añade `business_cost_matrix` como clave ANIDADA dentro de
+`dataset_schema_required` (junto a `target_column` / `feature_columns`), NUNCA como
+clave de nivel superior. La regla base "NO incluir claves extra" aplica a las claves de
+NIVEL SUPERIOR; este es un sub-campo declarado y validado del schema, no una clave extra.
+
+Forma exacta (dentro de `dataset_schema_required`):
+{{
+  "business_cost_matrix": {{
+    "fp_cost": 200,
+    "fn_cost": 5000,
+    "currency": "USD"
+  }}
+}}
 """
 
 # ── business + clasificación: bloque de target binario de dominio (Issue #301 PR2b) ──

--- a/backend/tests/test_issue301_pr2b_architect.py
+++ b/backend/tests/test_issue301_pr2b_architect.py
@@ -71,7 +71,9 @@ _MLDS_CTX: dict[str, object] = {
 # Frozen digest of the assembled ml_ds+clasificación prompt. If this changes, the ml_ds
 # prompt changed — confirm it was NOT the business gate leaking in before updating.
 _MLDS_ARCHITECT_PROMPT_SHA256 = (
-    "2cb71906c5f8599b54a5a212da2f824bc4778167ca24a386deb30cb01d4b6422"
+    # Issue #340 — regenerated deliberately after adding the conditional
+    # `business_cost_matrix` emission subsection to the classification anchor.
+    "87df26d56913add9211b1bb9e3825957835689807383e1b152b36778a24b9762"
 )
 
 

--- a/backend/tests/test_issue340_architect_cost_matrix_emission.py
+++ b/backend/tests/test_issue340_architect_cost_matrix_emission.py
@@ -13,10 +13,12 @@ the new instruction across profiles and families.
 from __future__ import annotations
 
 import os
+import re
 
 import pytest
 
 from case_generator.graph import _assemble_architect_prompt
+from case_generator.tools_and_schemas import _SUPPORTED_COST_CURRENCIES
 
 # Stable sentinels the subsection must expose. ``_COST_MATRIX_TOKEN`` is unique to the new
 # instruction (it appears nowhere in the base prompt), so its presence/absence cleanly
@@ -97,6 +99,24 @@ def test_business_classification_carries_gated_cost_matrix_text() -> None:
     assert _COST_MATRIX_TOKEN in assembled
     # The gate explicitly restricts emission to the ml_ds profile.
     assert _GATE_PHRASE in assembled
+
+
+# ── drift guard: prompt currency allowlist must stay in sync with the validator ──
+
+def test_prompt_currency_allowlist_stays_in_sync_with_validator() -> None:
+    """The anchor lists the supported currencies as prose; ``BusinessCostMatrix``
+    enforces the same set (``_SUPPORTED_COST_CURRENCIES``). If either drifts the LLM
+    would be taught a stale allowlist (and the validator would silently reject the
+    stray currency). Compare both directions so they can never diverge unnoticed."""
+    assembled = _assemble_architect_prompt(_ctx("ml_ds", "clasificacion"))
+    match = re.search(r"\{([A-Z]{3}(?:, [A-Z]{3})+)\}", assembled)
+    assert match is not None, "currency allowlist block not found in architect prompt"
+    prompt_codes = set(match.group(1).split(", "))
+    assert prompt_codes == set(_SUPPORTED_COST_CURRENCIES), (
+        "architect prompt currency list drifted from the BusinessCostMatrix validator "
+        f"(prompt={sorted(prompt_codes)}, validator={sorted(_SUPPORTED_COST_CURRENCIES)}); "
+        "update the anchor subsection and tools_and_schemas together."
+    )
 
 
 # ── (c) OPTIONAL live golden-eval (deferred) ──────────────────────────────────

--- a/backend/tests/test_issue340_architect_cost_matrix_emission.py
+++ b/backend/tests/test_issue340_architect_cost_matrix_emission.py
@@ -1,0 +1,114 @@
+"""Issue #340 — case_architect emits `business_cost_matrix`.
+
+Follow-up of #334 (which restored the M3 `cost_matrix` cell so it READS the matrix when
+present). Here we teach the architect to EMIT it: the classification anchor
+(`_M1_CLASSIFICATION_ANCHOR_ARCHITECT`) gains a conditional subsection, gated in-text to
+``ml_ds`` + binary target, mirroring the ``pregunta_eje`` precedent (Issue #242).
+
+Pure assembly — no LLM, no DB. The frozen-hash / differential tripwires for this prompt
+live in ``tests/test_issue301_pr2b_architect.py``; this file asserts presence/absence of
+the new instruction across profiles and families.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from case_generator.graph import _assemble_architect_prompt
+
+# Stable sentinels the subsection must expose. ``_COST_MATRIX_TOKEN`` is unique to the new
+# instruction (it appears nowhere in the base prompt), so its presence/absence cleanly
+# distinguishes "anchor applied" from "anchor-free base". ``_GATE_PHRASE`` proves the
+# emission is gated to ml_ds in-text (the analogue of pregunta_eje's gating).
+_COST_MATRIX_TOKEN = "business_cost_matrix"
+_GATE_PHRASE = "SOLO para el perfil ml_ds"
+
+
+# Full format context (union of _build_base_context keys + per-node injections), mirroring
+# tests/test_issue301_pr2b_architect.py::_MLDS_CTX. Profile/family are overridden per test.
+_BASE_CTX: dict[str, object] = {
+    "student_profile": "ml_ds",
+    "primary_family": "clasificacion",
+    "output_language": "es",
+    "case_id": "test-uuid-0000",
+    "course_level": "grad",
+    "max_investment_pct": 8,
+    "urgency_frame": "48-96 horas",
+    "protected_columns": '["target","id","date"]',
+    "main_risk_from_m3_m4": "",
+    "is_docente_only": True,
+    "implementation_timeframe": "",
+    "industria": "fintech",
+    "industry_cagr_range": "5-8%",
+    "nombre_empresa": "AcmeCorp",
+    "dilema_hypotheses": "",
+    "output_depth": "visual_plus_notebook",
+    "algoritmos": '["LogisticRegression"]',
+    "titulo": "Test título",
+    "grounding_modules": "[]",
+    "grounding_objectives": "[]",
+    "grounding_generation_hints": "{}",
+    "grounding_course_identity": "{}",
+    "teacher_input": "test teacher input",
+    "architect_output": "test architect output",
+    "pregunta_eje": "¿Debe la empresa priorizar retención selectiva?",
+}
+
+
+def _ctx(profile: str, family: str) -> dict[str, object]:
+    ctx = dict(_BASE_CTX)
+    ctx["student_profile"] = profile
+    ctx["primary_family"] = family
+    return ctx
+
+
+# ── (a) present for ml_ds + clasificación ─────────────────────────────────────
+
+def test_mlds_classification_prompt_emits_cost_matrix_instruction() -> None:
+    assembled = _assemble_architect_prompt(_ctx("ml_ds", "clasificacion"))
+    assert _COST_MATRIX_TOKEN in assembled
+    assert _GATE_PHRASE in assembled
+    # Reconciles _architect_base rule "NO incluir claves extra": nested sub-field, never top-level.
+    assert "clave ANIDADA dentro de" in assembled
+    assert "clave de nivel superior" in assembled
+
+
+# ── (b) absent for non-classification families (anchor not applied) ───────────
+
+@pytest.mark.parametrize("family", ["regresion", "clustering", "serie_temporal"])
+def test_non_classification_families_omit_cost_matrix_instruction(family: str) -> None:
+    """Non-classification families fall back to the anchor-free base
+    (CASE_ARCHITECT_PROMPT_BY_FAMILY has only ``clasificacion``), so the new
+    instruction must not appear — even for ml_ds."""
+    assembled = _assemble_architect_prompt(_ctx("ml_ds", family))
+    assert _COST_MATRIX_TOKEN not in assembled
+    assert _GATE_PHRASE not in assembled
+
+
+# ── (b') business + clasificación DOES carry the gated text (like pregunta_eje) ──
+
+def test_business_classification_carries_gated_cost_matrix_text() -> None:
+    """The anchor is shared by both profiles in clasificación, so business+clf
+    contains the instruction — but the in-text gate scopes EMISSION to ml_ds. The
+    'absent' assertion must therefore target non-classification families, never business."""
+    assembled = _assemble_architect_prompt(_ctx("business", "clasificacion"))
+    assert _COST_MATRIX_TOKEN in assembled
+    # The gate explicitly restricts emission to the ml_ds profile.
+    assert _GATE_PHRASE in assembled
+
+
+# ── (c) OPTIONAL live golden-eval (deferred) ──────────────────────────────────
+
+@pytest.mark.live_llm
+@pytest.mark.skipif(
+    os.environ.get("RUN_LIVE_LLM_TESTS") != "1",
+    reason="live LLM gate (set RUN_LIVE_LLM_TESTS=1)",
+)
+def test_architect_emits_valid_cost_matrix_for_asymmetric_case() -> None:
+    """Deferred live check: an ml_ds classification case with an explicit cost
+    asymmetry (e.g. fraud: fn≫fp) should yield a Pydantic-valid business_cost_matrix
+    with a plausible ratio; a symmetric case should yield ``null``. Wiring this to the
+    golden-eval harness is intentionally out of scope for the prompt-only change."""
+    pytest.skip("golden-eval wiring deferred — see plan §3(c)")


### PR DESCRIPTION
## Qué

Follow-up de #334 (PR #341, ya merged), que restauró la celda `cost_matrix` del notebook M3 para que **LEA** `dataset_schema_required.business_cost_matrix` cuando está presente. Hasta ahora ningún prompt instruía al `case_architect` a **EMITIR** la matriz, así que todos los casos caían en silencio al fallback genérico `fp=1 / fn=5 / USD` — la curva costo-vs-threshold quedaba desanclada de los costos asimétricos reales del caso.

`business_cost_matrix` ya es un sub-campo opcional y validado del output estructurado del architect (`DatasetSchemaRequired.business_cost_matrix` → `BusinessCostMatrix`). El LLM ya **podía** emitirlo; ningún prompt se lo pedía. **Cambio solo de prompt, no de schema.**

## Cómo

Añade una subsección **condicional** al ancla de clasificación `_M1_CLASSIFICATION_ANCHOR_ARCHITECT` (después de la regla 4, sin renumerar 1–4) que instruye al architect a emitir `business_cost_matrix`:

- **Gating in-text** (imita el precedente de `pregunta_eje`, Issue #242): SOLO para `ml_ds` + `clasificacion` + target **binario** (confusión 2×2). Para `business`, multiclase u otras familias → `null`.
- **Trazabilidad**: `fp_cost` = error de comisión, `fn_cost` = error de omisión — exactamente los dos errores que la **regla 3** del ancla ya obliga a narrar en el dilema. Derivados del `dilema_brief` + Exhibits financieros, nunca inventados.
- **Emisión condicional**: solo cuando los costos son genuinamente asimétricos y derivables; si son simétricos/no inferibles → `null` (no fabricar asimetría).
- **Bounds válidos** o el validador downstream la nulifica: `fp/fn > 0`, finitos, ≤ 1e9, ratio ≤ 1000:1, `currency` en allowlist EN MAYÚSCULAS.
- **Anidado** dentro de `dataset_schema_required`, nunca como clave de nivel superior (reconcilia la regla base "NO incluir claves extra", que aplica a claves de nivel superior).

### Por qué Estrategia A (editar el ancla)

`CASE_ARCHITECT_PROMPT_BY_FAMILY` solo tiene la clave `clasificacion`; `regresion`/`clustering`/`serie_temporal` caen al base sin ancla → el texto nuevo NO los alcanza (menor blast radius). El test diferencial `test_mlds_architect_prompt_unchanged_by_business_gate` (assembled ml_ds == `CASE_ARCHITECT_PROMPT_CLASSIFICATION.format(**ctx)`) se mantiene **verde** porque el cambio vive en el ancla, presente en ambos lados.

## Hash congelado

Editar el ancla cambia el prompt ensamblado de ml_ds, así que `_MLDS_ARCHITECT_PROMPT_SHA256` se **regeneró deliberadamente** (`2cb7190…` → `87df26d…`). Antes de actualizarlo confirmé que el test diferencial seguía verde — el bloque business NO se filtró al path ml_ds.

## Limitación aceptada (documentada)

El validador `_validate_business_cost_matrix` gatea por **familia** y valida la forma Pydantic, pero NO comprueba binariedad ni asimetría genuina, y no hace reprompt. Así que D3 (asimetría) y D4 (binario) quedan reforzados **solo a nivel de prompt** — coherente con la postura no-reprompt existente. Una matriz fabricada-pero-válida pasaría; se mitiga atando los números a la regla 3 + Exhibits.

## Evidencia

- **Focalizados** (`test_issue301_pr2b_architect`, `test_issue238_cost_matrix`, `test_issue242_pedagogical_coherence`, `test_issue340_...`): **89 passed, 1 skipped**.
- **Suite completa** (`uv run --directory backend pytest -q`): **1188 passed, 21 skipped** (1 warning sklearn preexistente, no relacionado).
- **Tipos** (`uv run --directory backend mypy src`): **Success: no issues found in 82 source files**.
- **Render manual** de `_assemble_architect_prompt`:
  - `ml_ds + clasificacion` → `business_cost_matrix=True`, gated_text=True ✅
  - `business + clasificacion` → `business_cost_matrix=True`, gated_text=True ✅ (texto presente, emisión gateada a ml_ds)
  - `ml_ds + regresion` → `business_cost_matrix=False`, gated_text=False ✅

## Docs

No se altera ningún contrato operativo documentado (M3 dispatch, grounding, guardrails Supabase…). **No requiere sincronizar `AGENTS.md` / `CLAUDE.md`.**

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
