### PR TITLE
fix(case_generator): RF interp TOC coherence + drop dead PDP import (#335)

### DIFF
--- a/backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py
+++ b/backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py
@@ -835,7 +835,7 @@ try:
   from sklearn.compose import ColumnTransformer
   from sklearn.ensemble import RandomForestClassifier
   from sklearn.impute import SimpleImputer
-  from sklearn.inspection import permutation_importance, PartialDependenceDisplay
+  from sklearn.inspection import permutation_importance
   from sklearn.model_selection import train_test_split
   from sklearn.pipeline import Pipeline
   from sklearn.preprocessing import StandardScaler, OneHotEncoder
@@ -1103,7 +1103,7 @@ TOC_MARKDOWN_CELL_BY_VARIANT: dict[ClassificationNotebookVariant, str] = {
         "# | 3.0.5.8 | Matriz de confusión normalizada |\n"
         "# | 3.0.6 | Matriz de costos del negocio + threshold tuning |\n"
         "# | 3.0.8 | Tuning de hiperparámetros — Random Forest |\n"
-        "# | 3.0.10 | Interpretabilidad RF: permutation importance + PDP top-2 |\n"
+        "# | 3.0.10 | Interpretabilidad RF: permutation importance tabular |\n"
         "# | 3.0.11 | Resumen ejecutable de métricas |"
     ),
     CLASSIFICATION_NOTEBOOK_VARIANT_LR_RF_CONTRAST: (
@@ -1129,7 +1129,7 @@ TOC_MARKDOWN_CELL_BY_VARIANT: dict[ClassificationNotebookVariant, str] = {
         "# | 3.0.7 | Tuning de hiperparámetros — Logistic Regression |\n"
         "# | 3.0.8 | Tuning de hiperparámetros — Random Forest |\n"
         "# | 3.0.9 | Interpretabilidad LR: odds ratios + CI bootstrap + VIF |\n"
-        "# | 3.0.10 | Interpretabilidad RF: permutation importance + PDP top-2 |\n"
+        "# | 3.0.10 | Interpretabilidad RF: permutation importance tabular |\n"
         "# | 3.0.11 | Resumen ejecutable de métricas |"
     ),
 }

--- a/backend/tests/test_issue230_classification_notebook_variants.py
+++ b/backend/tests/test_issue230_classification_notebook_variants.py
@@ -478,3 +478,90 @@ def test_base_template_toc_placeholder_is_replaced_for_non_classification_family
         "All families must call .replace('{toc_cell}', ...) before use."
     )
     assert "import io" in assembled, "Base template imports must survive the replacement"
+
+
+# ---------------------------------------------------------------------------
+# Issue #335 — TOC<->section coherence for RF interpretability (table-only)
+# ---------------------------------------------------------------------------
+#
+# The rf_only / lr_rf_contrast variants degrade RF interpretability to a
+# permutation-importance TABLE (RF_INTERP_TABLE_ONLY_SECTION, zero figures) so
+# the notebook stays within its hard 3-figure budget (ROC + confusion matrix +
+# cost matrix). Two artifacts had drifted out of sync: the TOC row still
+# promised "+ PDP top-2" and the section dragged a dead PartialDependenceDisplay
+# import. No existing test compared the TOC *descriptive text* against what the
+# section actually emits, so that incoherence shipped green. These tests close
+# that gap.
+#
+# The TOC and the algorithm body are assembled in SEPARATE layers (the TOC dict
+# is injected via {toc_cell}; the body is .format()-ed independently), so each
+# half asserts against its own object: Half A against TOC_MARKDOWN_CELL_BY_VARIANT,
+# Half B against the assembled body prompt.
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY, id="rf_only"),
+        pytest.param(
+            CLASSIFICATION_NOTEBOOK_VARIANT_LR_RF_CONTRAST, id="lr_rf_contrast"
+        ),
+    ],
+)
+def test_rf_interp_toc_row_is_table_only_truthful(variant: str) -> None:
+    """Half A (the real bug guard): the RF-interp TOC row must not promise a PDP
+    and must describe the table-only reality, matching the section header. Fails
+    against the pre-fix '... permutation importance + PDP top-2' string and
+    passes after the fix."""
+    toc = TOC_MARKDOWN_CELL_BY_VARIANT[variant]
+    assert "PDP" not in toc, (
+        f"{variant} TOC must not promise a PDP — the RF interpretability section "
+        "is table-only (zero figures) to respect the 3-figure budget"
+    )
+    assert "permutation importance tabular" in toc, (
+        f"{variant} TOC must describe the table-only RF interpretability, "
+        "matching the section header"
+    )
+
+
+def test_lr_only_toc_has_no_rf_interp_or_pdp() -> None:
+    """Half A (lr_only stays clean): the single-LR deep dive must not leak the RF
+    interpretability section (3.0.10) or any PDP mention."""
+    toc = TOC_MARKDOWN_CELL_BY_VARIANT[CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY]
+    assert "PDP" not in toc
+    assert "3.0.10" not in toc
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        pytest.param(M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_RF_ONLY, id="rf_only"),
+        pytest.param(
+            M3_NOTEBOOK_ALGO_PROMPT_CLASSIFICATION_LR_RF_CONTRAST,
+            id="lr_rf_contrast",
+        ),
+    ],
+)
+def test_rf_interp_section_is_table_only_no_pdp_render(prompt: str) -> None:
+    """Half B (positive table-only invariants on the assembled body): the RF
+    interpretability section prints the permutation-importance table, adds no
+    figure, and keeps the PartialDependenceDisplay token alive ONLY inside the
+    explanatory print() note. That surviving token is load-bearing for the
+    runtime validator (_validate_notebook_family_consistency) and for
+    test_single_model_prompts_do_not_seed_unselected_model_text."""
+    assert "permutation importance tabular" in prompt
+    assert "Top 10 permutation importance (RF):" in prompt
+    # The RF-interp section adds zero figures — the budget stays at exactly 3
+    # (ROC + confusion matrix + cost matrix).
+    assert _executable_region(prompt).count("plt.show()") == 3
+    # The validator token survives via the print() note, not via an import or a
+    # render call.
+    assert "PartialDependenceDisplay" in prompt
+    # Belt-and-suspenders, VACUOUS BY CONSTRUCTION: the render call
+    # `PartialDependenceDisplay.from_estimator` never appears in _shared.py in any
+    # state (it lives only in the legacy monolith notebook.py), so this assertion
+    # is trivially true for every variant and does NOT distinguish a correct
+    # prompt from a broken one. It is kept only as a tripwire against a future
+    # PDP-render reintroduction; the real guards of this half are the positive
+    # assertions above.
+    assert "PartialDependenceDisplay.from_estimator" not in prompt


### PR DESCRIPTION
## Summary

In the M3 classification notebook **variant** builder, the `rf_only` and `lr_rf_contrast` variants intentionally degrade RF interpretability to a **table-only** section (`RF_INTERP_TABLE_ONLY_SECTION`: permutation-importance table, **zero figures**) so the notebook stays within its hard **3-figure budget** (ROC + confusion matrix + cost matrix). Two artifacts had drifted out of sync with that reality:

1. The TOC row still advertised `Interpretabilidad RF: permutation importance + PDP top-2` in both `rf_only` and `lr_rf_contrast`.
2. The section dragged a **dead `PartialDependenceDisplay` import** (never used in the body).

This is a **TOC↔cell coherence + dead-import bug, not a runtime bug** (the notebook still runs). Closes #335.

## Scope decision — truthful TOC + dead-import removal (NO PDP restoration)

Restoring a real PDP is **out of scope**: the figure budget is exactly 3 and saturated, and `RF_INTERP_TABLE_ONLY_SECTION` has 0 `plt.show()`. Adding a 4th `plt.show()` breaks `test_variant_prompts_keep_three_chart_budget`, which asserts:

```python
assert _executable_region(prompt).count("plt.show()") == 3
```

The 2-figure PDP lives only in the legacy monolith (`prompts/clasificacion/notebook.py`) — exactly where the variant builder degraded it on purpose. The honest fix is to make the TOC truthful (`permutation importance tabular`, matching the section header) and drop the dead import.

## Changes

- `backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py` — 3 edits:
  - Two byte-identical TOC rows (`rf_only`, `lr_rf_contrast`): `permutation importance + PDP top-2` → `permutation importance tabular`.
  - Removed the dead `PartialDependenceDisplay` import from `RF_INTERP_TABLE_ONLY_SECTION`.
  - **Left the `print()` note byte-identical** — it is the load-bearing surviving occurrence of the `PartialDependenceDisplay` token, required by both the runtime validator (`_validate_notebook_family_consistency` → `_CLASSIFICATION_REQUIRED_APIS_BY_VARIANT` / `_FAMILY_REQUIRED_APIS`) and `test_single_model_prompts_do_not_seed_unselected_model_text`.
  - `lr_only` untouched.
- `backend/tests/test_issue230_classification_notebook_variants.py` — new **two-layer** regression test (the gap that let this ship green: existing TOC tests only checked section *numbers*, never descriptive text). The TOC and body are assembled in separate layers, so each half asserts against its own object:
  - **Half A** (the real bug guard): asserts `TOC_MARKDOWN_CELL_BY_VARIANT[variant]` has no `PDP` and contains `permutation importance tabular` for `rf_only`/`lr_rf_contrast`; `lr_only` stays clean (no `PDP`, no `3.0.10`).
  - **Half B** (positive table-only invariants on the assembled body): `permutation importance tabular`, `Top 10 permutation importance (RF):`, `_executable_region(prompt).count("plt.show()") == 3`, and `PartialDependenceDisplay` token still present (via the note). Includes a belt-and-suspenders `PartialDependenceDisplay.from_estimator not in prompt` check, explicitly annotated as **vacuous by construction** (that render call never exists in `_shared.py` in any state).

## Evidence

**Pre-fix → post-fix (proves the test is meaningful):**
- Pre-fix focused run: `2 failed, 3 passed` — Half A fails on `rf_only` and `lr_rf_contrast` (PDP present in TOC), everything else green.
- Post-fix focused run: `83 passed` across `test_issue230_classification_notebook_variants.py`, `test_issue240_classification_tuning_interpretability.py`, `test_m3_notebook_classification_hygiene.py`, `test_prompt_hygiene.py`.

**Full gate:**
- `uv run --directory backend pytest -q` → **1194 passed, 21 skipped** (no `test_issue340_*` failure → **no architect frozen hash regenerated**).
- `uv run --directory backend mypy src` → **Success: no issues found in 82 source files**.

**Two-layer render snippets:**

TOC layer:
| variant | `PDP` present | `permutation importance tabular` | `3.0.10` present |
|---|---|---|---|
| rf_only | False | True | True |
| lr_rf_contrast | False | True | True |
| lr_only | False | False (no RF interp) | False |

Section layer (`rf_only` and `lr_rf_contrast`, assembled body):
- import emitted: `from sklearn.inspection import permutation_importance` (no `PartialDependenceDisplay`)
- `PartialDependenceDisplay` substring present (via the `print()` note) → validator satisfied
- no `PartialDependenceDisplay.from_estimator` (zero PDP render)
- `Top 10 permutation importance (RF):` present, `permutation importance tabular` present
- `plt.show()` count = **3**

## Docs

No operational rule changed, so `AGENTS.md` / `CLAUDE.md` are intentionally **not** touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)