### PR TITLE
feat(authoring): compact loader once the live preview has content

### DIFF
--- a/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.test.tsx
@@ -61,6 +61,25 @@ describe("AuthoringProgressTimeline", () => {
         expect(screen.getByText("100%")).toBeTruthy();
     });
 
+    it("renders a slim bar with only the active step in compact mode", () => {
+        render(
+            <AuthoringProgressTimeline
+                activeAgent="m4_content_generator"
+                scope="technical"
+                jobStatus="processing"
+                compact
+            />,
+        );
+
+        // Percentage logic is shared with the full card.
+        expect(screen.getByText("71%")).toBeTruthy();
+        // Only the active step label is shown...
+        expect(screen.getByText("Calculando impacto financiero")).toBeTruthy();
+        // ...not the other steps, and not the full-card description block.
+        expect(screen.queryByText("Auditando evidencia")).toBeNull();
+        expect(screen.queryByText(/Los agentes de ADAM/)).toBeNull();
+    });
+
     it("keeps the last known step when the active agent temporarily disappears", () => {
         const { rerender } = render(
             <AuthoringProgressTimeline

--- a/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx
+++ b/frontend/src/features/teacher-authoring/AuthoringProgressTimeline.tsx
@@ -8,6 +8,12 @@ interface Props {
   bootstrapState?: AuthoringBootstrapState;
   scope: "narrative" | "technical";
   jobStatus?: "pending" | "processing" | "completed" | "failed" | "failed_resumable";
+  /**
+   * Slim variant: a single-line progress bar (active step + % + N/total) instead of the
+   * full-height card. Used once the live preview has content so the loader stops competing
+   * with the preview but still signals "sigue trabajando" (e.g. during the M3 notebook stall).
+   */
+  compact?: boolean;
 }
 
 const PIPELINE_STEPS: Array<{
@@ -80,7 +86,7 @@ function getStepStatus(
   return "pending";
 }
 
-export function AuthoringProgressTimeline({ activeAgent, bootstrapState, scope, jobStatus }: Props) {
+export function AuthoringProgressTimeline({ activeAgent, bootstrapState, scope, jobStatus, compact }: Props) {
   const [dots, setDots] = useState("");
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const lastValidIndexRef = useRef<number>(-1);
@@ -120,6 +126,47 @@ export function AuthoringProgressTimeline({ activeAgent, bootstrapState, scope, 
       }
     }
   }, [effectiveIndex]);
+
+  if (compact) {
+    const activeStep =
+      inferredActiveIndex >= 0
+        ? visibleSteps[Math.min(inferredActiveIndex, visibleSteps.length - 1)]
+        : undefined;
+    const heading = isBootstrapInitializing ? "Preparando generador" : "Generando caso";
+    return (
+      <div className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="relative h-5 w-5 flex-shrink-0">
+              <div className="absolute inset-0 rounded-full border-2 border-[#0144a0] border-t-transparent animate-spin" />
+            </div>
+            <p className="min-w-0 truncate text-sm font-semibold text-slate-800">
+              {heading}
+              <span className="inline-block w-4 text-left text-[#0144a0] animate-pulse">{dots}</span>
+              {activeStep && (
+                <>
+                  {" · "}
+                  <span className="font-bold text-[#0144a0]">{activeStep.label}</span>
+                </>
+              )}
+            </p>
+          </div>
+          <div className="flex flex-shrink-0 items-center gap-2">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+              {safeCurrentProgressIndex}/{visibleSteps.length}
+            </span>
+            <span className="text-sm font-black tabular-nums text-[#0144a0]">{progressPercent}%</span>
+          </div>
+        </div>
+        <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-[#0144a0] to-blue-400 transition-all duration-1000"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     // Redujimos el padding global de p-10 a p-4/p-6

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.test.tsx
@@ -6,7 +6,14 @@ vi.mock("./AuthoringForm", () => ({
     AuthoringForm: () => <div data-testid="authoring-form">Authoring form</div>,
 }));
 vi.mock("./AuthoringProgressTimeline", () => ({
-    AuthoringProgressTimeline: () => <div data-testid="authoring-progress">Progress</div>,
+    AuthoringProgressTimeline: (props: { compact?: boolean }) => (
+        <div data-testid="authoring-progress" data-compact={props.compact ? "true" : "false"}>
+            Progress
+        </div>
+    ),
+}));
+vi.mock("@/features/case-preview/LiveCasePreview", () => ({
+    LiveCasePreview: () => <div data-testid="live-case-preview">Live preview</div>,
 }));
 vi.mock("./AuthoringErrorState", () => ({
     AuthoringErrorState: (props: { message: string; onRetry?: () => void; onBack: () => void }) => (
@@ -90,6 +97,50 @@ describe("TeacherAuthoringPage", () => {
         expect(screen.getByText(/cargando vista previa/i)).toBeTruthy();
         expect(await screen.findByTestId("case-preview")).toBeTruthy();
         expect(screen.queryByTestId("authoring-form")).toBeNull();
+    });
+
+    it("shows the full-bleed loader and no live preview while generating without a partial yet", () => {
+        vi.mocked(useAuthoringJobProgress).mockReturnValue({
+            jobId: "job-gen",
+            status: "processing",
+            errorTrace: null,
+            result: null,
+            activeAgent: "case_architect",
+            submitJob: vi.fn(),
+            retryJob: vi.fn(),
+            reset: vi.fn(),
+            isStreaming: true,
+            progressScope: "technical",
+            bootstrapState: undefined,
+        });
+
+        render(<TeacherAuthoringPage />);
+
+        const progress = screen.getByTestId("authoring-progress");
+        expect(progress.getAttribute("data-compact")).toBe("false");
+        expect(screen.queryByTestId("live-case-preview")).toBeNull();
+    });
+
+    it("collapses the loader to compact and shows the live preview once a partial lands", async () => {
+        vi.mocked(useAuthoringJobProgress).mockReturnValue({
+            jobId: "job-gen",
+            status: "processing",
+            errorTrace: null,
+            result: { content: { narrative: "M1" } } as never,
+            activeAgent: "m4_content_generator",
+            submitJob: vi.fn(),
+            retryJob: vi.fn(),
+            reset: vi.fn(),
+            isStreaming: true,
+            progressScope: "technical",
+            bootstrapState: undefined,
+        });
+
+        render(<TeacherAuthoringPage />);
+
+        const progress = screen.getByTestId("authoring-progress");
+        expect(progress.getAttribute("data-compact")).toBe("true");
+        expect(await screen.findByTestId("live-case-preview")).toBeTruthy();
     });
 
     it("shows resumable error state and retries without resetting context", async () => {

--- a/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
+++ b/frontend/src/features/teacher-authoring/TeacherAuthoringPage.tsx
@@ -152,11 +152,16 @@ export function TeacherAuthoringPage() {
   }, [jobStatus, resetJob, retryJob]);
 
   const isPreviewActive = appState === "success" || appState === "paused";
+  // The full-screen loader (shown until the first module lands) must bleed full-width;
+  // otherwise its cream background is boxed to max-w-6xl and the page's #F0F4F8 shows as
+  // two bluish stripes on the sides.
+  const isFullLoaderOnly = appState === "generating" && !jobResult;
+  const isFullBleed = isPreviewActive || isFullLoaderOnly;
 
   return (
     <TeacherLayout
       testId="teacher-authoring-page"
-      contentClassName={isPreviewActive ? "w-full p-0" : "mx-auto w-full max-w-6xl"}
+      contentClassName={isFullBleed ? "w-full p-0" : "mx-auto w-full max-w-6xl"}
     >
       {(appState === "idle" || appState === "editing") && (
         <AuthoringForm
@@ -168,19 +173,30 @@ export function TeacherAuthoringPage() {
       )}
 
       {appState === "generating" && (
-        <div className="flex flex-col gap-6">
+        jobResult ? (
+          // Once the first module lands: slim progress bar + the live preview as the
+          // spotlight (inside max-w-6xl, with breathing room from the sticky topbar).
+          <div className="flex w-full flex-col gap-4 px-4 pt-6 pb-10">
+            <AuthoringProgressTimeline
+              activeAgent={activeAgent}
+              bootstrapState={bootstrapState}
+              jobStatus={jobStatus || undefined}
+              scope={progressScope || (formData.caseType === "harvard_only" ? "narrative" : "technical")}
+              compact
+            />
+            <Suspense fallback={<CasePreviewFallback />}>
+              <LiveCasePreview caseData={jobResult} isStreaming={true} />
+            </Suspense>
+          </div>
+        ) : (
+          // Full-bleed loader until the first module is ready.
           <AuthoringProgressTimeline
             activeAgent={activeAgent}
             bootstrapState={bootstrapState}
             jobStatus={jobStatus || undefined}
             scope={progressScope || (formData.caseType === "harvard_only" ? "narrative" : "technical")}
           />
-          {jobResult && (
-            <Suspense fallback={<CasePreviewFallback />}>
-              <LiveCasePreview caseData={jobResult} isStreaming={true} />
-            </Suspense>
-          )}
-        </div>
+        )
       )}
 
       {(appState === "success" || appState === "paused") && caseResult && (


### PR DESCRIPTION
## What

UX refinement on top of the live preview (#355). When generating, the full step-loader card and the live preview were both large and competed visually. Now:

- **Until the first module lands:** full-bleed step loader (fixes two bluish side stripes that appeared because its cream background was boxed to `max-w-6xl` while the page bg `#F0F4F8` showed on the sides).
- **Once a module is ready:** the loader collapses to a **slim progress bar** (active step + N/total + %) and the live preview takes the spotlight, with breathing room from the sticky topbar.

Pure layout/UX — single `AuthoringProgressTimeline` gains a `compact` variant (reuses the same percentage/step logic, no duplication); `TeacherAuthoringPage` toggles full-bleed loader vs compact+preview on `jobResult`.

## Tests

- `AuthoringProgressTimeline.test.tsx`: compact variant renders the slim bar with only the active step (not the full step list / description).
- `TeacherAuthoringPage.test.tsx`: generating without a partial → full (non-compact) loader, no preview; with a partial → compact loader + live preview.

Lint clean, build OK, 17 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)