### PR TITLE
fix(case_generator): renumber M3 clf TOC + headers consecutively after #353 trim

### DIFF
--- a/backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py
+++ b/backend/src/case_generator/prompts/clasificacion/notebooks/_shared.py
@@ -173,7 +173,7 @@ INTRO_BY_VARIANT: dict[ClassificationNotebookVariant, str] = {
 CV_SECTIONS: dict[ClassificationNotebookVariant, str] = {
     "lr_only": """
 # %% [markdown]
-# #### 3.0.5.4 Validación cruzada estratificada — Logistic Regression
+# #### 3.0.5.3 Validación cruzada estratificada — Logistic Regression
 
 # %%
 # === SECTION:cv_scores ===
@@ -193,7 +193,7 @@ except Exception as e:
 """,
     "rf_only": """
 # %% [markdown]
-# #### 3.0.5.4 Validación cruzada estratificada — Random Forest
+# #### 3.0.5.3 Validación cruzada estratificada — Random Forest
 
 # %%
 # === SECTION:cv_scores ===
@@ -407,7 +407,7 @@ except Exception as e:
 COMPARISON_SECTIONS: dict[ClassificationNotebookVariant, str] = {
     "lr_only": """
 # %% [markdown]
-# #### 3.0.5.7 Tabla final — Logistic Regression
+# #### 3.0.5.4 Tabla final — Logistic Regression
 
 # %%
 # === SECTION:comparison_table ===
@@ -433,7 +433,7 @@ except Exception as e:
 """,
     "rf_only": """
 # %% [markdown]
-# #### 3.0.5.7 Tabla final — Random Forest
+# #### 3.0.5.4 Tabla final — Random Forest
 
 # %%
 # === SECTION:comparison_table ===
@@ -459,7 +459,7 @@ except Exception as e:
 """,
     "lr_rf_contrast": """
 # %% [markdown]
-# #### 3.0.5.7 Tabla comparativa final — LR vs RF
+# #### 3.0.5.5 Tabla comparativa final — LR vs RF
 
 # %%
 # === SECTION:comparison_table ===
@@ -492,7 +492,7 @@ except Exception as e:
 COST_SECTIONS: dict[ClassificationNotebookVariant, str] = {
     "lr_only": """
 # %% [markdown]
-# ### 3.0.6 — Matriz de costos del negocio + threshold tuning
+# #### 3.0.5.6 — Matriz de costos del negocio + threshold tuning
 # El threshold default 0.5 SOLO es óptimo si FP y FN cuestan igual. En la
 # mayoría de los problemas de negocio (churn, fraude, mantenimiento) los
 # costos son asimétricos. Esta celda lee la matriz de costos del contrato
@@ -572,7 +572,7 @@ except Exception as e:
 """,
     "rf_only": """
 # %% [markdown]
-# ### 3.0.6 — Matriz de costos del negocio + threshold tuning
+# #### 3.0.5.6 — Matriz de costos del negocio + threshold tuning
 # El threshold default 0.5 SOLO es óptimo si FP y FN cuestan igual. En la
 # mayoría de los problemas de negocio (churn, fraude, mantenimiento) los
 # costos son asimétricos. Esta celda lee la matriz de costos del contrato
@@ -652,7 +652,7 @@ except Exception as e:
 """,
     "lr_rf_contrast": """
 # %% [markdown]
-# ### 3.0.6 — Matriz de costos del negocio + threshold tuning
+# #### 3.0.5.7 — Matriz de costos del negocio + threshold tuning
 # En contraste usamos LR como soporte de threshold por interpretabilidad.
 # El threshold default 0.5 SOLO es óptimo si FP y FN cuestan igual. En la
 # mayoría de los problemas de negocio (churn, fraude, mantenimiento) los
@@ -737,7 +737,7 @@ except Exception as e:
 CONFUSION_MATRIX_SECTIONS: dict[ClassificationNotebookVariant, str] = {
     "lr_only": """
 # %% [markdown]
-# #### 3.0.5.8 Matriz de confusión — Logistic Regression (normalizada por fila)
+# #### 3.0.5.5 Matriz de confusión — Logistic Regression (normalizada por fila)
 # Muestra la tasa de acierto por clase real a umbral fijo 0.5.
 # Normalizado por fila para que sea informativo en datasets desbalanceados.
 
@@ -765,7 +765,7 @@ except Exception as e:
 """,
     "rf_only": """
 # %% [markdown]
-# #### 3.0.5.8 Matriz de confusión — Random Forest (normalizada por fila)
+# #### 3.0.5.5 Matriz de confusión — Random Forest (normalizada por fila)
 # Muestra la tasa de acierto por clase real a umbral fijo 0.5.
 # Normalizado por fila para que sea informativo en datasets desbalanceados.
 
@@ -793,7 +793,7 @@ except Exception as e:
 """,
     "lr_rf_contrast": """
 # %% [markdown]
-# #### 3.0.5.8 Matrices de confusión — LR y RF (normalizadas por fila)
+# #### 3.0.5.6 Matrices de confusión — LR y RF (normalizadas por fila)
 # Ambos modelos en una sola figura para comparación directa (Regla L atomic charting).
 # Normalizado por fila para que sea informativo en datasets desbalanceados.
 
@@ -880,7 +880,7 @@ except Exception as e:
 METRICS_SECTIONS: dict[ClassificationNotebookVariant, str] = {
     "lr_only": """
 # %% [markdown]
-# ### 3.0.11 — Resumen ejecutable de métricas para grounding narrativo
+# #### 3.0.5.7 — Resumen ejecutable de métricas para grounding narrativo
 
 # %%
 # === SECTION:metrics_summary_json ===
@@ -939,7 +939,7 @@ print("ADAM_M3_METRICS_SUMMARY_JSON=" + _json_m3_metrics.dumps(_metrics_summary,
 """,
     "rf_only": """
 # %% [markdown]
-# ### 3.0.11 — Resumen ejecutable de métricas para grounding narrativo
+# #### 3.0.5.7 — Resumen ejecutable de métricas para grounding narrativo
 
 # %%
 # === SECTION:metrics_summary_json ===
@@ -998,7 +998,7 @@ print("ADAM_M3_METRICS_SUMMARY_JSON=" + _json_m3_metrics.dumps(_metrics_summary,
 """,
     "lr_rf_contrast": """
 # %% [markdown]
-# ### 3.0.11 — Resumen ejecutable de métricas para grounding narrativo
+# #### 3.0.5.8 — Resumen ejecutable de métricas para grounding narrativo
 
 # %%
 # === SECTION:metrics_summary_json ===
@@ -1079,11 +1079,11 @@ TOC_MARKDOWN_CELL_BY_VARIANT: dict[ClassificationNotebookVariant, str] = {
         "# | 3.0 | EDA Express |\n"
         "# | 3.0.5.1 | Baseline trivial — DummyClassifier + bootstrap de variables |\n"
         "# | 3.0.5.2 | Pipeline reproducible — Logistic Regression |\n"
-        "# | 3.0.5.4 | Validación cruzada estratificada |\n"
-        "# | 3.0.5.7 | Tabla final de métricas |\n"
-        "# | 3.0.5.8 | Matriz de confusión normalizada |\n"
-        "# | 3.0.6 | Matriz de costos del negocio + threshold tuning |\n"
-        "# | 3.0.11 | Resumen ejecutable de métricas |"
+        "# | 3.0.5.3 | Validación cruzada estratificada |\n"
+        "# | 3.0.5.4 | Tabla final de métricas |\n"
+        "# | 3.0.5.5 | Matriz de confusión normalizada |\n"
+        "# | 3.0.5.6 | Matriz de costos del negocio + threshold tuning |\n"
+        "# | 3.0.5.7 | Resumen ejecutable de métricas |"
     ),
     CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY: (
         "\n# %% [markdown]\n"
@@ -1097,12 +1097,12 @@ TOC_MARKDOWN_CELL_BY_VARIANT: dict[ClassificationNotebookVariant, str] = {
         "# | 3 | Módulos Experimentales |\n"
         "# | 3.0 | EDA Express |\n"
         "# | 3.0.5.1 | Baseline trivial — DummyClassifier + bootstrap de variables |\n"
-        "# | 3.0.5.3 | Pipeline reproducible — Random Forest |\n"
-        "# | 3.0.5.4 | Validación cruzada estratificada |\n"
-        "# | 3.0.5.7 | Tabla final de métricas |\n"
-        "# | 3.0.5.8 | Matriz de confusión normalizada |\n"
-        "# | 3.0.6 | Matriz de costos del negocio + threshold tuning |\n"
-        "# | 3.0.11 | Resumen ejecutable de métricas |"
+        "# | 3.0.5.2 | Pipeline reproducible — Random Forest |\n"
+        "# | 3.0.5.3 | Validación cruzada estratificada |\n"
+        "# | 3.0.5.4 | Tabla final de métricas |\n"
+        "# | 3.0.5.5 | Matriz de confusión normalizada |\n"
+        "# | 3.0.5.6 | Matriz de costos del negocio + threshold tuning |\n"
+        "# | 3.0.5.7 | Resumen ejecutable de métricas |"
     ),
     CLASSIFICATION_NOTEBOOK_VARIANT_LR_RF_CONTRAST: (
         "\n# %% [markdown]\n"
@@ -1119,10 +1119,10 @@ TOC_MARKDOWN_CELL_BY_VARIANT: dict[ClassificationNotebookVariant, str] = {
         "# | 3.0.5.2 | Pipeline reproducible — Logistic Regression |\n"
         "# | 3.0.5.3 | Pipeline reproducible — Random Forest |\n"
         "# | 3.0.5.4 | Validación cruzada estratificada — LR vs RF |\n"
-        "# | 3.0.5.7 | Tabla comparativa final — LR vs RF |\n"
-        "# | 3.0.5.8 | Matrices de confusión — LR y RF normalizadas |\n"
-        "# | 3.0.6 | Matriz de costos del negocio + threshold tuning |\n"
-        "# | 3.0.11 | Resumen ejecutable de métricas |"
+        "# | 3.0.5.5 | Tabla comparativa final — LR vs RF |\n"
+        "# | 3.0.5.6 | Matrices de confusión — LR y RF normalizadas |\n"
+        "# | 3.0.5.7 | Matriz de costos del negocio + threshold tuning |\n"
+        "# | 3.0.5.8 | Resumen ejecutable de métricas |"
     ),
 }
 
@@ -1150,6 +1150,16 @@ def build_classification_notebook_prompt(
         prompt = _remove_section(prompt, "# === SECTION:pipeline_rf ===")
     elif variant == "rf_only":
         prompt = _remove_section(prompt, "# === SECTION:pipeline_lr ===")
+        # #353 TOC — con pipeline_lr (3.0.5.2) eliminado, el pipeline RF asciende
+        # a la sección .2 para que la numeración quede consecutiva sin hueco. El
+        # header del pipeline RF vive en el legacy (compartido con contraste, donde
+        # SÍ es .3), así que el renumber es exclusivo de esta variante. Solo cambia
+        # el número de display; el sentinel `# === SECTION:pipeline_rf ===` queda
+        # byte-idéntico.
+        prompt = prompt.replace(
+            "# #### 3.0.5.3 Pipeline reproducible — Random Forest",
+            "# #### 3.0.5.2 Pipeline reproducible — Random Forest",
+        )
 
     # #353 — recorte al núcleo esencial: ROC/PR, tuning (GridSearchCV/
     # RandomizedSearchCV) e interpretabilidad avanzada (VIF/odds-ratios bootstrap/

--- a/backend/tests/test_issue230_classification_notebook_variants.py
+++ b/backend/tests/test_issue230_classification_notebook_variants.py
@@ -464,32 +464,34 @@ def test_variant_validator_rejects_unselected_lr_in_rf_only() -> None:
     [
         pytest.param(
             CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY,
-            ("3.0.5.2", "Logistic Regression"),
-            # #353 — ROC(3.0.5.5)/PR(3.0.5.6)/tuning(3.0.7/3.0.8)/interp(3.0.9/3.0.10)
-            # salieron del núcleo; el RF pipeline (3.0.5.3) nunca estuvo en lr_only.
-            ("3.0.5.3", "3.0.5.5", "3.0.5.6", "3.0.7", "3.0.8", "3.0.9", "3.0.10"),
+            ("Logistic Regression",),
+            ("Random Forest",),
             id="lr_only",
         ),
         pytest.param(
             CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY,
-            ("3.0.5.3", "Random Forest"),
-            ("3.0.5.2", "3.0.5.5", "3.0.5.6", "3.0.7", "3.0.8", "3.0.9", "3.0.10"),
+            ("Random Forest",),
+            ("Logistic Regression",),
             id="rf_only",
         ),
         pytest.param(
             CLASSIFICATION_NOTEBOOK_VARIANT_LR_RF_CONTRAST,
-            ("3.0.5.2", "3.0.5.3"),
-            ("3.0.5.5", "3.0.5.6", "3.0.7", "3.0.8", "3.0.9", "3.0.10"),
+            ("Logistic Regression", "Random Forest"),
+            (),
             id="lr_rf_contrast",
         ),
     ],
 )
-def test_toc_cell_contains_correct_sections_per_variant(
+def test_toc_cell_contains_correct_model_per_variant(
     variant: str,
     must_contain: tuple[str, ...],
     must_not_contain: tuple[str, ...],
 ) -> None:
-    """Each variant's TOC lists exactly its own sections and none of the absent ones."""
+    """Each variant's TOC names only its own model(s). #353 — asserted by MODEL,
+    not by section number: the renumber reuses the same number for different
+    sections across variants (e.g. 3.0.5.2 is the LR pipeline in lr_only but the
+    RF pipeline in rf_only). Number consecutiveness + TOC<->headers parity are
+    covered by test_toc_numbering_is_consecutive_and_matches_headers."""
     toc = TOC_MARKDOWN_CELL_BY_VARIANT[variant]
     assert "# %% [markdown]" in toc, "TOC must be a Jupytext markdown cell"
     assert "📋 Tabla de Contenido" in toc, "TOC must have the standard heading"
@@ -500,11 +502,47 @@ def test_toc_cell_contains_correct_sections_per_variant(
 
 
 def test_toc_cell_all_three_variants_share_base_sections() -> None:
-    """Sections 1, 2, 2.1, 3, 3.0, and 3.0.11 must appear in every variant TOC."""
-    base_sections = ("| 1 |", "| 2 |", "| 2.1 |", "| 3 |", "| 3.0 |", "| 3.0.11 |")
+    """Structural base rows 1, 2, 2.1, 3, 3.0 appear in every variant TOC. #353 —
+    the final modeling row is no longer 3.0.11; it is now the last consecutive
+    3.0.5.N (variant-specific), so it is not asserted as a shared base row."""
+    base_sections = ("| 1 |", "| 2 |", "| 2.1 |", "| 3 |", "| 3.0 |")
     for variant, toc in TOC_MARKDOWN_CELL_BY_VARIANT.items():
         for section in base_sections:
             assert section in toc, f"Section {section!r} missing from {variant} TOC"
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY, id="lr_only"),
+        pytest.param(CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY, id="rf_only"),
+        pytest.param(CLASSIFICATION_NOTEBOOK_VARIANT_LR_RF_CONTRAST, id="lr_rf_contrast"),
+    ],
+)
+def test_toc_numbering_is_consecutive_and_matches_headers(variant: str) -> None:
+    """#353 polish — the modeling section numbers must be CONSECUTIVE (no gaps,
+    the original bug) and the TOC must list exactly the section headers the cells
+    actually emit, in the same order (no desync). Guards against the vestigial
+    numbering (3.0.5.1 → .2 → .4 → .7 → .8 → 3.0.6 → 3.0.11) the trim left behind."""
+    import re as _re
+
+    rendered = CLASSIFICATION_NOTEBOOK_PROMPT_BY_VARIANT[variant].format(**SHARED_FORMAT_KEYS)
+    header_numbers = _re.findall(r"# #### (3\.0\.5\.\d+) ", rendered)
+    toc_numbers = _re.findall(r"\| (3\.0\.5\.\d+) \|", TOC_MARKDOWN_CELL_BY_VARIANT[variant])
+
+    # 1) Emitted headers are consecutive 3.0.5.1 .. 3.0.5.N (no gaps).
+    suffixes = [int(n.rsplit(".", 1)[1]) for n in header_numbers]
+    assert suffixes == list(range(1, len(suffixes) + 1)), (
+        f"{variant} headers not consecutive: {header_numbers}"
+    )
+    # 2) TOC lists exactly those numbers, in the same order (índice == headers).
+    assert toc_numbers == header_numbers, (
+        f"{variant} TOC<->headers mismatch: toc={toc_numbers} headers={header_numbers}"
+    )
+    # 3) No vestigial pre-trim section number leaks anywhere in the rendered prompt.
+    assert not _re.search(r"3\.0\.(?:6|7|8|9|10|11)\b", rendered), (
+        f"{variant} still emits a pre-trim section number (3.0.6/.7/.8/.9/.10/.11)"
+    )
 
 
 def test_toc_cell_starts_with_newline_for_clean_cell_boundary() -> None:


### PR DESCRIPTION
Follow-up de #353 (PR #358). **Pulido de presentación**, no rehace el recorte: ninguna celda se añade/quita/reordena, cero cambios de código ejecutable.

## Síntoma
Tras el recorte de #353, la TOC y los headers del notebook M3 de clasificación quedaron con numeración VESTIGIAL (huecos donde se quitaron ROC/PR/tuning/interp). Para un docente/estudiante parece que faltan secciones.

## Before → After (TOC, por variante)
| Variante | Before | After |
|---|---|---|
| `lr_only` | 3.0.5.1, .2, **.4, .7, .8, 3.0.6, 3.0.11** | 3.0.5.1 … 3.0.5.7 (consecutivo) |
| `rf_only` | 3.0.5.1, **.3, .4, .7, .8, 3.0.6, 3.0.11** | 3.0.5.1 … 3.0.5.7 (consecutivo) |
| `lr_rf_contrast` | 3.0.5.1, .2, .3, .4, **.7, .8, 3.0.6, 3.0.11** | 3.0.5.1 … 3.0.5.8 (consecutivo) |

## Qué cambia
- `_shared.py`: renumera los headers markdown de las secciones CV/COMPARISON/CONFUSION/COST/METRICS y las filas de `TOC_MARKDOWN_CELL_BY_VARIANT` para que sean consecutivas por variante. `cost`/`metrics` pasan de `###` a `####` para igualar el bloque `3.0.5.x`. El pipeline RF de `rf_only` se renumera `.3 → .2` en build-time (el header vive en el legacy, compartido con contraste donde sigue siendo `.3`).
- **Línea roja respetada:** los sentinelas `# === SECTION:... ===` quedan **byte-idénticos** — solo cambian los números de display. No se tocan otras familias ni `business`. No hay referencias cruzadas a estos números en M4/M5, `graph.py` ni otros prompts (verificado por grep).

## Tests
- TOC: aserción por **modelo** (robusta al renumber, ya que un mismo número mapea a secciones distintas entre variantes).
- **Nuevo guardarraíl** `test_toc_numbering_is_consecutive_and_matches_headers`: por variante, renderiza el prompt y exige (1) headers consecutivos `3.0.5.1..N` sin huecos, (2) TOC == headers (biyección de números + orden), (3) cero números pre-trim (3.0.6/.7/.8/.9/.10/.11). Convierte la desincronización TOC↔headers en un invariante de CI.

## Verificación
Render de los 3 variants (consecutivo, TOC==headers, sin números vestigiales), `uv run --directory backend pytest -q` → **1262 passed**, `mypy src` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
