### PR TITLE
fix(case_generator): M1 writer friction no longer contradicts the printed Exhibit-2 rate (#362)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1932,3 +1932,38 @@ modelo. Diferido y explícitamente gateado por ADR.
 
 **Depends on / blocked by:** ADR que apruebe un canal de tokens fuera del modelo Realtime actual;
 PR de preview progresivo por-módulo primero.
+
+---
+
+## TODO-362-A: Red de runtime para coherencia M1 (tasa-como-desconocida)
+
+**What:** Extender el validador de Issue #360 (`validate_narrative_exhibit_coherence` /
+`validate_questions_exhibit_coherence` en `case_generator/m1_grounding.py`) para que TAMBIÉN
+señale prosa de M1 que enmarque la tasa de ocurrencia del evento (la que imprime Exhibit 2)
+como **desconocida / no cuantificada / no computada** ("rate-as-unknown") — el espejo en
+runtime de lo que el fix de prompt de #362 corrige en el writer.
+
+**Why:** Issue #362 es **prompt-only**: reescribe la fricción de desbalance hacia la
+confiabilidad de la tasa y añade una guardia que la fija a "lo que SÍ se sabe". Pero M1 NO
+tiene validador propio para esta propiedad, así que el único modo de fallo silencioso —el LLM
+ignora la guardia y vuelve a colocar la tasa bajo "lo que no se sabe"— no tiene red en runtime.
+En un lanzamiento universitario, M1 es lo PRIMERO que lee el estudiante; una incoherencia ahí
+es ultra-crítica.
+
+**Pros:** Cierra el último vector silencioso de la contradicción prosa↔tasa-impresa con una
+defensa en profundidad determinista, sin depender solo de que el modelo obedezca el prompt.
+
+**Cons:** #360 hace match EXACTO de cifras citadas contra la tabla del anexo; "rate-as-unknown"
+es semántico (negación/ausencia), no numérico, así que requeriría una heurística distinta
+(p. ej. detectar la tasa/Exhibit 2 en proximidad de marcadores de desconocimiento como
+"no se sabe", "nunca se cuantificó", "se desconoce"). Riesgo de falsos positivos si la
+heurística es laxa; necesita pruebas negativas fuertes (la confiabilidad SÍ puede estar en duda).
+
+**Context:** #360 ya lee las tablas RAW de Exhibits del architect en `m1_grounding.py` y corre
+en `case_writer` / `case_questions` bajo el gate `_is_ml_ds_classification`. Es el hogar natural
+para el chequeo confiabilidad-vs-existencia. Reusar el patrón **reprompt-once-then-DEGRADE** de
+#360 (no hard-fail), prefijo de violación tipo `EXHIBIT_RATE_AS_UNKNOWN:`. Empezar por la prosa
+del writer (M1 narrativa); las preguntas usan el campo estructurado `exhibit_ref`.
+
+**Depends on / blocked by:** Issue #362 (fix de prompt) mergeado. Coordinar con #360 (mismo
+módulo/gate) y con #347 (de-churn: ligar la tasa de Exhibit 2 a la prevalencia real del dataset).

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/writer.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/writer.py
@@ -33,13 +33,23 @@ _M1_CLASSIFICATION_ANCHOR_WRITER = """
    - *Definición inconsistente del evento:* dos áreas de la empresa usaban
      criterios distintos para determinar cuándo ocurrió el evento objetivo
      (ej: "abandono" según Ventas vs según Servicio al Cliente).
-   - *Desbalance no documentado:* la empresa nunca cuantificó la proporción real
-     de ocurrencias del evento en su historial (ej: "nadie sabía cuántos clientes
-     realmente habían incumplido versus cuántos simplemente tardaron en pagar").
+   - *Tasa reportada poco confiable:* la empresa sí reporta una tasa de ocurrencia del
+     evento (Exhibit 2), pero como un porcentaje material de registros tiene campos
+     críticos incompletos (Exhibit 2), la dirección no puede afirmar que esa tasa refleje
+     la realidad — la proporción verdadera podría ser mayor o menor (ej: "la cifra de
+     morosidad figuraba en los reportes, pero con tantos expedientes a medio llenar su
+     exactitud estaba en duda").
    - *Ventana temporal ambigua:* no existía consenso sobre el periodo de observación
      necesario para declarar el evento (ej: "¿30 días de inactividad? ¿90 días?
      Cada área usaba un criterio distinto").
    Elige la fricción que mejor encaje con el dilema generado en `{architect_output}`.
+
+   **Coherencia obligatoria con Exhibit 2:** la tasa de ocurrencia del evento SIEMPRE
+   pertenece a "lo que SÍ se sabe" — el Exhibit 2 la imprime explícitamente. Al separar
+   "lo que se sabe" vs "lo que no se sabe" (sección "Problema Central"), NUNCA coloques la
+   proporción ni la magnitud reportada del evento bajo "lo que no se sabe". Lo que está en
+   duda es su confiabilidad o validez, jamás su existencia ni su valor reportado — esto
+   aplica bajo CUALQUIERA de las fricciones anteriores.
 
 2. **Prohibición de jerga técnica:** NUNCA escribas "clasificación", "modelo
    predictivo", "AUC", "precisión", "recall", "umbral" ni "threshold".

--- a/backend/tests/test_issue362_writer_friction_coherence.py
+++ b/backend/tests/test_issue362_writer_friction_coherence.py
@@ -1,0 +1,121 @@
+"""Issue #362 — the M1 writer friction must not contradict the printed Exhibit-2 rate.
+
+The classification-family writer anchor used to offer a "Desbalance no documentado"
+friction claiming the company *"nunca cuantificó la proporción"* del evento / *"nadie
+sabía cuántos…"*, while the architect is FORCED to print that very rate in Exhibit 2
+(``architect.py`` rule 4: "Tasa histórica de abandono: 8.3 %"). On the first page the
+student reads (M1) that is a visible self-contradiction.
+
+#362 (prompt-only, WRITER anchor only — the architect stays untouched) reframes the
+imbalance friction onto the RELIABILITY/validity of the rate, not its EXISTENCE, and adds
+a primary-defense guardrail pinning the rate to "lo que SÍ se sabe". This neutralizes BOTH
+vectors: the friction option (Vector 1) AND the "lo que se sabe / no se sabe" split in
+section "Problema Central" (Vector 2). The anchor is family-gated, so the fix covers
+``ml_ds`` AND ``business`` in ``clasificacion`` (no profile gate).
+
+Assertions are on the prompt STRING (``CASE_WRITER_PROMPT_CLASSIFICATION``) — no LLM is
+involved; the prompt text fully determines these properties. The jargon-absence check is
+scoped to the NEW text region only: a global ``count(token) == 1`` over the prohibited list
+would FALSE-fail because "clasificación" (~3×: family header + Rule 2) and "umbral" (2×:
+Rule 2 prohibition + its own translation example) appear legitimately elsewhere.
+
+``.format()`` brace-safety / dispatch (no new placeholders, sentinel intact, longer than
+generic) is covered by ``test_m1_clasificacion_dispatch.py`` — not duplicated here.
+"""
+
+from case_generator.prompts import CASE_WRITER_PROMPT_CLASSIFICATION
+
+# ── Stable substrings of the NEW text (reused across asserts — DRY) ───────────
+_REFRAME_LABEL = "Tasa reportada poco confiable"
+# Kept on a single prompt line (the full clause wraps as "…refleje\n   la realidad").
+_REFRAME_INFERENCE = "no puede afirmar que esa tasa refleje"
+_GUARD_HEADER = "Coherencia obligatoria con Exhibit 2"
+_GUARD_RATE_IS_KNOWN = 'pertenece a "lo que SÍ se sabe"'
+_GUARD_RELIABILITY = "confiabilidad o validez"
+_RULE2_PROHIBITION = 'NUNCA escribas "clasificación"'
+
+# Full prohibited DS-jargon vocabulary (Rule 2 list + its translation examples).
+_PROHIBIDOS = [
+    "clasificación",
+    "clasificar",
+    "modelo predictivo",
+    "AUC",
+    "precisión",
+    "recall",
+    "umbral",
+    "threshold",
+    "falso positivo",
+]
+
+# The 3 friction labels of Rule 1 — must stay present and distinct.
+_FRICTION_LABELS = {
+    "Definición inconsistente del evento",
+    "Tasa reportada poco confiable",
+    "Ventana temporal ambigua",
+}
+
+
+def _new_text_region(prompt: str) -> str:
+    """Slice covering ONLY the new/edited Rule-1 friction text (reframe + guardrail).
+
+    Spans from the rewritten option-2 label to the start of Rule 2, so it excludes
+    Rule 2 (which legitimately lists DS jargon) while including the reframe and the
+    guardrail. This region is the correct scope for the no-new-jargon invariant.
+    """
+    start = prompt.index(_REFRAME_LABEL)
+    end = prompt.index("2. **Prohibición de jerga técnica")
+    assert start < end, "new-text region anchors are out of order"
+    return prompt[start:end]
+
+
+# ── 1. The old contradictory phrasing is gone (Vector 1 neutralized) ──────────
+def test_old_contradictory_phrases_absent() -> None:
+    p = CASE_WRITER_PROMPT_CLASSIFICATION
+    assert "nunca cuantificó la proporción" not in p, (
+        "the 'rate never quantified' phrasing must be removed — it contradicts Exhibit 2"
+    )
+    assert "nadie sabía cuántos" not in p
+    assert "Desbalance no documentado" not in p, (
+        "the old friction label must be replaced, not appended"
+    )
+
+
+# ── 2. The reliability reframe is present AND articulates the inference ────────
+def test_reliability_reframe_present_and_articulated() -> None:
+    p = CASE_WRITER_PROMPT_CLASSIFICATION
+    assert _REFRAME_LABEL in p
+    # Must ARTICULATE "reported != reliable", not merely re-cite Exhibit 2.
+    assert _REFRAME_INFERENCE in p
+
+
+# ── 3. The Vector-2 guardrail pins the rate to "lo que SÍ se sabe" ────────────
+def test_vector2_guardrail_present() -> None:
+    p = CASE_WRITER_PROMPT_CLASSIFICATION
+    assert _GUARD_HEADER in p          # the guardrail names Exhibit 2
+    assert "Exhibit 2" in p
+    assert _GUARD_RATE_IS_KNOWN in p   # rate belongs to what IS known
+    assert _GUARD_RELIABILITY in p     # reliability-vs-existence contrast
+
+
+# ── 4. DS jargon still prohibited AND the new text introduced none ────────────
+def test_ds_jargon_prohibition_intact_and_no_new_jargon() -> None:
+    p = CASE_WRITER_PROMPT_CLASSIFICATION
+    # Rule 2 prohibition sentence is intact.
+    assert _RULE2_PROHIBITION in p
+    # The NEW friction text (reframe + guardrail) introduces zero DS jargon.
+    region = _new_text_region(p)
+    for token in _PROHIBIDOS:
+        assert token not in region, (
+            f"DS jargon '{token}' leaked into the new M1 friction text"
+        )
+    # 'AUC' is unique to Rule 2 today — a cheap global belt-and-suspenders that the
+    # reframe/guardrail did not add a second mention anywhere.
+    assert p.count("AUC") == 1
+
+
+# ── 5. The 3 frictions remain present and distinct ────────────────────────────
+def test_three_distinct_frictions_present() -> None:
+    p = CASE_WRITER_PROMPT_CLASSIFICATION
+    for label in _FRICTION_LABELS:
+        assert label in p, f"missing friction label: {label!r}"
+    assert len(_FRICTION_LABELS) == 3  # three distinguishable labels


### PR DESCRIPTION
## Closes #362

## Problem (audited, with `file:line`)
On the first page a student reads (M1), the **classification-family writer** prompt could self-contradict: friction option 2 told the model to narrate that the company *"nunca cuantificó la proporción"* del evento / *"nadie sabía cuántos…"* — while the **architect is forced to print that exact rate in Exhibit 2** and the writer must cite it. Visible self-contradiction on an ultra-critical first page (university launch).

Verified ground truth (re-checked this session, first-hand):
- Defect — friction option 2: `backend/src/case_generator/prompts/clasificacion/M1_clasificacion/writer.py:36–38`
- Vector 2 — "Separar lo que se 'sabe' vs 'no se sabe'" (Problema Central): `writer.py:115`
- Architect prints the rate (MANDATORY, **untouched**): `prompts/clasificacion/M1_clasificacion/architect.py:57–63`
- Writer must cite ≥2 Exhibit-2 metrics: `writer.py:73`
- Injection preserves figures: `graph.py:1216–1226` `sanitize_untrusted_payload(per_field_limit=2000, total_limit=8000)` → `.format()` dispatch at `graph.py:1229–1231` (brief's `1056–1067` was stale drift — immaterial, not edited)
- **No writer SHA256 snapshot exists** → zero snapshot churn. The frozen `_MLDS_ARCHITECT_PROMPT_SHA256` (`tests/test_issue301_pr2b_architect.py:73`) is architect-only.
- Friction is isolated to `writer.py:36–38` (not repeated in `questions.py`/M2).

## Design (prompt-only, WRITER anchor only — the architect is NOT touched)
The Exhibit-2 rate must stay mandatory (`schema_designer` + imbalance pedagogy need it). The fix moves the friction from the rate's **existence** to its **reliability/validity**, and neutralizes **both** vectors:

```
architect ──▶ Exhibit 2 prints "Tasa abandono: 8.3 %"  (MANDATORY, untouched)
   ▼ sanitize_untrusted_payload (keeps "8.3 %")
writer prompt (.format)
   ├─ base body (untouched): "cite ≥2 Exhibit-2 metrics" + "Separar se sabe/no se sabe"  ◀ VECTOR 2
   └─ anchor _M1_CLASSIFICATION_ANCHOR_WRITER  (★ edited here only ★)
        ├─ Rule 1 option 2  → REWRITE: reliability, not existence        ◀ VECTOR 1
        └─ Rule 1 + guardrail [NEW]: rate ALWAYS belongs to "lo que SÍ se sabe"  ═▶ VECTOR 2
```

1. **Option 2 rewritten** → *"Tasa reportada poco confiable"*: the company **does** report a rate (Exhibit 2), but because a material % of records have incomplete critical fields (Exhibit 2), management **cannot affirm the rate reflects reality**. Compatible with a printed rate; **distinct** from option 1 (definition) and option 3 (window); **articulates the inference** ("reported ≠ reliable") rather than re-citing Exhibit 2.
2. **Primary-defense guardrail** added to Rule 1: the event rate **SIEMPRE pertenece a "lo que SÍ se sabe"** (Exhibit 2 prints it); never file the rate/its reported magnitude under "lo que no se sabe" — only its **confiabilidad/validez** is in doubt — **bajo CUALQUIERA de las fricciones**. Names **"Exhibit 2"** + the confiabilidad-vs-existencia contrast → covers Vector 2 even if option 2 is not chosen.

Why **not** a mere re-cite: the writer already cites both Exhibit-2 rows (`writer.py:73`); the friction adds the *insight* that the reported rate may be unreliable.
Why the **architect is not touched**: the rate stays mandatory (downstream `schema_designer` + pedagogy + the future #347 de-churn rely on it); editing it would trip the frozen SHA256. The fix lives entirely in the **anchor** (appended after the verbatim body at `writer.py:136`).

**Family-gated, not profile-gated** → covers **`ml_ds` AND `business`** in `clasificacion`. No profile gate added.

## Scope guardrails honored
- Prompt-only: no validator/state/canonical key/bus/SSE, no dataset/prevalence/spine change (that's the separate #347 de-churn).
- No new `{...}` placeholders (so `.format()`/dispatch stays safe); DS-jargon prohibition (Rule 2) intact.
- **Doc-sync: N/A** (verified — no CLAUDE.md/AGENTS.md section describes the M1 imbalance friction today; no new section created).

## Tests — `backend/tests/test_issue362_writer_friction_coherence.py` (pure string, no LLM)
1. Old contradictory phrasing absent (`"nunca cuantificó la proporción"`, `"nadie sabía cuántos"`, old label gone).
2. Reliability reframe present **and articulated** (`no puede afirmar que esa tasa refleje`).
3. Guardrail present: names `Exhibit 2`, pins rate to `"lo que SÍ se sabe"`, reliability contrast (`confiabilidad o validez`).
4. DS-jargon prohibition intact **and** no new jargon — scoped to the **new text region** (a global `count==1` would false-fail: `"clasificación"` ≈3×, `"umbral"` 2× appear legitimately) + `count("AUC")==1` belt-and-suspenders.
5. The 3 frictions remain present and distinct.
6. Regression: `test_m1_clasificacion_dispatch.py` stays green (sentinel intact, `.format()` no KeyError, longer than generic).

## Validation evidence
```
$ uv run --directory backend pytest -q
1324 passed, 21 skipped, 2 warnings in 135.84s

$ uv run --directory backend mypy src
Success: no issues found in 85 source files
```

## Follow-up (deferred, not this PR)
`TODOS.md` → **TODO-362-A**: extend the #360 validator (`m1_grounding.py`) to flag "rate-as-unknown" prose at runtime — the one silent failure mode a prompt-only fix can't fully close (decided in eng review: ship prompt-only now, defer the runtime net rather than scope-creep a validator into this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
