### PR TITLE
fix(case_generator): M1 architect fija 3 opciones (A/B/C) y ancla Exhibit-2 para clasificación (#363)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1967,3 +1967,60 @@ del writer (M1 narrativa); las preguntas usan el campo estructurado `exhibit_ref
 
 **Depends on / blocked by:** Issue #362 (fix de prompt) mergeado. Coordinar con #360 (mismo
 módulo/gate) y con #347 (de-churn: ligar la tasa de Exhibit 2 a la prevalencia real del dataset).
+
+---
+
+## TODO-363-A: Resolver la contradicción undergrad-2 vs 3-opciones para familias no-clasificación
+
+**What:** El fix de Issue #363 corrige el conteo de opciones (undergrad debe emitir 3, no 2) SOLO
+para `clasificacion`, vía una cláusula de "supersede" en `_M1_CLASSIFICATION_ANCHOR_ARCHITECT`
+(`prompts/clasificacion/M1_clasificacion/architect.py`). Las familias `regresion`, `clustering` y
+`serie_temporal` caen al `CASE_ARCHITECT_PROMPT` genérico (sin anchor), por lo que siguen
+expuestas a la misma contradicción: el base dice `undergrad → 2 opciones estratégicas claras`
+(`_architect_base.py:88`) mientras el resto del producto asume 3 (A, B, C).
+
+**Why:** En la rama minoritaria donde el architect honra la línea 88 para un caso `undergrad` de
+otra familia, P3 / `solucion_esperada` / la columna "Postura (A/B/C)" del Exhibit 3 referencian una
+Opción C que el caso nunca definió — la misma incoherencia M1 que #363 cierra para clasificación.
+
+**Pros:** Cierra la contradicción a nivel de producto; M1 coherente en las 4 familias canónicas.
+
+**Cons:** `regresion`/`clustering`/`serie_temporal` no tienen hoy un anchor de architect M1 propio,
+así que cada una necesitaría uno (mismo patrón base+anchor que clasificación) — o bien una edición
+del base GATEADA por familia, que amplía el blast radius y requiere ADR según las reglas del repo.
+`serie_temporal` está retirada del catálogo activo.
+
+**Context:** Causa raíz compartida = `_architect_base.py:88`. #363 la arregla en el anchor para no
+tocar el base (el enfoque familia-por-familia del producto). Empezar por verificar si regresion/
+clustering tienen un anchor M1 que extender; si no, sopesar anchors por familia vs. un base
+gateado. El patrón de cláusula supersede + drift-guard de `test_issue363_architect_option_exhibit2.py`
+es el template a replicar. Independiente de #363.
+
+**Depends on / blocked by:** Issue #363 mergeado (establece el patrón). Ninguna dependencia técnica.
+
+---
+
+## TODO-363-B: Golden-eval live de que el supersede de conteo de opciones se OBEDECE
+
+**What:** Cuando el harness de golden-eval esté cableado, añadir un check `live_llm`
+(`RUN_LIVE_LLM_TESTS=1`) que verifique que un caso `undergrad` de clasificación realmente emite
+exactamente 3 opciones (A, B, C) — es decir, que el LLM honra la cláusula del anchor por encima de
+la línea base `undergrad → 2 opciones`.
+
+**Why:** El fix de #363 es prompt-only: una cláusula que DICE "siempre 3, reemplaza la regla base".
+Los tests deterministas de #363 prueban que la cláusula está PRESENTE y bien acoplada (drift-guard),
+pero NO que el modelo la obedezca. Ese es el modo de fallo silencioso #5 de la review: undergrad
+emite 2 → P3 cita una Opción C fantasma. En un lanzamiento universitario, M1 es lo PRIMERO que lee
+el estudiante; esa incoherencia es ultra-crítica.
+
+**Pros:** Cierra el único gap crítico marcado en la review; reutiliza la superficie de golden-eval
+ya diferida (`test_issue340_architect_cost_matrix_emission.py` §c, #361).
+
+**Cons:** El harness de golden-eval no está cableado aún; costo y flakiness de LLM real.
+
+**Context:** Este PR (#363) shippea solo-determinista por decisión de la review. El check vive
+naturalmente junto a los demás golden-eval diferidos, gateado por `RUN_LIVE_LLM_TESTS=1`. Sentinela
+sugerida: el `dilema_brief` generado expone opciones A, B y C (y no solo A/B) para
+`course_level="undergrad"` + `primary_family="clasificacion"`.
+
+**Depends on / blocked by:** Cableado del harness de golden-eval (diferido en #340/#361).

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
@@ -54,6 +54,14 @@ _M1_CLASSIFICATION_ANCHOR_ARCHITECT = """
    "el riesgo de destinar recursos donde el problema no existía" frente a
    "el riesgo de no actuar donde la pérdida era evitable".
 
+**Conteo de opciones en `dilema_brief` (anula la regla base de nivel de curso):** en
+clasificación, `dilema_brief` SIEMPRE contiene exactamente 3 opciones (A, B, C), también
+para `undergrad`. Esta regla REEMPLAZA la línea base de nivel de curso que sugiere
+"2 opciones estratégicas claras" para undergrad: en esta familia, undergrad emite 3
+opciones igual que grad. Las 3 son igualmente presentables pero no igualmente óptimas
+(como ya exige la regla base de balance A/B/C). Son 3 opciones de DECISIÓN gerencial;
+no 3 clases del target.
+
 4. **Exhibit 2 (Operativo) — 2 filas obligatorias de calidad de datos:**
    Añade exactamente 2 filas numéricas y específicas que capturen la realidad del
    evento objetivo en los datos históricos de la empresa:
@@ -61,6 +69,10 @@ _M1_CLASSIFICATION_ANCHOR_ARCHITECT = """
    - Completitud de campos críticos (ej: "% registros con campo contractual sin dato: 12 %").
    Sin estas filas el `schema_designer` downstream no puede modelar el desbalance de
    clases real del caso, comprometiendo la coherencia pedagógica del notebook M3.
+   Esta instrucción REEMPLAZA la regla base de "al menos 2 métricas de calidad de datos"
+   de Exhibit 2: para clasificación las 2 filas de calidad de datos son EXACTAMENTE las dos
+   anteriores (tasa de ocurrencia del evento objetivo + completitud de campos críticos) y
+   ninguna otra. No uses otras filas genéricas de plumbing como las 2 filas obligatorias.
 
 ## Matriz de costos de negocio (`business_cost_matrix`) — opcional, condicional
 

--- a/backend/tests/test_issue301_pr2b_architect.py
+++ b/backend/tests/test_issue301_pr2b_architect.py
@@ -71,9 +71,10 @@ _MLDS_CTX: dict[str, object] = {
 # Frozen digest of the assembled ml_ds+clasificación prompt. If this changes, the ml_ds
 # prompt changed — confirm it was NOT the business gate leaking in before updating.
 _MLDS_ARCHITECT_PROMPT_SHA256 = (
-    # Issue #340 — regenerated deliberately after adding the conditional
-    # `business_cost_matrix` emission subsection to the classification anchor.
-    "87df26d56913add9211b1bb9e3825957835689807383e1b152b36778a24b9762"
+    # Issue #363 — regenerated deliberately after adding option-count (D2) +
+    # Exhibit-2 (D3) supersede clauses to the classification anchor. Confirmed via
+    # test_mlds_architect_prompt_unchanged_by_business_gate (differential GREEN → not a leak).
+    "04af5c2947bf1f7bf522768370dbee455a660dde36bd7bf23b45de83d5678176"
 )
 
 

--- a/backend/tests/test_issue363_architect_option_exhibit2.py
+++ b/backend/tests/test_issue363_architect_option_exhibit2.py
@@ -1,0 +1,140 @@
+"""Issue #363 — M1 architect: option-count (D2) + Exhibit-2 (D3) supersede clauses.
+
+The classification anchor (`_M1_CLASSIFICATION_ANCHOR_ARCHITECT`) gains two prose
+"supersede" clauses that resolve internal base-prompt contradictions for the
+`clasificacion` family (which the family-gated anchor applies to ml_ds AND business):
+
+  D2 — `dilema_brief` SIEMPRE emits exactly 3 options (A, B, C), even for `undergrad`,
+       overriding the base course-level line `undergrad → 2 opciones estratégicas claras`
+       (`_architect_base.py:88`) that contradicts the rest of the product (Pydantic schema,
+       balance rule, writer, P3, Exhibit-3 "Postura (A/B/C)").
+  D3 — the anchor's "exactamente 2" Exhibit-2 data-quality rows EXPLICITLY replace the base
+       "al menos 2 métricas de calidad de datos" rule and pin the canonical pair
+       (occurrence rate + critical-field completeness), without echoing the base plumbing
+       examples (`% ID duplicado`, `lag`) — positive-pin to avoid negative-priming.
+
+Pure assembly — no LLM, no DB. The frozen-hash / differential tripwires for the assembled
+ml_ds prompt live in ``tests/test_issue301_pr2b_architect.py``; this file asserts the two
+clauses on the anchor string + the assembled prompt, plus the D2 drift-guard that keeps the
+supersede from orphaning if the base undergrad line is ever refactored away.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from case_generator.graph import _assemble_architect_prompt
+from case_generator.prompts import (
+    CASE_ARCHITECT_PROMPT,
+    CASE_ARCHITECT_PROMPT_CLASSIFICATION,
+)
+from case_generator.prompts.clasificacion.M1_clasificacion.architect import (
+    _M1_CLASSIFICATION_ANCHOR_ARCHITECT,
+)
+
+# Full format context (union of _build_base_context keys + per-node injections), mirroring
+# tests/test_issue340_architect_cost_matrix_emission.py::_BASE_CTX. ml_ds + clasificación.
+_BASE_CTX: dict[str, object] = {
+    "student_profile": "ml_ds",
+    "primary_family": "clasificacion",
+    "output_language": "es",
+    "case_id": "test-uuid-0000",
+    "course_level": "grad",
+    "max_investment_pct": 8,
+    "urgency_frame": "48-96 horas",
+    "protected_columns": '["target","id","date"]',
+    "main_risk_from_m3_m4": "",
+    "is_docente_only": True,
+    "implementation_timeframe": "",
+    "industria": "fintech",
+    "industry_cagr_range": "5-8%",
+    "nombre_empresa": "AcmeCorp",
+    "dilema_hypotheses": "",
+    "output_depth": "visual_plus_notebook",
+    "algoritmos": '["LogisticRegression"]',
+    "titulo": "Test título",
+    "grounding_modules": "[]",
+    "grounding_objectives": "[]",
+    "grounding_generation_hints": "{}",
+    "grounding_course_identity": "{}",
+    "teacher_input": "test teacher input",
+    "architect_output": "test architect output",
+    "pregunta_eje": "¿Debe la empresa priorizar retención selectiva?",
+}
+
+# Stable substrings of the two new clauses (placeholder-free → survive .format()).
+_D2_THREE_OPTIONS = "exactamente 3 opciones (A, B, C)"
+_D3_CANONICAL_PIN = "ninguna otra"
+# Verbatim base phrase the D2 supersede must name (couples the drift-guard to the wording).
+_BASE_UNDERGRAD_RULE = "2 opciones estratégicas"
+
+
+def _ctx(profile: str, family: str = "clasificacion") -> dict[str, object]:
+    ctx = dict(_BASE_CTX)
+    ctx["student_profile"] = profile
+    ctx["primary_family"] = family
+    return ctx
+
+
+# ── D2: option count ──────────────────────────────────────────────────────────
+
+def test_d2_anchor_pins_three_options_and_supersedes() -> None:
+    """The anchor states exactly 3 options (A,B,C) and that it REPLACES the base rule."""
+    assert _D2_THREE_OPTIONS in _M1_CLASSIFICATION_ANCHOR_ARCHITECT
+    assert "REEMPLAZA" in _M1_CLASSIFICATION_ANCHOR_ARCHITECT
+    # Disambiguation: 3 decision options, NOT 3 target classes (multiclass targets exist).
+    assert "no 3 clases del target" in _M1_CLASSIFICATION_ANCHOR_ARCHITECT
+
+
+def test_d2_drift_guard_base_intact_and_anchor_names_it() -> None:
+    """Drift guard (mirror of test_issue301::test_permissive_substitution_targets_still_
+    match_raw_template): the base undergrad-2 rule must still exist AND the anchor's
+    supersede clause must quote it. If a future refactor deletes the base line, this fails
+    and forces a review of the now-orphaned supersede."""
+    # base line 88 still carries the undergrad-2 rule the supersede targets
+    assert _BASE_UNDERGRAD_RULE in CASE_ARCHITECT_PROMPT
+    # anchor explicitly names that base rule (no orphan supersede)
+    assert _BASE_UNDERGRAD_RULE in _M1_CLASSIFICATION_ANCHOR_ARCHITECT
+
+
+# ── D3: Exhibit-2 rows ────────────────────────────────────────────────────────
+
+def test_d3_anchor_supersedes_exhibit2_and_pins_canonical_rows() -> None:
+    """The anchor states it REPLACES the base 'al menos 2' rule and pins the canonical pair."""
+    anchor = _M1_CLASSIFICATION_ANCHOR_ARCHITECT
+    assert 'REEMPLAZA la regla base de "al menos 2 métricas de calidad de datos"' in anchor
+    assert "tasa de ocurrencia del evento objetivo" in anchor
+    assert "completitud de campos críticos" in anchor
+    assert _D3_CANONICAL_PIN in anchor  # "ninguna otra" → excludes everything else
+
+
+def test_d3_anchor_does_not_echo_base_plumbing_examples() -> None:
+    """Positive-pin (LLM hygiene): the anchor must NOT reprint the base plumbing examples,
+    so it cannot negative-prime the model into emitting them as the 2 mandatory rows. Assert
+    against the ANCHOR constant, NOT the assembled prompt — the assembled prompt still
+    contains the base's own copies of these strings (_architect_base.py:84)."""
+    assert "ID duplicado" not in _M1_CLASSIFICATION_ANCHOR_ARCHITECT
+    assert "Lag promedio" not in _M1_CLASSIFICATION_ANCHOR_ARCHITECT
+
+
+# ── family-gated reach: ml_ds AND business in clasificación ───────────────────
+
+@pytest.mark.parametrize("profile", ["ml_ds", "business"])
+def test_clauses_reach_assembled_classification_prompt(profile: str) -> None:
+    """Both clauses must survive assembly + .format() for ml_ds AND business in clf
+    (the shared anchor applies to both — the intended #363 family-gated coverage)."""
+    assembled = _assemble_architect_prompt(_ctx(profile))
+    assert _D2_THREE_OPTIONS in assembled
+    assert _D3_CANONICAL_PIN in assembled
+
+
+# ── safety: no stray brace introduced by the new prose ────────────────────────
+
+def test_classification_prompt_still_formattable() -> None:
+    """Guard against an accidental un-doubled `{`/`}` in the new clauses."""
+    try:
+        CASE_ARCHITECT_PROMPT_CLASSIFICATION.format(**_BASE_CTX)
+    except KeyError as exc:
+        pytest.fail(
+            f"CASE_ARCHITECT_PROMPT_CLASSIFICATION raised KeyError on format(): {exc}"
+        )


### PR DESCRIPTION
## Qué y por qué

M1 es lo PRIMERO que lee el estudiante (lanzamiento universitario), así que la mínima incoherencia es crítica. El anchor de la familia `clasificacion` (`_M1_CLASSIFICATION_ANCHOR_ARCHITECT`) dejaba pasar dos contradicciones del prompt base:

- **D2 (MEDIO) — conteo de opciones.** El base dice `undergrad → 2 opciones estratégicas claras` (`_architect_base.py:88`), pero **todo lo demás asume 3 (A/B/C)**: el schema Pydantic (`tools_and_schemas.py:262`), la regla de balance (`_architect_base.py:62`), el spec de `dilema_brief` (`:109`), `grad → 3 opciones` (`:89`), la columna "Postura (A/B/C)" del Exhibit 3 (`:134`), el writer (`writer.py:133`), P3 (`questions.py:48`) y los charts M4 (`charts.py:80-82`). En la rama donde el architect honra la línea 88, un `undergrad` de clasificación emite **2** opciones mientras P3/`solucion_esperada` citan una **Opción C fantasma**.
- **D3 (BAJO) — Exhibit 2.** El base pide "**al menos 2**" filas genéricas de plumbing (`:83-85`, `:130`); la regla 4 del anchor ya fija "**exactamente 2**" filas del evento (`architect.py:57-63`), pero **sin declarar que reemplaza** la base → solapamiento semántico que puede inducir filas mezcladas.

## Diseño (prompt-only, SÓLO en el anchor)

Dos cláusulas de "supersede" **dentro del anchor** — nunca el base (editarlo cambiaría todas las familias + business y ampliaría el blast radius). El anchor se appendea tras el base (`architect.py:141`) y es más específico → puede anular reglas base.

**D2** (tras la regla 3, por afinidad temática):
> Conteo de opciones … `dilema_brief` SIEMPRE contiene **exactamente 3 opciones (A, B, C)**, también para `undergrad`. Esta regla **REEMPLAZA** la línea base … "2 opciones estratégicas claras" … Son 3 opciones de DECISIÓN gerencial; no 3 clases del target.

**D3** (refuerza la regla 4, *positive-pin sin echo*):
> Esta instrucción **REEMPLAZA** la regla base de "al menos 2 métricas de calidad de datos" … las 2 filas son EXACTAMENTE (tasa de ocurrencia + completitud) y **ninguna otra**. No uses otras filas genéricas de plumbing …

### Decisiones de review (plan-eng-review, SMALL CHANGE)
1. **Blast radius — unconditional.** El anchor es compartido por ml_ds y business en clf (`graph.py:873`), así que ambas cláusulas cubren **ml_ds Y business** (intencional: arregla undergrad-2 también para business; coherente con el schema Pydantic). Base/writer/questions/dataset **intactos**.
2. **D3 positive-pin (sin echo).** No reimprime `% ID duplicado`/`lag` para no *negative-primear* al LLM a emitirlas.
3. **Eval determinista + mypy** (golden-eval live diferido, como #340/#360/#361/#362) → `TODO-363-B`.

## Snapshot / hash regenerado deliberadamente

`_MLDS_ARCHITECT_PROMPT_SHA256` (`test_issue301_pr2b_architect.py`) pasa de `87df26d5…` → `04af5c29…`. **Antes de regenerar** confirmé que `test_mlds_architect_prompt_unchanged_by_business_gate` (diferencial + business-gate-no-leak) sigue **verde** → el cambio son SOLO mis dos cláusulas, no un leak del gate business.

## Tests

Nuevo `backend/tests/test_issue363_architect_option_exhibit2.py`:
- D2: el anchor fija "exactamente 3 opciones (A, B, C)" + "REEMPLAZA" + disambiguación "no 3 clases del target".
- **D2 drift-guard:** `"2 opciones estratégicas" in CASE_ARCHITECT_PROMPT` (base intacto) **y** en el anchor (nombra la regla → no queda huérfana si un refactor borra la línea 88). *Este guard ya atrapó un bug real durante el desarrollo: un salto de línea había partido la frase.*
- D3: supersede + par canónico (tasa de ocurrencia + completitud + "ninguna otra"); y NO eco de los ejemplos de plumbing del base (aserción contra el **anchor constant**, no el ensamblado).
- Cobertura family-gated: ml_ds **y** business+clf llevan ambas cláusulas; guard de `.format()` sin `KeyError`.

```
$ uv run --directory backend pytest tests/test_issue363_architect_option_exhibit2.py \
    tests/test_issue301_pr2b_architect.py tests/test_m1_clasificacion_dispatch.py \
    tests/test_issue340_architect_cost_matrix_emission.py -q
54 passed, 1 skipped, 1 warning in 1.63s

$ uv run --directory backend pytest -q
1331 passed, 21 skipped, 2 warnings in 170.93s

$ uv run --directory backend mypy src
Success: no issues found in 85 source files
```

## Auditoría (verificado este PR, con file:line)
Leídos en full: `architect.py`, `_architect_base.py`, `test_issue301_pr2b_architect.py`, `test_m1_clasificacion_dispatch.py`, `test_issue340_*`; grep/Read sobre `graph.py`, `tools_and_schemas.py` y todos los call sites de conteo de opciones. La cirugía `.replace()` de `_assemble_architect_prompt` (`graph.py:835-877`) sólo toca la regla 7 → no colisiona con D2/D3.

## Fuera de scope / follow-ups
- **No** se edita `_architect_base.py:88` (cambiaría todas las familias). La misma contradicción para `regresion/clustering/serie_temporal` → **`TODO-363-A`**.
- `prompts/__init__.py:1098` ("business → 2 opciones con mayor ROI") = falso positivo (top-2 de 3), correcto as-is.
- Doc-sync: ni `CLAUDE.md` ni `AGENTS.md` documentan el conteo de opciones M1 / el contrato de Exhibit 2 → sin sección nueva (documentado aquí).
- **Gap silencioso #5** (que el LLM OBEDEZCA el supersede) → `TODO-363-B` (golden-eval live, `RUN_LIVE_LLM_TESTS=1`).

Closes #363