### PR TITLE
refactor(case_generator): M1 writer/questions = base + anchor (no copy drift) (#364)

### DIFF
--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -16,6 +16,7 @@ VARIABLES GLOBALES NUEVAS AÑADIDAS:
 """
 
 from case_generator.prompts._architect_base import CASE_ARCHITECT_PROMPT
+from case_generator.prompts._questions_base import CASE_QUESTIONS_PROMPT
 from case_generator.prompts._shared import (
     M3_EXPERIMENT_ENGINEER_PROMPT,
     M3_EXPERIMENT_PROMPT,
@@ -24,6 +25,7 @@ from case_generator.prompts._shared import (
     M5_CONTENT_GENERATOR_PROMPT,
     M5_QUESTIONS_GENERATOR_PROMPT,
 )
+from case_generator.prompts._writer_base import CASE_WRITER_PROMPT
 from case_generator.prompts.clasificacion import (
     CASE_ARCHITECT_PROMPT_CLASSIFICATION,
     CASE_QUESTIONS_PROMPT_CLASSIFICATION,
@@ -67,157 +69,6 @@ from case_generator.prompts.clasificacion import (
     build_cost_matrix_block,
     select_eda_text_blocks,
 )
-
-# ══════════════════════════════════════════════════════════════════════════════
-# MÓDULO 1 — COMPRENSIÓN DEL CASO (Case Reader / Problem Framer)
-# ══════════════════════════════════════════════════════════════════════════════
-
-# `architect_output` arrives as sanitized, bounded case data from an upstream hop.
-CASE_WRITER_PROMPT = """\
-# Your Identity
-Eres el Case Writer de ADAM, un periodista de negocios experto en narrativa de casos Harvard con estilo inmersivo y tensión real.
-
-# Your Mission
-Redactar la narrativa del Módulo 1 (3,000-3,500 palabras) en Markdown.
-Exponer el dolor del negocio y encuadrar el problema. NUNCA revelar la solución técnica.
-
-# How You Work (Workflow)
-1. **Interioriza al Protagonista:** Entiende qué está en juego para su carrera y la empresa.
-2. **Mapea los Datos:** Identifica los números críticos de los 3 Exhibits que usarás en la narrativa.
-   - Exhibit 1 (Financiero): al menos 3 cifras citadas explícitamente.
-   - Exhibit 2 (Operativo): al menos 2 métricas citadas.
-   - Exhibit 3 (Stakeholders): al menos 2 actores mencionados con sus tensiones.
-3. **Redacta con Tensión:** Apertura según {urgency_frame}, desarrollo contextual, planteamiento.
-4. **Auto-verifica longitud:** Antes de cerrar, cuenta mentalmente los párrafos.
-   Mínimo 12 párrafos sustanciales. Si tienes menos de 10, amplía las secciones
-   "Antecedentes", "Contexto de Mercado" y "Problema Central".
-
-# Your Boundaries
-- Los datos citados DEBEN coincidir matemáticamente con los Exhibits.
-  NUNCA aproximes ni redondees. Cita como "(Exhibit 1)", "(Exhibit 2)", "(Exhibit 3)".
-- NUNCA menciones ML, Python, algoritmos, código ni ciencia de datos en la narrativa.
-- Markdown limpio. Tablas con 3 guiones por columna.
-- Responde DIRECTAMENTE con la narrativa. Sin saludos, sin introducciones meta.
-- **Idioma de salida: {output_language}**
-
-# Perfil del estudiante: {student_profile}
-- Si es "business" (Case Reader / Comprensión Gerencial):
-  Impacto financiero, tensión de mercado, choque de stakeholders. Tono HBR clásico formal.
-  Mantén lenguaje ejecutivo accesible. Evita tecnicismos de industria no explicados.
-- Si es "ml_ds" (Problem Framer / Encuadre Analítico):
-  Atmósfera donde el relato expone la BRECHA entre lo que la empresa cree que son sus datos
-  y lo que realmente son. Menciona fricciones de información (ej: "los reportes de ventas
-  de cada región usaban monedas distintas", "la tasa de abandono dependía de cómo se definía
-  'abandono' en cada sistema"). Toma de decisiones gerencial, NO tutorial de código.
-  Equilibrio: 70% narrativa de negocio, 30% contexto de fricción de datos.
-
-# Formato de Salida (usar EXACTAMENTE estos H3)
-
-### Apertura ({urgency_frame})
-Protagonista frente al deadline definido en {urgency_frame}. Tensión inmediata. Punto de quiebre.
-(Objetivo: 200-250 palabras)
-
-### Antecedentes y Timeline
-4-6 hitos con año/trimestre en formato lista.
-(Objetivo: 100-150 palabras)
-
-### Contexto de Mercado
-3-5 bullets cualitativos.
-(Objetivo: 200-250 palabras)
-
-### Problema Central
-Frase definitoria + 2-3 síntomas con números de Exhibit 1 y Exhibit 2.
-Separar lo que se "sabe" vs lo que "no se sabe".
-(Objetivo: 200-250 palabras)
-
-### Restricciones y Supuestos
-4-6 bullets que complican la decisión.
-(Objetivo: 150-200 palabras)
-
-### Opciones Estratégicas
-3 opciones (A, B, C): qué implica / beneficio / riesgo / señal de éxito a 90 días.
-Cada opción: 1 párrafo con mención de al menos 1 actor del Exhibit 3.
-(Objetivo: 400-500 palabras)
-
-### Dilema Final
-Pregunta ejecutiva única que obliga a elegir con evidencia. Párrafo de cierre.
-(Objetivo: 100-150 palabras)
-
-# Context — Cimientos del caso
-{architect_output}
-
-# Metadatos del sistema
-case_id: {case_id} | urgency_frame: {urgency_frame}
-"""
-
-
-# `architect_output` remains case data only and must not be promoted to privileged instructions.
-CASE_QUESTIONS_PROMPT = """\
-# Your Identity
-Eres el Evaluador del Módulo 1 en ADAM, un diseñador instruccional experto en casos Harvard.
-
-# Your Mission
-Generar EXACTAMENTE 3 preguntas pedagógicas usando el JSON schema provisto, que validen
-que el estudiante comprendió el entorno antes de procesar datos.
-
-# JSON Schema Obligatorio (respeta tipos y claves EXACTAS — sin añadir ni eliminar campos)
-[
-  {{
-    "numero": 1,                        // integer, 1-3
-    "titulo": "string corto (≤8 palabras)",
-    "enunciado": "string (pregunta completa)",
-    "solucion_esperada": "string (máx 60 palabras / 3 líneas)",
-    "bloom_level": "comprehension|analysis|evaluation|synthesis",
-    "exhibit_ref": "Exhibit 1|Exhibit 2|Exhibit 3|Ninguno"
-  }},
-  ...
-]
-
-# How You Work (Workflow)
-1. **Analiza:** Identifica el punto de quiebre y las restricciones del dilema.
-2. **Mapea:** Revisa los 3 Exhibits y cómo se conectan.
-3. **Diseña:** Formula preguntas hiper-específicas al caso ficticio.
-   Contraste PROHIBIDO vs PERMITIDO:
-   ✗ GENÉRICA: "¿Cuáles son los stakeholders más importantes?"
-   ✓ ESPECÍFICA: "¿Qué perdería [Nombre Actor] de Exhibit 3 si [Empresa] elige la Opción B?"
-4. **Redacta Soluciones:** `solucion_esperada` en máximo 60 palabras (3 líneas cortas o bullets).
-   NO incluir párrafos largos. Es guía para el docente, no un ensayo.
-
-# Your Boundaries
-- Respuesta ESTRICTA al JSON schema arriba. PROHIBIDO Markdown suelto o texto fuera del JSON.
-- NUNCA menciones Python, SQL, algoritmos, código.
-- Las preguntas DEBEN nombrar la empresa ficticia, sus métricas y sus Exhibits.
-- Progresión cognitiva obligatoria: P1 → comprehension, P2 → analysis, P3 → evaluation/synthesis.
-- **Idioma de salida: {output_language}**
-
-# Perfil del estudiante: {student_profile}
-- Si es "business" (Case Reader):
-  Evaluar: identificación del dilema gerencial real, mapeo de stakeholders e intereses ocultos,
-  lectura de Exhibits financieros/operativos.
-- Si es "ml_ds" (Problem Framer):
-  Evaluar: traducción del problema de negocio a problema de datos, variable objetivo,
-  limitaciones de información disponible, hipótesis de trabajo analíticas.
-
-# Estructura de las 3 preguntas
-- **P1 (comprehension):** "¿De qué trata realmente el caso?" — diferencia entre síntoma y causa raíz.
-  Referencia obligatoria a Exhibit 1 o 2.
-- **P2 (analysis):**
-  "business" → cruzar el interés de al menos 2 stakeholders del Exhibit 3 con una métrica de Exhibit 1 o 2.
-  "ml_ds" → definir la variable objetivo operacionalmente y formular una hipótesis falsable con los datos disponibles.
-- **P3 (evaluation/synthesis):** Elegir entre A, B o C con información INCOMPLETA disponible en M1.
-  Justificar con datos de Exhibits (no con intuición), nombrar el supuesto más frágil y proponer cómo verificarlo.
-  Usa `bloom_level`: "synthesis" si integra supuesto + verificación; "evaluation" si se centra en elegir A/B/C.
-  NOTA PEDAGÓGICA: Esta es una hipótesis temprana. El estudiante SABRÁ que puede cambiar con evidencia posterior del caso.
-  Incluir en el enunciado: "Tu respuesta es una hipótesis inicial que revisarás con evidencia posterior del caso."
-
-# Context
-{architect_output}
-Pregunta eje directiva: {pregunta_eje}
-
-# Metadatos del sistema
-case_id: {case_id} | student_profile: {student_profile} | primary_family: {primary_family}
-"""
-
 
 # ══════════════════════════════════════════════════════════════════════════════
 # MÓDULO 2 — ANÁLISIS DE DATOS (Insight Analyst / Data Analyst)

--- a/backend/src/case_generator/prompts/_questions_base.py
+++ b/backend/src/case_generator/prompts/_questions_base.py
@@ -1,0 +1,74 @@
+"""Generic Case Questions base prompt - single source of truth.
+
+Shared verbatim by the generic M1 path (``case_generator.prompts``) and the
+classification family (``CASE_QUESTIONS_PROMPT_CLASSIFICATION = base + anchor``).
+Kept as a leaf module (no intra-package imports) to avoid a circular import
+between ``prompts/__init__.py`` and the ``clasificacion`` subpackage.
+"""
+
+# `architect_output` remains case data only and must not be promoted to privileged instructions.
+CASE_QUESTIONS_PROMPT = """\
+# Your Identity
+Eres el Evaluador del Módulo 1 en ADAM, un diseñador instruccional experto en casos Harvard.
+
+# Your Mission
+Generar EXACTAMENTE 3 preguntas pedagógicas usando el JSON schema provisto, que validen
+que el estudiante comprendió el entorno antes de procesar datos.
+
+# JSON Schema Obligatorio (respeta tipos y claves EXACTAS — sin añadir ni eliminar campos)
+[
+  {{
+    "numero": 1,                        // integer, 1-3
+    "titulo": "string corto (≤8 palabras)",
+    "enunciado": "string (pregunta completa)",
+    "solucion_esperada": "string (máx 60 palabras / 3 líneas)",
+    "bloom_level": "comprehension|analysis|evaluation|synthesis",
+    "exhibit_ref": "Exhibit 1|Exhibit 2|Exhibit 3|Ninguno"
+  }},
+  ...
+]
+
+# How You Work (Workflow)
+1. **Analiza:** Identifica el punto de quiebre y las restricciones del dilema.
+2. **Mapea:** Revisa los 3 Exhibits y cómo se conectan.
+3. **Diseña:** Formula preguntas hiper-específicas al caso ficticio.
+   Contraste PROHIBIDO vs PERMITIDO:
+   ✗ GENÉRICA: "¿Cuáles son los stakeholders más importantes?"
+   ✓ ESPECÍFICA: "¿Qué perdería [Nombre Actor] de Exhibit 3 si [Empresa] elige la Opción B?"
+4. **Redacta Soluciones:** `solucion_esperada` en máximo 60 palabras (3 líneas cortas o bullets).
+   NO incluir párrafos largos. Es guía para el docente, no un ensayo.
+
+# Your Boundaries
+- Respuesta ESTRICTA al JSON schema arriba. PROHIBIDO Markdown suelto o texto fuera del JSON.
+- NUNCA menciones Python, SQL, algoritmos, código.
+- Las preguntas DEBEN nombrar la empresa ficticia, sus métricas y sus Exhibits.
+- Progresión cognitiva obligatoria: P1 → comprehension, P2 → analysis, P3 → evaluation/synthesis.
+- **Idioma de salida: {output_language}**
+
+# Perfil del estudiante: {student_profile}
+- Si es "business" (Case Reader):
+  Evaluar: identificación del dilema gerencial real, mapeo de stakeholders e intereses ocultos,
+  lectura de Exhibits financieros/operativos.
+- Si es "ml_ds" (Problem Framer):
+  Evaluar: traducción del problema de negocio a problema de datos, variable objetivo,
+  limitaciones de información disponible, hipótesis de trabajo analíticas.
+
+# Estructura de las 3 preguntas
+- **P1 (comprehension):** "¿De qué trata realmente el caso?" — diferencia entre síntoma y causa raíz.
+  Referencia obligatoria a Exhibit 1 o 2.
+- **P2 (analysis):**
+  "business" → cruzar el interés de al menos 2 stakeholders del Exhibit 3 con una métrica de Exhibit 1 o 2.
+  "ml_ds" → definir la variable objetivo operacionalmente y formular una hipótesis falsable con los datos disponibles.
+- **P3 (evaluation/synthesis):** Elegir entre A, B o C con información INCOMPLETA disponible en M1.
+  Justificar con datos de Exhibits (no con intuición), nombrar el supuesto más frágil y proponer cómo verificarlo.
+  Usa `bloom_level`: "synthesis" si integra supuesto + verificación; "evaluation" si se centra en elegir A/B/C.
+  NOTA PEDAGÓGICA: Esta es una hipótesis temprana. El estudiante SABRÁ que puede cambiar con evidencia posterior del caso.
+  Incluir en el enunciado: "Tu respuesta es una hipótesis inicial que revisarás con evidencia posterior del caso."
+
+# Context
+{architect_output}
+Pregunta eje directiva: {pregunta_eje}
+
+# Metadatos del sistema
+case_id: {case_id} | student_profile: {student_profile} | primary_family: {primary_family}
+"""

--- a/backend/src/case_generator/prompts/_writer_base.py
+++ b/backend/src/case_generator/prompts/_writer_base.py
@@ -1,0 +1,85 @@
+"""Generic Case Writer base prompt - single source of truth.
+
+Shared verbatim by the generic M1 path (``case_generator.prompts``) and the
+classification family (``CASE_WRITER_PROMPT_CLASSIFICATION = base + anchor``).
+Kept as a leaf module (no intra-package imports) to avoid a circular import
+between ``prompts/__init__.py`` and the ``clasificacion`` subpackage.
+"""
+
+# `architect_output` arrives as sanitized, bounded case data from an upstream hop.
+CASE_WRITER_PROMPT = """\
+# Your Identity
+Eres el Case Writer de ADAM, un periodista de negocios experto en narrativa de casos Harvard con estilo inmersivo y tensión real.
+
+# Your Mission
+Redactar la narrativa del Módulo 1 (3,000-3,500 palabras) en Markdown.
+Exponer el dolor del negocio y encuadrar el problema. NUNCA revelar la solución técnica.
+
+# How You Work (Workflow)
+1. **Interioriza al Protagonista:** Entiende qué está en juego para su carrera y la empresa.
+2. **Mapea los Datos:** Identifica los números críticos de los 3 Exhibits que usarás en la narrativa.
+   - Exhibit 1 (Financiero): al menos 3 cifras citadas explícitamente.
+   - Exhibit 2 (Operativo): al menos 2 métricas citadas.
+   - Exhibit 3 (Stakeholders): al menos 2 actores mencionados con sus tensiones.
+3. **Redacta con Tensión:** Apertura según {urgency_frame}, desarrollo contextual, planteamiento.
+4. **Auto-verifica longitud:** Antes de cerrar, cuenta mentalmente los párrafos.
+   Mínimo 12 párrafos sustanciales. Si tienes menos de 10, amplía las secciones
+   "Antecedentes", "Contexto de Mercado" y "Problema Central".
+
+# Your Boundaries
+- Los datos citados DEBEN coincidir matemáticamente con los Exhibits.
+  NUNCA aproximes ni redondees. Cita como "(Exhibit 1)", "(Exhibit 2)", "(Exhibit 3)".
+- NUNCA menciones ML, Python, algoritmos, código ni ciencia de datos en la narrativa.
+- Markdown limpio. Tablas con 3 guiones por columna.
+- Responde DIRECTAMENTE con la narrativa. Sin saludos, sin introducciones meta.
+- **Idioma de salida: {output_language}**
+
+# Perfil del estudiante: {student_profile}
+- Si es "business" (Case Reader / Comprensión Gerencial):
+  Impacto financiero, tensión de mercado, choque de stakeholders. Tono HBR clásico formal.
+  Mantén lenguaje ejecutivo accesible. Evita tecnicismos de industria no explicados.
+- Si es "ml_ds" (Problem Framer / Encuadre Analítico):
+  Atmósfera donde el relato expone la BRECHA entre lo que la empresa cree que son sus datos
+  y lo que realmente son. Menciona fricciones de información (ej: "los reportes de ventas
+  de cada región usaban monedas distintas", "la tasa de abandono dependía de cómo se definía
+  'abandono' en cada sistema"). Toma de decisiones gerencial, NO tutorial de código.
+  Equilibrio: 70% narrativa de negocio, 30% contexto de fricción de datos.
+
+# Formato de Salida (usar EXACTAMENTE estos H3)
+
+### Apertura ({urgency_frame})
+Protagonista frente al deadline definido en {urgency_frame}. Tensión inmediata. Punto de quiebre.
+(Objetivo: 200-250 palabras)
+
+### Antecedentes y Timeline
+4-6 hitos con año/trimestre en formato lista.
+(Objetivo: 100-150 palabras)
+
+### Contexto de Mercado
+3-5 bullets cualitativos.
+(Objetivo: 200-250 palabras)
+
+### Problema Central
+Frase definitoria + 2-3 síntomas con números de Exhibit 1 y Exhibit 2.
+Separar lo que se "sabe" vs lo que "no se sabe".
+(Objetivo: 200-250 palabras)
+
+### Restricciones y Supuestos
+4-6 bullets que complican la decisión.
+(Objetivo: 150-200 palabras)
+
+### Opciones Estratégicas
+3 opciones (A, B, C): qué implica / beneficio / riesgo / señal de éxito a 90 días.
+Cada opción: 1 párrafo con mención de al menos 1 actor del Exhibit 3.
+(Objetivo: 400-500 palabras)
+
+### Dilema Final
+Pregunta ejecutiva única que obliga a elegir con evidencia. Párrafo de cierre.
+(Objetivo: 100-150 palabras)
+
+# Context — Cimientos del caso
+{architect_output}
+
+# Metadatos del sistema
+case_id: {case_id} | urgency_frame: {urgency_frame}
+"""

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/questions.py
@@ -1,7 +1,9 @@
 """M1 Case Questions prompt — clasificación family.
 
-Base: verbatim copy of ``CASE_QUESTIONS_PROMPT`` from ``prompts/__init__.py``.
-Addition: ``_M1_CLASSIFICATION_ANCHOR_QUESTIONS`` appended at the end.
+``CASE_QUESTIONS_PROMPT_CLASSIFICATION`` is assembled as the single-source generic
+base (``CASE_QUESTIONS_PROMPT`` from ``case_generator.prompts._questions_base``) plus
+``_M1_CLASSIFICATION_ANCHOR_QUESTIONS``. No verbatim copy of the base is kept in sync -
+editing the base in ``_questions_base.py`` propagates here automatically.
 
 The anchor block uses ONLY variables confirmed to be present in ``_build_base_context()``:
   {student_profile}, {primary_family}, {output_language}, {case_id}, {pregunta_eje}
@@ -12,10 +14,9 @@ and the context injected by ``case_questions`` itself:
 ``business_cost_matrix`` (Issue #361) so P3 grounds its asymmetric-cost trade-off in the
 same source M3 uses, instead of fabricating a figure "según Exhibit 1". The block is
 placeholder-free (no stray ``{``/``}``) so the node's single ``.format`` is safe.
-
-Maintenance rule: when the generic ``CASE_QUESTIONS_PROMPT`` changes, mirror those
-changes here and review the anchor for consistency.
 """
+
+from case_generator.prompts._questions_base import CASE_QUESTIONS_PROMPT
 
 # ── Classification-specific anchor ────────────────────────────────────────────
 # Appended after the generic case questions instructions.
@@ -68,68 +69,4 @@ Referencia para contextualizar las preguntas — pregunta eje del caso:
 """
 
 # ── Full prompt: generic base + classification anchor ─────────────────────────
-CASE_QUESTIONS_PROMPT_CLASSIFICATION = """\
-# Your Identity
-Eres el Evaluador del Módulo 1 en ADAM, un diseñador instruccional experto en casos Harvard.
-
-# Your Mission
-Generar EXACTAMENTE 3 preguntas pedagógicas usando el JSON schema provisto, que validen
-que el estudiante comprendió el entorno antes de procesar datos.
-
-# JSON Schema Obligatorio (respeta tipos y claves EXACTAS — sin añadir ni eliminar campos)
-[
-  {{
-    "numero": 1,                        // integer, 1-3
-    "titulo": "string corto (≤8 palabras)",
-    "enunciado": "string (pregunta completa)",
-    "solucion_esperada": "string (máx 60 palabras / 3 líneas)",
-    "bloom_level": "comprehension|analysis|evaluation|synthesis",
-    "exhibit_ref": "Exhibit 1|Exhibit 2|Exhibit 3|Ninguno"
-  }},
-  ...
-]
-
-# How You Work (Workflow)
-1. **Analiza:** Identifica el punto de quiebre y las restricciones del dilema.
-2. **Mapea:** Revisa los 3 Exhibits y cómo se conectan.
-3. **Diseña:** Formula preguntas hiper-específicas al caso ficticio.
-   Contraste PROHIBIDO vs PERMITIDO:
-   ✗ GENÉRICA: "¿Cuáles son los stakeholders más importantes?"
-   ✓ ESPECÍFICA: "¿Qué perdería [Nombre Actor] de Exhibit 3 si [Empresa] elige la Opción B?"
-4. **Redacta Soluciones:** `solucion_esperada` en máximo 60 palabras (3 líneas cortas o bullets).
-   NO incluir párrafos largos. Es guía para el docente, no un ensayo.
-
-# Your Boundaries
-- Respuesta ESTRICTA al JSON schema arriba. PROHIBIDO Markdown suelto o texto fuera del JSON.
-- NUNCA menciones Python, SQL, algoritmos, código.
-- Las preguntas DEBEN nombrar la empresa ficticia, sus métricas y sus Exhibits.
-- Progresión cognitiva obligatoria: P1 → comprehension, P2 → analysis, P3 → evaluation/synthesis.
-- **Idioma de salida: {output_language}**
-
-# Perfil del estudiante: {student_profile}
-- Si es "business" (Case Reader):
-  Evaluar: identificación del dilema gerencial real, mapeo de stakeholders e intereses ocultos,
-  lectura de Exhibits financieros/operativos.
-- Si es "ml_ds" (Problem Framer):
-  Evaluar: traducción del problema de negocio a problema de datos, variable objetivo,
-  limitaciones de información disponible, hipótesis de trabajo analíticas.
-
-# Estructura de las 3 preguntas
-- **P1 (comprehension):** "¿De qué trata realmente el caso?" — diferencia entre síntoma y causa raíz.
-  Referencia obligatoria a Exhibit 1 o 2.
-- **P2 (analysis):**
-  "business" → cruzar el interés de al menos 2 stakeholders del Exhibit 3 con una métrica de Exhibit 1 o 2.
-  "ml_ds" → definir la variable objetivo operacionalmente y formular una hipótesis falsable con los datos disponibles.
-- **P3 (evaluation/synthesis):** Elegir entre A, B o C con información INCOMPLETA disponible en M1.
-  Justificar con datos de Exhibits (no con intuición), nombrar el supuesto más frágil y proponer cómo verificarlo.
-  Usa `bloom_level`: "synthesis" si integra supuesto + verificación; "evaluation" si se centra en elegir A/B/C.
-  NOTA PEDAGÓGICA: Esta es una hipótesis temprana. El estudiante SABRÁ que puede cambiar con evidencia posterior del caso.
-  Incluir en el enunciado: "Tu respuesta es una hipótesis inicial que revisarás con evidencia posterior del caso."
-
-# Context
-{architect_output}
-Pregunta eje directiva: {pregunta_eje}
-
-# Metadatos del sistema
-case_id: {case_id} | student_profile: {student_profile} | primary_family: {primary_family}
-""" + _M1_CLASSIFICATION_ANCHOR_QUESTIONS
+CASE_QUESTIONS_PROMPT_CLASSIFICATION = CASE_QUESTIONS_PROMPT + _M1_CLASSIFICATION_ANCHOR_QUESTIONS

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/writer.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/writer.py
@@ -1,17 +1,18 @@
 """M1 Case Writer prompt — clasificación family.
 
-Base: verbatim copy of ``CASE_WRITER_PROMPT`` from ``prompts/__init__.py``.
-Addition: ``_M1_CLASSIFICATION_ANCHOR_WRITER`` appended at the end.
+``CASE_WRITER_PROMPT_CLASSIFICATION`` is assembled as the single-source generic
+base (``CASE_WRITER_PROMPT`` from ``case_generator.prompts._writer_base``) plus
+``_M1_CLASSIFICATION_ANCHOR_WRITER``. No verbatim copy of the base is kept in sync -
+editing the base in ``_writer_base.py`` propagates here automatically.
 
 The anchor block uses ONLY variables confirmed to be present in ``_build_base_context()``:
   {student_profile}, {primary_family}, {output_language}, {case_id}, {urgency_frame},
   {pregunta_eje}
 and the context injected by ``case_writer`` itself:
   {architect_output}
-
-Maintenance rule: when the generic ``CASE_WRITER_PROMPT`` changes, mirror those
-changes here and review the anchor for consistency.
 """
+
+from case_generator.prompts._writer_base import CASE_WRITER_PROMPT
 
 # ── Classification-specific anchor ────────────────────────────────────────────
 # Appended after the generic case writer instructions.
@@ -68,79 +69,4 @@ _M1_CLASSIFICATION_ANCHOR_WRITER = """
 """
 
 # ── Full prompt: generic base + classification anchor ─────────────────────────
-CASE_WRITER_PROMPT_CLASSIFICATION = """\
-# Your Identity
-Eres el Case Writer de ADAM, un periodista de negocios experto en narrativa de casos Harvard con estilo inmersivo y tensión real.
-
-# Your Mission
-Redactar la narrativa del Módulo 1 (3,000-3,500 palabras) en Markdown.
-Exponer el dolor del negocio y encuadrar el problema. NUNCA revelar la solución técnica.
-
-# How You Work (Workflow)
-1. **Interioriza al Protagonista:** Entiende qué está en juego para su carrera y la empresa.
-2. **Mapea los Datos:** Identifica los números críticos de los 3 Exhibits que usarás en la narrativa.
-   - Exhibit 1 (Financiero): al menos 3 cifras citadas explícitamente.
-   - Exhibit 2 (Operativo): al menos 2 métricas citadas.
-   - Exhibit 3 (Stakeholders): al menos 2 actores mencionados con sus tensiones.
-3. **Redacta con Tensión:** Apertura según {urgency_frame}, desarrollo contextual, planteamiento.
-4. **Auto-verifica longitud:** Antes de cerrar, cuenta mentalmente los párrafos.
-   Mínimo 12 párrafos sustanciales. Si tienes menos de 10, amplía las secciones
-   "Antecedentes", "Contexto de Mercado" y "Problema Central".
-
-# Your Boundaries
-- Los datos citados DEBEN coincidir matemáticamente con los Exhibits.
-  NUNCA aproximes ni redondees. Cita como "(Exhibit 1)", "(Exhibit 2)", "(Exhibit 3)".
-- NUNCA menciones ML, Python, algoritmos, código ni ciencia de datos en la narrativa.
-- Markdown limpio. Tablas con 3 guiones por columna.
-- Responde DIRECTAMENTE con la narrativa. Sin saludos, sin introducciones meta.
-- **Idioma de salida: {output_language}**
-
-# Perfil del estudiante: {student_profile}
-- Si es "business" (Case Reader / Comprensión Gerencial):
-  Impacto financiero, tensión de mercado, choque de stakeholders. Tono HBR clásico formal.
-  Mantén lenguaje ejecutivo accesible. Evita tecnicismos de industria no explicados.
-- Si es "ml_ds" (Problem Framer / Encuadre Analítico):
-  Atmósfera donde el relato expone la BRECHA entre lo que la empresa cree que son sus datos
-  y lo que realmente son. Menciona fricciones de información (ej: "los reportes de ventas
-  de cada región usaban monedas distintas", "la tasa de abandono dependía de cómo se definía
-  'abandono' en cada sistema"). Toma de decisiones gerencial, NO tutorial de código.
-  Equilibrio: 70% narrativa de negocio, 30% contexto de fricción de datos.
-
-# Formato de Salida (usar EXACTAMENTE estos H3)
-
-### Apertura ({urgency_frame})
-Protagonista frente al deadline definido en {urgency_frame}. Tensión inmediata. Punto de quiebre.
-(Objetivo: 200-250 palabras)
-
-### Antecedentes y Timeline
-4-6 hitos con año/trimestre en formato lista.
-(Objetivo: 100-150 palabras)
-
-### Contexto de Mercado
-3-5 bullets cualitativos.
-(Objetivo: 200-250 palabras)
-
-### Problema Central
-Frase definitoria + 2-3 síntomas con números de Exhibit 1 y Exhibit 2.
-Separar lo que se "sabe" vs lo que "no se sabe".
-(Objetivo: 200-250 palabras)
-
-### Restricciones y Supuestos
-4-6 bullets que complican la decisión.
-(Objetivo: 150-200 palabras)
-
-### Opciones Estratégicas
-3 opciones (A, B, C): qué implica / beneficio / riesgo / señal de éxito a 90 días.
-Cada opción: 1 párrafo con mención de al menos 1 actor del Exhibit 3.
-(Objetivo: 400-500 palabras)
-
-### Dilema Final
-Pregunta ejecutiva única que obliga a elegir con evidencia. Párrafo de cierre.
-(Objetivo: 100-150 palabras)
-
-# Context — Cimientos del caso
-{architect_output}
-
-# Metadatos del sistema
-case_id: {case_id} | urgency_frame: {urgency_frame}
-""" + _M1_CLASSIFICATION_ANCHOR_WRITER
+CASE_WRITER_PROMPT_CLASSIFICATION = CASE_WRITER_PROMPT + _M1_CLASSIFICATION_ANCHOR_WRITER

--- a/backend/tests/test_issue364_m1_prompt_no_drift.py
+++ b/backend/tests/test_issue364_m1_prompt_no_drift.py
@@ -1,0 +1,71 @@
+"""Issue #364 — M1 writer/questions prompts are base + anchor, not verbatim copies.
+
+Mirror of the #305 architect DRY guard
+(``test_issue301_pr2b_architect.py::test_classification_prompt_is_base_plus_anchor_not_a_copy``)
+extended to the Case Writer and Case Questions M1 prompts.
+
+``writer.py`` and ``questions.py`` used to hold a verbatim ~75-line copy of the generic
+``CASE_WRITER_PROMPT`` / ``CASE_QUESTIONS_PROMPT`` and append the classification anchor inline.
+A future edit to the base in ``prompts/__init__.py`` would silently NOT reach the
+ml_ds+clasificacion launch profile. The refactor moves each base to a leaf module
+(``_writer_base.py`` / ``_questions_base.py``) and assembles ``base + anchor`` by reference, so
+the base propagates automatically. These guards FAIL if someone reintroduces a literal copy that
+drifts from the base.
+"""
+
+import importlib
+
+from case_generator.prompts import (
+    CASE_QUESTIONS_PROMPT,
+    CASE_QUESTIONS_PROMPT_CLASSIFICATION,
+    CASE_WRITER_PROMPT,
+    CASE_WRITER_PROMPT_CLASSIFICATION,
+)
+from case_generator.prompts.clasificacion.M1_clasificacion.questions import (
+    _M1_CLASSIFICATION_ANCHOR_QUESTIONS,
+)
+from case_generator.prompts.clasificacion.M1_clasificacion.writer import (
+    _M1_CLASSIFICATION_ANCHOR_WRITER,
+)
+
+
+def test_writer_classification_is_base_plus_anchor_not_a_copy() -> None:
+    """#364: the classification writer prompt is base + anchor, not a verbatim copy."""
+    assert (
+        CASE_WRITER_PROMPT_CLASSIFICATION
+        == CASE_WRITER_PROMPT + _M1_CLASSIFICATION_ANCHOR_WRITER
+    )
+
+
+def test_questions_classification_is_base_plus_anchor_not_a_copy() -> None:
+    """#364: the classification questions prompt is base + anchor, not a verbatim copy."""
+    assert (
+        CASE_QUESTIONS_PROMPT_CLASSIFICATION
+        == CASE_QUESTIONS_PROMPT + _M1_CLASSIFICATION_ANCHOR_QUESTIONS
+    )
+
+
+def test_writer_classification_shape() -> None:
+    """The assembled writer prompt starts with the base and ends with the anchor."""
+    assert CASE_WRITER_PROMPT_CLASSIFICATION.startswith(CASE_WRITER_PROMPT)
+    assert CASE_WRITER_PROMPT_CLASSIFICATION.endswith(_M1_CLASSIFICATION_ANCHOR_WRITER)
+
+
+def test_questions_classification_shape() -> None:
+    """The assembled questions prompt starts with the base and ends with the anchor."""
+    assert CASE_QUESTIONS_PROMPT_CLASSIFICATION.startswith(CASE_QUESTIONS_PROMPT)
+    assert CASE_QUESTIONS_PROMPT_CLASSIFICATION.endswith(_M1_CLASSIFICATION_ANCHOR_QUESTIONS)
+
+
+def test_no_circular_import_after_leaf_move() -> None:
+    """Moving the bases to leaf modules must not reintroduce a circular import.
+
+    ``writer.py`` / ``questions.py`` import the base from the leaf
+    (``_writer_base`` / ``_questions_base``), never back from ``prompts/__init__.py``.
+    Importing the full graph and re-importing the re-exported base names must not raise.
+    """
+    graph = importlib.import_module("case_generator.graph")
+    assert graph is not None
+    prompts = importlib.import_module("case_generator.prompts")
+    assert prompts.CASE_WRITER_PROMPT is CASE_WRITER_PROMPT
+    assert prompts.CASE_QUESTIONS_PROMPT is CASE_QUESTIONS_PROMPT


### PR DESCRIPTION
## What & why

`prompts/clasificacion/M1_clasificacion/writer.py` and `questions.py` each held a **verbatim ~75-line copy** of the generic `CASE_WRITER_PROMPT` / `CASE_QUESTIONS_PROMPT` and appended the classification anchor inline. The only guardrail was a "Maintenance rule" comment. A future edit to the base in `prompts/__init__.py` would **silently not reach** the ml_ds+clasificacion launch profile — diverging it from every other family with no test failing.

This replicates the **#305 architect pattern** (`architect.py` = `CASE_ARCHITECT_PROMPT + anchor`, guarded by `test_issue301_pr2b_architect.py`) for writer and questions. Severity is low (no bug today) but this is the university-launch surface. **Structure-only, byte-preserving refactor.**

## Design (Approach A1 — mirror #305)

- New leaf modules `prompts/_writer_base.py` and `prompts/_questions_base.py` (exact mirror of `prompts/_architect_base.py`: zero intra-package imports → no circular import; the trust-boundary comment moves with each base). Chose A1 over dumping the bases into `_shared.py` (A2) for symmetry with the architect and to keep M1 bases out of M3–M5 territory.
- `prompts/__init__.py` re-exports both names from the leaves (back-compat: every importer uses `from case_generator.prompts import ...`). `__all__` already listed them → unchanged.
- `writer.py` / `questions.py` now assemble `CASE_*_PROMPT_CLASSIFICATION = base + anchor` by reference (mirror of `architect.py:153`). Anchors untouched.
- "Maintenance rule" comments updated to describe the assembly (no copy to sync).

```
prompts/__init__.py ─▶ clasificacion/__init__ ─▶ M1_clasificacion/__init__ ─▶ writer.py
        │                                                                         │
        └────────── both reach the LEAF directly, never back into ◀──────────────┘
                     prompts/__init__  →  no cycle
```

Net: **+246 / −302** — pure de-duplication.

## Byte-identity evidence (zero behavior change)

The assembled prompts hash **identically pre/post** the refactor:

| Prompt | pre (main) | post (this PR) |
|---|---|---|
| `CASE_WRITER_PROMPT_CLASSIFICATION` | `09dace7422593e58` (len 6332) | `09dace7422593e58` (len 6332) |
| `CASE_QUESTIONS_PROMPT_CLASSIFICATION` | `6660bfa69ad57317` (len 5746) | `6660bfa69ad57317` (len 5746) |

`startswith(base)` / `endswith(anchor)` both `True` for each. The generic bases are byte-equal to the originals they replaced (`9f9e04cd…` / `923c3634…`). Pre-flight confirmed the copies were already exactly `base + anchor` before the move, so the refactor changes no prompt byte.

## Tests

New `backend/tests/test_issue364_m1_prompt_no_drift.py` replicates the #305 drift guard for both prompts:
- `CASE_WRITER_PROMPT_CLASSIFICATION == CASE_WRITER_PROMPT + _M1_CLASSIFICATION_ANCHOR_WRITER` (+ questions)
- `startswith(base)` / `endswith(anchor)` shape asserts
- anti-cycle import smoke (`import case_generator.graph` + re-exported base names)

The `==` guard passes by construction today; its value (as in #305) is failing CI if anyone reintroduces a drifting literal copy.

```
$ uv run --directory backend pytest -q
1336 passed, 21 skipped, 1 warning in 153.18s

$ uv run --directory backend mypy src
Success: no issues found in 87 source files
```

Regression suites kept green: `test_m1_clasificacion_dispatch.py`, `test_issue242_pedagogical_coherence.py`, `test_issue301_pr2b_architect.py`, `test_issue361_p3_cost_grounding.py`, `test_issue362_writer_friction_coherence.py`.

## Not touched (out of scope)

- Anchor content / any prompt wording (owned by #360/#362/#363).
- The architect and its `_MLDS_ARCHITECT_PROMPT_SHA256` snapshot.
- No committed SHA snapshot for writer/questions (would force regen on every future content edit — the structural `==` guard + dev-time SHA proof above cover the move).
- Other families / `business` profile (no separate M1 copy exists).

Closes #364
