### PR TITLE
fix(case_generator): M1 ml_ds+clf target identity (R2) + event-rate single source (F1)

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -983,6 +983,13 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
             contract_dict, family_resolved, result.titulo
         )
         coherence_warnings = list(coherence_warnings) + cost_warnings
+
+        # Issue F1 — valida la tasa de evento (fuente única M1↔M2) con la misma
+        # resolución de perfil/familia. Gateada a ml_ds + clasificación binaria.
+        contract_dict, rate_warnings = _validate_target_event_rate(
+            contract_dict, family_resolved, result.titulo, profile_resolved
+        )
+        coherence_warnings = list(coherence_warnings) + rate_warnings
         if target_enforced:
             coherence_warnings.append(
                 "target business+clasificación normalizado a classification_target binario "
@@ -2856,6 +2863,106 @@ def _validate_business_cost_matrix(
     return new_contract, warnings
 
 
+def _validate_target_event_rate(
+    contract: dict | None,
+    family: str | None,
+    case_title: str | None,
+    profile: str | None,
+) -> tuple[dict | None, list[str]]:
+    """Valida y sanitiza ``target_event_rate`` del contrato (Issue F1).
+
+    Fuente única de verdad de la prevalencia del evento: el architect la emite, Exhibit 2 la
+    imprime, y el generador determinista calibra la columna target a ella. Best-effort
+    (case_architect-style), NUNCA lanza ni muta el dict in-place:
+      * Gate = ml_ds + clasificación + target binario (``role==classification_target`` y
+        ``dtype==int``). Fuera del gate y poblado → warning + nulificado (no aplica a
+        business/multiclase/otras familias).
+      * Dentro del gate y ausente → warning estructurado (el generador cae al umbral ~0.50 y
+        Exhibit 2 quedará incoherente — señal accionable para operadores).
+      * Dentro del gate, presente pero fuera de [_MIN, _MAX] o no finito → warning + nulificado.
+      * OK → contrato con el rate como ``float``.
+    Devuelve ``(contract_or_copy, warnings)``.
+    """
+    from case_generator.tools_and_schemas import (
+        _MAX_TARGET_EVENT_RATE,
+        _MIN_TARGET_EVENT_RATE,
+    )
+
+    warnings: list[str] = []
+    if contract is None:
+        return contract, warnings
+
+    raw_value = contract.get("target_event_rate")
+    family_norm = (family or "").strip().lower()
+    profile_norm = (profile or "").strip().lower()
+    target = contract.get("target_column") or {}
+    is_binary_clf = (
+        profile_norm == "ml_ds"
+        and family_norm == "clasificacion"
+        and isinstance(target, dict)
+        and target.get("role") == "classification_target"
+        and target.get("dtype") == "int"
+    )
+
+    # Fuera del gate: si viene poblado, nulificar (no aplica).
+    if not is_binary_clf:
+        if raw_value is not None:
+            logger.warning(
+                "[case_architect.target_event_rate] emitido fuera del gate ml_ds+clf binario "
+                "(profile=%r, family=%r, case_title=%r) — nulificado",
+                profile, family, case_title or "<sin titulo>",
+            )
+            new_contract = dict(contract)
+            new_contract["target_event_rate"] = None
+            warnings.append(
+                "target_event_rate_wrong_scope: target_event_rate solo aplica a ml_ds + "
+                "clasificación binaria; se ignoró para este caso."
+            )
+            return new_contract, warnings
+        return contract, warnings
+
+    # Dentro del gate, ausente.
+    if raw_value is None:
+        logger.warning(
+            "[case_architect.target_event_rate] missing for ml_ds binary classification "
+            "(case_title=%r) — el generador usará ~0.50 y Exhibit 2 quedará incoherente",
+            case_title or "<sin titulo>",
+        )
+        warnings.append(
+            "target_event_rate_missing: caso ml_ds de clasificación sin tasa de evento; "
+            "el dataset usará prevalencia ~0.50 que puede no coincidir con Exhibit 2."
+        )
+        return contract, warnings
+
+    # Dentro del gate, presente — bounds + finitud (la comparación excluye NaN/inf sin `math`).
+    valid = (
+        isinstance(raw_value, (int, float))
+        and not isinstance(raw_value, bool)
+        and _MIN_TARGET_EVENT_RATE <= float(raw_value) <= _MAX_TARGET_EVENT_RATE
+    )
+    if not valid:
+        logger.warning(
+            "[case_architect.target_event_rate] inválido (%r) fuera de [%.2f, %.2f] o no finito "
+            "(case_title=%r) — nulificado",
+            raw_value, _MIN_TARGET_EVENT_RATE, _MAX_TARGET_EVENT_RATE,
+            case_title or "<sin titulo>",
+        )
+        new_contract = dict(contract)
+        new_contract["target_event_rate"] = None
+        warnings.append(
+            "target_event_rate_invalid: tasa de evento fuera del rango plausible [1%, 50%]; "
+            "se ignoró (el dataset usará prevalencia ~0.50)."
+        )
+        return new_contract, warnings
+
+    # OK — normaliza a float si vino como int.
+    if not isinstance(raw_value, float):
+        new_contract = dict(contract)
+        new_contract["target_event_rate"] = float(raw_value)
+        return new_contract, warnings
+    return contract, warnings
+
+
 def _format_dataset_contract_block(contract: dict | None) -> str:
     """Renderiza el contrato como bloque legible para inyectar en SCHEMA_DESIGNER_PROMPT.
 
@@ -2975,11 +3082,41 @@ def _augment_schema_with_contract(schema: dict, contract: dict | None) -> dict:
     target = contract.get("target_column") or {}
     target_name = (target.get("name") or "").strip()
     if target_name and target_name not in existing_names:
-        columns.append(_default_column(
-            name=target_name,
-            dtype=target.get("dtype", "float"),
-            description=target.get("description", "Variable objetivo declarada por contrato"),
-        ))
+        if (
+            target.get("role") == "classification_target"
+            and target.get("dtype") == "int"
+            and target_name.isidentifier()
+        ):
+            # Endurecimiento R2: un classification_target BINARIO (dtype int) inyectado DEBE ser
+            # {0,1} con señal, NO un int [0,100] random — el notebook lo resuelve contract-first
+            # (#348) y un target no-binario degrada el modeling entero. Lo inyectamos como
+            # `categoria`: int [0,1] dependiente de un driver numérico existente. Un target
+            # multiclase (dtype str) cae al `_default_column` (str categórico), sin tocar.
+            # El guard `.isidentifier()` espeja `_safe_contract_target_name`/`_align`: un nombre
+            # no-identificador NO debe producir una binaria inyectada (el notebook caería al
+            # alias `categoria`, dejando esta binaria como duplicado con leakage).
+            driver = _pick_numeric_driver(columns, exclude=target_name)
+            columns.append({
+                "name": target_name,
+                "type": "int",
+                "description": target.get(
+                    "description", "Variable objetivo binaria declarada por contrato"
+                ),
+                "range_min": 0,
+                "range_max": 1,
+                "nullable": False,
+                "trend": None,
+                "dependency": (
+                    {"depends_on": driver, "relationship": "linear", "noise_factor": 0.30}
+                    if driver else None
+                ),
+            })
+        else:
+            columns.append(_default_column(
+                name=target_name,
+                dtype=target.get("dtype", "float"),
+                description=target.get("description", "Variable objetivo declarada por contrato"),
+            ))
         existing_names.add(target_name)
         logger.warning(
             "[contract.augment] target '%s' faltante — inyectado con defaults seguros",
@@ -3003,6 +3140,121 @@ def _augment_schema_with_contract(schema: dict, contract: dict | None) -> dict:
         )
 
     new_schema["columns"] = columns
+    return new_schema
+
+
+def _pick_numeric_driver(columns: list[dict], *, exclude: str = "") -> str | None:
+    """Elige una columna numérica existente como driver de un target binario inyectado.
+
+    Prefiere ``churn_rate`` (el driver canónico del template ml_ds de clasificación); si no
+    está, la primera columna ``int``/``float`` con rango declarado distinta del propio target.
+    Devuelve ``None`` si no hay ninguna (→ el target se genera independiente, igual binario).
+    """
+    names = {c.get("name") for c in columns}
+    if "churn_rate" in names and exclude != "churn_rate":
+        return "churn_rate"
+    for c in columns:
+        if (
+            c.get("name") != exclude
+            and c.get("type") in ("int", "float")
+            and c.get("range_min") is not None
+            and c.get("range_max") is not None
+        ):
+            return c.get("name")
+    return None
+
+
+def _align_ml_ds_classification_target(
+    schema_result: dict,
+    contract: dict | None,
+    *,
+    profile: str,
+    primary_family: str | None,
+) -> dict:
+    """Reconcilia la identidad del target binario para ml_ds + clasificación (R2).
+
+    El architect nombra el target con un nombre de dominio (``churn_flag``) en el contrato,
+    pero el schema fijo M2 construye la binaria como ``categoria``. Si divergen, el notebook
+    (contract-first, #348) entrena el nombre del contrato: o el augmenter lo inyecta como
+    ``int [0,100]`` random (no binario → degrada el modeling) o coexiste con ``categoria`` (otra
+    binaria del MISMO driver → feature con leakage). Este normalizador garantiza UNA sola
+    binaria, con el nombre del contrato, derivada del driver:
+
+      1. renombra la binaria fija (``categoria``) al nombre del contrato si éste aún no es columna;
+      2. elimina cualquier binaria duplicada derivada del MISMO driver que el target (anti-leakage).
+
+    Determinista, 0 tokens, no muta el dict de entrada. NO toca business, otras familias, ni el
+    caso sin un ``classification_target`` de contrato con nombre válido (→ ``categoria`` se
+    preserva). Debe correr ANTES de ``_augment_schema_with_contract`` para que el augmenter vea
+    el target ya presente y no inyecte la columna ``[0,100]``.
+    """
+    if profile != "ml_ds":
+        return schema_result
+    # ml_ds: None family → "clasificacion" (espeja `_effective_family` de schema_designer,
+    # graph.py ~3494). Sin esto, un job ml_ds con algoritmos vacíos (primary_family=None)
+    # construye el template `categoria` pero NO se reconcilia aquí → el augmenter inyecta un
+    # duplicado del mismo driver (el leakage que esta función previene).
+    if (primary_family or "clasificacion") != "clasificacion":
+        return schema_result
+    contract_target = _safe_contract_target_name(contract)
+    if not contract_target:
+        return schema_result
+    tgt = (contract or {}).get("target_column") or {}
+    # Solo reconciliamos un target BINARIO (dtype int). Un classification_target multiclase
+    # (dtype str) NO debe heredar la binaria `categoria` — se deja intacto.
+    if tgt.get("role") != "classification_target" or tgt.get("dtype") != "int":
+        return schema_result
+
+    columns = [dict(c) for c in schema_result.get("columns", [])]
+    binary_targets = [
+        c for c in columns
+        if _is_declared_binary_int(c) and isinstance(c.get("dependency"), dict)
+    ]
+    if not binary_targets:
+        return schema_result  # nada que reconciliar; el augmenter endurecido es la red.
+
+    # Elige la binaria objetivo de forma orden-robusta (no asumas binary_targets[0]): la que ya
+    # lleva el nombre del contrato → la canónica `categoria` → la primera.
+    target_col = (
+        next((c for c in binary_targets if c.get("name") == contract_target), None)
+        or next((c for c in binary_targets if c.get("name") == "categoria"), None)
+        or binary_targets[0]
+    )
+    if target_col.get("name") != contract_target:
+        # Renombra la binaria al nombre del contrato — SOLO si ese nombre no colisiona con otra
+        # columna existente (evitar dos columnas homónimas → corrupción del df al ensamblar).
+        if contract_target in {c.get("name") for c in columns}:
+            logger.warning(
+                "[_align_ml_ds_classification_target] nombre de contrato '%s' ya existe como "
+                "columna no-objetivo — se omite el rename para no duplicar nombre.",
+                contract_target,
+            )
+            return schema_result
+        old_name = target_col.get("name")
+        target_col["name"] = contract_target
+        logger.info(
+            "[_align_ml_ds_classification_target] target binario '%s' → '%s' (nombre del contrato)",
+            old_name, contract_target,
+        )
+    keep_name = target_col.get("name")
+    keep_driver = (target_col.get("dependency") or {}).get("depends_on")
+    # anti-leakage: descarta otras binarias {0,1} derivadas del MISMO driver que el target.
+    new_columns = [
+        c for c in columns
+        if not (
+            c.get("name") != keep_name
+            and _is_declared_binary_int(c)
+            and isinstance(c.get("dependency"), dict)
+            and c["dependency"].get("depends_on") == keep_driver
+        )
+    ]
+    if len(new_columns) != len(columns):
+        logger.info(
+            "[_align_ml_ds_classification_target] binaria duplicada del driver '%s' eliminada "
+            "(anti-leakage) — target único: '%s'", keep_driver, keep_name,
+        )
+    new_schema = dict(schema_result)
+    new_schema["columns"] = new_columns
     return new_schema
 
 
@@ -3373,6 +3625,12 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
             #   2) validator: registra residuales (vacío post-augment) + leakage flags
             #      como data_gap_warnings que M2 EDA y M3 notebook leerán.
             contract = state.get("dataset_schema_required")
+            # R2 — reconcilia la identidad del target binario ANTES del augment (ml_ds+clf),
+            # para que el augmenter no inyecte un target [0,100] random y no quede una binaria
+            # duplicada con leakage. No-op fuera del gate.
+            schema_result = _align_ml_ds_classification_target(
+                schema_result, contract, profile=profile, primary_family=primary_family
+            )
             schema_result = _augment_schema_with_contract(schema_result, contract)
             # Issue #301 — spine determinista business+clasificación: garantiza un target
             # binario de dominio + driver (no el template fijo de churn). Business-only;
@@ -3411,6 +3669,10 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
     )
     # Issue #225 — incluso en fallback respetamos el contrato del architect.
     contract = state.get("dataset_schema_required")
+    # R2 — misma reconciliación de identidad del target que en el camino feliz.
+    fallback_schema = _align_ml_ds_classification_target(
+        fallback_schema, contract, profile=profile, primary_family=primary_family
+    )
     fallback_schema = _augment_schema_with_contract(fallback_schema, contract)
     # Issue #301 — el spine determinista también aplica en fallback (red de seguridad).
     fallback_schema, biz_notes, biz_target = _enforce_business_classification_schema(
@@ -3563,7 +3825,28 @@ def _is_declared_binary_int(col: dict) -> bool:
 # HELPER — _generate_dataset_from_schema (Python puro, 0 tokens LLM)
 # ─────────────────────────────────────────────────────────
 
-def _generate_dataset_from_schema(schema: dict, profile: str = "business") -> list:
+def _is_mlds_event_target(col: dict, target_col_name: str | None) -> bool:
+    """¿Es ``col`` el target binario ml_ds a calibrar (Issue F1)?
+
+    El target del contrato (ya reconciliado a una binaria por ``_align_ml_ds_classification_target``)
+    o ``categoria`` como fallback alias-first cuando no hay nombre de contrato — espejo de la
+    resolución contract-first del notebook (#348). Solo binarias {0,1} int.
+    """
+    if not _is_declared_binary_int(col):
+        return False
+    name = col.get("name")
+    if target_col_name:
+        return name == target_col_name
+    return name == "categoria"
+
+
+def _generate_dataset_from_schema(
+    schema: dict,
+    profile: str = "business",
+    *,
+    target_event_rate: float | None = None,
+    target_col_name: str | None = None,
+) -> list:
     """
     Genera filas de datos a partir del schema producido por schema_designer.
     Vectorizado con numpy. Cero tokens LLM. Determinista con seed derivado del schema.
@@ -3707,6 +3990,27 @@ def _generate_dataset_from_schema(schema: dict, profile: str = "business") -> li
 
         if col_type == "float":
             result = [None if null_mask[i] else round(float(values[i]), 2) for i in range(n_rows)]
+        elif (
+            profile == "ml_ds"
+            # isinstance (no solo `is not None`): defensa-en-profundidad sobre un valor de
+            # origen LLM, por si un rate malformado (str/bool/None) llegara sin pasar por
+            # `_validate_target_event_rate` — cae al camino round normal en vez de crashear.
+            and isinstance(target_event_rate, (int, float))
+            and not isinstance(target_event_rate, bool)
+            and _is_mlds_event_target(col, target_col_name)
+        ):
+            # Issue F1 — calibra la prevalencia del target binario ml_ds al `target_event_rate`
+            # anunciado en Exhibit 2 (fuente única M1↔M2). Umbral top-k por argsort sobre los
+            # `values` (= clip(base+noise), que ya codifican la señal driver→target): preserva
+            # el ORDEN (señal/AUC intacta) y fija la prevalencia EXACTA a la tasa. `k` con
+            # piso/techo garantiza ambas clases. Mutuamente excluyente con el balance business.
+            scores = np.asarray(values, dtype=float)
+            n = scores.size
+            k = max(1, min(n - 1, int(round(float(target_event_rate) * n))))
+            order = np.argsort(scores, kind="stable")  # ascendente, determinista con seed fijo
+            labels = np.zeros(n, dtype=int)
+            labels[order[n - k:]] = 1  # top-k scores → positivos → exactamente k=round(rate·n)
+            result = [None if null_mask[i] else int(labels[i]) for i in range(n_rows)]
         else:
             # Issue #301 — guard anti-degeneración del target binario de dominio (business).
             # SOLO el target que el spine etiquetó con ``is_domain_target`` se balancea;
@@ -3856,7 +4160,20 @@ def data_generator(state: ADAMState, config: RunnableConfig) -> dict:  # noqa: A
         if profile == "business":
             schema["n_rows"] = max(80, min(120, schema.get("n_rows", 100)))
 
-        rows = _generate_dataset_from_schema(schema, profile=profile)
+        # Issue F1 — pasa la tasa de evento + nombre del target (fuente única M1↔M2) para que
+        # el generador calibre la prevalencia del target binario ml_ds. Como kwargs (no en
+        # `schema`) el seed no cambia → datasets sin rate / business byte-idénticos.
+        contract = state.get("dataset_schema_required")
+        target_event_rate = (
+            contract.get("target_event_rate") if isinstance(contract, dict) else None
+        )
+        target_col_name = _safe_contract_target_name(contract) or None
+        rows = _generate_dataset_from_schema(
+            schema,
+            profile=profile,
+            target_event_rate=target_event_rate,
+            target_col_name=target_col_name,
+        )
         constraints = schema.get("constraints", {})
         constraints_with_count = {**constraints, "n_rows_expected": schema.get("n_rows", 100)}
 

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/architect.py
@@ -66,9 +66,12 @@ no 3 clases del target.
    Añade exactamente 2 filas numéricas y específicas que capturen la realidad del
    evento objetivo en los datos históricos de la empresa:
    - Tasa de ocurrencia del evento objetivo (ej: "Tasa histórica de abandono: 8.3 %").
+     Este porcentaje DEBE ser el MISMO número que emites en
+     `dataset_schema_required.target_event_rate`, expresado como fracción (8.3 % ⇔ 0.083).
+     El generador determinista del dataset calibra la columna objetivo a esa prevalencia,
+     de modo que si Exhibit 2 y `target_event_rate` difieren, el caso queda incoherente
+     (el estudiante vería en el dataset una proporción distinta a la que anuncia el caso).
    - Completitud de campos críticos (ej: "% registros con campo contractual sin dato: 12 %").
-   Sin estas filas el `schema_designer` downstream no puede modelar el desbalance de
-   clases real del caso, comprometiendo la coherencia pedagógica del notebook M3.
    Esta instrucción REEMPLAZA la regla base de "al menos 2 métricas de calidad de datos"
    de Exhibit 2: para clasificación las 2 filas de calidad de datos son EXACTAMENTE las dos
    anteriores (tasa de ocurrencia del evento objetivo + completitud de campos críticos) y
@@ -113,6 +116,23 @@ Forma exacta (dentro de `dataset_schema_required`):
     "fn_cost": 5000,
     "currency": "USD"
   }}
+}}
+
+## Tasa de ocurrencia del evento (`target_event_rate`) — ml_ds clasificación binaria
+
+Emite `target_event_rate` SOLO para el perfil ml_ds con target binario de clasificación
+(el mismo gate que `business_cost_matrix`). Es la fracción de la población que presenta el
+evento objetivo, y DEBE ser el MISMO número que la fila "Tasa de ocurrencia del evento" de
+Exhibit 2, expresado como fracción en [0.01, 0.50] (8.3 % → 0.083). El generador determinista
+del dataset calibra la columna objetivo a esta prevalencia (fuente única M1↔M2). Para business,
+target multiclase u otras familias: NO lo emitas (déjalo ausente / `null`).
+
+Ubicación EXACTA: clave ANIDADA dentro de `dataset_schema_required` (junto a `target_column`
+/ `business_cost_matrix`), NUNCA como clave de nivel superior.
+
+Forma exacta (dentro de `dataset_schema_required`):
+{{
+  "target_event_rate": 0.083
 }}
 """
 

--- a/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/dataset.py
+++ b/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/dataset.py
@@ -111,7 +111,9 @@ Notas críticas:
 - col 18 (categoria): type="int", range_min=0, range_max=1, trend=null.
   dependency.depends_on="churn_rate", relationship="linear", noise_factor=0.30.
   NUNCA type="str" para categoria — convierte el target en ruido aleatorio sin señal.
-- El data_generator normaliza el padre, agrega ruido gaussiano, y redondea a int → ~70% señal → AUC ≥ 0.70.
+- El data_generator normaliza el padre y agrega ruido gaussiano → ~70% señal → AUC ≥ 0.70.
+  Si el contrato trae `target_event_rate`, el target se calibra a esa prevalencia preservando
+  el ORDEN (la señal/AUC no cambia, solo la tasa de positivos); si no, usa el umbral ~0.50.
 - revenue en col 2 y 3: rev = revenue_annual_total / {max_rows} (por fila, no anual).
 
 ## Ejemplo de columnas con dependency y target (JSON listo para emitir)

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -14,6 +14,12 @@ _SUPPORTED_COST_CURRENCIES = frozenset({"USD", "EUR", "GBP", "COP", "MXN", "BRL"
 _MAX_BUSINESS_COST = 1_000_000_000.0
 _MAX_BUSINESS_COST_RATIO = 1_000.0
 
+# Issue F1 — prevalencia del evento objetivo anunciada en Exhibit 2. Un evento de
+# clasificación debe ser una minoría aprendible: piso 1% (≥1 positivo a n=600), techo 50%
+# (un evento "raro" no debería ser mayoría; > 0.5 sería el complemento).
+_MIN_TARGET_EVENT_RATE = 0.01
+_MAX_TARGET_EVENT_RATE = 0.50
+
 
 # ═══════════════════════════════════════════════════════
 # ISSUE #225 — Dataset Schema Required Contract
@@ -148,6 +154,35 @@ class DatasetSchemaRequired(BaseModel):
             "(predecir 0 cuando es 1). Si None, M3 usa fallback fp=1, fn=5."
         ),
     )
+    # Issue F1 — prevalencia del evento objetivo (fracción target=1) anunciada en la fila
+    # "Tasa de ocurrencia" de Exhibit 2. Solo ml_ds + clasificación binaria. El generador
+    # determinista calibra la columna target a esta prevalencia (fuente única M1↔M2); si None,
+    # usa el umbral histórico (~0.50). Mantiene Exhibit 2 ↔ dataset ↔ M3 prevalence coherentes.
+    #
+    # Los límites [_MIN, _MAX] NO se imponen como `ge`/`le` aquí a PROPÓSITO: un valor LLM fuera
+    # de rango (p. ej. emitir 8.3 en vez de 0.083) levantaría un ValidationError que abortaría el
+    # PARSE de TODO el `CaseArchitectOutput` y degradaría el caso entero a un placeholder de error.
+    # En su lugar, `graph._validate_target_event_rate` aplica los límites de forma TOLERANTE
+    # (fuera de rango → nulificado + warning, el caso COMPLETA con prevalencia ~0.50). Aquí solo
+    # rechazamos NaN/inf (no representables como prevalencia y nunca recuperables).
+    target_event_rate: Optional[float] = Field(
+        default=None,
+        description=(
+            "Prevalencia del evento objetivo (fracción de filas con target=1); el rango válido es "
+            "[0.01, 0.50]. DEBE coincidir con la 'Tasa de ocurrencia del evento' impresa en "
+            "Exhibit 2 (8.3 % → 0.083). Solo ml_ds + clasificación binaria; None en otro caso. "
+            "Fuera de rango se nulifica downstream (no falla el caso)."
+        ),
+    )
+
+    @field_validator("target_event_rate")
+    @classmethod
+    def _finite_event_rate(cls, v: Optional[float]) -> Optional[float]:
+        if v is None:
+            return v
+        if not math.isfinite(v):
+            raise ValueError("target_event_rate must be a finite number (no inf/nan)")
+        return v
 
 
 class BusinessCostMatrix(BaseModel):

--- a/backend/tests/test_issue301_pr2b_architect.py
+++ b/backend/tests/test_issue301_pr2b_architect.py
@@ -71,10 +71,11 @@ _MLDS_CTX: dict[str, object] = {
 # Frozen digest of the assembled ml_ds+clasificación prompt. If this changes, the ml_ds
 # prompt changed — confirm it was NOT the business gate leaking in before updating.
 _MLDS_ARCHITECT_PROMPT_SHA256 = (
-    # Issue #363 — regenerated deliberately after adding option-count (D2) +
-    # Exhibit-2 (D3) supersede clauses to the classification anchor. Confirmed via
-    # test_mlds_architect_prompt_unchanged_by_business_gate (differential GREEN → not a leak).
-    "04af5c2947bf1f7bf522768370dbee455a660dde36bd7bf23b45de83d5678176"
+    # Issue F1 — regenerated deliberately after tying the Exhibit-2 occurrence-rate row to the
+    # new `target_event_rate` contract field + adding its emission block (fuente única M1↔M2).
+    # Confirmed via test_mlds_architect_prompt_unchanged_by_business_gate (differential GREEN
+    # → not a business-gate leak).
+    "4807710d0ddcb1bd922bc8d1a9d7f444698449de079cef52476915b75ea69ab4"
 )
 
 

--- a/backend/tests/test_issue363_target_event_rate.py
+++ b/backend/tests/test_issue363_target_event_rate.py
@@ -1,0 +1,261 @@
+"""Issue F1 — `target_event_rate` como fuente única de la prevalencia (M1↔M2).
+
+Antes del fix, el architect anunciaba una tasa de evento en Exhibit 2 que el dataset
+ignoraba: el generador normalizaba el padre a [0,1] → prevalencia ~0.50 sin importar la
+tasa. Ahora el architect emite `target_event_rate`, Exhibit 2 imprime el mismo número, y el
+generador calibra la columna target a esa prevalencia (umbral top-k por argsort, que
+preserva el orden → señal/AUC intactas).
+
+Tests puros (sin LLM/DB). El seed deriva del schema → las propiedades estructurales valen.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from case_generator.graph import (
+    _generate_dataset_from_schema,
+    _validate_target_event_rate,
+)
+from case_generator.prompts.clasificacion.M1_clasificacion.architect import (
+    CASE_ARCHITECT_PROMPT_CLASSIFICATION,
+)
+from case_generator.tools_and_schemas import DatasetSchemaRequired, DatasetTargetSpec
+
+# ─────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────
+
+
+def _schema_with_binary_target(target: str = "churn_flag", n_rows: int = 600) -> dict:
+    """Schema ml_ds con un target binario (`target`) dependiente de churn_rate."""
+    return {
+        "columns": [
+            {"name": "period", "type": "str", "range_min": None, "range_max": None,
+             "nullable": False, "trend": None, "dependency": None},
+            {"name": "revenue", "type": "float", "range_min": 1000, "range_max": 2000,
+             "nullable": False, "trend": None, "dependency": None},
+            {"name": "churn_rate", "type": "float", "range_min": 0.02, "range_max": 0.15,
+             "nullable": False, "trend": None,
+             "dependency": {"depends_on": "revenue", "relationship": "inverse", "noise_factor": 0.1}},
+            {"name": target, "type": "int", "range_min": 0, "range_max": 1,
+             "nullable": False, "trend": None,
+             "dependency": {"depends_on": "churn_rate", "relationship": "linear", "noise_factor": 0.30}},
+        ],
+        "n_rows": n_rows, "time_granularity": "monthly", "constraints": {},
+    }
+
+
+def _gen(schema: dict, *, rate: float | None, target: str | None, profile: str = "ml_ds") -> list[dict]:
+    return _generate_dataset_from_schema(
+        schema, profile=profile, target_event_rate=rate, target_col_name=target
+    )
+
+
+def _clf_contract(rate: float | None, *, dtype: str = "int", role: str = "classification_target") -> dict:
+    c: dict = {"target_column": {"name": "churn_flag", "role": role, "dtype": dtype,
+                                 "description": "x"}, "feature_columns": []}
+    if rate is not None:
+        c["target_event_rate"] = rate
+    return c
+
+
+# ─────────────────────────────────────────────────────────
+# (a) prevalencia EXACTA ≈ rate
+# ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("rate", [0.05, 0.083, 0.20, 0.40])
+def test_prevalence_matches_rate_exactly(rate: float) -> None:
+    rows = _gen(_schema_with_binary_target(), rate=rate, target="churn_flag")
+    prevalence = sum(r["churn_flag"] for r in rows) / len(rows)
+    assert prevalence == round(rate * 600) / 600, (
+        f"prevalencia {prevalence} debe ser exactamente round({rate}*600)/600"
+    )
+
+
+def test_uncalibrated_is_not_rate_aware() -> None:
+    # Sin rate, la prevalencia cae al ~0.50 histórico (NO la tasa anunciada) — el bug original.
+    rows = _gen(_schema_with_binary_target(), rate=None, target="churn_flag")
+    prevalence = sum(r["churn_flag"] for r in rows) / len(rows)
+    assert 0.35 < prevalence < 0.65
+
+
+# ─────────────────────────────────────────────────────────
+# (b) ambas clases siempre
+# ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("rate", [0.01, 0.50])
+def test_both_classes_at_extremes(rate: float) -> None:
+    rows = _gen(_schema_with_binary_target(), rate=rate, target="churn_flag")
+    assert {r["churn_flag"] for r in rows} == {0, 1}
+
+
+def test_both_classes_small_n() -> None:
+    rows = _gen(_schema_with_binary_target(n_rows=20), rate=0.05, target="churn_flag")
+    assert {r["churn_flag"] for r in rows} == {0, 1}  # k=max(1,...) garantiza ≥1 positivo
+
+
+# ─────────────────────────────────────────────────────────
+# (c) señal/AUC preservada (orden intacto)
+# ─────────────────────────────────────────────────────────
+
+
+def test_signal_preserved_correlation_positive() -> None:
+    schema = _schema_with_binary_target()
+    rows = _gen(schema, rate=0.083, target="churn_flag")
+    churn = np.array([r["churn_rate"] for r in rows])
+    target = np.array([r["churn_flag"] for r in rows])
+    corr = np.corrcoef(churn, target)[0, 1]
+    assert corr > 0.05, f"el target debe seguir correlacionado con el driver, corr={corr}"
+
+
+# ─────────────────────────────────────────────────────────
+# (d) business / sin rate → byte-idéntico
+# ─────────────────────────────────────────────────────────
+
+
+def test_business_byte_identical() -> None:
+    biz = {
+        "columns": [
+            {"name": "period", "type": "str", "range_min": None, "range_max": None,
+             "nullable": False, "trend": None, "dependency": None},
+            {"name": "flag", "type": "int", "range_min": 0, "range_max": 1,
+             "nullable": False, "trend": None, "dependency": None, "is_domain_target": True},
+        ],
+        "n_rows": 100, "time_granularity": "monthly", "constraints": {},
+    }
+    base = _generate_dataset_from_schema(biz, profile="business")
+    with_rate = _generate_dataset_from_schema(
+        biz, profile="business", target_event_rate=0.083, target_col_name="flag"
+    )
+    assert base == with_rate
+
+
+def test_ml_ds_no_rate_byte_identical() -> None:
+    schema = _schema_with_binary_target()
+    base = _generate_dataset_from_schema(schema, profile="ml_ds")
+    same = _generate_dataset_from_schema(
+        schema, profile="ml_ds", target_event_rate=None, target_col_name="churn_flag"
+    )
+    assert base == same
+
+
+# ─────────────────────────────────────────────────────────
+# (e) validador _validate_target_event_rate
+# ─────────────────────────────────────────────────────────
+
+
+def test_validator_ml_ds_binary_preserved() -> None:
+    out, warns = _validate_target_event_rate(
+        _clf_contract(0.083), "clasificacion", "Caso X", "ml_ds"
+    )
+    assert out["target_event_rate"] == 0.083
+    assert warns == []
+
+
+def test_validator_business_nulified() -> None:
+    out, warns = _validate_target_event_rate(
+        _clf_contract(0.083), "clasificacion", "Caso X", "business"
+    )
+    assert out["target_event_rate"] is None
+    assert any("wrong_scope" in w for w in warns)
+
+
+def test_validator_wrong_family_nulified() -> None:
+    out, warns = _validate_target_event_rate(
+        _clf_contract(0.083), "regresion", "Caso X", "ml_ds"
+    )
+    assert out["target_event_rate"] is None
+    assert any("wrong_scope" in w for w in warns)
+
+
+def test_validator_multiclass_str_target_nulified() -> None:
+    out, warns = _validate_target_event_rate(
+        _clf_contract(0.083, dtype="str"), "clasificacion", "Caso X", "ml_ds"
+    )
+    assert out["target_event_rate"] is None
+    assert any("wrong_scope" in w for w in warns)
+
+
+def test_validator_missing_warns_unchanged() -> None:
+    out, warns = _validate_target_event_rate(
+        _clf_contract(None), "clasificacion", "Caso X", "ml_ds"
+    )
+    assert out.get("target_event_rate") is None
+    assert any("missing" in w for w in warns)
+
+
+@pytest.mark.parametrize("bad", [0.0, 0.7, 1.5, float("nan"), float("inf")])
+def test_validator_out_of_bounds_nulified(bad: float) -> None:
+    out, warns = _validate_target_event_rate(
+        _clf_contract(bad), "clasificacion", "Caso X", "ml_ds"
+    )
+    assert out["target_event_rate"] is None
+    assert any("invalid" in w for w in warns)
+
+
+def test_validator_none_contract_noop() -> None:
+    out, warns = _validate_target_event_rate(None, "clasificacion", "Caso X", "ml_ds")
+    assert out is None and warns == []
+
+
+# ─────────────────────────────────────────────────────────
+# (f) bounds Pydantic
+# ─────────────────────────────────────────────────────────
+
+
+def _target() -> DatasetTargetSpec:
+    return DatasetTargetSpec(name="churn_flag", role="classification_target", dtype="int", description="x")
+
+
+def test_pydantic_accepts_valid_rate() -> None:
+    m = DatasetSchemaRequired(target_column=_target(), target_event_rate=0.083)
+    assert m.target_event_rate == 0.083
+
+
+def test_pydantic_accepts_none() -> None:
+    m = DatasetSchemaRequired(target_column=_target())
+    assert m.target_event_rate is None
+
+
+@pytest.mark.parametrize("val", [0.6, 0.0, 1.0, -0.1, 8.3])
+def test_pydantic_accepts_finite_out_of_range(val: float) -> None:
+    # Los límites [0.01,0.50] se aplican de forma TOLERANTE en _validate_target_event_rate, NO
+    # como ge/le en el modelo: un valor LLM fuera de rango (p. ej. 8.3 en vez de 0.083) debe
+    # PARSEAR para que no aborte el CaseArchitectOutput entero → el caso completa con rate
+    # nulificado en vez de degradar a un placeholder de error.
+    m = DatasetSchemaRequired(target_column=_target(), target_event_rate=val)
+    assert m.target_event_rate == val
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_pydantic_rejects_non_finite(bad: float) -> None:
+    # NaN/inf nunca son una prevalencia recuperable → único caso que sí rechaza el modelo.
+    with pytest.raises(ValidationError):
+        DatasetSchemaRequired(target_column=_target(), target_event_rate=bad)
+
+
+def test_out_of_range_parse_then_nulify_is_graceful() -> None:
+    # Camino completo B2: 8.3 (porcentaje en vez de fracción) PARSEA en el modelo y luego el
+    # validador determinista lo nulifica con warning — el caso completa, no se aborta.
+    m = DatasetSchemaRequired(target_column=_target(), target_event_rate=8.3)
+    contract = m.model_dump()
+    out, warns = _validate_target_event_rate(contract, "clasificacion", "Caso X", "ml_ds")
+    assert out["target_event_rate"] is None
+    assert any("invalid" in w for w in warns)
+
+
+# ─────────────────────────────────────────────────────────
+# (g) prompt: el architect emite el bloque + ancla Exhibit 2
+# ─────────────────────────────────────────────────────────
+
+
+def test_architect_prompt_has_emission_block_and_exhibit_anchor() -> None:
+    raw = CASE_ARCHITECT_PROMPT_CLASSIFICATION
+    assert "target_event_rate" in raw
+    assert "MISMO número" in raw  # Exhibit 2 ↔ target_event_rate
+    assert "fuente única M1↔M2" in raw

--- a/backend/tests/test_issueR2_mlds_target_identity.py
+++ b/backend/tests/test_issueR2_mlds_target_identity.py
@@ -1,0 +1,293 @@
+"""R2 — identidad del target binario para ml_ds + clasificación.
+
+Garantiza, SIN LLM, que el target entrenado downstream (contract-first, #348) sea
+SIEMPRE una única columna binaria {0,1} con el NOMBRE del contrato y correlacionada con
+un driver — nunca la inyección ``int [0,100]`` random del augmenter (que el notebook ve
+no-binaria → degrada el modeling) ni una binaria duplicada del mismo driver (leakage).
+
+Antes del fix, un contrato con target de dominio (``churn_flag``) ausente del schema fijo
+M2 (que usa ``categoria``) producía ``churn_flag`` con ~52 valores distintos en [0,100].
+Este test es ese probe convertido en regresión.
+
+Aserciones por PROPIEDAD: el seed de ``_generate_dataset_from_schema`` deriva del schema;
+las propiedades estructurales (binariedad, unicidad del target, byte-identidad business)
+valen con cualquier seed.
+"""
+
+from __future__ import annotations
+
+from case_generator.graph import (
+    _align_ml_ds_classification_target,
+    _augment_schema_with_contract,
+    _generate_dataset_from_schema,
+    _is_declared_binary_int,
+)
+
+# ─────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────
+
+
+def _ml_ds_fixed_schema(*, with_churn_flag: bool = False) -> dict:
+    """Schema ml_ds de clasificación tipo el que emite schema_designer: `categoria` binaria
+    (depends_on churn_rate). Con ``with_churn_flag`` añade además una binaria `churn_flag`
+    derivada del mismo driver (caso de duplicado/leakage)."""
+    cols = [
+        {"name": "period", "type": "str", "range_min": None, "range_max": None,
+         "nullable": False, "trend": None, "dependency": None},
+        {"name": "revenue", "type": "float", "range_min": 1000, "range_max": 2000,
+         "nullable": False, "trend": None, "dependency": None},
+        {"name": "churn_rate", "type": "float", "range_min": 0.02, "range_max": 0.15,
+         "nullable": False, "trend": None,
+         "dependency": {"depends_on": "revenue", "relationship": "inverse", "noise_factor": 0.1}},
+        {"name": "categoria", "type": "int", "range_min": 0, "range_max": 1,
+         "nullable": False, "trend": None,
+         "dependency": {"depends_on": "churn_rate", "relationship": "linear", "noise_factor": 0.30}},
+    ]
+    if with_churn_flag:
+        cols.append(
+            {"name": "churn_flag", "type": "int", "range_min": 0, "range_max": 1,
+             "nullable": False, "trend": None,
+             "dependency": {"depends_on": "churn_rate", "relationship": "linear", "noise_factor": 0.30}}
+        )
+    return {"columns": cols, "n_rows": 600, "time_granularity": "monthly", "constraints": {}}
+
+
+def _clf_contract(name: str = "churn_flag") -> dict:
+    return {
+        "target_column": {"name": name, "role": "classification_target",
+                          "dtype": "int", "description": "evento de abandono"},
+        "feature_columns": [],
+    }
+
+
+def _col(schema: dict, name: str) -> dict | None:
+    return next((c for c in schema["columns"] if c.get("name") == name), None)
+
+
+def _binary_target_cols(schema: dict) -> list[dict]:
+    return [c for c in schema["columns"]
+            if _is_declared_binary_int(c) and isinstance(c.get("dependency"), dict)]
+
+
+# ─────────────────────────────────────────────────────────
+# (a) contrato churn_flag ausente → renombrado, NO inyección [0,100]
+# ─────────────────────────────────────────────────────────
+
+
+def test_align_renames_fixed_binary_to_contract_name() -> None:
+    schema = _ml_ds_fixed_schema()
+    aligned = _align_ml_ds_classification_target(
+        schema, _clf_contract("churn_flag"), profile="ml_ds", primary_family="clasificacion"
+    )
+    # categoria renombrada a churn_flag; sigue binaria [0,1] depends_on churn_rate.
+    assert _col(aligned, "categoria") is None
+    cf = _col(aligned, "churn_flag")
+    assert cf is not None and _is_declared_binary_int(cf)
+    assert cf["dependency"]["depends_on"] == "churn_rate"
+
+
+def test_augment_after_align_does_not_inject_0_100_target() -> None:
+    schema = _ml_ds_fixed_schema()
+    contract = _clf_contract("churn_flag")
+    aligned = _align_ml_ds_classification_target(
+        schema, contract, profile="ml_ds", primary_family="clasificacion"
+    )
+    augmented = _augment_schema_with_contract(aligned, contract)
+    cf = _col(augmented, "churn_flag")
+    assert cf is not None
+    # NUNCA el default [0,100] sin dependencia del augmenter.
+    assert cf["range_min"] == 0 and cf["range_max"] == 1
+    assert isinstance(cf.get("dependency"), dict)
+
+
+def test_generated_target_is_binary_after_reconciliation() -> None:
+    schema = _ml_ds_fixed_schema()
+    contract = _clf_contract("churn_flag")
+    aligned = _align_ml_ds_classification_target(
+        schema, contract, profile="ml_ds", primary_family="clasificacion"
+    )
+    augmented = _augment_schema_with_contract(aligned, contract)
+    rows = _generate_dataset_from_schema(augmented, profile="ml_ds")
+    vals = {r["churn_flag"] for r in rows}
+    assert vals == {0, 1}, f"target debe ser binario, got {sorted(vals)[:8]}"
+
+
+# ─────────────────────────────────────────────────────────
+# (b) augmenter endurecido: sin binaria que renombrar → inyecta BINARIA, no [0,100]
+# ─────────────────────────────────────────────────────────
+
+
+def test_augment_injects_classification_target_as_binary() -> None:
+    # schema sin categoria (sin binaria que renombrar) → align no-op → augment inyecta.
+    schema = _ml_ds_fixed_schema()
+    schema["columns"] = [c for c in schema["columns"] if c["name"] != "categoria"]
+    contract = _clf_contract("churn_flag")
+    aligned = _align_ml_ds_classification_target(
+        schema, contract, profile="ml_ds", primary_family="clasificacion"
+    )
+    augmented = _augment_schema_with_contract(aligned, contract)
+    cf = _col(augmented, "churn_flag")
+    assert cf is not None and cf["type"] == "int"
+    assert cf["range_min"] == 0 and cf["range_max"] == 1  # NO [0,100]
+    rows = _generate_dataset_from_schema(augmented, profile="ml_ds")
+    assert {r["churn_flag"] for r in rows} == {0, 1}
+
+
+# ─────────────────────────────────────────────────────────
+# (c) duplicado del mismo driver → un solo target binario (anti-leakage)
+# ─────────────────────────────────────────────────────────
+
+
+def test_align_drops_duplicate_binary_same_driver() -> None:
+    schema = _ml_ds_fixed_schema(with_churn_flag=True)  # categoria + churn_flag, ambos del driver
+    aligned = _align_ml_ds_classification_target(
+        schema, _clf_contract("churn_flag"), profile="ml_ds", primary_family="clasificacion"
+    )
+    bins = _binary_target_cols(aligned)
+    assert len(bins) == 1 and bins[0]["name"] == "churn_flag"
+    assert _col(aligned, "categoria") is None  # duplicado del mismo driver eliminado
+
+
+# ─────────────────────────────────────────────────────────
+# (d) sin contrato / fuera del gate → categoria intacta
+# ─────────────────────────────────────────────────────────
+
+
+def test_no_contract_preserves_categoria() -> None:
+    schema = _ml_ds_fixed_schema()
+    out = _align_ml_ds_classification_target(
+        schema, None, profile="ml_ds", primary_family="clasificacion"
+    )
+    assert _col(out, "categoria") is not None
+    assert _col(out, "churn_flag") is None
+
+
+def test_contract_target_equal_categoria_is_noop() -> None:
+    schema = _ml_ds_fixed_schema()
+    out = _align_ml_ds_classification_target(
+        schema, _clf_contract("categoria"), profile="ml_ds", primary_family="clasificacion"
+    )
+    assert _col(out, "categoria") is not None
+
+
+def test_regression_target_not_touched() -> None:
+    schema = _ml_ds_fixed_schema()
+    contract = {"target_column": {"name": "revenue_next", "role": "regression_target",
+                                  "dtype": "float", "description": "ingreso futuro"}}
+    out = _align_ml_ds_classification_target(
+        schema, contract, profile="ml_ds", primary_family="clasificacion"
+    )
+    assert _col(out, "categoria") is not None  # no es classification_target → no-op
+
+
+# ─────────────────────────────────────────────────────────
+# (e) business / otras familias → byte-idéntico
+# ─────────────────────────────────────────────────────────
+
+
+def test_business_is_byte_identical_noop() -> None:
+    schema = _ml_ds_fixed_schema()
+    out = _align_ml_ds_classification_target(
+        schema, _clf_contract("churn_flag"), profile="business", primary_family="clasificacion"
+    )
+    assert out == schema
+
+
+def test_other_family_is_byte_identical_noop() -> None:
+    schema = _ml_ds_fixed_schema()
+    out = _align_ml_ds_classification_target(
+        schema, _clf_contract("churn_flag"), profile="ml_ds", primary_family="regresion"
+    )
+    assert out == schema
+
+
+# ─────────────────────────────────────────────────────────
+# (f) B1 — ml_ds con algoritmos vacíos (primary_family=None) → se reconcilia igual
+# ─────────────────────────────────────────────────────────
+
+
+def test_align_handles_none_family_for_ml_ds() -> None:
+    # schema_designer trata ml_ds+None como 'clasificacion' (categoria, 600 filas);
+    # _align DEBE reconciliar también con primary_family=None (si no, leakage duplicado).
+    schema = _ml_ds_fixed_schema()
+    aligned = _align_ml_ds_classification_target(
+        schema, _clf_contract("churn_flag"), profile="ml_ds", primary_family=None
+    )
+    assert _col(aligned, "categoria") is None
+    cf = _col(aligned, "churn_flag")
+    assert cf is not None and _is_declared_binary_int(cf)
+
+
+def test_align_none_family_then_augment_single_binary() -> None:
+    schema = _ml_ds_fixed_schema()
+    contract = _clf_contract("churn_flag")
+    aligned = _align_ml_ds_classification_target(
+        schema, contract, profile="ml_ds", primary_family=None
+    )
+    augmented = _augment_schema_with_contract(aligned, contract)
+    bins = _binary_target_cols(augmented)
+    assert len(bins) == 1 and bins[0]["name"] == "churn_flag"
+
+
+# ─────────────────────────────────────────────────────────
+# (g) B3 — colisión de nombre: el target del contrato ya existe como columna NO binaria
+# ─────────────────────────────────────────────────────────
+
+
+def test_align_skips_rename_on_name_collision() -> None:
+    schema = _ml_ds_fixed_schema()  # categoria binaria
+    schema["columns"].append(
+        {"name": "churn_flag", "type": "float", "range_min": 0.0, "range_max": 1.0,
+         "nullable": False, "trend": None, "dependency": None}
+    )
+    out = _align_ml_ds_classification_target(
+        schema, _clf_contract("churn_flag"), profile="ml_ds", primary_family="clasificacion"
+    )
+    names = [c["name"] for c in out["columns"]]
+    assert names.count("churn_flag") == 1  # NUNCA dos columnas homónimas
+    assert _col(out, "categoria") is not None  # no se pisó la binaria
+
+
+# ─────────────────────────────────────────────────────────
+# (h) B5 — preferir la canónica `categoria`, no la primera binaria del listado
+# ─────────────────────────────────────────────────────────
+
+
+def test_align_prefers_categoria_over_first_binary() -> None:
+    schema = _ml_ds_fixed_schema()
+    # binaria 'other_flag' (driver distinto: nps) ANTES de categoria
+    schema["columns"].insert(3, {"name": "nps", "type": "int", "range_min": 0, "range_max": 100,
+                                 "nullable": False, "trend": None, "dependency": None})
+    schema["columns"].insert(4, {"name": "other_flag", "type": "int", "range_min": 0, "range_max": 1,
+                                 "nullable": False, "trend": None,
+                                 "dependency": {"depends_on": "nps", "relationship": "linear",
+                                                "noise_factor": 0.3}})
+    out = _align_ml_ds_classification_target(
+        schema, _clf_contract("churn_flag"), profile="ml_ds", primary_family="clasificacion"
+    )
+    cf = _col(out, "churn_flag")
+    assert cf is not None
+    assert cf["dependency"]["depends_on"] == "churn_rate"  # heredó categoria, no other_flag
+    assert _col(out, "other_flag") is not None  # driver distinto → preservada
+    assert _col(out, "categoria") is None  # fue la renombrada
+
+
+# ─────────────────────────────────────────────────────────
+# (i) B4 — nombre de contrato no-identificador no se inyecta como binaria (evita duplicado)
+# ─────────────────────────────────────────────────────────
+
+
+def test_augment_non_identifier_target_not_binary() -> None:
+    schema = _ml_ds_fixed_schema()  # categoria binaria
+    contract = {"target_column": {"name": "churn flag", "role": "classification_target",
+                                  "dtype": "int", "description": "x"}, "feature_columns": []}
+    aligned = _align_ml_ds_classification_target(
+        schema, contract, profile="ml_ds", primary_family="clasificacion"
+    )
+    augmented = _augment_schema_with_contract(aligned, contract)
+    cf = _col(augmented, "churn flag")
+    assert cf is not None
+    assert not (cf.get("range_min") == 0 and cf.get("range_max") == 1)  # NO binaria [0,1]
+    # categoria sigue siendo la única binaria objetivo → el notebook entrena el alias
+    assert [b["name"] for b in _binary_target_cols(augmented)] == ["categoria"]


### PR DESCRIPTION
## Contexto

Auditoría profunda de M1 (architect → writer → questions) para `studentProfile == "ml_ds"` + familia `clasificacion`, de cara al lanzamiento a universidades. Se encontraron y corrigieron **2 defectos de coherencia M1↔datos** que una audiencia de ciencia de datos detecta de inmediato.

## F1 — la tasa del evento del Exhibit 2 no coincidía con la prevalencia del dataset

El architect imprime "Tasa de ocurrencia del evento" en Exhibit 2 (#363, ej. 8.3 %), la narrativa la cita y P2 pide medirla — **pero el dataset tenía ~50 % de prevalencia** porque el generador determinista normaliza el padre a [0,1] → la tasa anunciada era estructuralmente irrelevante (probado multi-seed: rate [0.02,0.15] o [0.01,0.03] → ambos ~0.50).

**Fix:** nuevo sub-campo validado `target_event_rate` en `dataset_schema_required` (fuente única M1↔M2). El architect lo emite, Exhibit 2 imprime el mismo número, y el generador calibra la prevalencia del target binario con **umbral top-k por argsort** → prevalencia exacta `round(rate·n)`, con el orden (y por tanto AUC/señal) preservado.

## R2 — identidad del target binario (bug pre-existente)

El contrato nombra el target con un nombre de dominio (`churn_flag`) pero el schema fijo M2 construye `categoria`. Cuando divergen, el augmenter inyectaba `churn_flag` como `int [0,100]` random → el notebook (contract-first, #348) lo veía **no-binario → degradaba el modeling entero** (reproducido determinísticamente).

**Fix:** `_align_ml_ds_classification_target` (corre antes del augment) renombra la binaria fija al nombre del contrato y deduplica binarias del mismo driver (anti-leakage); el augmenter endurecido inyecta un `classification_target` dtype int como binario [0,1]+dependency.

## Review adversarial (multi-agente) → hardening incluido

Una review adversarial de 4 lentes encontró y este PR corrige:
- **B1 (alto):** `_align` gateaba por `primary_family` crudo (None para ml_ds con algoritmos vacíos) → no-op donde el schema vecino sí trata el caso como clasificación. Ahora resuelve `None→clasificacion` igual que `_effective_family`.
- **B2 (medio):** `ge/le` en el modelo Pydantic hacía que un valor LLM fuera de rango (8.3 en vez de 0.083) abortara el `CaseArchitectOutput` entero → caso degradado a placeholder. Ahora los límites se aplican de forma **tolerante** en `_validate_target_event_rate` (fuera de rango → nulificado + warning, el caso completa).
- **B3/B4/B5:** guard de colisión de nombre, criterio `.isidentifier()` alineado augmenter↔align, preferencia por `categoria`.
- **B6 (AUC > 0.99):** refutado empíricamente — CV-AUC se mantiene en [0.65, 0.73] para todos los rates (gate del executor [0.55, 0.99]).

## Garantías

- **Business y ml_ds-sin-rate byte-idénticos** (rate pasado como kwarg → el seed `json.dumps(schema)` no cambia). El spine #301 sigue siendo dueño del target business (override incondicional).
- Hash congelado del architect ml_ds regenerado (`4807710d…`); drift-guards verdes.
- Sin nuevas claves canónicas/teacher/student-facing, sin migraciones, sin cambios de estado.

## Validación

- `uv run --directory backend pytest -q` → **1385 passed, 21 skipped**
- `uv run --directory backend mypy src` → **clean**
- Tests nuevos: `test_issueR2_mlds_target_identity.py` (16), `test_issue363_target_event_rate.py` (37).

## Seguimiento (issues separados, NO en este PR)

Huecos de enforcement determinista de M1 detectados en la misma auditoría: #370 (moneda cost_matrix), #371 (plausibilidad fp/fn), #372 (filas Exhibit 2), #373 (mínimo de cifras citadas). Epic #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
