### PR TITLE
fix(case_generator): drop fabricated author/article refs from M2 expected solutions

### DIFF
--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -535,7 +535,7 @@ sesgo de confirmación y confusión entre correlación y causalidad.
     "numero": 1,
     "titulo": "string corto (≤8 palabras)",
     "enunciado": "string (pregunta completa referenciando datos reales del M2)",
-    "solucion_esperada": "string (respuesta modelo en un párrafo fluido que integra concepto, ejemplo del caso e implicación ejecutiva; incluye referencia académica al final; máx 120 palabras; docente-only)",
+    "solucion_esperada": "string (respuesta modelo en un párrafo fluido que integra concepto, ejemplo del caso e implicación ejecutiva; máx 120 palabras; docente-only)",
     "bloom_level": "analysis|evaluation|synthesis",
     "chart_ref": "chart_01|chart_02|...|Ninguno",
     "exhibit_ref": "Exhibit 1|Exhibit 2|Dataset|Ninguno",
@@ -550,7 +550,7 @@ sesgo de confirmación y confusión entre correlación y causalidad.
 3. **Diseña:** Preguntas que obliguen al estudiante a cuestionar lo que los datos PARECEN decir.
    Usa los IDs y títulos del `{chart_manifest}` para que las referencias sean precisas.
 4. **Redacta:** `solucion_esperada` como un párrafo fluido que integre el concepto, el ejemplo
-   concreto del caso y la implicación ejecutiva. Incluye la referencia académica al final.
+   concreto del caso y la implicación ejecutiva.
    Máx 120 palabras. No uses sub-campos ni estructuras anidadas — solo texto plano.
 5. **task_type siempre "text_response":** M2 no genera notebook — todas las preguntas son argumentativas.
 
@@ -558,7 +558,6 @@ sesgo de confirmación y confusión entre correlación y causalidad.
 - Solo JSON schema. PROHIBIDO Markdown libre.
 - Toda pregunta referencia métricas, variables o gráficas reales y exactas del M2.
 - Las referencias a gráficos deben usar el `id` y `title` del `{chart_manifest}`.
-- La referencia académica va integrada al final del párrafo `solucion_esperada` — sin inventar DOIs ni URLs.
 - **Idioma de salida: {output_language}**
 
 # Perfil del estudiante: {student_profile}

--- a/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/eda_questions.py
@@ -39,7 +39,7 @@ correlación/causalidad, sino los específicos de clasificación binaria:
       "numero": 1,
       "titulo": "string corto (≤8 palabras)",
       "enunciado": "string (pregunta completa que cita métricas y datos reales del M2)",
-      "solucion_esperada": "string (respuesta modelo en un párrafo fluido que integra concepto, ejemplo del caso e implicación ejecutiva; incluye referencia académica al final; máx 120 palabras; docente-only)",
+      "solucion_esperada": "string (respuesta modelo en un párrafo fluido que integra concepto, ejemplo del caso e implicación ejecutiva; máx 120 palabras; docente-only)",
       "bloom_level": "analysis",
       "chart_ref": "id del chart de distribución de clases del manifest, o null si no existe",
       "exhibit_ref": "Dataset",
@@ -80,8 +80,7 @@ correlación/causalidad, sino los específicos de clasificación binaria:
    (accuracy) hacia métricas de negocio (recall, F-beta, AUC-ROC, costo de retención).
 6. **Redacta solucion_esperada como un párrafo fluido** que integre el concepto estadístico,
    el ejemplo concreto del caso y la implicación ejecutiva en una sola prosa coherente.
-   Incluye la referencia académica al final del párrafo. Máx 120 palabras. No uses
-   sub-campos ni estructuras anidadas — solo texto plano.
+   Máx 120 palabras. No uses sub-campos ni estructuras anidadas — solo texto plano.
 7. **task_type siempre "text_response"** — M2 no genera notebook; ambas preguntas son argumentativas.
 
 # Your Boundaries
@@ -90,7 +89,6 @@ correlación/causalidad, sino los específicos de clasificación binaria:
 - Las referencias a gráficos: `chart_ref` contiene SOLO el `id` del chart (string exacto del
   manifest). Usa el `title` únicamente para identificar cuál chart seleccionar — nunca lo
   incluyas en el valor de `chart_ref`.
-- La referencia académica va integrada al final del párrafo `solucion_esperada` — sin inventar DOIs ni URLs.
 - PROHIBIDO usar "sesgo de confirmación" o "correlación vs causalidad" como tema principal
   de P1 o P2 — esos pertenecen al prompt genérico para otras familias.
 - P1 es SIEMPRE accuracy_paradox (bloom: "analysis"), P2 es SIEMPRE precision_recall
@@ -127,8 +125,7 @@ solucion_esperada: (párrafo único, ej:)
   sin capturar ni un solo churner real — eso es el accuracy paradox. Usar threshold=0.5 en
   un dataset 92/8 implica que LR o RF 'funcionan' en accuracy pero el equipo pierde 40-60%
   de churners reales y el presupuesto de retención se dirige al segmento equivocado. La
-  alternativa es evaluar con recall, F-beta (beta>1) o AUC-ROC. Ref: Chawla et al. (2002)
-  'SMOTE'; James et al. 'An Introduction to Statistical Learning' cap. sobre imbalanced data."
+  alternativa es evaluar con recall, F-beta (beta>1) o AUC-ROC."
 
 chart_ref: id del chart de distribución de clases/target de {chart_manifest}
 exhibit_ref: "Dataset"
@@ -149,8 +146,7 @@ solucion_esperada: (párrafo único, ej:)
   puede dar recall ~40%; bajarlo a 0.3 sube el recall a ~70% con +15pp de falsos positivos.
   La decisión depende del ratio costo_retención / ingreso_perdido por churner: si perder un
   churner cuesta más que retener a un cliente leal, F-beta con beta>1 es la métrica correcta
-  sobre AUC-ROC. Ref: Provost & Fawcett 'Data Science for Business' (2013); Fawcett (2006)
-  'An Introduction to ROC Analysis' Pattern Recognition Letters."
+  sobre AUC-ROC."
 
 chart_ref: id del chart de correlación o scatter de {chart_manifest}, o null si no hay relevante
 exhibit_ref: "Dataset"


### PR DESCRIPTION
## Qué

Quita las referencias académicas fabricadas (autores/artículos) de las `solucion_esperada` del **Módulo 2** (EDA / Evaluador Socrático, visibles solo para el docente). Hoy terminan en colas como:

- `Ref: Provost & Fawcett 'Data Science for Business' (2013); Fawcett (2006) 'An Introduction to ROC Analysis'.`
- `Ref: James et al. 'An Introduction to Statistical Learning'; Chawla et al. (2002) 'SMOTE'.`

## Por qué

No es un bug: dos prompts de M2 **pedían explícitamente** la cita y mostraban ejemplos `Ref: ...` para imitar. El docente no necesita la bibliografía; ensucia la respuesta y empuja al LLM a inventar referencias (sin DOI/URL verificable). Esto alinea M2 con la política ya vigente en M3/M4/M5 (narrative grounding prohíbe citar autores/papers).

## Cambios (solo prompts, +6/−11)

- `prompts/clasificacion/M2_clasificacion/eda_questions.py` (clasificación, el de las capturas): quita la instrucción de referencia en el schema-desc, el paso 6 del workflow y el boundary; recorta las colas `Ref:` de los dos ejemplos.
- `prompts/__init__.py` → `EDA_QUESTIONS_GENERATOR_PROMPT` (fallback genérico: regresión/clustering/serie_temporal): mismas 3 deleciones.

Cubre todas las familias de M2 y ambos perfiles (`business` y `ml_ds`) porque comparten estos dos prompts.

## No se toca

- Sin cambios de lógica, esquema, DB ni manejo de salida del LLM.
- Las 7 claves `{...}` del prompt de clasificación quedan intactas → `test_eda_questions_classification_placeholder_contract` y `..._format_smoke` siguen verdes.
- No hay hash/SHA guard sobre los prompts de M2.

## Verificación

- `pytest tests/test_m2_clasificacion_dispatch.py tests/test_issue242_pedagogical_coherence.py` → 64 passed
- Suite backend completa → 1335 passed, 21 skipped (1 flake de ordenamiento no relacionado: `tenants` ausente, pasa en aislamiento)
- `mypy src` → clean (87 files)
- grep confirma 0 `referencia académica` / `Ref:` / autores en `prompts/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)