### PR TITLE
fix(case_generator): F4 validador determinista de filas de Exhibit 2 + acople F1 (#372)

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -165,6 +165,8 @@ from case_generator.narrative_grounding import (
     validate_narrative_grounding,
 )
 from case_generator.m1_grounding import (
+    detect_exhibit2_completeness_row,
+    validate_exhibit2_event_rate,
     validate_narrative_exhibit_coherence,
     validate_questions_exhibit_coherence,
 )
@@ -996,6 +998,18 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
                 "(#301): revisar que el nombre refleje el evento del dilema."
             )
 
+        # Issue #372 — verifica que Exhibit 2 imprima la fila de tasa de ocurrencia del
+        # evento con el MISMO número que `target_event_rate` (acople F1). Reprompt-once-
+        # then-DEGRADE targeted al anexo; gateado a ml_ds+clf, best-effort, nunca lanza. La
+        # fila de completitud es warning-only. No toca el prompt → SHA256 intacto; no-op
+        # byte-idéntico para business y otras familias.
+        anexo_operativo_final = _invoke_m1_exhibit2_coherence(
+            llm=llm,
+            state=state,
+            anexo_operativo=result.anexo_operativo,
+            contract=contract_dict,
+        )
+
         return {
             "current_agent": "case_architect",
             "titulo": result.titulo,
@@ -1005,7 +1019,7 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
             "pregunta_eje": pregunta_eje,
             "doc1_instrucciones": result.instrucciones_estudiante,
             "doc1_anexo_financiero": result.anexo_financiero,
-            "doc1_anexo_operativo": result.anexo_operativo,
+            "doc1_anexo_operativo": anexo_operativo_final,
             "doc1_anexo_stakeholders": result.anexo_stakeholders,
             # downstream nodes leen state["dataset_schema_required"] y degradan
             # gracefully al comportamiento previo si es None.
@@ -1184,6 +1198,121 @@ def _apply_m1_questions_exhibit_coherence(
             extra={"node": "case_questions", "case_id": state.get("case_id")},
         )
         return preguntas_dict
+
+
+# ─────────────────────────────────────────────────────────
+# Issue #372 — Exhibit 2 mandatory-row coherence (ml_ds + clasificacion)
+# Runs INSIDE case_architect (the owner of anexo_operativo + target_event_rate), unlike
+# #360 which runs in the writer/questions fan-out. Only the architect can fix a missing
+# row. Reprompt-once-then-DEGRADE; best-effort; never raises. The PRIMARY trigger is the
+# deterministic F1 coupling; the completeness row is heuristic → warning-only (never
+# reprompts). No prompt-constant edit → _MLDS_ARCHITECT_PROMPT_SHA256 stays frozen.
+# ─────────────────────────────────────────────────────────
+# A corrected anexo shorter than this fraction of the original is treated as a gutted
+# rewrite (rate row added at the cost of dropping operational rows) and rejected, so the
+# writer/questions never read a thinner Exhibit 2 than the architect produced.
+_M1_EXHIBIT2_MIN_REPROMPT_RATIO = 0.6
+
+
+def _m1_exhibit2_reprompt(anexo_operativo: str, rate_pct: float) -> str:
+    """Focused, self-contained reprompt to rewrite the COMPLETE Exhibit 2 anexo (#372).
+
+    Asks for the full anexo (heading + every row), changing only what's needed to print the
+    rate row, so the corrected text replaces ``doc1_anexo_operativo`` at comparable length
+    (the length-floor guard at the call site rejects a gutted rewrite). Carries the EXACT
+    required number (``rate_pct``) so the correction is deterministic, not a vague "you are
+    incoherent". Concatenated at runtime (never ``.format`` — the anexo may carry ``{}``) and
+    is a runtime string, so it never touches the frozen architect prompt.
+    """
+    return (
+        "\n\n# CORRECCIÓN OBLIGATORIA DE EXHIBIT 2 (Operativo)\n"
+        "El Exhibit 2 (Operativo) que generaste NO imprime la fila obligatoria de calidad "
+        "de datos «Tasa de ocurrencia del evento objetivo» con el número correcto. Reescribe "
+        "el Exhibit 2 (Operativo) COMPLETO — su encabezado y TODAS sus filas — corrigiendo "
+        "ÚNICAMENTE lo necesario para que incluya una fila de calidad de datos cuya tasa de "
+        f"ocurrencia del evento sea EXACTAMENTE {rate_pct:.1f} % (debe coincidir con la "
+        "prevalencia del dataset). Conserva la fila de completitud de campos críticos y toda "
+        "otra fila operativa existente. Devuelve SOLO el markdown del Exhibit 2 (Operativo) "
+        "(encabezado + tabla), sin otros Exhibits ni texto adicional.\n\n"
+        "Exhibit 2 actual:\n"
+        f"{anexo_operativo}\n"
+    )
+
+
+def _invoke_m1_exhibit2_coherence(
+    *, llm: Any, state: ADAMState, anexo_operativo: str, contract: dict | None
+) -> str:
+    """Validate + reprompt-once-then-DEGRADE the Exhibit 2 rate row (Issue #372).
+
+    Gated to ml_ds + clasificacion (byte-identical no-op otherwise). PRIMARY check is the
+    deterministic F1 coupling: a miss triggers ONE targeted text reprompt that rewrites the
+    full Exhibit 2 with the exact number; the rewrite is accepted only if it now prints the
+    rate AND preserves the anexo's bulk, otherwise the original is kept. The completeness row
+    is a SECONDARY heuristic that only logs a warning — it NEVER drives the reprompt.
+    Best-effort: any internal error keeps the original anexo and the job continues. Never raises.
+    """
+    if not _is_ml_ds_classification(state):
+        return anexo_operativo
+    try:
+        rate = contract.get("target_event_rate") if isinstance(contract, dict) else None
+
+        # SECONDARY heuristic — warning-only, never reprompt (D2).
+        completeness_violations = detect_exhibit2_completeness_row(anexo_operativo)
+        if completeness_violations:
+            logger.warning(
+                "[case_architect] Exhibit 2 sin fila de completitud reconocible "
+                "(heurística, warning-only)",
+                extra={
+                    "node": "case_architect",
+                    "violations": completeness_violations,
+                    "case_id": state.get("case_id"),
+                },
+            )
+
+        # PRIMARY deterministic F1 coupling — reprompt-worthy.
+        violations = validate_exhibit2_event_rate(anexo_operativo, rate)
+        if not violations:
+            return anexo_operativo
+        if not isinstance(rate, (int, float)) or isinstance(rate, bool):
+            return anexo_operativo  # unreachable when violations≠[]; satisfies typing
+        rate_pct = float(rate) * 100.0
+        print(
+            f"[case_architect] Exhibit 2 no imprime la tasa F1 ({rate_pct:.1f} %): "
+            f"{violations}. Reprompt targeted (1/1)."
+        )
+        corrected = sanitize_markdown(
+            _extract_text(llm.invoke(_m1_exhibit2_reprompt(anexo_operativo, rate_pct)))
+        )
+        # Accept ONLY a rewrite that (a) now prints the rate AND (b) preserves the anexo's
+        # bulk. A gutted rewrite that satisfies the rate by dropping operational rows is
+        # rejected — we keep the original (richer, only rate-incoherent) anexo instead of
+        # shipping a thinner one downstream. F1 presence is binary, so there is no
+        # "partially better" pass to salvage.
+        corrected_ok = (
+            bool(corrected)
+            and not validate_exhibit2_event_rate(corrected, rate)
+            and len(corrected) >= int(len(anexo_operativo) * _M1_EXHIBIT2_MIN_REPROMPT_RATIO)
+        )
+        if corrected_ok:
+            print("[case_architect] Reprompt coherencia Exhibit 2 F1 OK")
+            return corrected
+        logger.warning(
+            "[case_architect] coherencia Exhibit 2 F1 no corregida tras reprompt — "
+            "se conserva el anexo original",
+            extra={
+                "node": "case_architect",
+                "violations": violations,
+                "case_id": state.get("case_id"),
+            },
+        )
+        return anexo_operativo
+    except Exception as exc:  # best-effort — a validator bug must never fail M1
+        logger.warning(
+            "[case_architect] validador coherencia Exhibit 2 F1 falló (best-effort): %s",
+            exc,
+            extra={"node": "case_architect", "case_id": state.get("case_id")},
+        )
+        return anexo_operativo
 
 
 # ─────────────────────────────────────────────────────────

--- a/backend/src/case_generator/m1_grounding.py
+++ b/backend/src/case_generator/m1_grounding.py
@@ -94,6 +94,23 @@ _EXHIBIT_TO_ANEXO_KEY = {1: "financiero", 2: "operativo", 3: "stakeholders"}
 
 _FLOAT_EPSILON = 1e-9
 
+# ── Exhibit 2 mandatory-row checks (Issue #372) ───────────────────────────────
+# Tolerance for the F1 coupling (rate row ⇔ ``target_event_rate``), in percentage
+# points. The deterministic dataset generator calibrates the target prevalence EXACTLY
+# to ``target_event_rate`` (graph.py top-k argsort), so the only legitimate display
+# variance between the printed Exhibit-2 rate and the contract is rounding to ~1 decimal.
+# ±0.5pp absorbs that while still catching a missing row or a grossly wrong number. This is
+# deliberately NOT ``narrative_grounding._within_tolerance`` (its ±2pp/±2% is for fuzzy
+# model metrics and would mask a 1-2pp authoring drift in a calibrated number).
+_RATE_PCT_TOLERANCE = 0.5
+
+# Conservative keyword set for the SECONDARY completeness-row heuristic. A row counts as a
+# completeness data-quality row when it carries one of these tokens AND a ``%`` figure.
+_COMPLETENESS_KEYWORD_RE = re.compile(
+    r"completitud|incompletos?|sin\s+dato|faltantes?|nulos?|missing",
+    re.IGNORECASE,
+)
+
 
 # ── Public API ────────────────────────────────────────────────────────────────
 
@@ -187,7 +204,111 @@ def validate_questions_exhibit_coherence(
     return violations
 
 
+def validate_exhibit2_event_rate(
+    anexo_operativo: str, target_event_rate: float | None
+) -> list[str]:
+    """Return a violation if Exhibit 2 does not print the F1 occurrence rate (Issue #372).
+
+    PRIMARY, deterministic, zero-FP-by-construction. When ``target_event_rate`` is present
+    (the ml_ds + clasificación binary gate), some ``%`` figure in the Exhibit-2 table must
+    fall within ``_RATE_PCT_TOLERANCE`` of ``target_event_rate * 100`` — or some bare figure
+    must equal the fraction itself. A miss means the mandatory rate row is absent,
+    mislabeled-without-the-number, or prints the wrong number; all three are the SAME defect
+    (the dataset prevalence is untraceable to the anexo). ``None`` rate → ``[]`` (that case
+    is already surfaced by ``_validate_target_event_rate``'s ``target_event_rate_missing``).
+
+    Zero false positives: extra ``%`` only add match chances, never create a violation, and
+    BOTH display forms (``8.3 %`` and the bare fraction ``0.083``) are accepted. The accepted
+    cost is a false NEGATIVE: an unrelated cell that happens to sit within ±0.5pp of the rate
+    suppresses the violation. That errs SAFE — it can only fail to flag a defect, never degrade
+    a good case — which is the deliberate priority for this validator (zero FP over zero FN).
+    """
+    if not isinstance(target_event_rate, (int, float)) or isinstance(
+        target_event_rate, bool
+    ):
+        return []
+    rate = float(target_event_rate)
+    rate_pct = rate * 100.0
+    for pct in _iter_table_percentages(anexo_operativo):
+        if abs(pct - rate_pct) <= _RATE_PCT_TOLERANCE:
+            return []
+    # Fallback — the anexo may print the bare fraction (0.083) instead of "8.3 %".
+    for value in _iter_table_numbers(anexo_operativo):
+        if abs(value - rate) <= _FLOAT_EPSILON * max(1.0, abs(value), abs(rate)):
+            return []
+    return [
+        f"EXHIBIT2_RATE_MISMATCH: la tasa de ocurrencia del evento "
+        f"({rate_pct:.1f} %) no aparece impresa en Exhibit 2"
+    ]
+
+
+def detect_exhibit2_completeness_row(anexo_operativo: str) -> list[str]:
+    """Return a heuristic warning if no completeness data-quality row is recognizable (#372).
+
+    SECONDARY and heuristic — the completeness row has no contract anchor, so it can only be
+    matched by keyword + a ``%`` figure on the same table row. The caller treats this as
+    WARNING-ONLY (never a reprompt/degrade), so a missed synonym only adds a log line and
+    never degrades a good case. Conservative: a row counts only when it carries BOTH a
+    completeness keyword and a ``%`` figure; the violation fires only when no such row exists.
+    """
+    for line in anexo_operativo.splitlines():
+        cells = _split_markdown_table_row(line)
+        if not cells or _is_markdown_separator_row(cells):
+            continue
+        row_text = " ".join(cells)
+        if _COMPLETENESS_KEYWORD_RE.search(row_text) and _row_has_percentage(row_text):
+            return []
+    return [
+        "EXHIBIT2_COMPLETENESS_MISSING: no se reconoce una fila de completitud de "
+        "campos críticos (keyword + %) en Exhibit 2"
+    ]
+
+
 # ── Internals ─────────────────────────────────────────────────────────────────
+
+def _iter_table_cells(text: str) -> list[str]:
+    """Yield the cell strings of every markdown-table data row in ``text`` (skips
+    separators / non-table lines). Shared by the Exhibit-2 row checks (#372)."""
+    out: list[str] = []
+    for line in text.splitlines():
+        cells = _split_markdown_table_row(line)
+        if not cells or _is_markdown_separator_row(cells):
+            continue
+        out.extend(cells)
+    return out
+
+
+def _iter_table_percentages(text: str) -> list[float]:
+    """Every ``%``-shaped figure in the markdown-table cells of ``text`` (#372)."""
+    values: list[float] = []
+    for cell in _iter_table_cells(text):
+        for match in _NUMBER_TOKEN_RE.finditer(cell):
+            if not match.group("pct"):
+                continue
+            mantissa = _normalize_core(match.group("core"))
+            if mantissa is None:
+                continue
+            if match.group("sign") == "-":
+                mantissa = -mantissa
+            values.append(mantissa)
+    return values
+
+
+def _iter_table_numbers(text: str) -> list[float]:
+    """Every numeric magnitude candidate in the markdown-table cells of ``text`` (#372).
+
+    Reuses ``_iter_numbers`` so a suffixed cell yields both its literal and scaled value.
+    """
+    values: list[float] = []
+    for cell in _iter_table_cells(text):
+        for _raw, candidates, _is_figure in _iter_numbers(cell):
+            values.extend(candidates)
+    return values
+
+
+def _row_has_percentage(row_text: str) -> bool:
+    return any(match.group("pct") for match in _NUMBER_TOKEN_RE.finditer(row_text))
+
 
 def _anchors_by_exhibit(anexos: Mapping[str, str]) -> dict[int, list[float]]:
     return {

--- a/backend/tests/test_issue372_m1_exhibit2_rows.py
+++ b/backend/tests/test_issue372_m1_exhibit2_rows.py
@@ -1,0 +1,308 @@
+"""Issue #372 — Exhibit 2 mandatory-row validator (ml_ds + clasificación).
+
+Two surfaces, per the plan:
+
+* **Pure validator** — `validate_exhibit2_event_rate` (the deterministic F1 coupling,
+  zero-FP-by-construction) and `detect_exhibit2_completeness_row` (the secondary
+  heuristic). No LLM, no DB, no network.
+* **Node wiring** — `_invoke_m1_exhibit2_coherence` reprompt-once-then-DEGRADE in
+  `case_architect`, driven by a fake text LLM: gate no-op for business / non-clf,
+  best-effort never-raise, completeness is warning-only (never reprompts).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import case_generator.graph as graph_module
+from case_generator.m1_grounding import (
+    detect_exhibit2_completeness_row,
+    validate_exhibit2_event_rate,
+)
+
+# ── Exhibit 2 fixtures (markdown tables, like the real anexo_operativo) ────────
+RATE = 0.083  # 8.3 % — the F1 target_event_rate under test
+
+OP_GOOD = (
+    "### Exhibit 2 — Indicadores Operativos\n"
+    "| Indicador | Valor |\n"
+    "|---|---|\n"
+    "| Tasa histórica de abandono | 8.3 % |\n"
+    "| Completitud de campos críticos | 88 % |\n"
+    "| Tickets mensuales | 14,500 |\n"
+)
+OP_NO_RATE = (
+    "### Exhibit 2 — Indicadores Operativos\n"
+    "| Indicador | Valor |\n"
+    "|---|---|\n"
+    "| Churn bruto reportado | 9 % |\n"
+    "| Completitud de campos críticos | 88 % |\n"
+    "| Tickets | 14,500 |\n"
+)
+OP_NO_COMPLETENESS = (
+    "### Exhibit 2 — Indicadores Operativos\n"
+    "| Indicador | Valor |\n"
+    "|---|---|\n"
+    "| Tasa histórica de abandono | 8.3 % |\n"
+    "| Tickets | 14,500 |\n"
+)
+OP_EXTRA_PCT = (  # zero-FP: correct rate row buried among other operational %s
+    "### Exhibit 2 — Indicadores Operativos\n"
+    "| Indicador | Valor |\n"
+    "|---|---|\n"
+    "| Utilización de capacidad | 80 % |\n"
+    "| Tasa histórica de abandono | 8.3 % |\n"
+    "| Churn bruto | 11 % |\n"
+    "| Completitud de campos críticos | 88 % |\n"
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Pure validator — F1 numeric coupling (the deterministic core)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestEventRateCoupling:
+    def test_matching_rate_row_passes(self) -> None:
+        assert validate_exhibit2_event_rate(OP_GOOD, RATE) == []
+
+    @pytest.mark.parametrize("printed", ["8.3 %", "8.30 %", "8,3 %", "8.3%", "8 %"])
+    def test_display_variants_within_tolerance_pass(self, printed: str) -> None:
+        anexo = f"| Tasa de abandono | {printed} |\n"
+        assert validate_exhibit2_event_rate(anexo, RATE) == []
+
+    def test_bare_fraction_form_passes(self) -> None:
+        # The anexo may print the bare fraction (0.083) rather than "8.3 %".
+        anexo = "| Tasa de ocurrencia (fracción) | 0.083 |\n"
+        assert validate_exhibit2_event_rate(anexo, RATE) == []
+
+    def test_rate_absent_violates(self) -> None:
+        v = validate_exhibit2_event_rate(OP_NO_RATE, RATE)
+        assert v and "EXHIBIT2_RATE_MISMATCH" in v[0]
+
+    def test_grossly_wrong_number_violates(self) -> None:
+        # Dataset calibrated to 8.3 % but Exhibit 2 prints 12 % — the F1 defect.
+        anexo = "| Tasa de abandono | 12 % |\n"
+        assert validate_exhibit2_event_rate(anexo, RATE) != []
+
+    def test_just_outside_tolerance_violates(self) -> None:
+        # 8.9 % vs 8.3 % → 0.6pp > ±0.5pp.
+        assert validate_exhibit2_event_rate("| Tasa | 8.9 % |\n", RATE) != []
+
+    def test_none_rate_is_noop(self) -> None:
+        assert validate_exhibit2_event_rate(OP_NO_RATE, None) == []
+
+    def test_extra_percentages_do_not_create_false_positive(self) -> None:
+        # Multiple operational %s + the correct rate row → no violation (zero FP).
+        assert validate_exhibit2_event_rate(OP_EXTRA_PCT, RATE) == []
+
+    def test_other_rate_matches_its_own_percentage(self) -> None:
+        # rate 0.11 ⇔ 11 % present among others → no violation.
+        assert validate_exhibit2_event_rate(OP_EXTRA_PCT, 0.11) == []
+
+    def test_malformed_input_does_not_raise(self) -> None:
+        # Pure function never raises on junk; the value just isn't present → violation.
+        assert validate_exhibit2_event_rate("", RATE) != []
+        assert validate_exhibit2_event_rate("texto sin tabla ni cifras", RATE) != []
+        assert validate_exhibit2_event_rate("", None) == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Pure validator — completeness row (secondary heuristic)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCompletenessRow:
+    def test_completeness_row_present_passes(self) -> None:
+        assert detect_exhibit2_completeness_row(OP_GOOD) == []
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "Completitud de campos críticos",
+            "% registros con campo contractual sin dato",
+            "Registros incompletos",
+            "Campos faltantes",
+            "Valores nulos",
+        ],
+    )
+    def test_keyword_variants_with_pct_pass(self, label: str) -> None:
+        anexo = f"| {label} | 12 % |\n"
+        assert detect_exhibit2_completeness_row(anexo) == []
+
+    def test_completeness_absent_warns(self) -> None:
+        v = detect_exhibit2_completeness_row(OP_NO_COMPLETENESS)
+        assert v and "EXHIBIT2_COMPLETENESS_MISSING" in v[0]
+
+    def test_keyword_without_percentage_does_not_count(self) -> None:
+        # Conservative: a completeness keyword with no % is not a data-quality row.
+        anexo = "| Completitud de campos | revisada manualmente |\n"
+        assert detect_exhibit2_completeness_row(anexo) != []
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Node wiring — fakes + state
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class _Resp:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeLLM:
+    """Queue of text outputs for the targeted Exhibit-2 reprompt; counts invokes."""
+
+    def __init__(self, outputs: list[str] | None = None) -> None:
+        self._outputs = list(outputs or [])
+        self.calls = 0
+
+    def invoke(self, _prompt: str) -> _Resp:
+        self.calls += 1
+        if not self._outputs:
+            raise AssertionError("LLM invoked more times than expected")
+        return _Resp(self._outputs.pop(0))
+
+
+class _RecordingLogger:
+    """Captures logger.warning text; immune to suite-wide logging reconfiguration."""
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def warning(self, msg: object, *args: object, **_kwargs: object) -> None:
+        text = str(msg)
+        if args:
+            try:
+                text = text % args
+            except Exception:
+                pass
+        self.messages.append(text)
+
+    def info(self, *_a: object, **_k: object) -> None: ...
+    def error(self, *_a: object, **_k: object) -> None: ...
+    def debug(self, *_a: object, **_k: object) -> None: ...
+
+
+def _state(*, profile: str = "ml_ds", algoritmos: list[str] | None = None) -> dict:
+    """Minimal state for the `_is_ml_ds_classification` gate (mirrors #360)."""
+    return {
+        "studentProfile": profile,
+        "algoritmos": algoritmos if algoritmos is not None else ["Logistic Regression"],
+        "algorithm_mode": "single",
+        "case_id": "case_issue_372",
+        "output_language": "es",
+    }
+
+
+def _contract(rate: float | None = RATE) -> dict:
+    return {
+        "target_column": {"role": "classification_target", "dtype": "int"},
+        "target_event_rate": rate,
+    }
+
+
+def _invoke(llm: object, state: dict, anexo: str, contract: dict | None):
+    return graph_module._invoke_m1_exhibit2_coherence(
+        llm=llm, state=state, anexo_operativo=anexo, contract=contract
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Node wiring — reprompt-once-then-DEGRADE, gate, best-effort
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_happy_path_no_reprompt() -> None:
+    fake = _FakeLLM()  # would raise if invoked
+    out = _invoke(fake, _state(), OP_GOOD, _contract())
+    assert fake.calls == 0
+    assert out == OP_GOOD
+
+
+def test_reprompt_corrects_missing_rate() -> None:
+    fake = _FakeLLM([OP_GOOD])  # corrected anexo prints 8.3 %
+    out = _invoke(fake, _state(), OP_NO_RATE, _contract())
+    assert fake.calls == 1
+    # The corrected anexo is sanitized (trailing-newline strip), so assert the F1
+    # coupling now passes and the rate is printed — not byte-equality with the fixture.
+    assert validate_exhibit2_event_rate(out, RATE) == []
+    assert "8.3 %" in out
+
+
+def test_degrade_keeps_original_when_reprompt_still_violates() -> None:
+    rec = _RecordingLogger()
+    still_bad = "| Churn | 9 % |\n| Completitud campos | 88 % |\n"  # still no 8.3 %
+    fake = _FakeLLM([still_bad])
+    graph_module_logger = graph_module.logger
+    try:
+        graph_module.logger = rec  # type: ignore[assignment]
+        out = _invoke(fake, _state(), OP_NO_RATE, _contract())
+    finally:
+        graph_module.logger = graph_module_logger  # type: ignore[assignment]
+    assert fake.calls == 1  # reprompted once, never a 2nd
+    # Reprompt still violates → keep the original anexo.
+    assert out == OP_NO_RATE
+    assert any("no corregida" in m for m in rec.messages)
+
+
+def test_gutted_reprompt_is_rejected() -> None:
+    # A rate-valid but drastically shorter rewrite (operational rows dropped) must NOT
+    # replace the original — the length-floor guard keeps the richer original anexo.
+    rec = _RecordingLogger()
+    gutted = "| Tasa | 8.3 % |\n"  # prints the rate, but lost every other row
+    fake = _FakeLLM([gutted])
+    saved = graph_module.logger
+    try:
+        graph_module.logger = rec  # type: ignore[assignment]
+        out = _invoke(fake, _state(), OP_NO_RATE, _contract())
+    finally:
+        graph_module.logger = saved  # type: ignore[assignment]
+    assert fake.calls == 1
+    assert out == OP_NO_RATE  # gutted rewrite rejected → original preserved
+    assert any("no corregida" in m for m in rec.messages)
+
+
+def test_gate_noop_for_business() -> None:
+    fake = _FakeLLM()  # never invoked
+    out = _invoke(fake, _state(profile="business"), OP_NO_RATE, _contract())
+    assert fake.calls == 0
+    assert out == OP_NO_RATE  # byte-identical passthrough
+
+
+def test_gate_noop_for_non_classification_family() -> None:
+    fake = _FakeLLM()
+    out = _invoke(
+        fake, _state(algoritmos=["Linear Regression"]), OP_NO_RATE, _contract()
+    )
+    assert fake.calls == 0
+    assert out == OP_NO_RATE
+
+
+def test_rate_none_is_noop() -> None:
+    fake = _FakeLLM()
+    out = _invoke(fake, _state(), OP_NO_RATE, _contract(rate=None))
+    assert fake.calls == 0
+    assert out == OP_NO_RATE
+
+
+def test_completeness_missing_warns_but_never_reprompts() -> None:
+    # Rate row OK → no reprompt; completeness absent → warning-only.
+    rec = _RecordingLogger()
+    fake = _FakeLLM()  # would raise if invoked
+    saved = graph_module.logger
+    try:
+        graph_module.logger = rec  # type: ignore[assignment]
+        out = _invoke(fake, _state(), OP_NO_COMPLETENESS, _contract())
+    finally:
+        graph_module.logger = saved  # type: ignore[assignment]
+    assert fake.calls == 0  # completeness is heuristic → never reprompts
+    assert out == OP_NO_COMPLETENESS
+    assert any("completitud" in m.lower() for m in rec.messages)
+
+
+def test_best_effort_when_validator_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_k: object) -> list[str]:
+        raise RuntimeError("validator bug")
+
+    monkeypatch.setattr(graph_module, "validate_exhibit2_event_rate", _boom)
+    fake = _FakeLLM()
+    out = _invoke(fake, _state(), OP_NO_RATE, _contract())
+    assert fake.calls == 0  # raised before any reprompt; job continues
+    assert out == OP_NO_RATE


### PR DESCRIPTION
## Qué

Cierra **#372** (F4, epic #352). Añade un validador **determinista best-effort** que verifica que **Exhibit 2** (`anexo_operativo`) imprima la **tasa de ocurrencia del evento** con el MISMO número que `dataset_schema_required.target_event_rate` — cerrando de forma dura el lazo que F1 (PR #374) dejó sin verificar (el dataset se calibra a esa prevalencia, pero nada garantizaba que el anexo la imprimiera).

## Diseño

- **Check primario (zero-FP por construcción):** acople numérico F1 — alguna `%` de la tabla de Exhibit 2 ≈ `target_event_rate·100` (±0.5pp) o la fracción cruda. Subsume presencia + etiquetado + exactitud de la fila de tasa sin keywords.
- **Check secundario (heurístico):** presencia de la fila de completitud → **solo `logger.warning`, nunca reprompt/degrade** (separación limpia determinista→actúa / heurístico→observa).
- **Política:** reprompt-once-then-DEGRADE dentro de `case_architect` (único dueño del anexo + `target_event_rate`). El reprompt es **targeted** (reescribe Exhibit 2 con el número exacto) y se acepta solo si vuelve a imprimir la tasa **y** preserva el volumen del anexo (guardia anti-rewrite-vacío, ratio 0.6). Si no, se conserva el original.
- **Gate** `_is_ml_ds_classification` → **no-op byte-idéntico** para business y `regresion`/`clustering`/`serie_temporal`.

## Restricciones respetadas

- No toca el prompt del architect → `_MLDS_ARCHITECT_PROMPT_SHA256` intacto (guard verde).
- Sin nueva clave canónica/teacher/student-facing, sin `case_sanitization`, sin nuevo campo de estado (logger-only). Corre en nodo secuencial → sin hazard de fan-out.
- Best-effort: cualquier excepción interna degrada y continúa; **nunca falla un job**.

## Tests / verificación

- `backend/tests/test_issue372_m1_exhibit2_rows.py` (31): match/mismatch F1, variantes de display, fracción, ausencia, tabla malformada, cero-FP, completitud warning-only, gate no-op business/no-clf, best-effort, reprompt corrige / degrada / rewrite-vacío rechazado.
- `uv run --directory backend pytest -q` → **1417 passed, 21 skipped**.
- `uv run --directory backend mypy src` → **clean**.
- Drift-guards #360/#361/#363 + frozen-hash verdes.
- Revisión adversarial independiente: 0 P0/P1; el único riesgo real (rewrite-vacío) endurecido.

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)