### PR TITLE
feat(auth): ocultar botón "Continuar con Microsoft" tras flag central

### DIFF
--- a/frontend/src/features/student-auth/StudentJoinPage.test.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.test.tsx
@@ -6,6 +6,7 @@ import { StudentJoinPage } from "./StudentJoinPage";
 
 vi.mock("@/shared/activationContext");
 vi.mock("@/shared/supabaseClient");
+vi.mock("@/shared/authConfig");
 vi.mock("@/app/auth/useAuth", () => ({
     useAuth: vi.fn(),
 }));
@@ -43,6 +44,7 @@ import {
     saveActivationContext,
 } from "@/shared/activationContext";
 import { api } from "@/shared/api";
+import { isMicrosoftLoginEnabled } from "@/shared/authConfig";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 import { useAuth } from "@/app/auth/useAuth";
 import { useNavigate } from "react-router-dom";
@@ -114,6 +116,8 @@ describe("StudentJoinPage", () => {
         vi.mocked(clearActivationContext).mockImplementation(() => undefined);
         vi.mocked(saveActivationContext).mockImplementation(() => undefined);
         vi.mocked(getSupabaseClient).mockReturnValue(makeSupabaseMock() as never);
+        // Default: Microsoft login deshabilitado (estado de producción actual).
+        vi.mocked(isMicrosoftLoginEnabled).mockReturnValue(false);
     });
 
     it("shows invalid link state when there is no activation context", () => {
@@ -341,6 +345,7 @@ describe("StudentJoinPage", () => {
     });
 
     it("stores oauth intent for course-access Microsoft sign-in", async () => {
+        vi.mocked(isMicrosoftLoginEnabled).mockReturnValue(true);
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "student_join_course_access",
             token_kind: "course_access",
@@ -376,6 +381,32 @@ describe("StudentJoinPage", () => {
         expect(supabaseMock.auth.signInWithOAuth).toHaveBeenCalledWith(
             expect.objectContaining({ provider: "azure" }),
         );
+    });
+
+    it("hides the Microsoft button even when the backend allows it, while disabled", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-tok-oauth",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveCourseAccess).mockResolvedValue({
+            course_id: "course-1",
+            course_title: "Gerencia Estrategica",
+            university_name: "Universidad Demo",
+            teacher_display_name: "Julio Paz",
+            course_status: "active",
+            link_status: "active",
+            allowed_auth_methods: ["microsoft", "password"],
+        });
+
+        renderPage();
+
+        // El formulario de password aparece aunque el backend permita Microsoft.
+        await screen.findByPlaceholderText("tu.correo@universidad.edu");
+
+        expect(screen.queryByText(/Continuar con Microsoft/i)).toBeNull();
+        expect(screen.queryByText(/o crea una contraseña/i)).toBeNull();
     });
 
     it("auto-enrolls an already-authenticated student into a second course without showing the form", async () => {

--- a/frontend/src/features/student-auth/StudentJoinPage.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.tsx
@@ -13,6 +13,7 @@ import type {
     CourseAccessResolveResponse,
     InviteResolveResponse,
 } from "@/shared/adam-types";
+import { isMicrosoftLoginEnabled } from "@/shared/authConfig";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 
 function resolveInviteErrorMessage(err: ApiError | null, inviteStatus?: string): string {
@@ -364,7 +365,8 @@ export function StudentJoinPage() {
     }
 
     const isInviteFlow = joinContext?.token_kind === "invite";
-    const allowMicrosoft = isInviteFlow || resolvedCourseAccess?.allowed_auth_methods.includes("microsoft") || false;
+    // Microsoft login oculto tras isMicrosoftLoginEnabled (manda sobre allowed_auth_methods del backend)
+    const allowMicrosoft = isMicrosoftLoginEnabled() && (isInviteFlow || resolvedCourseAccess?.allowed_auth_methods.includes("microsoft") || false);
     const universityName = isInviteFlow ? resolvedInvite?.university_name : resolvedCourseAccess?.university_name;
     const courseTitle = isInviteFlow ? resolvedInvite?.course_title : resolvedCourseAccess?.course_title;
     const teacherName = isInviteFlow ? resolvedInvite?.teacher_name : resolvedCourseAccess?.teacher_display_name;

--- a/frontend/src/features/student-auth/StudentLoginPage.test.tsx
+++ b/frontend/src/features/student-auth/StudentLoginPage.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { StudentLoginPage } from "./StudentLoginPage";
 
 vi.mock("@/shared/supabaseClient");
+vi.mock("@/shared/authConfig");
 vi.mock("@/shared/activationContext", () => ({
     readActivationContext: vi.fn(),
     saveActivationContext: vi.fn(),
@@ -15,6 +16,7 @@ vi.mock("react-router-dom", async () => {
 });
 
 import { readActivationContext, saveActivationContext } from "@/shared/activationContext";
+import { isMicrosoftLoginEnabled } from "@/shared/authConfig";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 import { useNavigate } from "react-router-dom";
 
@@ -45,9 +47,19 @@ describe("StudentLoginPage", () => {
         vi.mocked(getSupabaseClient).mockReturnValue(makeSupabaseMock() as never);
         vi.mocked(readActivationContext).mockReturnValue(null);
         vi.mocked(useNavigate).mockReturnValue(mockNavigate);
+        // Default: Microsoft login deshabilitado (estado de producción actual).
+        vi.mocked(isMicrosoftLoginEnabled).mockReturnValue(false);
+    });
+
+    it("does not render the Microsoft button when Microsoft login is disabled", () => {
+        renderPage();
+
+        expect(screen.queryByText(/Continuar con Microsoft/i)).toBeNull();
+        expect(screen.queryByText(/o usa contraseña/i)).toBeNull();
     });
 
     it("calls signInWithOAuth with provider azure when Microsoft button is clicked", async () => {
+        vi.mocked(isMicrosoftLoginEnabled).mockReturnValue(true);
         const supabaseMock = makeSupabaseMock();
         vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
 
@@ -63,6 +75,7 @@ describe("StudentLoginPage", () => {
     });
 
     it("stores oauth auth_path when resuming a course-access login with Microsoft", async () => {
+        vi.mocked(isMicrosoftLoginEnabled).mockReturnValue(true);
         const supabaseMock = makeSupabaseMock();
         vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
         vi.mocked(readActivationContext).mockReturnValue({

--- a/frontend/src/features/student-auth/StudentLoginPage.tsx
+++ b/frontend/src/features/student-auth/StudentLoginPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { readActivationContext, saveActivationContext } from "@/shared/activationContext";
+import { isMicrosoftLoginEnabled } from "@/shared/authConfig";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 
 /**
@@ -86,24 +87,29 @@ export function StudentLoginPage() {
                     <h1 className="text-xl font-semibold">Acceso estudiantes</h1>
                 </div>
 
-                <button
-                    type="button"
-                    onClick={() => void handleMicrosoftLogin()}
-                    className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
-                >
-                    Continuar con Microsoft
-                </button>
+                {/* Microsoft login oculto tras isMicrosoftLoginEnabled */}
+                {isMicrosoftLoginEnabled() && (
+                    <>
+                        <button
+                            type="button"
+                            onClick={() => void handleMicrosoftLogin()}
+                            className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+                        >
+                            Continuar con Microsoft
+                        </button>
 
-                <div className="relative">
-                    <div className="absolute inset-0 flex items-center">
-                        <span className="w-full border-t border-border" />
-                    </div>
-                    <div className="relative flex justify-center">
-                        <span className="bg-background px-2 text-xs text-muted-foreground">
-                            o usa contraseña
-                        </span>
-                    </div>
-                </div>
+                        <div className="relative">
+                            <div className="absolute inset-0 flex items-center">
+                                <span className="w-full border-t border-border" />
+                            </div>
+                            <div className="relative flex justify-center">
+                                <span className="bg-background px-2 text-xs text-muted-foreground">
+                                    o usa contraseña
+                                </span>
+                            </div>
+                        </div>
+                    </>
+                )}
 
                 <form onSubmit={(event) => void handlePasswordSubmit(event)} className="space-y-4">
                     <div className="space-y-2">

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.test.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.test.tsx
@@ -9,6 +9,7 @@ import { TeacherActivatePage } from "./TeacherActivatePage";
 
 vi.mock("@/shared/activationContext");
 vi.mock("@/shared/supabaseClient");
+vi.mock("@/shared/authConfig");
 vi.mock("react-router-dom", async () => {
     const actual = await vi.importActual<typeof import("react-router-dom")>(
         "react-router-dom",
@@ -41,6 +42,7 @@ import {
     clearActivationContext,
     saveActivationContext,
 } from "@/shared/activationContext";
+import { isMicrosoftLoginEnabled } from "@/shared/authConfig";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 import { useNavigate } from "react-router-dom";
 import { api } from "@/shared/api";
@@ -84,6 +86,8 @@ describe("TeacherActivatePage", () => {
         vi.mocked(clearActivationContext).mockImplementation(() => undefined);
         vi.mocked(saveActivationContext).mockImplementation(() => undefined);
         vi.mocked(getSupabaseClient).mockReturnValue(makeSupabaseMock() as never);
+        // Default: Microsoft login deshabilitado (estado de producción actual).
+        vi.mocked(isMicrosoftLoginEnabled).mockReturnValue(false);
         // Default: resolve hangs (never resolves) unless overridden per test
         vi.mocked(api.auth.resolveInvite).mockReturnValue(new Promise(() => undefined));
     });
@@ -298,8 +302,9 @@ describe("TeacherActivatePage", () => {
         expect(screen.getByText(/Activar cuenta/i)).toBeTruthy();
     });
 
-    // 9. Botón Microsoft → llama signInWithOAuth con provider: "azure"
+    // 9. Botón Microsoft → llama signInWithOAuth con provider: "azure" (flag on)
     it("calls signInWithOAuth with provider azure when Microsoft button is clicked", async () => {
+        vi.mocked(isMicrosoftLoginEnabled).mockReturnValue(true);
         vi.mocked(readActivationContext).mockReturnValue({
             flow: "teacher_activate",
             token_kind: "invite",
@@ -322,5 +327,26 @@ describe("TeacherActivatePage", () => {
         expect(supabaseMock.auth.signInWithOAuth).toHaveBeenCalledWith(
             expect.objectContaining({ provider: "azure" }),
         );
+    });
+
+    // 10. Por defecto (flag off) el botón Microsoft no se renderiza en el formulario de activación
+    it("does not render the Microsoft button when Microsoft login is disabled", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            token_kind: "invite",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        // Espera a que el formulario de activación (estado 4) esté montado.
+        await waitFor(() => screen.getByRole("button", { name: /Activar cuenta/i }));
+
+        expect(screen.queryByText(/Continuar con Microsoft/i)).toBeNull();
+        expect(screen.queryByText(/Activar con Microsoft/i)).toBeNull();
+        expect(screen.queryByText(/o usa contraseña/i)).toBeNull();
     });
 });

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api, ApiError } from "@/shared/api";
+import { isMicrosoftLoginEnabled } from "@/shared/authConfig";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 import {
     saveActivationContext,
@@ -232,28 +233,32 @@ export function TeacherActivatePage() {
                     />
                 </div>
 
-                {/* Opción A — Microsoft */}
-                <div className="space-y-2">
-                    <p className="text-sm font-medium">Activar con Microsoft (recomendado)</p>
-                    <button
-                        type="button"
-                        onClick={() => void handleMicrosoftActivation()}
-                        className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
-                    >
-                        Continuar con Microsoft
-                    </button>
-                </div>
+                {/* Opción A — Microsoft (oculto tras isMicrosoftLoginEnabled) */}
+                {isMicrosoftLoginEnabled() && (
+                    <>
+                        <div className="space-y-2">
+                            <p className="text-sm font-medium">Activar con Microsoft (recomendado)</p>
+                            <button
+                                type="button"
+                                onClick={() => void handleMicrosoftActivation()}
+                                className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+                            >
+                                Continuar con Microsoft
+                            </button>
+                        </div>
 
-                <div className="relative">
-                    <div className="absolute inset-0 flex items-center">
-                        <span className="w-full border-t border-border" />
-                    </div>
-                    <div className="relative flex justify-center">
-                        <span className="bg-background px-2 text-xs text-muted-foreground">
-                            o usa contraseña
-                        </span>
-                    </div>
-                </div>
+                        <div className="relative">
+                            <div className="absolute inset-0 flex items-center">
+                                <span className="w-full border-t border-border" />
+                            </div>
+                            <div className="relative flex justify-center">
+                                <span className="bg-background px-2 text-xs text-muted-foreground">
+                                    o usa contraseña
+                                </span>
+                            </div>
+                        </div>
+                    </>
+                )}
 
                 {/* Opción B — Password */}
                 <form onSubmit={(e) => void handlePasswordSubmit(e)} className="space-y-4">

--- a/frontend/src/features/teacher-auth/TeacherLoginPage.test.tsx
+++ b/frontend/src/features/teacher-auth/TeacherLoginPage.test.tsx
@@ -8,7 +8,9 @@ import { TeacherLoginPage } from "./TeacherLoginPage";
 // ---------------------------------------------------------------------------
 
 vi.mock("@/shared/supabaseClient");
+vi.mock("@/shared/authConfig");
 
+import { isMicrosoftLoginEnabled } from "@/shared/authConfig";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 
 function makeSupabaseMock(
@@ -34,10 +36,21 @@ describe("TeacherLoginPage", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.mocked(getSupabaseClient).mockReturnValue(makeSupabaseMock() as never);
+        // Default: Microsoft login deshabilitado (estado de producción actual).
+        vi.mocked(isMicrosoftLoginEnabled).mockReturnValue(false);
     });
 
-    // 1. Botón Microsoft → llama signInWithOAuth con provider: "azure"
+    // 0. Por defecto (flag off) el botón Microsoft no se renderiza
+    it("does not render the Microsoft button when Microsoft login is disabled", () => {
+        renderPage();
+
+        expect(screen.queryByText(/Continuar con Microsoft/i)).toBeNull();
+        expect(screen.queryByText(/o usa contraseña/i)).toBeNull();
+    });
+
+    // 1. Botón Microsoft → llama signInWithOAuth con provider: "azure" (flag on)
     it("calls signInWithOAuth with provider azure when Microsoft button is clicked", async () => {
+        vi.mocked(isMicrosoftLoginEnabled).mockReturnValue(true);
         const supabaseMock = makeSupabaseMock();
         vi.mocked(getSupabaseClient).mockReturnValue(supabaseMock as never);
 

--- a/frontend/src/features/teacher-auth/TeacherLoginPage.tsx
+++ b/frontend/src/features/teacher-auth/TeacherLoginPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { isMicrosoftLoginEnabled } from "@/shared/authConfig";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 
 /**
@@ -62,25 +63,29 @@ export function TeacherLoginPage() {
                     <h1 className="text-xl font-semibold">Acceso docentes</h1>
                 </div>
 
-                {/* Opción A — Microsoft */}
-                <button
-                    type="button"
-                    onClick={() => void handleMicrosoftLogin()}
-                    className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
-                >
-                    Continuar con Microsoft
-                </button>
+                {/* Opción A — Microsoft (oculto tras isMicrosoftLoginEnabled) */}
+                {isMicrosoftLoginEnabled() && (
+                    <>
+                        <button
+                            type="button"
+                            onClick={() => void handleMicrosoftLogin()}
+                            className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+                        >
+                            Continuar con Microsoft
+                        </button>
 
-                <div className="relative">
-                    <div className="absolute inset-0 flex items-center">
-                        <span className="w-full border-t border-border" />
-                    </div>
-                    <div className="relative flex justify-center">
-                        <span className="bg-background px-2 text-xs text-muted-foreground">
-                            o usa contraseña
-                        </span>
-                    </div>
-                </div>
+                        <div className="relative">
+                            <div className="absolute inset-0 flex items-center">
+                                <span className="w-full border-t border-border" />
+                            </div>
+                            <div className="relative flex justify-center">
+                                <span className="bg-background px-2 text-xs text-muted-foreground">
+                                    o usa contraseña
+                                </span>
+                            </div>
+                        </div>
+                    </>
+                )}
 
                 {/* Opción B — Password */}
                 <form onSubmit={(e) => void handlePasswordSubmit(e)} className="space-y-4">

--- a/frontend/src/shared/authConfig.ts
+++ b/frontend/src/shared/authConfig.ts
@@ -1,0 +1,18 @@
+/**
+ * Microsoft (Azure AD) social login kill-switch.
+ *
+ * `false` (2026-06-20): el botón "Continuar con Microsoft" se oculta en TODAS las
+ * superficies de auth (login/activación de docentes y estudiantes). Los handlers
+ * `handleMicrosoftLogin/Activation/Join` y TODO el backend OAuth
+ * (university_sso_configs, allowed_auth_methods_for_university,
+ * /activate/oauth/complete) quedan intactos.
+ *
+ * Para retomar Microsoft login: devolver `true` aquí (flip de una línea).
+ *
+ * Se usa una función (no `const`) a propósito: el tipo de retorno `boolean` evita
+ * que TypeScript estreche la rama JSX a `never` (mantiene los handlers OAuth
+ * "usados" → sin error de unused-var) y es trivialmente mockeable en tests.
+ */
+export function isMicrosoftLoginEnabled(): boolean {
+    return false;
+}


### PR DESCRIPTION
## Qué

Quita el botón **"Continuar con Microsoft"** del frontend en las **4 superficies de auth** (login docentes/estudiantes, activación docente, unirse a curso), ocultándolo tras un único **flag central** `isMicrosoftLoginEnabled()` (default `false`) en `frontend/src/shared/authConfig.ts`.

## Por qué

Petición de producto: quitar el botón del frontend ahora, **dejando intacto el backend** para retomar Microsoft OAuth en el futuro.

## Cómo

- **Nuevo** `frontend/src/shared/authConfig.ts` → `isMicrosoftLoginEnabled()` (función `boolean`, mockeable, evita unused-var en los handlers).
- Botón + divisor gateados por el flag en `TeacherLoginPage`, `StudentLoginPage`, `TeacherActivatePage` y `StudentJoinPage` (en este último el flag manda sobre `allowed_auth_methods` del backend).
- Handlers OAuth **no se borran** (quedan referenciados dentro del bloque gateado).

## Intacto (deliberado)

Todo el backend OAuth: `university_sso_configs`, `allowed_auth_methods_for_university`, endpoints `/activate/oauth/complete`, `MICROSOFT_TENANT_ID`; e infra frontend (`supabaseClient`, `AuthCallbackPage`, `activationContext`, `VITE_AUTH_CALLBACK_URL`).

## Retomar

Cambiar `return false;` → `return true;` en `authConfig.ts` (una línea).

## Tests / verificación

- `npm run lint` limpio · `npm run test` **463/463** (incluye nuevos asserts de "botón oculto" en las 4 pantallas; los tests OAuth se preservan activando el flag) · `npm run build` OK.
- Backend sin cambios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)