### PR TITLE
fix(teacher-dashboard): tarjetas de "Cursos Activos" con alto/ancho uniforme

### DIFF
--- a/frontend/src/features/teacher-dashboard/CursosActivosSection.test.tsx
+++ b/frontend/src/features/teacher-dashboard/CursosActivosSection.test.tsx
@@ -169,6 +169,32 @@ describe("CursosActivosSection", () => {
         expect(navigate).toHaveBeenCalledWith("/teacher/courses/course-1");
     });
 
+    it("decouples card height from title length (clamp + full-title tooltip + equal-height affordances)", () => {
+        const longTitle =
+            "Gerencia Estratégica y Modelos de Negocio en Ecosistemas Digitales";
+        useTeacherCourses.mockReturnValue({
+            data: {
+                courses: [{ ...courses[0], title: longTitle }],
+                total: 1,
+            },
+            isLoading: false,
+            isError: false,
+        });
+
+        const { container } = renderWithProviders(<CursosActivosSection />);
+
+        const heading = screen.getByRole("heading", { name: longTitle, level: 3 });
+        // Full title preserved via native tooltip even though it is visually clamped.
+        expect(heading).toHaveAttribute("title", longTitle);
+        // Title reserves a fixed two-line block so single- and multi-line titles match.
+        expect(heading.className).toContain("line-clamp-2");
+
+        // The card stretches to fill its grid cell so siblings share a row height.
+        const article = container.querySelector("article.course-card");
+        expect(article?.className).toContain("h-full");
+        expect(article?.className).toContain("flex-col");
+    });
+
     it("falls back to a dash semester badge when there are no courses", () => {
         useTeacherCourses.mockReturnValue({
             data: { courses: [], total: 0 },

--- a/frontend/src/features/teacher-dashboard/CursosActivosSection.tsx
+++ b/frontend/src/features/teacher-dashboard/CursosActivosSection.tsx
@@ -69,7 +69,7 @@ function CourseCard({ course }: CourseCardProps) {
     return (
         <article
             className={[
-                "course-card relative overflow-hidden rounded-[18px] border-[1.5px] border-[#e2e8f0] bg-white transition-all duration-[180ms]",
+                "course-card relative flex h-full flex-col overflow-hidden rounded-[18px] border-[1.5px] border-[#e2e8f0] bg-white transition-all duration-[180ms]",
                 isActive
                     ? "hover:-translate-y-0.5 hover:border-[#bfdbfe] hover:shadow-[0_12px_40px_-8px_rgba(1,68,160,0.13)]"
                     : "opacity-75",
@@ -77,7 +77,7 @@ function CourseCard({ course }: CourseCardProps) {
         >
             <AccentBar status={course.status} />
 
-            <div className="p-6 pl-8">
+            <div className="flex flex-1 flex-col p-6 pl-8">
                 <div className="mb-4 flex items-start justify-between gap-4">
                     <div className="min-w-0">
                         <div className="mb-2 flex flex-wrap items-center gap-2">
@@ -88,7 +88,10 @@ function CourseCard({ course }: CourseCardProps) {
                                 {course.semester} · {course.code}
                             </span>
                         </div>
-                        <h3 className="text-[16px] font-bold leading-snug text-slate-900">
+                        <h3
+                            title={course.title}
+                            className="line-clamp-2 min-h-[2.8em] text-[16px] font-bold leading-snug text-slate-900"
+                        >
                             {course.title}
                         </h3>
                     </div>
@@ -101,7 +104,7 @@ function CourseCard({ course }: CourseCardProps) {
                     <StatPill value="—" label="Promedio" />
                 </div>
 
-                <div className="border-t border-slate-100 pt-5">
+                <div className="mt-auto border-t border-slate-100 pt-5">
                     {isActive ? (
                         <button
                             type="button"
@@ -260,7 +263,7 @@ export function CursosActivosSection() {
                     {filteredCourses.map((course, index) => (
                         <div
                             key={course.id}
-                            className="fade-card"
+                            className="fade-card h-full"
                             style={{
                                 opacity: 0,
                                 animation: "cardIn 0.35s ease forwards",


### PR DESCRIPTION
## Contexto

En el dashboard docente, la sección **"Cursos Activos"** mostraba tarjetas con **altura dependiente del largo del título**: un curso de título corto (1 línea) producía una tarjeta más baja que uno de título largo (2 líneas), desalineando las tarjetas de una misma fila y sus botones "Entrar al curso".

**Causa raíz:** el `<article>` no rellenaba la celda del grid (`align-items: stretch` estira el wrapper, pero el article quedaba a la altura de su contenido) y el `<h3>` del título no tenía límite de líneas ni alto reservado.

## Cambios

Solo layout en [`CursosActivosSection.tsx`](frontend/src/features/teacher-dashboard/CursosActivosSection.tsx) (sin tocar datos, navegación ni la animación `cardIn`):

- **Wrapper `.fade-card`** → `h-full`.
- **`<article>`** → `flex h-full flex-col` (rellena la celda, contenido en columna).
- **Contenedor interno** `p-6 pl-8` → `flex flex-1 flex-col`.
- **Título `<h3>`** → `line-clamp-2 min-h-[2.8em]` (reserva exactamente 2 líneas; los largos se recortan con elipsis) + `title={course.title}` (tooltip con el nombre completo, sin perder información).
- **Footer del botón** → `mt-auto` (botón fijado al fondo, alineado entre tarjetas).

Resultado: **todas las tarjetas comparten alto y ancho**, incluso entre filas distintas, desacoplado del largo del título. El ancho ya era uniforme por la grilla.

## Tests

Caso nuevo en [`CursosActivosSection.test.tsx`](frontend/src/features/teacher-dashboard/CursosActivosSection.test.tsx) que verifica el contrato: tooltip con título completo, `line-clamp-2`, y `h-full`/`flex-col` en la tarjeta.

## Validación

- `vitest` (CursosActivosSection) ✅ 10/10
- `eslint` archivos tocados ✅
- `tsc -b` ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)