### PR TITLE
feat(teacher-course): vista de curso full-bleed alineada con el shell del portal

### DIFF
--- a/frontend/src/features/teacher-course/TeacherCoursePage.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/features/teacher-course/teacherCourseModel";
 import { copyToClipboard } from "@/shared/clipboard";
 import { useToast } from "@/shared/toast-context";
+import { PORTAL_CONTENT_SHELL_CLASSNAME } from "@/shared/ui/layout";
 
 const SYLLABUS_TAB_ID = "teacher-course-tab-syllabus";
 const CASOS_TAB_ID = "teacher-course-tab-casos";
@@ -104,7 +105,7 @@ function TeacherCourseLoadingState() {
     return (
         <TeacherLayout
             testId="teacher-course-loading"
-            contentClassName="mx-auto max-w-[1440px] px-6 py-8"
+            contentClassName={`${PORTAL_CONTENT_SHELL_CLASSNAME} py-8`}
         >
             <div className="grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)]">
                 <aside className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-sm">
@@ -482,7 +483,7 @@ export function TeacherCoursePage() {
         return (
             <TeacherLayout
                 testId="teacher-course-page"
-                contentClassName="mx-auto max-w-[1440px] px-6 py-8"
+                contentClassName={`${PORTAL_CONTENT_SHELL_CLASSNAME} py-8`}
             >
                 <section
                     className="rounded-[24px] border border-red-200 bg-white p-8 shadow-sm"
@@ -527,7 +528,7 @@ export function TeacherCoursePage() {
     return (
         <TeacherLayout
             testId="teacher-course-page"
-            contentClassName="mx-auto max-w-[1440px] px-6 py-8"
+            contentClassName={`${PORTAL_CONTENT_SHELL_CLASSNAME} py-8`}
         >
             <div className="teacher-course-page grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)]">
                 <aside className="h-fit rounded-[24px] border border-slate-200 bg-white p-4 shadow-sm lg:sticky lg:top-[104px]">


### PR DESCRIPTION
## Qué

La vista de curso del docente (`TeacherCoursePage`) — tarjeta lateral del curso (sidebar) + panel **"Casos del curso"** — quedaba encerrada en un contenedor propio `max-w-[1440px] px-6`, dejando grandes márgenes vacíos a izquierda y derecha en monitores anchos (~230px por lado en una pantalla ~1900px).

Ahora usa el **shell estándar del portal** `PORTAL_CONTENT_SHELL_CLASSNAME` (`mx-auto w-full max-w-[2400px] px-4 sm:px-6 lg:px-8`) + `py-8`, igual que `TeacherDashboardPage`. El contenido es prácticamente full-bleed en monitores normales (≤2400px) y sus bordes quedan alineados con la barra superior azul.

## Cómo

- `frontend/src/features/teacher-course/TeacherCoursePage.tsx`:
  - Import de la constante existente `PORTAL_CONTENT_SHELL_CLASSNAME` desde `@/shared/ui/layout` (misma fuente de verdad que el dashboard).
  - Reemplazadas las **3** ocurrencias de `contentClassName="mx-auto max-w-[1440px] px-6 py-8"` (estados de carga, error y contenido) por `` contentClassName={`${PORTAL_CONTENT_SHELL_CLASSNAME} py-8`} ``.
- No se toca la grilla interna (`lg:grid-cols-[260px_minmax(0,1fr)]`), el sidebar, ni el padding vertical. La columna de casos se expande sola con el ancho extra.

## Fuera de alcance

- `TeacherCaseViewPage.tsx` (vista de un caso individual) sigue con `max-w-[1440px]`: es otra página, no "entrar a un curso".

## Verificación

- Lint: ✅ `npm --prefix frontend run lint`
- Tests: ✅ `npm --prefix frontend run test` — 465/465 (61 archivos)
- Build: ✅ `npm --prefix frontend run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)