### PR TITLE
feat(teacher-case-submissions): vista Entregas del caso full-bleed (alineada con el shell del portal)

### DIFF
--- a/frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.tsx
+++ b/frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.tsx
@@ -14,6 +14,7 @@ import {
 import "@/features/teacher-course/teacherCoursePage.css";
 
 import { TeacherLayout } from "@/features/teacher-layout/TeacherLayout";
+import { PORTAL_CONTENT_SHELL_CLASSNAME } from "@/shared/ui/layout";
 import {
     formatTeacherCourseTimestamp,
     formatTeacherGradebookCellStatus,
@@ -85,7 +86,7 @@ export function TeacherCaseSubmissionsPage() {
         : null;
 
     return (
-        <TeacherLayout contentClassName="teacher-course-page mx-auto w-full max-w-6xl px-6 py-9" testId="teacher-case-submissions-page">
+        <TeacherLayout contentClassName={`teacher-course-page ${PORTAL_CONTENT_SHELL_CLASSNAME} py-9`} testId="teacher-case-submissions-page">
             <div className="space-y-6">
                 <section className="rounded-[24px] border border-slate-200 bg-white p-6 shadow-sm md:p-8">
                     <div className="teacher-gradebook-header">


### PR DESCRIPTION
## Qué

La vista **"Entregas del caso"** del portal docente (`TeacherCaseSubmissionsPage`) dejaba demasiado espacio en blanco a izquierda y derecha: era el único *outlier* del portal, limitando el contenido a `max-w-6xl` (1536px) con gutter `px-6`.

Este PR la alinea con el shell compartido del portal, reusando la constante existente `PORTAL_CONTENT_SHELL_CLASSNAME` (`mx-auto w-full max-w-[2400px] px-4 sm:px-6 lg:px-8`) — el mismo cambio que ya aplicó el #393 a `TeacherCoursePage`. Ahora la cabecera, las tarjetas de métricas, el buscador y la tabla quedan pegados a los bordes y alineados con la barra superior, igual que el Dashboard y la vista de Curso.

## Cambio

Un solo archivo, 2 líneas — `frontend/src/features/teacher-case-submissions/TeacherCaseSubmissionsPage.tsx`:

- Import de `PORTAL_CONTENT_SHELL_CLASSNAME` desde `@/shared/ui/layout`.
- `contentClassName`: `teacher-course-page mx-auto w-full max-w-6xl px-6 py-9` → `` `teacher-course-page ${PORTAL_CONTENT_SHELL_CLASSNAME} py-9` `` (conserva la clase `teacher-course-page` y `py-9`).

## Fuera de alcance

`TeacherCaseSubmissionDetailPage` ("Ver entrega y calificar") se deja sin tocar: es una vista de lectura/calificación de una entrega, intencionalmente angosta (`max-w-4xl`) para legibilidad.

## Verificación

- `npm --prefix frontend run lint` ✅ limpio
- `npm --prefix frontend run build` (`tsc -b` + vite) ✅
- `TeacherCaseSubmissionsPage.test.tsx` ✅ 10/10
- `AuthoringForm.test.tsx` (no relacionado) ✅ 30/30 con timeout de 40s — los timeouts de 10s vistos antes eran *flake* ambiental (conjunto de fallos no determinista), sin relación con este cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
