### PR TITLE
feat(teacher-course): marcar campos obligatorios del syllabus y reducir fricción

### DIFF
--- a/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
@@ -502,7 +502,7 @@ describe("TeacherCoursePage", () => {
         renderTeacherCoursePage();
 
         await screen.findByRole("heading", { name: /Syllabus de la asignatura/i });
-        fireEvent.change(screen.getByLabelText("Departamento que la ofrece"), {
+        fireEvent.change(screen.getByLabelText(/Departamento que la ofrece/i), {
             target: { value: "Escuela de Negocios Digitales" },
         });
         fireEvent.click(screen.getAllByRole("button", { name: /Guardar cambios|Guardar y publicar/i })[0]);
@@ -533,7 +533,7 @@ describe("TeacherCoursePage", () => {
         renderTeacherCoursePage();
 
         await screen.findByRole("heading", { name: /Syllabus de la asignatura/i });
-        fireEvent.change(screen.getByLabelText("Departamento que la ofrece"), {
+        fireEvent.change(screen.getByLabelText(/Departamento que la ofrece/i), {
             target: { value: "" },
         });
         fireEvent.click(screen.getAllByRole("button", { name: /Guardar cambios|Guardar y publicar/i })[0]);
@@ -686,7 +686,7 @@ describe("TeacherCoursePage", () => {
         renderTeacherCoursePage();
 
         await screen.findByRole("heading", { name: /Syllabus de la asignatura/i });
-        fireEvent.change(screen.getByLabelText("Departamento que la ofrece"), {
+        fireEvent.change(screen.getByLabelText(/Departamento que la ofrece/i), {
             target: { value: "Departamento en borrador" },
         });
 
@@ -703,7 +703,7 @@ describe("TeacherCoursePage", () => {
 
         fireEvent.click(screen.getByRole("tab", { name: /Syllabus/i }));
 
-        expect(await screen.findByLabelText("Departamento que la ofrece")).toHaveValue(
+        expect(await screen.findByLabelText(/Departamento que la ofrece/i)).toHaveValue(
             "Departamento en borrador",
         );
     });

--- a/frontend/src/features/teacher-course/TeacherCoursePage.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.tsx
@@ -683,6 +683,10 @@ export function TeacherCoursePage() {
                                 </span>
                             </div>
 
+                            <p className="text-[12px] text-slate-500">
+                                <span className="text-red-500 font-semibold">*</span> Campos obligatorios
+                            </p>
+
                             {formError ? (
                                 <div className="alert-strip alert-warn" role="alert">
                                     <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
@@ -716,22 +720,26 @@ export function TeacherCoursePage() {
                                     </div>
                                     <div>
                                         <label className="form-label" htmlFor="syllabus-department">
-                                            Departamento que la ofrece
+                                            Departamento que la ofrece{" "}
+                                            <span className="text-red-500" aria-hidden="true">*</span>
                                         </label>
                                         <input
                                             id="syllabus-department"
                                             className="form-input"
+                                            aria-required="true"
                                             value={draft.department}
                                             onChange={(event) => updateDraft("department", event.target.value)}
                                         />
                                     </div>
                                     <div>
                                         <label className="form-label" htmlFor="syllabus-knowledge-area">
-                                            Área de conocimiento
+                                            Área de conocimiento{" "}
+                                            <span className="text-red-500" aria-hidden="true">*</span>
                                         </label>
                                         <input
                                             id="syllabus-knowledge-area"
                                             className="form-input"
+                                            aria-required="true"
                                             value={draft.knowledge_area}
                                             onChange={(event) =>
                                                 updateDraft("knowledge_area", event.target.value)
@@ -740,11 +748,13 @@ export function TeacherCoursePage() {
                                     </div>
                                     <div>
                                         <label className="form-label" htmlFor="syllabus-nbc">
-                                            Núcleo Básico del Conocimiento (NBC)
+                                            Núcleo Básico del Conocimiento (NBC){" "}
+                                            <span className="text-red-500" aria-hidden="true">*</span>
                                         </label>
                                         <input
                                             id="syllabus-nbc"
                                             className="form-input"
+                                            aria-required="true"
                                             value={draft.nbc}
                                             onChange={(event) => updateDraft("nbc", event.target.value)}
                                         />
@@ -834,11 +844,13 @@ export function TeacherCoursePage() {
                             <SectionCard step={3} title="Descripción de la Asignatura" highlightAdam>
                                 <div>
                                     <label className="form-label" htmlFor="syllabus-course-description">
-                                        Descripción
+                                        Descripción{" "}
+                                        <span className="text-red-500" aria-hidden="true">*</span>
                                     </label>
                                     <textarea
                                         id="syllabus-course-description"
                                         className="form-input min-h-[220px]"
+                                        aria-required="true"
                                         value={draft.course_description}
                                         onChange={(event) =>
                                             updateDraft("course_description", event.target.value)
@@ -851,11 +863,13 @@ export function TeacherCoursePage() {
                                 <div className="space-y-5">
                                     <div>
                                         <label className="form-label" htmlFor="syllabus-general-objective">
-                                            Objetivo general
+                                            Objetivo general{" "}
+                                            <span className="text-red-500" aria-hidden="true">*</span>
                                         </label>
                                         <textarea
                                             id="syllabus-general-objective"
                                             className="form-input min-h-[140px]"
+                                            aria-required="true"
                                             value={draft.general_objective}
                                             onChange={(event) =>
                                                 updateDraft("general_objective", event.target.value)
@@ -971,11 +985,13 @@ export function TeacherCoursePage() {
                                                 <div className="grid gap-5 md:grid-cols-2">
                                                     <div>
                                                         <label className="form-label" htmlFor={`module-title-${moduleIndex}`}>
-                                                            Título del módulo
+                                                            Título del módulo{" "}
+                                                            <span className="text-red-500" aria-hidden="true">*</span>
                                                         </label>
                                                         <input
                                                             id={`module-title-${moduleIndex}`}
                                                             className="form-input"
+                                                            aria-required="true"
                                                             value={module.module_title}
                                                             onChange={(event) =>
                                                                 updateModuleField(
@@ -1007,11 +1023,13 @@ export function TeacherCoursePage() {
 
                                                 <div>
                                                     <label className="form-label" htmlFor={`module-summary-${moduleIndex}`}>
-                                                        Resumen del módulo
+                                                        Resumen del módulo{" "}
+                                                        <span className="text-red-500" aria-hidden="true">*</span>
                                                     </label>
                                                     <textarea
                                                         id={`module-summary-${moduleIndex}`}
                                                         className="form-input min-h-[120px]"
+                                                        aria-required="true"
                                                         value={module.module_summary}
                                                         onChange={(event) =>
                                                             updateModuleField(

--- a/frontend/src/features/teacher-course/teacherCourseModel.test.ts
+++ b/frontend/src/features/teacher-course/teacherCourseModel.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    createEmptyTeacherSyllabusModule,
+    createEmptyTeacherSyllabusPayload,
+    validateTeacherCourseDraft,
+    type TeacherCourseDraft,
+} from "./teacherCourseModel";
+
+function buildValidDraft(): TeacherCourseDraft {
+    return {
+        ...createEmptyTeacherSyllabusPayload(),
+        department: "Gestión de las Organizaciones",
+        knowledge_area: "Economía, Administración, Contaduría y afines",
+        nbc: "Administración",
+        course_description: "Curso sobre modelos de negocio en ecosistemas digitales.",
+        general_objective: "Diseñar estrategias para ecosistemas digitales.",
+        modules: [
+            {
+                ...createEmptyTeacherSyllabusModule(),
+                module_title: "Módulo 1",
+                module_summary: "Fundamentos de los ecosistemas digitales.",
+            },
+        ],
+    };
+}
+
+describe("validateTeacherCourseDraft", () => {
+    it("passes with only the core required fields plus one module", () => {
+        expect(validateTeacherCourseDraft(buildValidDraft())).toBeNull();
+    });
+
+    it.each([
+        ["department", "Completa el departamento que ofrece la asignatura."],
+        ["knowledge_area", "Completa el área de conocimiento."],
+        ["nbc", "Completa el núcleo básico del conocimiento."],
+        ["course_description", "Completa la descripción de la asignatura."],
+        ["general_objective", "Completa el objetivo general de aprendizaje."],
+    ] as const)("blocks save when the core field %s is empty", (field, message) => {
+        const draft = { ...buildValidDraft(), [field]: "" };
+        expect(validateTeacherCourseDraft(draft)).toBe(message);
+    });
+
+    it("requires at least one module with title and summary", () => {
+        const draft = { ...buildValidDraft(), modules: [] };
+        expect(validateTeacherCourseDraft(draft)).toBe(
+            "Agrega al menos un módulo con título y resumen.",
+        );
+    });
+
+    it("still enforces completeness of a started module", () => {
+        const draft = {
+            ...buildValidDraft(),
+            modules: [
+                {
+                    ...createEmptyTeacherSyllabusModule(),
+                    module_title: "Módulo 1",
+                    module_summary: "",
+                },
+            ],
+        };
+        expect(validateTeacherCourseDraft(draft)).toBe(
+            "Completa el título y resumen del módulo 1.",
+        );
+    });
+
+    it("no longer blocks save on the de-prioritized optional fields", () => {
+        const draft: TeacherCourseDraft = {
+            ...buildValidDraft(),
+            version_label: "",
+            academic_load: "",
+            integrative_project: "",
+            didactic_strategy: {
+                methodological_perspective: "",
+                pedagogical_modality: "",
+            },
+        };
+        expect(validateTeacherCourseDraft(draft)).toBeNull();
+    });
+});

--- a/frontend/src/features/teacher-course/teacherCourseModel.ts
+++ b/frontend/src/features/teacher-course/teacherCourseModel.ts
@@ -442,17 +442,12 @@ export function validateTeacherCourseDraft(draft: TeacherCourseDraft): string | 
     if (!payload.department) return "Completa el departamento que ofrece la asignatura.";
     if (!payload.knowledge_area) return "Completa el área de conocimiento.";
     if (!payload.nbc) return "Completa el núcleo básico del conocimiento.";
-    if (!payload.version_label) return "Completa la versión del syllabus antes de guardar.";
-    if (!payload.academic_load) return "Completa la carga académica y logística del curso.";
     if (!payload.course_description) return "Completa la descripción de la asignatura.";
     if (!payload.general_objective) return "Completa el objetivo general de aprendizaje.";
-    if (!payload.didactic_strategy.methodological_perspective) {
-        return "Completa la perspectiva metodológica.";
+
+    if (payload.modules.length === 0) {
+        return "Agrega al menos un módulo con título y resumen.";
     }
-    if (!payload.didactic_strategy.pedagogical_modality) {
-        return "Completa la modalidad pedagógica.";
-    }
-    if (!payload.integrative_project) return "Completa el proyecto integrador.";
 
     for (const [index, module] of payload.modules.entries()) {
         if (!module.module_title || !module.module_summary) {


### PR DESCRIPTION
## Contexto

En el syllabus del curso del docente, el guardado bloqueaba sobre ~10 campos —incluidos varios que ADAM no lee (Versión del syllabus, Carga académica, Proyecto integrador, Estrategias didácticas)— y **ningún campo mostraba el icono de obligatorio**. El docente chocaba con errores de "campo requerido" sin pista visual previa y sobre campos que no aportan a la generación → fricción.

## Cambios (solo frontend)

- **Marcadores visuales** (`TeacherCoursePage.tsx`): icono `*` rojo (mismo patrón que `AuthoringForm`) + `aria-required` en los **6 campos núcleo** que ADAM lee para generar casos: Departamento, Área de conocimiento, NBC, Descripción, Objetivo general y Título/Resumen de módulo. Más la leyenda **"\* Campos obligatorios"**.
- **Validación relajada** (`teacherCourseModel.ts`): se quitan del bloqueo Versión, Carga académica, Proyecto integrador y las dos Estrategias didácticas; se exige **al menos un módulo** con título y resumen; se conserva la completitud por fila de módulos/evaluación.
- **Sin cambios de backend**: el schema Pydantic acepta strings vacíos y el frontend siempre envía todas las claves; relajar la obligatoriedad es 100% UI.
- **Tests**: nuevo `teacherCourseModel.test.ts` que fija el contrato (núcleo + ≥1 módulo obligatorios; campos de-priorizados ya no bloquean); las consultas de etiqueta del test de página pasan a regex `/.../i`, la convención que ya usa el repo para etiquetas con `*`.

Los campos `readonly` autollenados (Nombre, Código, Semestre, etc.) no llevan marcador.

## Verificación

- Lint: limpio ✓
- Tests: suite completa **474/474** (incluye 9 nuevos) ✓
- Build: OK ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)