### PR TITLE
fix(auth): impedir que una cuenta de docente/admin se inscriba como estudiante

### DIFF
--- a/backend/src/shared/course_access.py
+++ b/backend/src/shared/course_access.py
@@ -198,6 +198,49 @@ def _get_student_membership_id(actor: CurrentActor, university_id: str) -> str:
     )
 
 
+def _assert_not_staff_account(
+    db: Session,
+    *,
+    auth_user_id: str,
+    context: CourseAccessContext,
+    event: str,
+    course_access_token: str,
+) -> None:
+    """Reject a staff account from taking a student role via a course-access link.
+
+    GLOBAL scope: an account that holds an ACTIVE teacher or university_admin
+    membership at ANY university can never be granted a student membership. A staff
+    account is not a student account; without this guard a teacher who signs in
+    through the join flow gets a fresh ``role="student"`` membership minted on their
+    teacher account (the ``Membership`` unique key is per ``(user, university, role)``,
+    so dual roles are otherwise allowed). No-op for non-staff accounts.
+    """
+    staff_membership_id = db.scalar(
+        select(Membership.id).where(
+            Membership.user_id == auth_user_id,
+            Membership.role.in_(("teacher", "university_admin")),
+            Membership.status == "active",
+        )
+    )
+    if staff_membership_id is None:
+        return
+    audit_log(
+        event,
+        "denied",
+        auth_user_id=auth_user_id,
+        university_id=context.course.university_id,
+        course_id=context.course.id,
+        link_id=context.link.id,
+        token_hash_prefix=_course_access_hash_prefix(course_access_token),
+        http_status=status.HTTP_403_FORBIDDEN,
+        reason="staff_account_cannot_enroll_as_student",
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="staff_account_cannot_enroll_as_student",
+    )
+
+
 def _ensure_course_capacity_available(
     db: Session,
     *,
@@ -330,6 +373,13 @@ def enroll_with_course_access(
         )
 
     ensure_email_domain_allowed(db, context.course.university_id, actor.email)
+    _assert_not_staff_account(
+        db,
+        auth_user_id=actor.auth_user_id,
+        context=context,
+        event="course_access.enroll",
+        course_access_token=request.course_access_token,
+    )
     membership_id = _get_student_membership_id(actor, context.course.university_id)
     try:
         _ensure_course_capacity_available(
@@ -487,6 +537,19 @@ def activate_course_access_password(
         auth_user = created_user_result.user
         created_new_user = created_user_result.created
 
+    # Defense in depth: `find_user_by_email` returned None above (so the 409
+    # existing-account branch did not fire), but `get_or_create_user_by_email`
+    # reuses an existing Supabase user when the email already exists. Without this
+    # check a staff account whose lookup briefly mis-resolved could still have a
+    # student role minted onto it here. No-op for a genuinely new account.
+    _assert_not_staff_account(
+        db,
+        auth_user_id=auth_user.id,
+        context=context,
+        event="course_access.activate_password",
+        course_access_token=request.course_access_token,
+    )
+
     try:
         ensure_profile(
             db,
@@ -606,6 +669,13 @@ def _activate_course_access_authenticated(
         )
 
     ensure_email_domain_allowed(db, context.course.university_id, normalized_email)
+    _assert_not_staff_account(
+        db,
+        auth_user_id=identity.auth_user_id,
+        context=context,
+        event=event,
+        course_access_token=course_access_token,
+    )
     if _activation_state_exists_for_user(
         db,
         auth_user_id=identity.auth_user_id,

--- a/backend/tests/test_issue57_course_access.py
+++ b/backend/tests/test_issue57_course_access.py
@@ -1252,3 +1252,218 @@ def test_issue57_course_access_audit_never_logs_raw_token(
     assert response.status_code == 200
     flattened = " ".join(str(item) for item in captured)
     assert token not in flattened
+
+
+def _assert_no_student_membership(db, *, user_id: str) -> None:
+    student_membership = db.scalar(
+        select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.role == "student",
+        )
+    )
+    assert student_membership is None
+
+
+@pytest.mark.parametrize("staff_role", ["teacher", "university_admin"])
+def test_issue57_course_access_activate_complete_rejects_staff_account(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+    staff_role: str,
+) -> None:
+    # A staff account (teacher/admin) must not be able to take a student role via a
+    # course-access link. activate/complete is the real exploit hole: it mints a
+    # student membership for any verified identity.
+    university_id = str(uuid.uuid4())
+    course_owner = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="course.owner.staffblock@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    staff = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email=f"{staff_role}.staffblock@example.edu",
+        role=staff_role,
+        university_id=university_id,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=course_owner["membership"].id,
+        title="Curso Staff Block",
+        code=f"COURSE-ACCESS-STAFF-{staff_role[:4].upper()}",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/complete",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(
+            sub=staff["profile"].id,
+            email=f"{staff_role}.staffblock@example.edu",
+        ),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "staff_account_cannot_enroll_as_student"
+    _assert_no_student_membership(db, user_id=staff["profile"].id)
+
+
+def test_issue57_course_access_activate_complete_blocks_staff_globally(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    # GLOBAL scope: a teacher at university Y cannot enroll as a student in a course
+    # at university X either.
+    teacher_university_id = str(uuid.uuid4())
+    course_university_id = str(uuid.uuid4())
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.crossuniv@example.edu",
+        role="teacher",
+        university_id=teacher_university_id,
+    )
+    course_owner = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="owner.crossuniv@example.edu",
+        role="teacher",
+        university_id=course_university_id,
+    )
+    course = seed_course(
+        university_id=course_university_id,
+        teacher_membership_id=course_owner["membership"].id,
+        title="Curso Cross Univ",
+        code="COURSE-ACCESS-CROSSUNIV",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/complete",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(
+            sub=teacher["profile"].id,
+            email="teacher.crossuniv@example.edu",
+        ),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "staff_account_cannot_enroll_as_student"
+    _assert_no_student_membership(db, user_id=teacher["profile"].id)
+
+
+def test_issue57_course_access_activate_oauth_complete_rejects_staff_account(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    university_id = str(uuid.uuid4())
+    course_owner = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="owner.oauth.staffblock@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    teacher = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="teacher.oauth.staffblock@universidad.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    db.add(
+        UniversitySsoConfig(
+            university_id=university_id,
+            provider="azure",
+            azure_tenant_id="azure-tenant-staffblock",
+            client_id="client-id-staffblock",
+            enabled=True,
+        )
+    )
+    db.commit()
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=course_owner["membership"].id,
+        title="Curso OAuth Staff Block",
+        code="COURSE-ACCESS-OAUTH-STAFF",
+    )
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/activate/oauth/complete",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(
+            sub=teacher["profile"].id,
+            email="teacher.oauth.staffblock@universidad.edu",
+        ),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "staff_account_cannot_enroll_as_student"
+    _assert_no_student_membership(db, user_id=teacher["profile"].id)
+
+
+def test_issue57_course_access_enroll_rejects_dual_role_staff_account(
+    client,
+    db,
+    seed_identity,
+    seed_course,
+    seed_course_access_link,
+    auth_headers_factory,
+) -> None:
+    # Defense in depth for legacy dual-role data: an account that already holds BOTH
+    # a teacher and a student membership is still blocked from enrolling via the link.
+    university_id = str(uuid.uuid4())
+    owner = seed_identity(
+        user_id=str(uuid.uuid4()),
+        email="owner.dual@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    dual_user_id = str(uuid.uuid4())
+    seed_identity(
+        user_id=dual_user_id,
+        email="dual.role@example.edu",
+        role="teacher",
+        university_id=university_id,
+    )
+    dual_student = seed_identity(
+        user_id=dual_user_id,
+        email="dual.role@example.edu",
+        role="student",
+        university_id=university_id,
+        create_legacy_user=False,
+    )
+    course = seed_course(
+        university_id=university_id,
+        teacher_membership_id=owner["membership"].id,
+        title="Curso Dual Role",
+        code="COURSE-ACCESS-DUAL",
+    )
+    db.commit()
+    _, token = seed_course_access_link(course_id=course.id, status="active")
+
+    response = client.post(
+        "/api/course-access/enroll",
+        json=_resolve_payload(token),
+        headers=auth_headers_factory(sub=dual_user_id, email="dual.role@example.edu"),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "staff_account_cannot_enroll_as_student"
+    # The student membership existed before, but the link must not enroll it.
+    enrollment = db.scalar(
+        select(CourseMembership).where(
+            CourseMembership.course_id == course.id,
+            CourseMembership.membership_id == dual_student["membership"].id,
+        )
+    )
+    assert enrollment is None

--- a/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.test.tsx
@@ -362,6 +362,51 @@ describe("AuthCallbackPage", () => {
         );
     });
 
+    it("shows a staff-account rejection when a teacher tries to enroll as a student", async () => {
+        const teacherActor: AuthMeActor = {
+            auth_user_id: "teacher-staffblock",
+            profile: { id: "teacher-staffblock", full_name: "Docente" },
+            memberships: [
+                {
+                    id: "m-teacher",
+                    university_id: "uni1",
+                    role: "teacher",
+                    status: "active",
+                    must_rotate_password: false,
+                },
+            ],
+            must_rotate_password: false,
+            primary_role: "teacher",
+        };
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-access-staffblock",
+            auth_path: "password_sign_in",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(useAuth).mockReturnValue({ ...baseCtx, actor: teacherActor });
+        vi.mocked(api.auth.activateCourseAccessComplete).mockRejectedValue(
+            Object.assign(new Error("staff_account_cannot_enroll_as_student"), {
+                detail: "staff_account_cannot_enroll_as_student",
+                status: 403,
+            }),
+        );
+
+        render(
+            <MemoryRouter>
+                <AuthCallbackPage />
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(api.auth.activateCourseAccessComplete).toHaveBeenCalledWith("course-access-staffblock"),
+        );
+        await waitFor(() =>
+            expect(screen.getByText(/docente o administrador/i)).toBeTruthy(),
+        );
+    });
+
     it("redirects a teacher actor without activation context to /teacher/dashboard", async () => {
         vi.mocked(useAuth).mockReturnValue({
             ...baseCtx,

--- a/frontend/src/features/auth-callback/AuthCallbackPage.tsx
+++ b/frontend/src/features/auth-callback/AuthCallbackPage.tsx
@@ -25,6 +25,8 @@ function parseActivationError(err: ApiError): string {
         case "membership_required":
         case "student_membership_required":
             return "No tienes una membresía activa para este curso.";
+        case "staff_account_cannot_enroll_as_student":
+            return "Tu cuenta es de docente o administrador; no puede unirse a un curso como estudiante.";
         case "auth_method_not_allowed":
             return "Microsoft no está habilitado para este curso.";
         default:

--- a/frontend/src/features/student-auth/StudentJoinPage.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.tsx
@@ -68,6 +68,8 @@ function resolveSubmitError(err: ApiError, tokenKind: "invite" | "course_access"
             return "Tu correo institucional no está habilitado para esta universidad.";
         case "account_exists_sign_in_required":
             return "Ya existe una cuenta con este correo. Inicia sesión para completar la inscripción.";
+        case "staff_account_cannot_enroll_as_student":
+            return "Tu cuenta es de docente o administrador; no puede unirse a un curso como estudiante.";
         default:
             return tokenKind === "invite"
                 ? "No se pudo completar la activación. Intenta de nuevo."


### PR DESCRIPTION
## Bug

Una cuenta **staff** (docente / `university_admin`) podía quedar inscrita en un curso como **estudiante**.

**Causa raíz:** `_activate_course_access_authenticated` (`backend/src/shared/course_access.py`) minteaba una membresía `role="student"` para **cualquier** identidad verificada y solo chequeaba si ya existía una membresía de *estudiante* — nunca si la cuenta ya era docente/admin. Exploit: un docente sin sesión abre un link de curso → "Ya tengo cuenta" → inicia sesión con credenciales de docente → `/auth/callback` → se le crea una membresía de estudiante sobre su cuenta docente (cuenta dual).

## Fix (backend authz, alcance GLOBAL)

- Nuevo guard `_assert_not_staff_account` (en `course_access.py`): **403 `staff_account_cannot_enroll_as_student`** si la cuenta tiene una membresía `teacher`/`university_admin` activa en **cualquier** universidad. Una cuenta staff no es una cuenta de estudiante.
- Cableado en **3 sitios** que pueden otorgar rol de estudiante a un autenticado:
  - `_activate_course_access_authenticated` (el hueco real; antes del chequeo de estado de activación → bloquea incluso replays).
  - `enroll_with_course_access` (defensa para datos dual-role legacy).
  - `activate_course_access_password` (defensa para el edge donde `find_user_by_email` no resuelve pero `get_or_create_user_by_email` reutiliza un usuario existente).
- Precedencia (CLAUDE.md): es un check **role/context**, tras identidad/contexto. Audita `denied`.

## Frontend

- Mensaje en `parseActivationError` (AuthCallbackPage, superficie principal del 403) y `resolveSubmitError` (StudentJoinPage): *"Tu cuenta es de docente o administrador; no puede unirse a un curso como estudiante."*

## Tests

- Backend (`test_issue57_course_access.py`): rechazo en `activate/complete` (teacher **y** university_admin, parametrizado), `activate/oauth/complete`, **global** cross-universidad, y **enroll** con cuenta dual-role; cada uno afirma que NO se creó membresía de estudiante. Regresión: el estudiante real sigue inscribiéndose.
- Frontend (`AuthCallbackPage.test.tsx`): el 403 renderiza el mensaje en español.

## Alcance

- **NO** toca el flujo invite legacy (caso simétrico estudiante→docente queda como follow-up; los invites de docente son admin-gated).
- `activate_course_access_password` para cuentas nuevas: sin cambios de comportamiento (el guard es no-op para emails nuevos).

## Validación (en el worktree)

- `uv run --directory backend pytest -q` → **1516 passed, 22 skipped**; `mypy src` limpio.
- `npm --prefix frontend run lint` ✓ · changed-file tests ✓ · `build` ✓
- Revisión adversarial (read-only) cerró el único hueco extra que faltaba (la 3ra superficie `activate_password`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)