### PR TITLE
feat(teacher-auth): rediseño de la activación docente en panel de dos columnas

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -97,11 +97,14 @@ function App() {
         location.pathname.startsWith("/student/dashboard") ||
         location.pathname.startsWith("/student/cases") ||
         location.pathname === "/student";
+    // Pantalla de activación docente: experiencia de marca autocontenida (panel
+    // de dos columnas), sin la barra azul global — igual que el login (landing).
+    const isTeacherActivateRoute = location.pathname === "/teacher/activate";
 
     return (
         <ToastProvider>
         <div className="flex min-h-screen flex-col bg-bg-page font-sans type-body">
-            {!isLandingRoute && !isAdminDashboardRoute && !isTeacherShellRoute && !isStudentShellRoute && <SiteHeader />}
+            {!isLandingRoute && !isAdminDashboardRoute && !isTeacherShellRoute && !isStudentShellRoute && !isTeacherActivateRoute && <SiteHeader />}
 
             <main className="flex-1">
                 <Suspense fallback={<RouteFallback />}>

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.test.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act, createEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { TeacherActivatePage } from "./TeacherActivatePage";
 
@@ -348,5 +348,183 @@ describe("TeacherActivatePage", () => {
         expect(screen.queryByText(/Continuar con Microsoft/i)).toBeNull();
         expect(screen.queryByText(/Activar con Microsoft/i)).toBeNull();
         expect(screen.queryByText(/o usa contraseña/i)).toBeNull();
+    });
+
+    // 11. Toggle "Mostrar" cambia el input de contraseña a texto visible
+    it("toggles password visibility when 'Mostrar' is clicked", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            token_kind: "invite",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Activar cuenta/i));
+
+        const pwInput = document.getElementById("activate-password") as HTMLInputElement;
+        expect(pwInput.type).toBe("password");
+
+        const toggles = screen.getAllByRole("button", { name: /Mostrar/i });
+        expect(toggles[0].getAttribute("aria-pressed")).toBe("false");
+        await act(async () => {
+            fireEvent.click(toggles[0]);
+        });
+        expect(pwInput.type).toBe("text");
+
+        // Toggle back to hidden — label flips to "Ocultar" and type returns to password
+        const ocultar = screen.getAllByRole("button", { name: /Ocultar/i })[0];
+        expect(ocultar.getAttribute("aria-pressed")).toBe("true");
+        await act(async () => {
+            fireEvent.click(ocultar);
+        });
+        expect(pwInput.type).toBe("password");
+    });
+
+    // 12. Indicador "Las contraseñas coinciden" cuando ambas coinciden
+    it("shows the match indicator when both passwords are equal", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            token_kind: "invite",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Activar cuenta/i));
+
+        const allInputs = document.querySelectorAll("input[type=password]");
+        fireEvent.change(allInputs[0], { target: { value: "Password123!" } });
+        fireEvent.change(allInputs[1], { target: { value: "Password123!" } });
+
+        expect(screen.getByText(/Las contraseñas coinciden/i)).toBeTruthy();
+    });
+
+    // 13. Badge "Verificado" visible junto al correo enmascarado
+    it("renders the 'Verificado' badge next to the masked email", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            token_kind: "invite",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        await waitFor(() => screen.getByDisplayValue("d****@uni.edu"));
+        expect(screen.getByText("Verificado")).toBeTruthy();
+    });
+
+    // 14. Aviso de Bloq Mayús aparece al escribir con CapsLock y se limpia al salir del campo
+    it("shows the caps-lock notice while typing with CapsLock on, clears on blur", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            token_kind: "invite",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Activar cuenta/i));
+
+        const pwInput = document.getElementById("activate-password") as HTMLInputElement;
+        // The KeyboardEvent constructor ignores an unknown `getModifierState`
+        // init key, so build the event and patch the method directly — React's
+        // synthetic event delegates getModifierState to the native event.
+        const capsEvent = createEvent.keyDown(pwInput, { key: "a" });
+        Object.defineProperty(capsEvent, "getModifierState", { value: () => true });
+        await act(async () => {
+            fireEvent(pwInput, capsEvent);
+        });
+        expect(screen.getByText(/Bloq Mayús está activado/i)).toBeTruthy();
+
+        await act(async () => {
+            fireEvent.blur(pwInput);
+        });
+        expect(screen.queryByText(/Bloq Mayús está activado/i)).toBeNull();
+    });
+
+    // 15. El indicador "coinciden" NO aparece cuando las contraseñas difieren (control negativo)
+    it("does not show the match indicator when passwords differ", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            token_kind: "invite",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Activar cuenta/i));
+
+        const allInputs = document.querySelectorAll("input[type=password]");
+        fireEvent.change(allInputs[0], { target: { value: "Password123!" } });
+        fireEvent.change(allInputs[1], { target: { value: "Different456!" } });
+
+        expect(screen.queryByText(/Las contraseñas coinciden/i)).toBeNull();
+    });
+
+    // 16. El panel de marca muestra el curso de la invitación
+    it("renders the course title from the invite in the brand panel", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            token_kind: "invite",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Activar cuenta/i));
+        expect(screen.getByText(/Analítica de Datos/)).toBeTruthy();
+    });
+
+    // 17. Editar la contraseña limpia un error de submit previo (evita contradecir al indicador)
+    it("clears a prior submit error when the password is edited", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "teacher_activate",
+            token_kind: "invite",
+            invite_token: "tok-abc",
+            role: "teacher",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveInvite).mockResolvedValue(pendingResolveResponse);
+
+        renderPage();
+
+        await waitFor(() => screen.getByText(/Activar cuenta/i));
+
+        const allInputs = document.querySelectorAll("input[type=password]");
+        fireEvent.change(allInputs[0], { target: { value: "password123" } });
+        fireEvent.change(allInputs[1], { target: { value: "different456" } });
+
+        const form = document.querySelector("form")!;
+        await act(async () => {
+            fireEvent.submit(form);
+        });
+        expect(screen.getByText(/Las contraseñas no coinciden/i)).toBeTruthy();
+
+        // Al corregir la confirmación, el error previo se limpia y no coexiste
+        // con el indicador verde de coincidencia.
+        await act(async () => {
+            fireEvent.change(allInputs[1], { target: { value: "password123" } });
+        });
+        expect(screen.queryByText(/Las contraseñas no coinciden/i)).toBeNull();
+        expect(screen.getByText(/Las contraseñas coinciden/i)).toBeTruthy();
     });
 });

--- a/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
+++ b/frontend/src/features/teacher-auth/TeacherActivatePage.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import {
+    ArrowRight,
+    Check,
+    GraduationCap,
+    Lock,
+    Mail,
+    ShieldCheck,
+    TriangleAlert,
+} from "lucide-react";
 import { api, ApiError } from "@/shared/api";
 import { isMicrosoftLoginEnabled } from "@/shared/authConfig";
 import { getSupabaseClient } from "@/shared/supabaseClient";
@@ -9,6 +18,14 @@ import {
     clearActivationContext,
 } from "@/shared/activationContext";
 import type { InviteResolveResponse } from "@/shared/adam-types";
+
+// Instrument Serif ya está cargada en index.html (la usa la landing pública).
+// Reutilizamos el mismo patrón inline que AppLanding.tsx para los títulos.
+const SERIF = '"Instrument Serif", Georgia, serif';
+const BRAND_GRADIENT = "linear-gradient(158deg, #0B57B8 0%, #023C88 55%, #04275C 100%)";
+const BUTTON_GRADIENT = "linear-gradient(160deg, #0A57B5, #013C8F)";
+const INPUT_CLS =
+    "w-full rounded-[10px] border border-[#dee3ec] bg-white px-3.5 py-2.5 text-[0.92rem] text-[#16181d] placeholder:text-[#9aa3b2] outline-none transition focus:border-[#0a57b5] focus:ring-2 focus:ring-[#0a57b5]/15";
 
 function resolveErrorMessage(err: ApiError | null, status?: string): string {
     if (status === "expired") {
@@ -24,6 +41,152 @@ function resolveErrorMessage(err: ApiError | null, status?: string): string {
         return "No se pudo validar la invitación. Intenta de nuevo más tarde.";
     }
     return "No se pudo validar la invitación. Intenta de nuevo más tarde.";
+}
+
+/**
+ * Panel de marca (columna izquierda) — gradiente azul + branding docente.
+ * Réplica del lenguaje visual del login (AppLanding): gradientes radiales,
+ * grid sutil, anillos decorativos, icono GraduationCap y titular serif.
+ *
+ * `universityName` se renderiza como nodo de texto propio (un <span>) para
+ * conservar el contrato de test `getByText(university_name)` cuando hay
+ * invitación resuelta; en los estados de error/carga se omite la frase
+ * personalizada.
+ */
+function BrandPanel({
+    universityName,
+    courseTitle,
+}: {
+    universityName?: string;
+    courseTitle?: string | null;
+}) {
+    return (
+        <aside
+            className="relative flex flex-col overflow-hidden px-7 py-9 text-white sm:px-9 sm:py-11 lg:px-11 lg:py-12"
+            style={{ background: BRAND_GRADIENT }}
+        >
+            <div
+                aria-hidden
+                className="pointer-events-none absolute inset-0"
+                style={{
+                    background:
+                        "radial-gradient(ellipse 80% 60% at 20% 85%, rgba(1,85,200,0.45) 0%, transparent 60%), radial-gradient(ellipse 60% 50% at 95% 5%, rgba(11,87,184,0.55) 0%, transparent 55%)",
+                }}
+            />
+            <div
+                aria-hidden
+                className="pointer-events-none absolute inset-0"
+                style={{
+                    backgroundImage:
+                        "linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px)",
+                    backgroundSize: "46px 46px",
+                }}
+            />
+            <div
+                aria-hidden
+                className="pointer-events-none absolute -right-[18%] -top-[12%] aspect-square w-[70%] rounded-full border border-white/10"
+            />
+            <div
+                aria-hidden
+                className="pointer-events-none absolute -bottom-24 -left-16 h-72 w-72 rounded-full border border-white/10"
+            />
+
+            <div className="relative z-10 flex h-full min-h-[240px] flex-col">
+                <div className="flex items-center gap-3">
+                    <div className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-[13px] border border-white/25 bg-white/10 shadow-[0_4px_16px_rgba(0,0,0,0.22),inset_0_1px_0_rgba(255,255,255,0.2)] backdrop-blur-md">
+                        <GraduationCap aria-hidden className="h-6 w-6 text-white" strokeWidth={2} />
+                    </div>
+                    <span className="text-[0.68rem] font-bold uppercase tracking-[0.18em] text-[#d8b873]">
+                        Invitación docente
+                    </span>
+                </div>
+
+                <div className="mt-9 sm:mt-12">
+                    <h2
+                        className="text-[1.8rem] leading-[1.15] tracking-[-0.01em] text-white sm:text-[2.1rem]"
+                        style={{ fontFamily: SERIF }}
+                    >
+                        Te damos la bienvenida como docente
+                    </h2>
+                    <p className="mt-4 max-w-[42ch] text-[0.95rem] leading-[1.65] text-[#c6d4e8]">
+                        {universityName ? (
+                            <>
+                                <span className="font-semibold text-white">{universityName}</span>{" "}
+                                te ha invitado a impartir en su campus digital. Activa tu cuenta
+                                para gestionar tus cursos y estudiantes.
+                            </>
+                        ) : (
+                            <>
+                                Activa tu cuenta docente para gestionar tus cursos y dar
+                                seguimiento a tus estudiantes.
+                            </>
+                        )}
+                    </p>
+                    {courseTitle ? (
+                        <p className="mt-3 text-[0.78rem] font-medium uppercase tracking-[0.08em] text-white/55">
+                            Curso · {courseTitle}
+                        </p>
+                    ) : null}
+                </div>
+
+                <div className="mt-auto flex items-center gap-2.5 pt-10">
+                    <ShieldCheck aria-hidden className="h-4 w-4 shrink-0 text-[#d8b873]" strokeWidth={2} />
+                    <span className="text-[0.8rem] leading-snug text-[#e7d3a8]">
+                        Invitación verificada y vinculada a tu correo
+                    </span>
+                </div>
+            </div>
+        </aside>
+    );
+}
+
+/**
+ * Tarjeta de dos paneles centrada (réplica del mockup). El panel de marca va a
+ * la izquierda en desktop y arriba en móvil; el contenido del formulario/estado
+ * llega como `children`.
+ */
+function AuthShell({
+    universityName,
+    courseTitle,
+    children,
+}: {
+    universityName?: string;
+    courseTitle?: string | null;
+    children: React.ReactNode;
+}) {
+    return (
+        <div className="flex min-h-screen w-full items-center justify-center bg-[#eef3fb] px-4 py-8 sm:py-12">
+            <div
+                className="grid w-full max-w-[1040px] overflow-hidden rounded-[26px] bg-white shadow-[0_30px_80px_-40px_rgba(2,28,74,0.45)] ring-1 ring-[#e6ecf6] lg:grid-cols-[5fr_7fr]"
+                style={{ animation: "fadeInUp 0.5s ease both" }}
+            >
+                <BrandPanel universityName={universityName} courseTitle={courseTitle} />
+                <div className="px-6 py-8 sm:px-10 sm:py-10 lg:px-12 lg:py-12">{children}</div>
+            </div>
+        </div>
+    );
+}
+
+/** Panel de estado (enlace inválido / expirado / consumido / error). */
+function StatusPane({ message }: { message: string }) {
+    return (
+        <div className="flex h-full min-h-[220px] flex-col justify-center">
+            <h1
+                className="text-[1.6rem] leading-[1.2] tracking-[-0.01em] text-[#16181d] sm:text-[1.85rem]"
+                style={{ fontFamily: SERIF }}
+            >
+                Activación de cuenta docente
+            </h1>
+            <div className="mt-4 flex items-start gap-2.5 rounded-[12px] border border-[#f3d6cf] bg-[#fdf3f2] px-4 py-3.5">
+                <TriangleAlert
+                    aria-hidden
+                    className="mt-0.5 h-5 w-5 shrink-0 text-[#c2462e]"
+                    strokeWidth={2}
+                />
+                <p className="text-[0.9rem] leading-[1.55] text-[#8a4435]">{message}</p>
+            </div>
+        </div>
+    );
 }
 
 /**
@@ -56,6 +219,21 @@ export function TeacherActivatePage() {
     const [confirmPassword, setConfirmPassword] = useState("");
     const [submitting, setSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState<string | null>(null);
+
+    // UI-only state para las affordances del rediseño (no afecta la lógica).
+    const [showPassword, setShowPassword] = useState(false);
+    const [showConfirm, setShowConfirm] = useState(false);
+    const [capsLock, setCapsLock] = useState(false);
+    const [activePwField, setActivePwField] = useState<"pw" | "confirm" | null>(null);
+
+    const passwordsMatch = password.length > 0 && password === confirmPassword;
+
+    function handlePwKey(field: "pw" | "confirm", e: React.KeyboardEvent<HTMLInputElement>) {
+        if (typeof e.getModifierState === "function") {
+            setCapsLock(e.getModifierState("CapsLock"));
+            setActivePwField(field);
+        }
+    }
 
     // Parse hash and save to sessionStorage
     useEffect(() => {
@@ -174,34 +352,33 @@ export function TeacherActivatePage() {
     // State 1: No activation context
     if (!inviteToken && !resolving) {
         return (
-            <div className="flex flex-col items-center justify-center gap-6 px-4 py-24 text-center">
-                <h1 className="text-xl font-semibold">Activación de cuenta docente</h1>
-                <p className="text-sm text-danger max-w-sm">
-                    Este enlace de activación no es válido. Solicita un nuevo enlace al
-                    administrador de tu universidad.
-                </p>
-            </div>
+            <AuthShell>
+                <StatusPane message="Este enlace de activación no es válido. Solicita un nuevo enlace al administrador de tu universidad." />
+            </AuthShell>
         );
     }
 
     // State 2: Resolving invite
     if (resolving) {
         return (
-            <div className="flex flex-col items-center justify-center gap-4 px-4 py-24">
-                <span className="text-sm text-muted-foreground">
-                    Validando invitación…
-                </span>
-            </div>
+            <AuthShell>
+                <div className="flex h-full min-h-[220px] flex-col items-center justify-center gap-3 text-center">
+                    <span
+                        aria-hidden
+                        className="h-7 w-7 animate-spinner rounded-full border-2 border-[#dbe3f0] border-t-[#0a57b5]"
+                    />
+                    <span className="text-[0.92rem] text-[#667085]">Validando invitación…</span>
+                </div>
+            </AuthShell>
         );
     }
 
     // State 3: Invite invalid (expired/consumed/revoked/error)
     if (resolveError) {
         return (
-            <div className="flex flex-col items-center justify-center gap-6 px-4 py-24 text-center">
-                <h1 className="text-xl font-semibold">Activación de cuenta docente</h1>
-                <p className="text-sm text-danger max-w-sm">{resolveError}</p>
-            </div>
+            <AuthShell>
+                <StatusPane message={resolveError} />
+            </AuthShell>
         );
     }
 
@@ -209,108 +386,219 @@ export function TeacherActivatePage() {
     if (!resolvedInvite) return null;
 
     return (
-        <div className="flex flex-col items-center justify-center gap-6 px-4 py-16">
-            <div className="w-full max-w-sm space-y-6">
-                <div className="space-y-1 text-center">
-                    <h1 className="text-xl font-semibold">Activación de cuenta docente</h1>
-                    <p className="text-sm text-muted-foreground">
-                        {resolvedInvite.university_name}
+        <AuthShell
+            universityName={resolvedInvite.university_name}
+            courseTitle={resolvedInvite.course_title}
+        >
+            <h1
+                className="text-[1.7rem] leading-[1.2] tracking-[-0.01em] text-[#16181d] sm:text-[1.9rem]"
+                style={{ fontFamily: SERIF }}
+            >
+                Activación de cuenta docente
+            </h1>
+            <p className="mt-2 text-[0.92rem] leading-[1.6] text-[#667085]">
+                Define tu contraseña para completar el acceso. Tu correo ya está confirmado
+                por la invitación.
+            </p>
+
+            {/* Correo electrónico — deshabilitado, pre-rellenado desde el resolve */}
+            <div className="mt-7 space-y-1.5">
+                <label htmlFor="activate-email" className="block text-[0.82rem] font-semibold text-[#2b3340]">
+                    Correo electrónico
+                </label>
+                <div className="relative">
+                    <Mail
+                        aria-hidden
+                        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8a93a3]"
+                        strokeWidth={2}
+                    />
+                    <input
+                        id="activate-email"
+                        type="email"
+                        value={resolvedInvite.email_masked}
+                        disabled
+                        className="w-full rounded-[10px] border border-[#dee3ec] bg-[#f6f8fb] py-2.5 pl-10 pr-28 text-[0.92rem] text-[#4a5160]"
+                    />
+                    <span className="absolute right-2.5 top-1/2 inline-flex -translate-y-1/2 items-center gap-1 rounded-full bg-[#e4f1e8] px-2.5 py-1 text-[0.72rem] font-semibold text-[#2e7d55]">
+                        <Check aria-hidden className="h-3.5 w-3.5" strokeWidth={2.5} />
+                        Verificado
+                    </span>
+                </div>
+            </div>
+
+            {/* Opción A — Microsoft (oculto tras isMicrosoftLoginEnabled) */}
+            {isMicrosoftLoginEnabled() && (
+                <div className="mt-5 space-y-3">
+                    <p className="text-[0.82rem] font-semibold text-[#2b3340]">
+                        Activar con Microsoft (recomendado)
                     </p>
-                    {resolvedInvite.course_title && (
-                        <p className="text-sm text-muted-foreground">
-                            Curso: {resolvedInvite.course_title}
+                    <button
+                        type="button"
+                        onClick={() => void handleMicrosoftActivation()}
+                        className="inline-flex w-full items-center justify-center gap-2 rounded-[11px] border border-[#dee3ec] bg-white px-4 py-2.5 text-[0.9rem] font-semibold text-[#16181d] transition hover:bg-[#f6f8fb]"
+                    >
+                        Continuar con Microsoft
+                    </button>
+                    <div className="relative py-1">
+                        <div className="absolute inset-0 flex items-center">
+                            <span className="w-full border-t border-[#e5e8ef]" />
+                        </div>
+                        <div className="relative flex justify-center">
+                            <span className="bg-white px-3 text-[0.74rem] text-[#8a93a3]">
+                                o usa contraseña
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Opción B — Password */}
+            <form onSubmit={(e) => void handlePasswordSubmit(e)} className="mt-5 space-y-4">
+                <div className="space-y-1.5">
+                    <label htmlFor="activate-name" className="block text-[0.82rem] font-semibold text-[#2b3340]">
+                        Nombre completo{" "}
+                        <span className="font-normal text-[#9aa3b2]">(opcional)</span>
+                    </label>
+                    <input
+                        id="activate-name"
+                        type="text"
+                        value={fullName}
+                        onChange={(e) => setFullName(e.target.value)}
+                        placeholder="Cómo aparecerás ante tus estudiantes."
+                        className={INPUT_CLS}
+                    />
+                </div>
+
+                <div className="space-y-1.5">
+                    <div className="flex items-center justify-between gap-3">
+                        <label htmlFor="activate-password" className="block text-[0.82rem] font-semibold text-[#2b3340]">
+                            Contraseña <span className="text-[#c2462e]">*</span>
+                        </label>
+                        <button
+                            type="button"
+                            onClick={() => setShowPassword((v) => !v)}
+                            aria-pressed={showPassword}
+                            className="text-[0.78rem] font-semibold text-[#0a57b5] transition hover:underline"
+                        >
+                            {showPassword ? "Ocultar" : "Mostrar"}
+                        </button>
+                    </div>
+                    <input
+                        id="activate-password"
+                        type={showPassword ? "text" : "password"}
+                        value={password}
+                        onChange={(e) => {
+                            setPassword(e.target.value);
+                            // Limpia un error de submit previo (p.ej. "no coinciden")
+                            // para que no contradiga al indicador de coincidencia en vivo.
+                            if (submitError) setSubmitError(null);
+                        }}
+                        onKeyUp={(e) => handlePwKey("pw", e)}
+                        onKeyDown={(e) => handlePwKey("pw", e)}
+                        onFocus={() => setActivePwField("pw")}
+                        onBlur={() => {
+                            setActivePwField(null);
+                            setCapsLock(false);
+                        }}
+                        required
+                        placeholder="Mínimo 8 caracteres"
+                        className={INPUT_CLS}
+                    />
+                    {capsLock && activePwField === "pw" && (
+                        <p
+                            className="flex items-center gap-1.5 text-[0.78rem] text-[#b5740e]"
+                            aria-live="polite"
+                        >
+                            <TriangleAlert aria-hidden className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />
+                            Bloq Mayús está activado
                         </p>
                     )}
                 </div>
 
-                <div className="space-y-2">
-                    <label className="text-sm font-medium">Correo electrónico</label>
+                <div className="space-y-1.5">
+                    <div className="flex items-center justify-between gap-3">
+                        <label htmlFor="activate-confirm" className="block text-[0.82rem] font-semibold text-[#2b3340]">
+                            Confirmar contraseña <span className="text-[#c2462e]">*</span>
+                        </label>
+                        <button
+                            type="button"
+                            onClick={() => setShowConfirm((v) => !v)}
+                            aria-pressed={showConfirm}
+                            className="text-[0.78rem] font-semibold text-[#0a57b5] transition hover:underline"
+                        >
+                            {showConfirm ? "Ocultar" : "Mostrar"}
+                        </button>
+                    </div>
                     <input
-                        type="email"
-                        value={resolvedInvite.email_masked}
-                        disabled
-                        className="w-full rounded-md border border-input bg-muted px-3 py-2 text-sm text-muted-foreground"
+                        id="activate-confirm"
+                        type={showConfirm ? "text" : "password"}
+                        value={confirmPassword}
+                        onChange={(e) => {
+                            setConfirmPassword(e.target.value);
+                            if (submitError) setSubmitError(null);
+                        }}
+                        onKeyUp={(e) => handlePwKey("confirm", e)}
+                        onKeyDown={(e) => handlePwKey("confirm", e)}
+                        onFocus={() => setActivePwField("confirm")}
+                        onBlur={() => {
+                            setActivePwField(null);
+                            setCapsLock(false);
+                        }}
+                        required
+                        placeholder="Repite tu contraseña"
+                        className={INPUT_CLS}
                     />
+                    {capsLock && activePwField === "confirm" && (
+                        <p
+                            className="flex items-center gap-1.5 text-[0.78rem] text-[#b5740e]"
+                            aria-live="polite"
+                        >
+                            <TriangleAlert aria-hidden className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />
+                            Bloq Mayús está activado
+                        </p>
+                    )}
+                    {passwordsMatch && (
+                        <p
+                            className="flex items-center gap-1.5 text-[0.78rem] font-medium text-[#2e7d55]"
+                            aria-live="polite"
+                        >
+                            <Check aria-hidden className="h-3.5 w-3.5 shrink-0" strokeWidth={2.5} />
+                            Las contraseñas coinciden
+                        </p>
+                    )}
                 </div>
 
-                {/* Opción A — Microsoft (oculto tras isMicrosoftLoginEnabled) */}
-                {isMicrosoftLoginEnabled() && (
-                    <>
-                        <div className="space-y-2">
-                            <p className="text-sm font-medium">Activar con Microsoft (recomendado)</p>
-                            <button
-                                type="button"
-                                onClick={() => void handleMicrosoftActivation()}
-                                className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
-                            >
-                                Continuar con Microsoft
-                            </button>
-                        </div>
-
-                        <div className="relative">
-                            <div className="absolute inset-0 flex items-center">
-                                <span className="w-full border-t border-border" />
-                            </div>
-                            <div className="relative flex justify-center">
-                                <span className="bg-background px-2 text-xs text-muted-foreground">
-                                    o usa contraseña
-                                </span>
-                            </div>
-                        </div>
-                    </>
+                {submitError && (
+                    <p
+                        className="flex items-center gap-1.5 text-[0.82rem] text-[#c2462e]"
+                        aria-live="polite"
+                    >
+                        <TriangleAlert aria-hidden className="h-4 w-4 shrink-0" strokeWidth={2} />
+                        {submitError}
+                    </p>
                 )}
 
-                {/* Opción B — Password */}
-                <form onSubmit={(e) => void handlePasswordSubmit(e)} className="space-y-4">
-                    <div className="space-y-2">
-                        <label className="text-sm font-medium">
-                            Nombre completo{" "}
-                            <span className="text-muted-foreground">(opcional)</span>
-                        </label>
-                        <input
-                            type="text"
-                            value={fullName}
-                            onChange={(e) => setFullName(e.target.value)}
-                            placeholder="Nombre completo (opcional)"
-                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        />
-                    </div>
-
-                    <div className="space-y-2">
-                        <label className="text-sm font-medium">Contraseña</label>
-                        <input
-                            type="password"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                            required
-                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        />
-                    </div>
-
-                    <div className="space-y-2">
-                        <label className="text-sm font-medium">Confirmar contraseña</label>
-                        <input
-                            type="password"
-                            value={confirmPassword}
-                            onChange={(e) => setConfirmPassword(e.target.value)}
-                            required
-                            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                        />
-                    </div>
-
-                    {submitError && (
-                        <p className="text-sm text-danger">{submitError}</p>
+                <button
+                    type="submit"
+                    disabled={submitting}
+                    className="mt-1 inline-flex w-full items-center justify-center gap-2 rounded-[11px] px-4 py-3 text-[0.92rem] font-semibold text-white shadow-[0_12px_24px_-12px_rgba(1,60,143,0.7)] transition hover:brightness-[1.06] disabled:cursor-not-allowed disabled:opacity-60"
+                    style={{ background: BUTTON_GRADIENT }}
+                >
+                    {submitting ? (
+                        "Activando…"
+                    ) : (
+                        <>
+                            Activar cuenta
+                            <ArrowRight aria-hidden className="h-4 w-4" strokeWidth={2.5} />
+                        </>
                     )}
+                </button>
+            </form>
 
-                    <button
-                        type="submit"
-                        disabled={submitting}
-                        className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-                    >
-                        {submitting ? "Activando…" : "Activar cuenta"}
-                    </button>
-                </form>
-            </div>
-        </div>
+            <p className="mt-6 flex items-center justify-center gap-1.5 text-center text-[0.76rem] text-[#8a93a3]">
+                <Lock aria-hidden className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />
+                Tus datos están protegidos y solo se usan para tu acceso.
+            </p>
+        </AuthShell>
     );
 }


### PR DESCRIPTION
## Qué

Replica el mockup de la pantalla de **activación/invitación docente** (`/teacher/activate`) con el mismo lenguaje visual del login unificado (`AppLanding`): panel de marca azul con gradiente + formulario blanco, títulos en **Instrument Serif** (ya cargada), badge "✓ Verificado" en el correo, toggles de mostrar/ocultar contraseña, aviso de Bloq Mayús, indicador de coincidencia en vivo y microcopys de confianza.

Antes era un formulario plano centrado bajo la barra azul global. Ahora es una experiencia de marca autocontenida, coherente con el login.

## Cómo / alcance

- **Sin fuentes ni dependencias nuevas** (Instrument Serif + Inter + `lucide-react` ya están en el repo). Sin cambios al design system.
- `TeacherActivatePage.tsx`: reescritura **solo presentacional + affordances**. Toda la lógica de activación/seguridad se conserva intacta: resolución de token, hash-stripping (`replaceState`), email **deshabilitado**, ruta Microsoft tras `isMicrosoftLoginEnabled()`, submit (`activatePassword → signInWithPassword → navigate`), validaciones client-side y los 4 estados de render.
- `App.tsx`: 1 línea aditiva — `/teacher/activate` se excluye del `SiteHeader` global (igual que la landing).
- Limpia un error de submit previo al editar la contraseña para que no contradiga al indicador de coincidencia en vivo (defecto detectado en review).
- Corrige typo de copy: `apareceras` → `aparecerás`.

## Tests / verificación

- `TeacherActivatePage.test.tsx`: **10 tests existentes preservados + 7 nuevos** (toggle + control negativo, indicador de coincidencia + control negativo, badge, Bloq Mayús, curso, limpieza de error de submit). 17/17 verdes.
- `npm run lint` limpio · `tsc -b && vite build` OK.
- Verificación visual desktop (1440) + móvil (390): coincide con el mockup; la barra azul global ya no aparece en esta ruta.
- Review multi-agente (correctitud, seguridad, testing/mantenibilidad, red-team): **0 hallazgos bloqueantes**; los 2 P3 detectados (typo + contradicción de mensajes de contraseña) ya están corregidos en este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)