### PR TITLE
feat(student-auth): rediseno premium de la vista de invitacion al curso (/join)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,10 +5,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ADAM — EDU</title>
-  <!-- Inter Variable + Instrument Serif para la landing pública -->
+  <!-- Inter Variable + Instrument Serif (landing) + Plus Jakarta Sans / Source Serif 4 (invitación /join) -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:ital,opsz,wght@0,14..32,300..800;1,14..32,300..800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:ital,opsz,wght@0,14..32,300..800;1,14..32,300..800&family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,500;8..60,600&display=swap" rel="stylesheet" />
 </head>
 
 <body>

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -178,10 +178,21 @@ describe("App admin shell layout", () => {
         vi.mocked(useAuth).mockReturnValue(baseContext);
 
         renderWithProviders(<App />, {
-            initialEntries: ["/join"],
+            initialEntries: ["/auth/callback"],
         });
 
         expect(screen.getByTestId("site-header")).toBeTruthy();
+    });
+
+    it("does not render the global SiteHeader on /join (full-bleed course invitation)", async () => {
+        vi.mocked(useAuth).mockReturnValue(baseContext);
+
+        renderWithProviders(<App />, {
+            initialEntries: ["/join"],
+        });
+
+        expect(await screen.findByTestId("student-join-page")).toBeTruthy();
+        expect(screen.queryByTestId("site-header")).toBeNull();
     });
 
     it("does not render the global SiteHeader on the public landing route", async () => {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -100,11 +100,14 @@ function App() {
     // Pantalla de activación docente: experiencia de marca autocontenida (panel
     // de dos columnas), sin la barra azul global — igual que el login (landing).
     const isTeacherActivateRoute = location.pathname === "/teacher/activate";
+    // /join se renderiza a sangre completa (tarjeta de invitación con su propio fondo
+    // degradado), igual que la landing pública: sin la barra azul global.
+    const isJoinRoute = location.pathname === "/join";
 
     return (
         <ToastProvider>
         <div className="flex min-h-screen flex-col bg-bg-page font-sans type-body">
-            {!isLandingRoute && !isAdminDashboardRoute && !isTeacherShellRoute && !isStudentShellRoute && !isTeacherActivateRoute && <SiteHeader />}
+            {!isLandingRoute && !isAdminDashboardRoute && !isTeacherShellRoute && !isStudentShellRoute && !isTeacherActivateRoute && !isJoinRoute && <SiteHeader />}
 
             <main className="flex-1">
                 <Suspense fallback={<RouteFallback />}>

--- a/frontend/src/features/student-auth/StudentJoinPage.test.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.test.tsx
@@ -262,7 +262,7 @@ describe("StudentJoinPage", () => {
         fireEvent.change(screen.getByPlaceholderText(/tu.correo@universidad.edu/i), {
             target: { value: "student@universidad.edu" },
         });
-        fireEvent.change(screen.getByPlaceholderText(/Nombre completo/i), {
+        fireEvent.change(screen.getByPlaceholderText(/Nombre y apellidos/i), {
             target: { value: "Estudiante Test" },
         });
         const passwordInputs = document.querySelectorAll("input[type=password]");
@@ -325,7 +325,7 @@ describe("StudentJoinPage", () => {
         fireEvent.change(screen.getByPlaceholderText(/tu.correo@universidad.edu/i), {
             target: { value: "student@universidad.edu" },
         });
-        fireEvent.change(screen.getByPlaceholderText(/Nombre completo/i), {
+        fireEvent.change(screen.getByPlaceholderText(/Nombre y apellidos/i), {
             target: { value: "Estudiante Test" },
         });
         const passwordInputs = document.querySelectorAll("input[type=password]");
@@ -519,7 +519,7 @@ describe("StudentJoinPage", () => {
         fireEvent.change(screen.getByPlaceholderText(/tu.correo@universidad.edu/i), {
             target: { value: "ya@universidad.edu" },
         });
-        fireEvent.change(screen.getByPlaceholderText(/Nombre completo/i), {
+        fireEvent.change(screen.getByPlaceholderText(/Nombre y apellidos/i), {
             target: { value: "Estudiante Test" },
         });
         const passwordInputs = document.querySelectorAll("input[type=password]");
@@ -736,7 +736,7 @@ describe("StudentJoinPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Crear cuenta" }));
 
         // Activation form restored: full name + two password fields, both cleared.
-        expect(screen.getByPlaceholderText(/Nombre completo/i)).toBeTruthy();
+        expect(screen.getByPlaceholderText(/Nombre y apellidos/i)).toBeTruthy();
         const passwordInputs = document.querySelectorAll("input[type=password]");
         expect(passwordInputs.length).toBe(2);
         expect((passwordInputs[0] as HTMLInputElement).value).toBe("");
@@ -884,5 +884,99 @@ describe("StudentJoinPage", () => {
 
         await screen.findByPlaceholderText("tu.correo@universidad.edu");
         expect(api.auth.enrollWithCourseAccess).not.toHaveBeenCalled();
+    });
+
+    it("renders the course details in the invitation hero panel", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-tok-hero",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveCourseAccess).mockResolvedValue({
+            course_id: "course-1",
+            course_title: "Gerencia Estrategica",
+            university_name: "Universidad Demo",
+            teacher_display_name: "Julio Paz",
+            course_status: "active",
+            link_status: "active",
+            allowed_auth_methods: ["password"],
+        });
+
+        renderPage();
+
+        await waitFor(() => {
+            expect(screen.getByText(/Activar cuenta/i)).toBeTruthy();
+        });
+        expect(screen.getByText("Universidad Demo")).toBeTruthy();
+        expect(screen.getByText("Gerencia Estrategica")).toBeTruthy();
+        expect(screen.getByText("Julio Paz")).toBeTruthy();
+        expect(screen.getByText(/invitación al curso/i)).toBeTruthy();
+    });
+
+    it("keeps both password fields hidden by default and reveals one on toggle", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-tok-toggle-pw",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveCourseAccess).mockResolvedValue({
+            course_id: "course-1",
+            course_title: "Gerencia Estrategica",
+            university_name: "Universidad Demo",
+            teacher_display_name: "Julio Paz",
+            course_status: "active",
+            link_status: "active",
+            allowed_auth_methods: ["password"],
+        });
+
+        renderPage();
+
+        await waitFor(() => {
+            expect(screen.getByText(/Activar cuenta/i)).toBeTruthy();
+        });
+
+        // Default: both password fields hidden (type=password); toggles are buttons.
+        expect(document.querySelectorAll("input[type=password]").length).toBe(2);
+
+        const [firstToggle] = screen.getAllByRole("button", { name: /mostrar contraseña/i });
+        fireEvent.click(firstToggle);
+
+        // One field revealed (type=text) → only the confirm stays type=password.
+        expect(document.querySelectorAll("input[type=password]").length).toBe(1);
+        expect(screen.getAllByRole("button", { name: /ocultar contraseña/i }).length).toBe(1);
+    });
+
+    it("shows the password strength meter only after the user types", async () => {
+        vi.mocked(readActivationContext).mockReturnValue({
+            flow: "student_join_course_access",
+            token_kind: "course_access",
+            course_access_token: "course-tok-strength",
+            expires_at: Date.now() + 300000,
+        });
+        vi.mocked(api.auth.resolveCourseAccess).mockResolvedValue({
+            course_id: "course-1",
+            course_title: "Gerencia Estrategica",
+            university_name: "Universidad Demo",
+            teacher_display_name: "Julio Paz",
+            course_status: "active",
+            link_status: "active",
+            allowed_auth_methods: ["password"],
+        });
+
+        renderPage();
+
+        await waitFor(() => {
+            expect(screen.getByText(/Activar cuenta/i)).toBeTruthy();
+        });
+
+        expect(screen.queryByText(/^(Débil|Aceptable|Buena|Fuerte)$/)).toBeNull();
+
+        fireEvent.change(document.querySelectorAll("input[type=password]")[0], {
+            target: { value: "Str0ng!Pass99" },
+        });
+
+        expect(screen.getByText("Fuerte")).toBeTruthy();
     });
 });

--- a/frontend/src/features/student-auth/StudentJoinPage.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.tsx
@@ -17,6 +17,17 @@ import type {
 import { isMicrosoftLoginEnabled } from "@/shared/authConfig";
 import { getSupabaseClient } from "@/shared/supabaseClient";
 
+import { JoinHeroPanel } from "./components/JoinHeroPanel";
+import { PasswordField } from "./components/PasswordField";
+import { FIELD_INPUT_CLASS, FIELD_LABEL_CLASS, TOGGLE_LINK_CLASS } from "./components/fieldStyles";
+import {
+    AlertCircleIcon,
+    ArrowRightIcon,
+    CheckCircleIcon,
+    LockIcon,
+    SpinnerIcon,
+} from "./components/icons";
+
 function resolveInviteErrorMessage(err: ApiError | null, inviteStatus?: string): string {
     if (inviteStatus === "expired") {
         return "Tu invitación ha expirado. Solicita una nueva al docente.";
@@ -82,6 +93,30 @@ function isStudentJoinContext(
 ): ctx is Extract<ActivationContext, { flow: "student_join_invite" | "student_join_course_access" }> {
     return ctx?.flow === "student_join_invite" || ctx?.flow === "student_join_course_access";
 }
+
+const SUBMIT_BUTTON_CLASS =
+    "flex w-full items-center justify-center gap-[9px] rounded-[13px] border-none " +
+    "bg-[linear-gradient(160deg,#0A57B5,#013C8F)] p-[15px] text-[15px] font-bold text-white " +
+    "shadow-[0_12px_26px_-10px_rgba(1,68,160,0.5)] transition-transform " +
+    "hover:-translate-y-0.5 active:translate-y-0 disabled:translate-y-0 " +
+    "disabled:cursor-not-allowed disabled:opacity-60";
+
+function isValidEmail(value: string): boolean {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
+}
+
+/** Full-bleed cool-gradient backdrop shared by every /join render state. */
+function JoinShell({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="flex min-h-screen flex-col items-center justify-center bg-[radial-gradient(120%_110%_at_50%_-10%,#F5F8FC_0%,#E9EEF6_58%,#DCE4F0_100%)] p-[40px_24px] font-['Plus_Jakarta_Sans'] antialiased">
+            {children}
+        </div>
+    );
+}
+
+const MESSAGE_CARD_CLASS =
+    "w-full max-w-md rounded-[26px] border border-[rgba(12,32,72,0.07)] bg-white p-10 text-center " +
+    "shadow-[0_40px_90px_-38px_rgba(12,32,72,0.30),_0_2px_10px_rgba(0,0,0,0.04)]";
 
 export function StudentJoinPage() {
     const navigate = useNavigate();
@@ -406,41 +441,51 @@ export function StudentJoinPage() {
 
     if (!joinContext && !resolving) {
         return (
-            <div className="flex flex-col items-center justify-center gap-6 px-4 py-24 text-center">
-                <h1 className="text-xl font-semibold">Unirse a un curso</h1>
-                <p className="text-sm text-danger max-w-sm">
-                    Este enlace de acceso no es válido. Solicita un nuevo enlace.
-                </p>
-            </div>
+            <JoinShell>
+                <div className={MESSAGE_CARD_CLASS}>
+                    <h1 className="font-['Source_Serif_4'] text-[22px] font-semibold text-[#16181D]">
+                        Unirse a un curso
+                    </h1>
+                    <p className="mt-3 text-[14px] leading-[1.5] text-[#C2462E]">
+                        Este enlace de acceso no es válido. Solicita un nuevo enlace.
+                    </p>
+                </div>
+            </JoinShell>
         );
     }
 
     if (resolving) {
         return (
-            <div className="flex flex-col items-center justify-center gap-4 px-4 py-24">
-                <span className="text-sm text-muted-foreground">
+            <JoinShell>
+                <div className="flex items-center gap-3 text-[14px] text-[#667085]">
+                    <SpinnerIcon className="text-[#0144a0]" />
                     Verificando acceso...
-                </span>
-            </div>
+                </div>
+            </JoinShell>
         );
     }
 
     if (autoEnrolling) {
         return (
-            <div className="flex flex-col items-center justify-center gap-4 px-4 py-24">
-                <span className="text-sm text-muted-foreground">
+            <JoinShell>
+                <div className="flex items-center gap-3 text-[14px] text-[#667085]">
+                    <SpinnerIcon className="text-[#0144a0]" />
                     Inscribiéndote en el curso...
-                </span>
-            </div>
+                </div>
+            </JoinShell>
         );
     }
 
     if (resolveError) {
         return (
-            <div className="flex flex-col items-center justify-center gap-6 px-4 py-24 text-center">
-                <h1 className="text-xl font-semibold">Unirse a un curso</h1>
-                <p className="text-sm text-danger max-w-sm">{resolveError}</p>
-            </div>
+            <JoinShell>
+                <div className={MESSAGE_CARD_CLASS}>
+                    <h1 className="font-['Source_Serif_4'] text-[22px] font-semibold text-[#16181D]">
+                        Unirse a un curso
+                    </h1>
+                    <p className="mt-3 text-[14px] leading-[1.5] text-[#C2462E]">{resolveError}</p>
+                </div>
+            </JoinShell>
         );
     }
 
@@ -454,198 +499,256 @@ export function StudentJoinPage() {
     if (isInviteFlow && !resolvedInvite) return null;
     if (!isInviteFlow && !resolvedCourseAccess) return null;
 
+    const isSignIn = authMode === "signin" && !isInviteFlow && !session;
+
     return (
-        <div className="flex flex-col items-center justify-center gap-6 px-4 py-16">
-            <div className="w-full max-w-sm space-y-6">
-                <div className="space-y-1 text-center">
-                    <h1 className="text-xl font-semibold">Unirse a un curso</h1>
-                    <p className="text-sm text-muted-foreground">{universityName}</p>
-                    {courseTitle && (
-                        <p className="text-sm text-muted-foreground">Curso: {courseTitle}</p>
-                    )}
-                    {teacherName && (
-                        <p className="text-sm text-muted-foreground">Docente: {teacherName}</p>
-                    )}
-                </div>
+        <JoinShell>
+            <div className="flex w-full max-w-[1040px] flex-col overflow-hidden rounded-[26px] border border-[rgba(12,32,72,0.07)] bg-white shadow-[0_40px_90px_-38px_rgba(12,32,72,0.30),_0_2px_10px_rgba(0,0,0,0.04)] md:flex-row">
+                <JoinHeroPanel
+                    universityName={universityName}
+                    courseTitle={courseTitle}
+                    teacherName={teacherName}
+                />
 
-                {authMode === "signin" && !isInviteFlow && !session ? (
-                    <>
-                        <p className="text-center text-sm text-muted-foreground">
-                            {signInNotice ?? "Inicia sesión para unirte a este curso."}
-                        </p>
+                <div className="flex w-full flex-col p-[36px_28px_32px] md:w-auto md:min-w-[340px] md:flex-[1.18_1_420px] md:p-[48px_48px_40px]">
+                    {isSignIn ? (
+                        <>
+                            <h1 className="mb-2 font-['Source_Serif_4'] text-[27px] font-semibold tracking-[-0.4px] text-[#16181D]">
+                                Inicia sesión
+                            </h1>
+                            <p className="mb-7 text-[14.5px] leading-[1.5] text-[#667085]">
+                                {signInNotice ?? "Inicia sesión para unirte a este curso."}
+                            </p>
 
-                        <div className="space-y-2">
-                            <label className="text-sm font-medium">Correo electrónico</label>
-                            <input
-                                type="email"
-                                value={email}
-                                onChange={(event) => setEmail(event.target.value)}
-                                placeholder="tu.correo@universidad.edu"
-                                required
-                                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                            />
-                        </div>
-
-                        <form onSubmit={(event) => void handleSignInSubmit(event)} className="space-y-4">
-                            <div className="space-y-2">
-                                <label className="text-sm font-medium">Contraseña</label>
-                                <input
-                                    type="password"
-                                    value={password}
-                                    onChange={(event) => setPassword(event.target.value)}
-                                    required
-                                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                                />
-                            </div>
-
-                            {signInError && (
-                                <p className="text-sm text-danger">{signInError}</p>
-                            )}
-
-                            <button
-                                type="submit"
-                                disabled={signInSubmitting}
-                                className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-                            >
-                                {signInSubmitting ? "Iniciando sesión..." : "Iniciar sesión"}
-                            </button>
-                        </form>
-
-                        <p className="text-center text-sm text-muted-foreground">
-                            ¿Eres nuevo?{" "}
-                            <button
-                                type="button"
-                                onClick={goToActivate}
-                                className="font-medium underline hover:opacity-80"
-                            >
-                                Crear cuenta
-                            </button>
-                        </p>
-                    </>
-                ) : (
-                    <>
-                        <div className="space-y-2">
-                            <label className="text-sm font-medium">Correo electrónico</label>
-                            {isInviteFlow ? (
-                                <input
-                                    type="email"
-                                    value={resolvedInvite?.email_masked ?? ""}
-                                    disabled
-                                    className="w-full rounded-md border border-input bg-muted px-3 py-2 text-sm text-muted-foreground"
-                                />
-                            ) : (
-                                <input
-                                    type="email"
-                                    value={email}
-                                    onChange={(event) => setEmail(event.target.value)}
-                                    placeholder="tu.correo@universidad.edu"
-                                    required
-                                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                                />
-                            )}
-                        </div>
-
-                        {allowMicrosoft && (
-                            <div className="space-y-2">
-                                <p className="text-sm font-medium">Continuar con Microsoft</p>
-                                <button
-                                    type="button"
-                                    onClick={() => void handleMicrosoftJoin()}
-                                    className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
-                                >
-                                    Continuar con Microsoft
-                                </button>
-                            </div>
-                        )}
-
-                        {allowMicrosoft && (
-                            <div className="relative">
-                                <div className="absolute inset-0 flex items-center">
-                                    <span className="w-full border-t border-border" />
-                                </div>
-                                <div className="relative flex justify-center">
-                                    <span className="bg-background px-2 text-xs text-muted-foreground">
-                                        o crea una contraseña
-                                    </span>
-                                </div>
-                            </div>
-                        )}
-
-                        <form onSubmit={(event) => void handlePasswordSubmit(event)} className="space-y-4">
-                            <div className="space-y-2">
-                                <label className="text-sm font-medium">
-                                    Nombre completo <span className="text-danger">*</span>
+                            <div className="mb-[18px]">
+                                <label htmlFor="join-signin-email" className={`${FIELD_LABEL_CLASS} mb-2`}>
+                                    Correo electrónico <span className="text-[#0144a0]">*</span>
                                 </label>
-                                <input
-                                    type="text"
-                                    value={fullName}
-                                    onChange={(event) => setFullName(event.target.value)}
-                                    placeholder="Nombre completo"
-                                    required
-                                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="text-sm font-medium">Contraseña</label>
-                                <input
-                                    type="password"
-                                    value={password}
-                                    onChange={(event) => setPassword(event.target.value)}
-                                    required
-                                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="text-sm font-medium">Confirmar contraseña</label>
-                                <input
-                                    type="password"
-                                    value={confirmPassword}
-                                    onChange={(event) => setConfirmPassword(event.target.value)}
-                                    required
-                                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                                />
-                            </div>
-
-                            {submitError && (
-                                <div className="space-y-2">
-                                    <p className="text-sm text-danger">{submitError}</p>
-                                    {submitError.includes("Inicia sesión") && (
-                                        <Link
-                                            to="/"
-                                            className="inline-flex text-sm font-medium underline hover:opacity-80"
-                                        >
-                                            Iniciar sesión para continuar
-                                        </Link>
+                                <div className="relative">
+                                    <input
+                                        id="join-signin-email"
+                                        type="email"
+                                        autoComplete="email"
+                                        value={email}
+                                        onChange={(event) => setEmail(event.target.value)}
+                                        placeholder="tu.correo@universidad.edu"
+                                        required
+                                        className={`${FIELD_INPUT_CLASS} pr-[42px]`}
+                                    />
+                                    {isValidEmail(email) && (
+                                        <span className="absolute right-[14px] top-1/2 -translate-y-1/2">
+                                            <CheckCircleIcon />
+                                        </span>
                                     )}
                                 </div>
-                            )}
+                            </div>
 
-                            <button
-                                type="submit"
-                                disabled={submitting}
-                                className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
-                            >
-                                {submitting ? "Activando..." : "Activar cuenta"}
-                            </button>
-                        </form>
+                            <form onSubmit={(event) => void handleSignInSubmit(event)}>
+                                <div className="mb-[18px]">
+                                    <PasswordField
+                                        id="join-signin-password"
+                                        name="password"
+                                        label="Contraseña"
+                                        value={password}
+                                        onChange={(event) => setPassword(event.target.value)}
+                                        autoComplete="current-password"
+                                    />
+                                </div>
 
-                        {!isInviteFlow && !session && (
-                            <p className="text-center text-sm text-muted-foreground">
-                                ¿Ya tienes una cuenta?{" "}
+                                {signInError && (
+                                    <p
+                                        role="alert"
+                                        className="mb-[18px] flex items-center gap-[5px] text-[12.5px] text-[#C2462E]"
+                                    >
+                                        <AlertCircleIcon />
+                                        {signInError}
+                                    </p>
+                                )}
+
+                                <button type="submit" disabled={signInSubmitting} className={SUBMIT_BUTTON_CLASS}>
+                                    {signInSubmitting ? (
+                                        <>
+                                            <SpinnerIcon className="text-white" />
+                                            Iniciando sesión…
+                                        </>
+                                    ) : (
+                                        <>
+                                            Iniciar sesión
+                                            <ArrowRightIcon />
+                                        </>
+                                    )}
+                                </button>
+                            </form>
+
+                            <div className="mt-[22px] border-t border-[#EAEDF2] pt-[22px] text-center text-[13.5px] text-[#667085]">
+                                ¿Eres nuevo?{" "}
                                 <button
                                     type="button"
-                                    onClick={() => goToSignIn(null)}
-                                    className="font-medium underline hover:opacity-80"
+                                    onClick={goToActivate}
+                                    className={TOGGLE_LINK_CLASS}
                                 >
-                                    Inicia sesión
+                                    Crear cuenta
                                 </button>
+                            </div>
+                        </>
+                    ) : (
+                        <>
+                            <h1 className="mb-2 font-['Source_Serif_4'] text-[27px] font-semibold tracking-[-0.4px] text-[#16181D]">
+                                Activa tu cuenta
+                            </h1>
+                            <p className="mb-7 text-[14.5px] leading-[1.5] text-[#667085]">
+                                Completa tus datos para unirte al curso. Solo te tomará un momento.
                             </p>
-                        )}
-                    </>
-                )}
+
+                            <div className="mb-[18px]">
+                                <label htmlFor="join-email" className={`${FIELD_LABEL_CLASS} mb-2`}>
+                                    Correo electrónico <span className="text-[#0144a0]">*</span>
+                                </label>
+                                <div className="relative">
+                                    {isInviteFlow ? (
+                                        <input
+                                            id="join-email"
+                                            type="email"
+                                            value={resolvedInvite?.email_masked ?? ""}
+                                            disabled
+                                            className={`${FIELD_INPUT_CLASS} disabled:cursor-not-allowed disabled:text-[#667085]`}
+                                        />
+                                    ) : (
+                                        <>
+                                            <input
+                                                id="join-email"
+                                                type="email"
+                                                autoComplete="email"
+                                                value={email}
+                                                onChange={(event) => setEmail(event.target.value)}
+                                                placeholder="tu.correo@universidad.edu"
+                                                required
+                                                className={`${FIELD_INPUT_CLASS} pr-[42px]`}
+                                            />
+                                            {isValidEmail(email) && (
+                                                <span className="absolute right-[14px] top-1/2 -translate-y-1/2">
+                                                    <CheckCircleIcon />
+                                                </span>
+                                            )}
+                                        </>
+                                    )}
+                                </div>
+                            </div>
+
+                            {allowMicrosoft && (
+                                <>
+                                    <button
+                                        type="button"
+                                        onClick={() => void handleMicrosoftJoin()}
+                                        className="mb-[18px] w-full rounded-[13px] border-[1.5px] border-[#DEE3EC] bg-white p-[13px] text-[14px] font-semibold text-[#2B3340] transition-colors hover:bg-[#F6F8FB]"
+                                    >
+                                        Continuar con Microsoft
+                                    </button>
+                                    <div className="mb-[18px] flex items-center gap-3">
+                                        <span className="h-px flex-1 bg-[#EAEDF2]" />
+                                        <span className="text-[12px] text-[#98A1B0]">o crea una contraseña</span>
+                                        <span className="h-px flex-1 bg-[#EAEDF2]" />
+                                    </div>
+                                </>
+                            )}
+
+                            <form onSubmit={(event) => void handlePasswordSubmit(event)}>
+                                <div className="mb-[18px]">
+                                    <label htmlFor="join-name" className={`${FIELD_LABEL_CLASS} mb-2`}>
+                                        Nombre completo <span className="text-[#0144a0]">*</span>
+                                    </label>
+                                    <input
+                                        id="join-name"
+                                        name="name"
+                                        type="text"
+                                        autoComplete="name"
+                                        value={fullName}
+                                        onChange={(event) => setFullName(event.target.value)}
+                                        placeholder="Nombre y apellidos"
+                                        required
+                                        className={FIELD_INPUT_CLASS}
+                                    />
+                                </div>
+
+                                <div className="mb-[18px]">
+                                    <PasswordField
+                                        id="join-password"
+                                        name="password"
+                                        label="Contraseña"
+                                        value={password}
+                                        onChange={(event) => setPassword(event.target.value)}
+                                        autoComplete="new-password"
+                                        showMeter
+                                    />
+                                </div>
+
+                                <div className="mb-[26px]">
+                                    <PasswordField
+                                        id="join-confirm"
+                                        name="confirm_password"
+                                        label="Confirmar contraseña"
+                                        value={confirmPassword}
+                                        onChange={(event) => setConfirmPassword(event.target.value)}
+                                        autoComplete="new-password"
+                                    />
+                                </div>
+
+                                {submitError && (
+                                    <div className="mb-[18px] space-y-2">
+                                        <p
+                                            role="alert"
+                                            className="flex items-center gap-[5px] text-[12.5px] text-[#C2462E]"
+                                        >
+                                            <AlertCircleIcon />
+                                            {submitError}
+                                        </p>
+                                        {submitError.includes("Inicia sesión") && (
+                                            <Link
+                                                to="/"
+                                                className="inline-flex text-[13px] font-semibold text-[#0144a0] hover:opacity-80"
+                                            >
+                                                Iniciar sesión para continuar
+                                            </Link>
+                                        )}
+                                    </div>
+                                )}
+
+                                <button type="submit" disabled={submitting} className={SUBMIT_BUTTON_CLASS}>
+                                    {submitting ? (
+                                        <>
+                                            <SpinnerIcon className="text-white" />
+                                            Activando tu cuenta…
+                                        </>
+                                    ) : (
+                                        <>
+                                            Activar cuenta
+                                            <ArrowRightIcon />
+                                        </>
+                                    )}
+                                </button>
+
+                                <div className="mt-4 flex items-center justify-center gap-1.5 text-[12px] text-[#98A1B0]">
+                                    <LockIcon />
+                                    Tus datos están protegidos y solo se usan para tu acceso.
+                                </div>
+                            </form>
+
+                            {!isInviteFlow && !session && (
+                                <div className="mt-[22px] border-t border-[#EAEDF2] pt-[22px] text-center text-[13.5px] text-[#667085]">
+                                    ¿Ya tienes una cuenta?{" "}
+                                    <button
+                                        type="button"
+                                        onClick={() => goToSignIn(null)}
+                                        className={TOGGLE_LINK_CLASS}
+                                    >
+                                        Inicia sesión
+                                    </button>
+                                </div>
+                            )}
+                        </>
+                    )}
+                </div>
             </div>
-        </div>
+        </JoinShell>
     );
 }

--- a/frontend/src/features/student-auth/components/JoinHeroPanel.tsx
+++ b/frontend/src/features/student-auth/components/JoinHeroPanel.tsx
@@ -1,0 +1,66 @@
+import { GradCapIcon, LockIcon } from "./icons";
+
+interface JoinHeroPanelProps {
+    universityName?: string | null;
+    courseTitle?: string | null;
+    teacherName?: string | null;
+}
+
+/**
+ * Left navy/gold "invitation" hero of the /join split card. Shared by the
+ * activation and in-place sign-in views. Degrades gracefully when the course
+ * title or teacher are unknown (e.g. an invite with a null course_title).
+ */
+export function JoinHeroPanel({ universityName, courseTitle, teacherName }: JoinHeroPanelProps) {
+    const teacherInitial = teacherName?.trim().charAt(0).toUpperCase() ?? "";
+
+    return (
+        <div className="relative flex w-full flex-col overflow-hidden p-[36px_28px] text-[#EDE7D6] bg-[linear-gradient(158deg,#0B57B8_0%,#023C88_55%,#04275C_100%)] md:w-auto md:min-w-[320px] md:flex-[1_1_380px] md:p-[48px_46px]">
+            {/* Decorative gold rings + glow */}
+            <div aria-hidden className="pointer-events-none absolute -right-[90px] -top-[90px] h-[280px] w-[280px] rounded-full border border-[rgba(216,184,115,0.22)]" />
+            <div aria-hidden className="pointer-events-none absolute -right-[50px] -top-[50px] h-[180px] w-[180px] rounded-full border border-[rgba(216,184,115,0.14)]" />
+            <div aria-hidden className="pointer-events-none absolute -bottom-[120px] -left-[80px] h-[300px] w-[300px] rounded-full bg-[radial-gradient(circle,rgba(216,184,115,0.08)_0%,rgba(216,184,115,0)_70%)]" />
+
+            <div className="relative flex flex-1 flex-col md:min-h-[440px]">
+                <div className="flex items-center gap-3">
+                    <div className="flex h-[42px] w-[42px] items-center justify-center rounded-[12px] border border-[rgba(216,184,115,0.3)] bg-[rgba(216,184,115,0.14)]">
+                        <GradCapIcon />
+                    </div>
+                    {universityName && (
+                        <div className="text-[14px] font-semibold tracking-[0.2px] text-[#F1ECDD]">
+                            {universityName}
+                        </div>
+                    )}
+                </div>
+
+                <div className="my-auto">
+                    <div className="mb-[14px] text-[11px] font-bold uppercase tracking-[2.4px] text-[#D8B873]">
+                        Invitación al curso
+                    </div>
+                    <h2 className="mb-[26px] font-['Source_Serif_4'] text-[30px] font-medium leading-[1.18] tracking-[-0.4px] text-[#FBF8F0]">
+                        {courseTitle ?? "Te damos la bienvenida a tu curso"}
+                    </h2>
+
+                    {teacherName && (
+                        <div className="flex items-center gap-[13px] rounded-[14px] border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] p-[14px_16px]">
+                            <div className="flex h-[42px] w-[42px] flex-none items-center justify-center rounded-full bg-[linear-gradient(145deg,#D8B873,#B68F46)] font-['Source_Serif_4'] text-[18px] font-semibold text-[#04275C]">
+                                {teacherInitial}
+                            </div>
+                            <div>
+                                <div className="mb-0.5 text-[11.5px] tracking-[0.3px] text-[#A9C2B5]">
+                                    Impartido por
+                                </div>
+                                <div className="text-[15px] font-semibold text-[#F1ECDD]">{teacherName}</div>
+                            </div>
+                        </div>
+                    )}
+                </div>
+
+                <div className="flex items-center gap-2 text-[12.5px] text-[rgba(237,231,214,0.72)]">
+                    <LockIcon className="text-[rgba(216,184,115,0.9)]" />
+                    Acceso inmediato y seguro a tu invitación
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/student-auth/components/PasswordField.tsx
+++ b/frontend/src/features/student-auth/components/PasswordField.tsx
@@ -1,0 +1,89 @@
+import { useId, useState } from "react";
+
+import { FIELD_INPUT_CLASS, FIELD_LABEL_CLASS } from "./fieldStyles";
+import { AlertCircleIcon } from "./icons";
+import { PasswordStrengthMeter } from "./PasswordStrengthMeter";
+
+interface PasswordFieldProps {
+    id: string;
+    name: string;
+    label: string;
+    value: string;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+    autoComplete: "new-password" | "current-password";
+    /** Show the strength meter (only meaningful while creating a password). */
+    showMeter?: boolean;
+    error?: string | null;
+    required?: boolean;
+}
+
+/**
+ * Password input with an inline show/hide toggle and an optional strength meter.
+ *
+ * Contract relied on by StudentJoinPage.test.tsx: the toggle is a `type="button"`
+ * (never counted by `querySelectorAll('input[type=password]')`) and the input
+ * defaults to `type="password"` (hidden), so the activate/sign-in password counts
+ * stay 2 / 1.
+ */
+export function PasswordField({
+    id,
+    name,
+    label,
+    value,
+    onChange,
+    onBlur,
+    placeholder,
+    autoComplete,
+    showMeter = false,
+    error,
+    required,
+}: PasswordFieldProps) {
+    const [show, setShow] = useState(false);
+    const errorId = useId();
+
+    return (
+        <div>
+            <div className="mb-2 flex items-center justify-between">
+                <label htmlFor={id} className={FIELD_LABEL_CLASS}>
+                    {label} <span className="text-[#0144a0]">*</span>
+                </label>
+                <button
+                    type="button"
+                    onClick={() => setShow((prev) => !prev)}
+                    aria-pressed={show}
+                    aria-label={show ? "Ocultar contraseña" : "Mostrar contraseña"}
+                    className="cursor-pointer rounded-[4px] border-none bg-transparent p-0 text-[12.5px] font-semibold text-[#0144a0] hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0144a0]"
+                >
+                    {show ? "Ocultar" : "Mostrar"}
+                </button>
+            </div>
+            <input
+                id={id}
+                name={name}
+                type={show ? "text" : "password"}
+                value={value}
+                onChange={onChange}
+                onBlur={onBlur}
+                placeholder={placeholder}
+                autoComplete={autoComplete}
+                required={required}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? errorId : undefined}
+                className={FIELD_INPUT_CLASS}
+            />
+            {showMeter && <PasswordStrengthMeter password={value} />}
+            {error && (
+                <p
+                    id={errorId}
+                    role="alert"
+                    className="mt-[7px] flex items-center gap-[5px] text-[12.5px] text-[#C2462E]"
+                >
+                    <AlertCircleIcon />
+                    {error}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/features/student-auth/components/PasswordStrengthMeter.tsx
+++ b/frontend/src/features/student-auth/components/PasswordStrengthMeter.tsx
@@ -1,0 +1,66 @@
+interface PasswordStrength {
+    /** 0 = empty (no meter), 1..4 once the user has typed something. */
+    score: 0 | 1 | 2 | 3 | 4;
+    label: string;
+    color: string;
+}
+
+/**
+ * Pure, deterministic password-strength heuristic used only for visual feedback on
+ * the /join form. It never gates submission — the real minimum (8 chars) is enforced
+ * by `handlePasswordSubmit` / the backend. Empty input yields score 0 (meter hidden).
+ */
+function computePasswordStrength(password: string): PasswordStrength {
+    if (!password) {
+        return { score: 0, label: "", color: "" };
+    }
+
+    let raw = 0;
+    if (password.length >= 8) raw += 1;
+    if (password.length >= 12) raw += 1;
+    if (/[a-z]/.test(password) && /[A-Z]/.test(password)) raw += 1;
+    if (/\d/.test(password)) raw += 1;
+    if (/[^A-Za-z0-9]/.test(password)) raw += 1;
+
+    const score = Math.min(4, Math.max(1, raw)) as 1 | 2 | 3 | 4;
+    const META: Record<1 | 2 | 3 | 4, { label: string; color: string }> = {
+        1: { label: "Débil", color: "#C2462E" },
+        2: { label: "Aceptable", color: "#D9774B" },
+        3: { label: "Buena", color: "#C99A3B" },
+        4: { label: "Fuerte", color: "#1C7A55" },
+    };
+    return { score, ...META[score] };
+}
+
+export function PasswordStrengthMeter({ password }: { password: string }) {
+    const { score, label, color } = computePasswordStrength(password);
+    if (score === 0) return null;
+
+    return (
+        <div
+            className="mt-2.5 flex items-center gap-2.5"
+            role="meter"
+            aria-valuenow={score}
+            aria-valuemin={0}
+            aria-valuemax={4}
+            aria-label="Seguridad de la contraseña"
+        >
+            <div className="flex flex-1 gap-1.5" aria-hidden="true">
+                {[1, 2, 3, 4].map((bar) => (
+                    <div
+                        key={bar}
+                        className="h-[5px] flex-1 rounded-[3px] transition-colors"
+                        style={{ backgroundColor: bar <= score ? color : "#EAEDF2" }}
+                    />
+                ))}
+            </div>
+            <span
+                className="min-w-[68px] text-right text-[12px] font-semibold"
+                style={{ color }}
+                aria-live="polite"
+            >
+                {label}
+            </span>
+        </div>
+    );
+}

--- a/frontend/src/features/student-auth/components/fieldStyles.ts
+++ b/frontend/src/features/student-auth/components/fieldStyles.ts
@@ -1,0 +1,16 @@
+// Shared field styling for the /join invitation form. Centralised so the email/name
+// inputs in StudentJoinPage and the PasswordField stay byte-identical (no drift).
+
+export const FIELD_INPUT_CLASS =
+    "w-full rounded-[13px] border-[1.5px] border-[#DEE3EC] bg-[#F6F8FB] px-[15px] py-[13px] " +
+    "text-[15px] text-[#16181D] outline-none transition-[border-color,box-shadow] " +
+    "placeholder:text-[#9AA3B2] focus-visible:border-[#0144a0] focus-visible:bg-white " +
+    "focus-visible:shadow-[0_0_0_4px_rgba(1,68,160,0.14)] aria-[invalid=true]:border-[#C2462E]";
+
+export const FIELD_LABEL_CLASS =
+    "flex items-center gap-[5px] text-[13px] font-semibold text-[#2B3340]";
+
+// Inline text-link buttons ("Inicia sesión" / "Crear cuenta") used to toggle auth modes.
+export const TOGGLE_LINK_CLASS =
+    "cursor-pointer rounded-[4px] border-none bg-transparent p-0 font-bold text-[#0144a0] " +
+    "hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0144a0]";

--- a/frontend/src/features/student-auth/components/icons.tsx
+++ b/frontend/src/features/student-auth/components/icons.tsx
@@ -1,0 +1,66 @@
+// Inline SVG icons for the /join invitation redesign. Decorative icons carry
+// aria-hidden; colour comes from `currentColor` unless the mark is intrinsically
+// branded (gold cap, green success check).
+
+type IconProps = { className?: string };
+
+export function AlertCircleIcon({ className }: IconProps) {
+    return (
+        <svg className={className} width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2" />
+            <path d="M12 7.5v5M12 16h.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+    );
+}
+
+export function CheckCircleIcon({ className }: IconProps) {
+    return (
+        <svg className={className} width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <circle cx="12" cy="12" r="9" fill="#E4F1E8" />
+            <path d="M8 12.2 11 15l5-5.5" stroke="#2E7D55" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+    );
+}
+
+export function ArrowRightIcon({ className }: IconProps) {
+    return (
+        <svg className={className} width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M4 12h14M12.5 6l6 6-6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+    );
+}
+
+export function SpinnerIcon({ className }: IconProps) {
+    return (
+        <svg
+            className={`animate-spin motion-reduce:animate-none ${className ?? ""}`}
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            aria-hidden="true"
+        >
+            <circle cx="12" cy="12" r="9" stroke="currentColor" strokeOpacity="0.3" strokeWidth="2.5" />
+            <path d="M12 3a9 9 0 0 1 9 9" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+        </svg>
+    );
+}
+
+export function LockIcon({ className }: IconProps) {
+    return (
+        <svg className={className} width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect x="5" y="11" width="14" height="9" rx="2" stroke="currentColor" strokeWidth="1.8" />
+            <path d="M8 11V8a4 4 0 0 1 8 0v3" stroke="currentColor" strokeWidth="1.8" />
+        </svg>
+    );
+}
+
+export function GradCapIcon({ className }: IconProps) {
+    return (
+        <svg className={className} width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M12 3 1.5 8.5 12 14l10.5-5.5L12 3Z" stroke="#D8B873" strokeWidth="1.5" strokeLinejoin="round" />
+            <path d="M5.5 11v4.2c0 1.3 2.9 2.6 6.5 2.6s6.5-1.3 6.5-2.6V11" stroke="#D8B873" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M22 8.5v5.5" stroke="#D8B873" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+    );
+}


### PR DESCRIPTION
## Que hace

Replica el mockup navy/oro en la vista de invitacion del estudiante (`/join`,
`StudentJoinPage`): tarjeta a dos paneles (hero de invitacion a la izquierda +
formulario a la derecha) sobre un fondo degradado, **a sangre completa** (sin la
barra azul `SiteHeader`), con tipografias **Source Serif 4** (titulos) +
**Plus Jakarta Sans** (cuerpo).

## Cambios

- **Nuevos componentes** en `features/student-auth/components/`: `JoinHeroPanel`
  (universidad, curso en serif, docente; degrada si faltan datos), `PasswordField`
  (mostrar/ocultar, `type=button`, default oculto), `PasswordStrengthMeter`
  (`role=meter`), `fieldStyles`, `icons`.
- **`StudentJoinPage`** reescrito a nivel de presentacion. Preserva TODOS los
  flujos: invite vs course_access, email enmascarado+disabled en invite, sign-in
  in-place (toggle / auto-switch 409 / 201), auto-enroll, Microsoft OAuth,
  restamp-TTL y todos los mensajes de error.
- **`index.html`**: anade Source Serif 4 + Plus Jakarta Sans al `<link>` de Google
  Fonts (solo `/join`, sin tocar el default Inter global).
- **`App.tsx`**: oculta `SiteHeader` en `/join`. **`App.test.tsx`**: mueve la
  asercion "header visible" a `/auth/callback` + nuevo test de header oculto en `/join`.
- **Responsive**: los paneles apilan en movil (`flex-col md:flex-row`) sin overflow.
- **A11y**: `label`/`htmlFor`, `aria-invalid`/`aria-describedby`, `role=meter`,
  `focus-visible`, `motion-reduce`, iconos `aria-hidden`.

## Decisiones (acordadas con el usuario)

- Tipografia fiel al mockup (2 fuentes nuevas).
- Sin pantalla de exito: al activar, redirige directo a `/student/dashboard`.
- `/join` a sangre completa, sin barra superior.

## Verificacion

- `npm --prefix frontend run test`: **493/493** verdes (incluye 3 tests nuevos:
  hero, toggle de password, medidor de fuerza).
- `npm --prefix frontend run lint` y `npm --prefix frontend run build`: limpios.
- Verificado visualmente en navegador real (desktop + movil 390px, 0px de overflow).
- Review multi-agente (5 especialistas + red-team): 1 falso positivo P1 descartado
  con prueba (optional chaining hace short-circuit), 4 mejoras aplicadas (responsive
  movil, focus-visible, semantica del medidor, DRY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
