### PR TITLE
fix(teacher-grading): la vista de entrega no debe caer 500 si falla la carga de notas

### DIFF
--- a/backend/src/shared/teacher_reads.py
+++ b/backend/src/shared/teacher_reads.py
@@ -1000,14 +1000,30 @@ def get_teacher_case_submission_detail(
             detail="case_canonical_output_invalid",
         )
 
-    # Attach per-question grades AFTER truncation so they never affect the size cap
-    # and are never part of the binary-search payload. Teacher path only.
-    grades_by_qid = _load_question_grades_by_qid(
-        db,
-        assignment_id=assignment.id,
-        membership_id=membership_id,
-    )
-    modules = _inject_question_grades_into_modules(modules, grades_by_qid)
+    # Attach per-question grades AFTER truncation so they never affect the size cap and are never
+    # part of the binary-search payload. Teacher path only.
+    #
+    # BEST-EFFORT: per-question grades are supplementary data; the submission-detail view is a core,
+    # pre-existing read that worked before grading existed. A failure here — the case_question_grades
+    # migration not yet applied on this DB (deploy that ships code before migrations), the H12
+    # owner-assert aborting the migration, or any transient DB error — must NEVER 500 the whole view.
+    # Degrade to "no grades" + a structured warning, rolling back the aborted transaction first; this
+    # self-heals once the migration lands. Mirrors the codebase's best-effort supplementary pattern
+    # (CostCallbackHandler, partial-preview writes: "swallows all errors and must never fail a job").
+    try:
+        grades_by_qid = _load_question_grades_by_qid(
+            db,
+            assignment_id=assignment.id,
+            membership_id=membership_id,
+        )
+        modules = _inject_question_grades_into_modules(modules, grades_by_qid)
+    except Exception:
+        db.rollback()
+        _logger.warning(
+            "teacher_case_submission_detail_grade_injection_failed",
+            extra={"assignment_id": assignment.id, "membership_id": membership_id},
+            exc_info=True,
+        )
 
     return TeacherCaseSubmissionDetailResponse(
         is_truncated=is_truncated,

--- a/backend/tests/test_teacher_question_grading.py
+++ b/backend/tests/test_teacher_question_grading.py
@@ -428,6 +428,30 @@ def test_detail_returns_grade_per_question(
     assert by_id["M2-Q2"]["grade"] is None
 
 
+def test_detail_view_survives_grade_load_failure(
+    client, db, seed_identity, seed_course, seed_course_membership, auth_headers_factory, monkeypatch
+) -> None:
+    """If loading per-question grades fails (e.g. case_question_grades migration not yet applied),
+    the submission-detail view must still return 200 WITHOUT grades — never 500."""
+    fx = _setup(db, seed_identity, seed_course, seed_course_membership, auth_headers_factory,
+                university_id=str(uuid.uuid4()))
+    db.commit()
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("simulated: relation case_question_grades does not exist")
+
+    monkeypatch.setattr("shared.teacher_reads._load_question_grades_by_qid", _boom)
+
+    resp = client.get(
+        f"/api/teacher/cases/{fx.assignment.id}/submissions/{fx.membership_id}", headers=fx.headers
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    questions = [q for module in payload["modules"] for q in module["questions"]]
+    assert questions  # the core view still renders the questions
+    assert all(q["grade"] is None for q in questions)  # degraded cleanly: no grades, no 500
+
+
 # --------------------------------------------------------------------------- IDOR (H10)
 
 


### PR DESCRIPTION
## Problema

Tras #401, abrir "Ver entrega y calificar" devolvía **500** (`relation "case_question_grades" does not exist`) en entornos donde la migración `b7e4c2a9f3d1` aún no se había aplicado. La causa inmediata es operacional (correr `alembic upgrade head`), pero destapa un riesgo real de producción: el GET de detalle consultaba `case_question_grades` de forma **incondicional**, así que un deploy que publique el código antes de migrar — o un error transitorio del DB — tiraba **toda** la vista de entrega, aunque las notas por pregunta son **data suplementaria** de una vista que ya existía.

## Fix

`get_teacher_case_submission_detail` (`teacher_reads.py`) ahora envuelve la carga + inyección de notas en un bloque **best-effort**: ante cualquier excepción → `db.rollback()` + `logger.warning(exc_info)` + devolver el detalle **sin notas**. La respuesta se arma de objetos Pydantic ya materializados (no hay más I/O tras el fallo). **Se auto-sana** apenas la migración aplica. Mismo patrón que el resto del repo para data suplementaria (`CostCallbackHandler`, preview parcial).

**Fuera de alcance a propósito:** los endpoints de **escritura** (`PUT/DELETE`) siguen fallando duro si la tabla falta — la migración es prerequisito del feature de calificación.

## Test
`test_detail_view_survives_grade_load_failure`: monkeypatchea la carga de notas para lanzar y asegura **200 sin notas** (no 500). Backend `pytest` + `mypy` verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)