### PR TITLE
feat(student-auth): /join a pantalla completa (split-screen edge-to-edge)

### DIFF
--- a/frontend/src/features/student-auth/StudentJoinPage.tsx
+++ b/frontend/src/features/student-auth/StudentJoinPage.tsx
@@ -502,15 +502,15 @@ export function StudentJoinPage() {
     const isSignIn = authMode === "signin" && !isInviteFlow && !session;
 
     return (
-        <JoinShell>
-            <div className="flex w-full max-w-[1040px] flex-col overflow-hidden rounded-[26px] border border-[rgba(12,32,72,0.07)] bg-white shadow-[0_40px_90px_-38px_rgba(12,32,72,0.30),_0_2px_10px_rgba(0,0,0,0.04)] md:flex-row">
-                <JoinHeroPanel
-                    universityName={universityName}
-                    courseTitle={courseTitle}
-                    teacherName={teacherName}
-                />
+        <div className="flex min-h-screen w-full flex-col bg-white font-['Plus_Jakarta_Sans'] antialiased lg:flex-row">
+            <JoinHeroPanel
+                universityName={universityName}
+                courseTitle={courseTitle}
+                teacherName={teacherName}
+            />
 
-                <div className="flex w-full flex-col p-[36px_28px_32px] md:w-auto md:min-w-[340px] md:flex-[1.18_1_420px] md:p-[48px_48px_40px]">
+            <div className="flex w-full flex-col p-[40px_28px_36px] lg:flex-1 lg:justify-center lg:p-[64px_72px]">
+                <div className="mx-auto w-full max-w-[440px]">
                     {isSignIn ? (
                         <>
                             <h1 className="mb-2 font-['Source_Serif_4'] text-[27px] font-semibold tracking-[-0.4px] text-[#16181D]">
@@ -749,6 +749,6 @@ export function StudentJoinPage() {
                     )}
                 </div>
             </div>
-        </JoinShell>
+        </div>
     );
 }

--- a/frontend/src/features/student-auth/components/JoinHeroPanel.tsx
+++ b/frontend/src/features/student-auth/components/JoinHeroPanel.tsx
@@ -15,13 +15,13 @@ export function JoinHeroPanel({ universityName, courseTitle, teacherName }: Join
     const teacherInitial = teacherName?.trim().charAt(0).toUpperCase() ?? "";
 
     return (
-        <div className="relative flex w-full flex-col overflow-hidden p-[36px_28px] text-[#EDE7D6] bg-[linear-gradient(158deg,#0B57B8_0%,#023C88_55%,#04275C_100%)] md:w-auto md:min-w-[320px] md:flex-[1_1_380px] md:p-[48px_46px]">
+        <div className="relative flex w-full flex-col overflow-hidden p-[40px_32px] text-[#EDE7D6] bg-[linear-gradient(158deg,#0B57B8_0%,#023C88_55%,#04275C_100%)] lg:w-[44%] lg:min-w-[400px] lg:max-w-[600px] lg:p-[60px_56px]">
             {/* Decorative gold rings + glow */}
             <div aria-hidden className="pointer-events-none absolute -right-[90px] -top-[90px] h-[280px] w-[280px] rounded-full border border-[rgba(216,184,115,0.22)]" />
             <div aria-hidden className="pointer-events-none absolute -right-[50px] -top-[50px] h-[180px] w-[180px] rounded-full border border-[rgba(216,184,115,0.14)]" />
             <div aria-hidden className="pointer-events-none absolute -bottom-[120px] -left-[80px] h-[300px] w-[300px] rounded-full bg-[radial-gradient(circle,rgba(216,184,115,0.08)_0%,rgba(216,184,115,0)_70%)]" />
 
-            <div className="relative flex flex-1 flex-col md:min-h-[440px]">
+            <div className="relative flex flex-1 flex-col gap-10 md:min-h-[440px] lg:gap-0">
                 <div className="flex items-center gap-3">
                     <div className="flex h-[42px] w-[42px] items-center justify-center rounded-[12px] border border-[rgba(216,184,115,0.3)] bg-[rgba(216,184,115,0.14)]">
                         <GradCapIcon />


### PR DESCRIPTION
## Que hace

Seguimiento del rediseño de `/join` (#402). La vista dejaba la tarjeta **centrada
y flotante** con márgenes de degradado alrededor. Ahora ocupa **toda la pantalla**:
layout split-screen edge-to-edge (hero navy a altura completa a la izquierda +
formulario a la derecha), como la landing.

## Cambios (solo 2 archivos frontend)

- **`StudentJoinPage`**: el wrapper principal pasa a `min-h-screen w-full flex-col lg:flex-row`
  (sin tarjeta/borde/sombra/radio). El panel del formulario es `lg:flex-1 lg:justify-center`
  con el contenido centrado en `max-w-[440px]` para que no se estire en pantallas anchas.
- **`JoinHeroPanel`**: panel izquierdo full-height, `lg:w-[44%]` acotado por
  `lg:min-w-[400px]` / `lg:max-w-[600px]` (no crece en ultra-wide).
- Breakpoint `lg`: en tablet/móvil los paneles se apilan (hero compacto arriba, formulario
  abajo) sin overflow horizontal. Los estados loading/error/invalid conservan su contenedor centrado.

## Verificación

- Verificado en navegador real contra el **bundle de producción** (`vite preview`):
  desktop 1600px → hero `width=600px max-w=600px` acotado, 0px overflow; tablet 768 y
  móvil 390 → apilados, 0px overflow.
- `npm --prefix frontend run test`: **523/523**. `lint` y `build` limpios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
