### PR TITLE
feat(teacher-grading): progreso de calificación en vivo en el topbar de la entrega

### DIFF
--- a/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
@@ -59,6 +59,41 @@ function buildGradeMap(
     }, {});
 }
 
+// Points use their own formatter (no forced decimal) so a running tally reads "23 / 30" and "8,5",
+// not "23,0 / 30,0" like the 0-5 gradebook score.
+const POINTS_FORMATTER = new Intl.NumberFormat("es-CO", { maximumFractionDigits: 2 });
+
+function formatPoints(value: number): string {
+    return POINTS_FORMATTER.format(value);
+}
+
+interface GradeProgress {
+    graded: number;
+    total: number;
+    earned: number;
+    max: number;
+}
+
+/** Live grading progress derived from the per-question grades injected into the detail. */
+function buildGradeProgress(detail: TeacherCaseSubmissionDetailResponse): GradeProgress {
+    let graded = 0;
+    let total = 0;
+    let earned = 0;
+    let max = 0;
+    for (const module of detail.modules) {
+        for (const question of module.questions) {
+            total += 1;
+            const grade = question.grade;
+            if (grade) {
+                graded += 1;
+                earned += grade.points_awarded;
+                max += grade.max_points;
+            }
+        }
+    }
+    return { graded, total, earned, max };
+}
+
 function formatTimestamp(value: string | null, fallback: string): string {
     return value ? formatTeacherCourseTimestamp(value) : fallback;
 }
@@ -109,6 +144,7 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
     const canonicalOutput = useMemo(() => toCanonicalCaseOutput(detail), [detail]);
     const answers = useMemo(() => buildAnswersMap(detail), [detail]);
     const gradeMap = useMemo(() => buildGradeMap(detail), [detail]);
+    const gradeProgress = useMemo(() => buildGradeProgress(detail), [detail]);
     const visibleModules = useMemo(() => getVisibleModules(detail), [detail]);
     const membershipId = detail.student.membership_id;
     const saveGrade = useSaveQuestionGrade(assignmentId, membershipId);
@@ -236,6 +272,29 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                         </div>
 
                         <div className="flex items-center gap-3">
+                            {canGrade ? (
+                                <div
+                                    className="hidden items-center gap-2 lg:flex"
+                                    data-testid="teacher-submission-grading-progress"
+                                >
+                                    <span
+                                        className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700 ring-1 ring-inset ring-slate-200"
+                                        title="Preguntas calificadas"
+                                    >
+                                        <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">Calificadas</span>
+                                        <span data-testid="grading-progress-count">{gradeProgress.graded}/{gradeProgress.total}</span>
+                                    </span>
+                                    <span
+                                        className="inline-flex items-center gap-1.5 rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-200"
+                                        title="Puntos otorgados sobre el total de las preguntas calificadas"
+                                    >
+                                        <span className="text-[10px] font-bold uppercase tracking-wider text-indigo-400">Puntos</span>
+                                        <span data-testid="grading-progress-points">
+                                            {formatPoints(gradeProgress.earned)} / {formatPoints(gradeProgress.max)}
+                                        </span>
+                                    </span>
+                                </div>
+                            ) : null}
                             <span className={`hidden rounded-full px-3 py-1 text-xs font-semibold lg:inline-flex ${statusBadgeClasses}`}>
                                 {statusLabel}
                             </span>

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
@@ -151,6 +151,48 @@ describe("TeacherSubmissionPreview", () => {
         expect(renderer.getAttribute("data-has-grading")).toBe("false");
         expect(screen.getByTestId("teacher-submission-grading-locked")).toBeTruthy();
         expect(screen.queryByTestId("question-grading-panel")).toBeNull();
+        // no grading progress chips when the response is not gradeable
+        expect(screen.queryByTestId("teacher-submission-grading-progress")).toBeNull();
+    });
+
+    it("shows live grading progress in the topbar (graded count + running points)", async () => {
+        renderPreview({
+            detail: createSubmissionDetailResponse({
+                modules: [
+                    {
+                        id: "M1",
+                        title: "Módulo 1",
+                        questions: [
+                            {
+                                id: "M1-Q1", order: 1, statement: "", context: null, expected_solution: "",
+                                student_answer: null, student_answer_chars: 0, is_answer_from_draft: false,
+                                grade: { question_id: "M1-Q1", points_awarded: 7, max_points: 10, feedback: null, graded_at: "2026-06-06T18:00:00Z", graded_by_membership_id: "t" },
+                            },
+                            {
+                                id: "M1-Q2", order: 2, statement: "", context: null, expected_solution: "",
+                                student_answer: null, student_answer_chars: 0, is_answer_from_draft: false,
+                                grade: { question_id: "M1-Q2", points_awarded: 8.5, max_points: 10, feedback: "ok", graded_at: "2026-06-06T18:00:00Z", graded_by_membership_id: "t" },
+                            },
+                        ],
+                    },
+                    {
+                        id: "M5",
+                        title: "Módulo 5",
+                        questions: [
+                            {
+                                id: "M5-Q1", order: 1, statement: "", context: null, expected_solution: "",
+                                student_answer: null, student_answer_chars: 0, is_answer_from_draft: false, grade: null,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        });
+
+        const progress = await screen.findByTestId("teacher-submission-grading-progress");
+        expect(within(progress).getByTestId("grading-progress-count").textContent).toBe("2/3");
+        // 7 + 8,5 = 15,5 awarded out of 10 + 10 = 20 over the graded questions
+        expect(within(progress).getByTestId("grading-progress-points").textContent).toBe("15,5 / 20");
     });
 
     it("passes canonical output, answers and read-only flags to the renderer", async () => {


### PR DESCRIPTION
## Qué

En el topbar de "Ver entrega y calificar", junto a la badge de estado (ENTREGADO), se agregan dos chips que se **actualizan en vivo** a medida que el docente califica:

- **Calificadas X/N** — preguntas calificadas sobre el total.
- **Puntos Σ / Σ** — puntos otorgados sobre el máximo de las preguntas ya calificadas (denominador crece a medida que se califica).

## Detalle

- **Solo frontend**, derivado de `detail.modules[].grade` (ya inyectado por el backend). Se actualiza solo gracias al patch de caché `setQueryData` que ya hace cada guardado/limpieza.
- Gateado por `canGrade` (`submitted`/`graded`): si la entrega no es calificable, los chips no se muestran (consistente con que tampoco hay paneles).
- Formateador de puntos sin decimal forzado (`23`, `8,5`) para no leer `23,0`; el sidebar sigue mostrando la nota global 0–5.
- Breakpoint `lg` (igual que la badge) para no saturar el header en pantallas chicas.

## Test
`TeacherSubmissionPreview.test.tsx`: chips presentes con `2/3` y `15,5 / 20` con notas parciales; ausentes cuando la entrega es `in_progress`. Lint + build + 524 tests verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)