### PR TITLE
fix(business): preguntas M4/M5 de clasificación alineadas al arco LR (#306/#319)

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -135,6 +135,7 @@ from case_generator.prompts import (
     M4_CONTENT_GENERATOR_PROMPT,
     M4_NARRATIVE_PROMPT_CLASSIFICATION_BY_VARIANT,
     M4_BUSINESS_PROMPT_CLASSIFICATION,
+    M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION,
     M4_CHART_GENERATOR_PROMPT,
     M4_CHART_BUSINESS_PROMPT_CLASSIFICATION,
     M4_CHARTS_PROMPT_BY_FAMILY,
@@ -142,6 +143,7 @@ from case_generator.prompts import (
     M5_CONTENT_GENERATOR_PROMPT,
     M5_NARRATIVE_PROMPT_CLASSIFICATION_BY_VARIANT,
     M5_BUSINESS_PROMPT_CLASSIFICATION,
+    M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION,
     TEACHING_NOTE_PART1_PROMPT,
     TEACHING_NOTE_PART2_PROMPT,
     SCHEMA_DESIGNER_PROMPT,
@@ -4825,6 +4827,11 @@ def m4_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
         })
 
         prompt = _resolve_family_prompt(state, M4_QUESTIONS_PROMPT_BY_FAMILY, M4_QUESTIONS_GENERATOR_PROMPT)
+        # Issue #329 — business+clasificación: alinea las preguntas con el arco LR (#306/#319).
+        # No-op para ml_ds y para business no-clasificación (mismo gate que el contenido).
+        prompt = _maybe_business_classification_prompt(
+            state, prompt, M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+        )
         resultado: GeneradorPreguntasOutput = llm.with_structured_output(
             GeneradorPreguntasOutput
         ).invoke(prompt.format(**context))
@@ -4883,6 +4890,11 @@ def m5_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
         )
         prompt_text = _resolve_family_prompt(
             state, M5_QUESTIONS_PROMPT_BY_FAMILY, M5_QUESTIONS_GENERATOR_PROMPT
+        )
+        # Issue #329 — business+clasificación: alinea el memorándum con el arco LR (#306/#319).
+        # No-op para ml_ds y para business no-clasificación (mismo gate que el contenido).
+        prompt_text = _maybe_business_classification_prompt(
+            state, prompt_text, M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
         )
         context.update({
             "m5_content": state.get("m5_content", ""),

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -1092,12 +1092,72 @@ las Secciones 1–3 ya existentes (NO agregues secciones nuevas):
   métricas. Refiérete a la decisión apoyada por el modelo, no a su matemática.
 """
 
+# Bloques para las PREGUNTAS de M4/M5 business+clasificación (Issue #329). Aditivos sobre el prompt
+# de preguntas GENÉRICO (NO sobre el prompt ml_ds), que es el que hoy reciben las preguntas business
+# (despacho de familia ml_ds-only en _resolve_family_prompt). Cierran la incoherencia con el arco de
+# contenido LR (#306/#319): las preguntas pasan de gerenciales-genéricas a clasificación-aware.
+# Igual que M4_CHART_LR_BUSINESS_BLOCK, NO nombran jerga DS (AUC/umbral/drift/reentrenamiento/A-B)
+# ni siquiera para prohibirla: steerean con framing gerencial positivo, de modo que el render sea
+# genuinamente libre de jerga (el test de ausencia de jerga corre sobre el prompt renderizado).
+# Texto ESTÁTICO: cero placeholders .format() y CERO llaves literales { } (el nodo hace
+# base+bloque .format(**context); una llave rompería el render).
+M4_QUESTIONS_LR_BUSINESS_BLOCK = """
+
+# Enfoque business+clasificación: preguntas alineadas a la lógica de priorización
+Este caso decide con un modelo que estima, por cliente u operación, una probabilidad de evento
+(abandono, impago, incumplimiento…), un número entre 0% y 100%. Las 3 preguntas deben razonar sobre
+esa lógica en lenguaje 100% gerencial, para un directivo (no un científico de datos). NO uses
+nombres de métricas internas ni vocabulario técnico del modelo; cuantifica el impacto en términos de
+negocio.
+- **Dónde se concentra el valor (P1):** lo que está en juego por cliente u operación es su
+  probabilidad de evento × el valor en riesgo de ese cliente u operación (ingreso, saldo o contrato
+  expuesto). El presupuesto de intervención se prioriza hacia los de mayor probabilidad × valor, no
+  por igual entre todos.
+- **El trade-off directivo (P2):** contrasta intervenir sobre quien no iba a tener el evento (falsa
+  alarma → gasto desperdiciado) con no intervenir sobre quien sí lo tiene (evento no evitado → valor
+  perdido); y el costo de intervenir frente al valor que se protege al evitar el evento.
+- **Riesgo de ejecución (P3):** si las relaciones halladas en el M2 no se sostienen, priorizar por
+  probabilidad puede dirigir el presupuesto al lugar equivocado; pide una mitigación concreta en
+  términos de negocio (a quién priorizar, con qué presupuesto, cómo confirmar el supuesto), no una
+  receta técnica del modelo.
+- **Honestidad:** usa únicamente cifras del caso (Exhibits, M2, M4). NO inventes probabilidades,
+  tasas ni valores nuevos; razona sobre la lógica de priorización, no sobre métricas del modelo.
+"""
+
+M5_QUESTIONS_LR_BUSINESS_BLOCK = """
+
+# Enfoque business+clasificación: memorándum apoyado en el ranking de riesgo del modelo
+La consigna de este caso se apoya en un modelo que ordena a los clientes u operaciones por su
+probabilidad de evento (abandono, incumplimiento, impago…). El memorándum se dirige a la
+Junta Directiva, en lenguaje gerencial (no técnico): NO uses nombres de métricas internas ni
+vocabulario del modelo.
+- **Cómo se prioriza la acción:** la recomendación atiende primero a quienes concentran mayor
+  probabilidad de evento × valor en riesgo; el modelo ordena la acción, no dicta una verdad.
+- **El trade-off directivo:** plantea la tensión entre falsas alarmas (intervenir sobre quien no iba
+  a tener el evento → gasto desperdiciado) y eventos no evitados (no intervenir sobre quien sí lo
+  tiene → valor perdido).
+- **Mitigación en términos de negocio:** la respuesta al riesgo principal pondera el costo de
+  intervenir contra el valor en riesgo que se protege; exprésala en lenguaje de negocio, con un
+  responsable y una señal de seguimiento, no en vocabulario técnico del modelo.
+- **Honestidad:** usa solo cifras del caso (M2, Exhibits, M4); NO inventes probabilidades ni
+  métricas. Refiérete a la decisión apoyada por el modelo, no a su matemática.
+"""
+
 # Variantes business+clasificación: aditivas sobre el base (ensambladas en import). El gate vive
 # en graph.py::_maybe_business_classification_prompt; aquí solo se declara la composición.
 M4_BUSINESS_PROMPT_CLASSIFICATION = M4_CONTENT_GENERATOR_PROMPT + M4_LR_BUSINESS_BLOCK
 M5_BUSINESS_PROMPT_CLASSIFICATION = M5_CONTENT_GENERATOR_PROMPT + M5_LR_BUSINESS_BLOCK
 # Issue #319 — variante de GRÁFICOS business+clasificación (aditiva sobre el chart prompt genérico).
 M4_CHART_BUSINESS_PROMPT_CLASSIFICATION = M4_CHART_GENERATOR_PROMPT + M4_CHART_LR_BUSINESS_BLOCK
+# Issue #329 — variantes de PREGUNTAS business+clasificación (aditivas sobre el prompt de preguntas
+# GENÉRICO; el gate ml_ds-only de _resolve_family_prompt deja a business en el genérico, así que el
+# swap business las alinea con el arco LR sin tocar ml_ds).
+M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION = (
+    M4_QUESTIONS_GENERATOR_PROMPT + M4_QUESTIONS_LR_BUSINESS_BLOCK
+)
+M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION = (
+    M5_QUESTIONS_GENERATOR_PROMPT + M5_QUESTIONS_LR_BUSINESS_BLOCK
+)
 
 # ── SCHEMA_DESIGNER_PROMPT_BY_FAMILY — dispatch table consumed by
 # graph.py::schema_designer.  Keys MUST match values returned by
@@ -2235,7 +2295,9 @@ __all__ = [
   "M4_NARRATIVE_PROMPT_CLASSIFICATION_BY_VARIANT",
   "M4_PROMPT_BY_FAMILY",
   "M4_PROMPT_CLASSIFICATION",
+  "M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION",
   "M4_QUESTIONS_GENERATOR_PROMPT",
+  "M4_QUESTIONS_LR_BUSINESS_BLOCK",
   "M4_QUESTIONS_PROMPT_CLASSIFICATION",
   "M4_QUESTIONS_PROMPT_BY_FAMILY",
   "M5_BUSINESS_PROMPT_CLASSIFICATION",
@@ -2247,7 +2309,9 @@ __all__ = [
   "M5_NARRATIVE_PROMPT_CLASSIFICATION_BY_VARIANT",
   "M5_PROMPT_BY_FAMILY",
   "M5_PROMPT_CLASSIFICATION",
+  "M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION",
   "M5_QUESTIONS_GENERATOR_PROMPT",
+  "M5_QUESTIONS_LR_BUSINESS_BLOCK",
   "M5_QUESTIONS_PROMPT_BY_FAMILY",
   "M5_QUESTIONS_PROMPT_CLASSIFICATION",
   "NOTEBOOK_BASE_TEMPLATE",

--- a/backend/tests/integration/test_business_lr_live.py
+++ b/backend/tests/integration/test_business_lr_live.py
@@ -12,6 +12,7 @@ Verifica el arco completo del cambio business+LR:
   * El dataset sintético tiene una correlación NPS↔churn REAL (no inventada).
 """
 
+import re
 import uuid
 
 import pandas as pd
@@ -98,5 +99,31 @@ async def test_business_lr_e2e() -> None:
     for nb in ("m3_notebook_code", "doc6_notebook"):
         if final_state.get(nb):
             errors.append(f"[FAIL] {nb} presente en business (solo ml_ds genera notebook)")
+
+    # 5. Issue #329 — las preguntas business de clasificación quedan jargon-free (coherencia con #306/#319).
+    # Tokens DS-específicos: NO bare "umbral" (un memo dice "umbral de rentabilidad") ni bare "roc"
+    # (falso positivo con "proceso"); roc/auc se chequean con frontera de palabra.
+    questions_jargon = (
+        "concept drift",
+        "drift",
+        "reentrena",
+        "monitoreo de auc",
+        "umbral de decisión",
+        "a/b testing",
+        "log-odds",
+        "odds ratio",
+    )
+    for key in ("m4_questions", "m5_questions"):
+        qs = final_state.get(key) or []
+        blob = " ".join(
+            f"{q.get('enunciado', '')} {q.get('solucion_esperada', '')}"
+            for q in qs
+            if isinstance(q, dict)
+        ).lower()
+        found = [t for t in questions_jargon if t in blob]
+        if re.search(r"\b(roc|auc)\b", blob):
+            found.append("roc/auc")
+        if found:
+            errors.append(f"[FAIL] {key} business expone jerga DS: {found}")
 
     assert not errors, "\n".join(errors)

--- a/backend/tests/test_m4_clasificacion_dispatch.py
+++ b/backend/tests/test_m4_clasificacion_dispatch.py
@@ -23,6 +23,7 @@ These are pure-Python unit tests — no LLM calls, no DB, no fixtures.
 """
 
 import inspect as _inspect
+import re as _re
 import string as _string
 
 from case_generator.graph import (
@@ -36,6 +37,7 @@ from case_generator.graph import (
 )
 from case_generator.prompts import (
     M4_BUSINESS_PROMPT_CLASSIFICATION,
+    M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION,
     M4_CHART_BUSINESS_PROMPT_CLASSIFICATION,
     M4_CHART_GENERATOR_PROMPT,
     M4_CHARTS_PROMPT_BY_FAMILY,
@@ -543,3 +545,148 @@ def test_m4_content_generator_node_wires_variant_dispatch() -> None:
     assert "M4_NARRATIVE_PROMPT_CLASSIFICATION_BY_VARIANT" in source
     # El override está gateado a ml_ds + clasificación (no toca business ni otras familias).
     assert '"clasificacion"' in source
+
+
+# ── 13. Issue #329 — business+clasificación QUESTIONS prompt swap ─────────────
+#
+# m4_questions_generator resuelve el prompt en dos pasos (graph.py):
+#     prompt = _resolve_family_prompt(state, M4_QUESTIONS_PROMPT_BY_FAMILY, M4_QUESTIONS_GENERATOR_PROMPT)
+#     prompt = _maybe_business_classification_prompt(state, prompt, M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION)
+# _resolve_questions_prompt replica esa cadena. CLAVE (diagnóstico corregido): _resolve_family_prompt
+# despacha por familia SOLO para ml_ds, así que business hoy recibe el GENÉRICO (no el prompt ml_ds);
+# el swap business lo alinea con el arco LR de contenido (#306/#319). No es un fix de leak de jerga.
+
+
+def _resolve_questions_prompt(state: dict) -> str:
+    """Replica la cadena de resolución de prompt de m4_questions_generator."""
+    prompt = _resolve_family_prompt(
+        state, M4_QUESTIONS_PROMPT_BY_FAMILY, M4_QUESTIONS_GENERATOR_PROMPT
+    )
+    return _maybe_business_classification_prompt(
+        state, prompt, M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+    )
+
+
+def test_m4_questions_business_clasificacion_resolves_business_prompt() -> None:
+    """business + clasificación → M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION (no genérico, no ml_ds)."""
+    state = _make_state(student_profile="business", algoritmos=["Logistic Regression"])
+    result = _resolve_questions_prompt(state)
+    assert result is M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+    assert result is not M4_QUESTIONS_GENERATOR_PROMPT
+    assert result is not M4_QUESTIONS_PROMPT_BY_FAMILY["clasificacion"]  # no el prompt ml_ds
+
+
+def test_m4_questions_business_regresion_stays_generic() -> None:
+    """business + regresión → genérico (el swap es no-op fuera de clasificación)."""
+    state = _make_state(student_profile="business", algoritmos=["Linear Regression"])
+    result = _resolve_questions_prompt(state)
+    assert result is M4_QUESTIONS_GENERATOR_PROMPT
+    assert result is not M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+
+
+def test_m4_questions_business_clustering_stays_generic() -> None:
+    """business + clustering → genérico (el swap es no-op fuera de clasificación)."""
+    state = _make_state(student_profile="business", algoritmos=["K-Means"])
+    result = _resolve_questions_prompt(state)
+    assert result is M4_QUESTIONS_GENERATOR_PROMPT
+    assert result is not M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+
+
+def test_m4_questions_mlds_clasificacion_unchanged() -> None:
+    """ml_ds + clasificación → prompt ml_ds intacto (swap no-op para ml_ds → byte-idéntico)."""
+    state = _make_state(student_profile="ml_ds", algoritmos=["Logistic Regression"])
+    result = _resolve_questions_prompt(state)
+    assert result is M4_QUESTIONS_PROMPT_BY_FAMILY["clasificacion"]
+    assert result is not M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+
+
+def test_m4_questions_mlds_regresion_unchanged() -> None:
+    """ml_ds + regresión → genérico (familias no-clasificación intactas)."""
+    state = _make_state(student_profile="ml_ds", algoritmos=["Linear Regression"])
+    result = _resolve_questions_prompt(state)
+    assert result is M4_QUESTIONS_GENERATOR_PROMPT
+    assert result is not M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+
+
+def test_m4_questions_generator_node_wires_business_swap() -> None:
+    """m4_questions_generator debe llamar _maybe_business_classification_prompt con el prompt business.
+
+    Cierra el wiring: una línea olvidada dejaría las preguntas business en el genérico sin que las
+    pruebas de comportamiento (que ejercitan los helpers) lo detecten.
+    """
+    from case_generator import graph as _graph
+
+    source = _inspect.getsource(_graph.m4_questions_generator)
+    assert "_maybe_business_classification_prompt" in source, (
+        "m4_questions_generator must apply the business+clasificación swap"
+    )
+    assert "M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION" in source, (
+        "m4_questions_generator must swap to M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION"
+    )
+
+
+# ── 14. Issue #329 — contrato del prompt business de preguntas (jerga / framing / placeholders) ─
+
+# Context que cubre los 6 placeholders del base genérico de preguntas M4. Valores benignos.
+_M4_QUESTIONS_CONTEXT: dict[str, object] = {
+    "m4_content": "Análisis de impacto del Módulo 4.",
+    "anexo_financiero": "Exhibit 1: inversión y flujos.",
+    "student_profile": "business",
+    "output_language": "Spanish",
+    "case_id": "case-0001",
+    "nombre_empresa": "ACME",
+}
+
+# Jerga DS que una audiencia gerencial NO debe ver en el render de las preguntas.
+_QUESTIONS_DS_JARGON = (
+    "auc",
+    "drift",
+    "reentrena",
+    "umbral",
+    "a/b testing",
+    "architect engineer",
+    "log-odds",
+)
+
+
+def _normalize_ws(text: str) -> str:
+    """Colapsa espacios/saltos de línea (el wrapping del prompt no debe romper un match multi-palabra)."""
+    return " ".join(text.split())
+
+
+def test_m4_questions_business_prompt_no_ds_jargon() -> None:
+    """El render business+clasificación NO expone jerga DS a una audiencia gerencial."""
+    rendered = _normalize_ws(
+        M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION.format(**_M4_QUESTIONS_CONTEXT).lower()
+    )
+    leaked = [t for t in _QUESTIONS_DS_JARGON if t in rendered]
+    assert not leaked, f"business questions render leaked DS jargon: {leaked}"
+    # 'roc' vía word-boundary: el substring crudo daría falso positivo con 'proceso'/'producto'.
+    assert not _re.search(r"\broc\b", rendered), "business questions render leaked 'roc'"
+
+
+def test_m4_questions_business_prompt_keeps_priorization_framing() -> None:
+    """El bloque #329 vuelve las preguntas clasificación-aware (lógica de priorización LR)."""
+    rendered = _normalize_ws(M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION.lower())
+    assert "probabilidad de evento" in rendered
+    assert "valor en riesgo" in rendered
+
+
+def test_m4_questions_business_prompt_placeholder_contract() -> None:
+    """El bloque #329 NO añade placeholders y se ensambla sobre el GENÉRICO (no el prompt ml_ds).
+
+    Igualdad con el set del genérico ⇒ bloque estático sin placeholders. Desigualdad con el set del
+    ml_ds (que tiene {algoritmos}/{algorithm_mode}/{computed_metrics_block}) ⇒ guard anti-trampa:
+    si alguien ensamblara sobre el prompt ml_ds, este test fallaría.
+    """
+    assert _placeholders(M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION) == _placeholders(
+        M4_QUESTIONS_GENERATOR_PROMPT
+    ), "M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION must not add/remove placeholders vs the generic base"
+    assert _placeholders(M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION) != _placeholders(
+        M4_QUESTIONS_PROMPT_CLASSIFICATION
+    ), "must be assembled over the GENERIC base, not the ml_ds clasificación prompt"
+
+
+def test_m4_questions_business_prompt_format_smoke() -> None:
+    """.format(**context) no lanza KeyError/ValueError (caza llaves literales sin escapar)."""
+    assert M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION.format(**_M4_QUESTIONS_CONTEXT)

--- a/backend/tests/test_m4_clasificacion_dispatch.py
+++ b/backend/tests/test_m4_clasificacion_dispatch.py
@@ -638,15 +638,17 @@ _M4_QUESTIONS_CONTEXT: dict[str, object] = {
 }
 
 # Jerga DS que una audiencia gerencial NO debe ver en el render de las preguntas.
-_QUESTIONS_DS_JARGON = (
-    "auc",
+# Multi-char (substring seguro) vs corto-palabra: 'auc'/'umbral'/'roc' como substring crudo
+# darían falso positivo con cauce/penumbral/proceso, así que se chequean con frontera de palabra
+# (igual que el `\b(roc|auc)\b` del test live).
+_QUESTIONS_DS_JARGON_SUBSTR = (
     "drift",
     "reentrena",
-    "umbral",
     "a/b testing",
     "architect engineer",
     "log-odds",
 )
+_QUESTIONS_DS_JARGON_WORD = ("auc", "umbral", "roc")
 
 
 def _normalize_ws(text: str) -> str:
@@ -659,10 +661,9 @@ def test_m4_questions_business_prompt_no_ds_jargon() -> None:
     rendered = _normalize_ws(
         M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION.format(**_M4_QUESTIONS_CONTEXT).lower()
     )
-    leaked = [t for t in _QUESTIONS_DS_JARGON if t in rendered]
+    leaked = [t for t in _QUESTIONS_DS_JARGON_SUBSTR if t in rendered]
+    leaked += [t for t in _QUESTIONS_DS_JARGON_WORD if _re.search(rf"\b{t}\b", rendered)]
     assert not leaked, f"business questions render leaked DS jargon: {leaked}"
-    # 'roc' vía word-boundary: el substring crudo daría falso positivo con 'proceso'/'producto'.
-    assert not _re.search(r"\broc\b", rendered), "business questions render leaked 'roc'"
 
 
 def test_m4_questions_business_prompt_keeps_priorization_framing() -> None:

--- a/backend/tests/test_m5_clasificacion_dispatch.py
+++ b/backend/tests/test_m5_clasificacion_dispatch.py
@@ -414,15 +414,16 @@ _M5_QUESTIONS_CONTEXT: dict[str, object] = {
     "output_language": "Spanish",
 }
 
-_QUESTIONS_DS_JARGON = (
-    "auc",
+# Multi-char (substring seguro) vs corto-palabra: 'auc'/'umbral'/'roc' como substring crudo
+# darían falso positivo con cauce/penumbral/proceso → frontera de palabra (igual que el live).
+_QUESTIONS_DS_JARGON_SUBSTR = (
     "drift",
     "reentrena",
-    "umbral",
     "a/b testing",
     "architect engineer",
     "log-odds",
 )
+_QUESTIONS_DS_JARGON_WORD = ("auc", "umbral", "roc")
 
 
 def _normalize_ws(text: str) -> str:
@@ -509,9 +510,9 @@ def test_m5_questions_business_prompt_no_ds_jargon() -> None:
     rendered = _normalize_ws(
         M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION.format(**_M5_QUESTIONS_CONTEXT).lower()
     )
-    leaked = [t for t in _QUESTIONS_DS_JARGON if t in rendered]
+    leaked = [t for t in _QUESTIONS_DS_JARGON_SUBSTR if t in rendered]
+    leaked += [t for t in _QUESTIONS_DS_JARGON_WORD if _re.search(rf"\b{t}\b", rendered)]
     assert not leaked, f"business M5 questions render leaked DS jargon: {leaked}"
-    assert not _re.search(r"\broc\b", rendered), "business M5 questions render leaked 'roc'"
 
 
 def test_m5_questions_business_prompt_keeps_priorization_framing() -> None:

--- a/backend/tests/test_m5_clasificacion_dispatch.py
+++ b/backend/tests/test_m5_clasificacion_dispatch.py
@@ -22,6 +22,7 @@ These are pure-Python unit tests — no LLM calls, no DB, no fixtures.
 """
 
 import inspect as _inspect
+import re as _re
 import string as _string
 
 from case_generator.graph import (
@@ -30,10 +31,12 @@ from case_generator.graph import (
     _extract_state_algoritmos,
     _maybe_business_classification_prompt,
     _resolve_classification_notebook_variant,
+    _resolve_family_prompt,
     _resolve_generation_focus,
 )
 from case_generator.prompts import (
     M5_BUSINESS_PROMPT_CLASSIFICATION,
+    M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION,
     M5_CONTENT_GENERATOR_PROMPT,
     M5_PROMPT_BY_FAMILY,
     M5_QUESTIONS_GENERATOR_PROMPT,
@@ -386,3 +389,149 @@ def test_m5_content_generator_node_wires_variant_dispatch() -> None:
     # El contrato M5 (matriz de decisión) sigue cableado vía _is_ml_ds_classification.
     assert "_invoke_m5_content_with_contract" in source
     assert "require_decision_matrix" in source
+
+
+# ── 14. Issue #329 — business+clasificación QUESTIONS prompt swap (M5) ────────
+#
+# m5_questions_generator resuelve el prompt en dos pasos (graph.py):
+#     prompt_text = _resolve_family_prompt(state, M5_QUESTIONS_PROMPT_BY_FAMILY, M5_QUESTIONS_GENERATOR_PROMPT)
+#     prompt_text = _maybe_business_classification_prompt(state, prompt_text, M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION)
+# CLAVE (diagnóstico corregido): _resolve_family_prompt despacha por familia SOLO para ml_ds, así que
+# business hoy recibe el GENÉRICO (ya enmarcado a "Junta Directiva"), no el prompt ml_ds. El swap lo
+# alinea con el arco LR de contenido (#306/#319): no es un fix de leak de jerga.
+
+# Context que cubre los placeholders del base genérico de preguntas M5. Valores benignos.
+_M5_QUESTIONS_CONTEXT: dict[str, object] = {
+    "m5_content": "Informe de resolución del Módulo 5.",
+    "doc1_preguntas_complejas": "[]",
+    "pregunta_eje": "¿Qué intervención debería priorizar la dirección?",
+    "main_risk_from_m3_m4": "El supuesto hallado en M2 podría no sostenerse.",
+    "implementation_timeframe": "90 días",
+    "nombre_empresa": "ACME",
+    "case_id": "case-0001",
+    "student_profile": "business",
+    "primary_family": "clasificacion",
+    "output_language": "Spanish",
+}
+
+_QUESTIONS_DS_JARGON = (
+    "auc",
+    "drift",
+    "reentrena",
+    "umbral",
+    "a/b testing",
+    "architect engineer",
+    "log-odds",
+)
+
+
+def _normalize_ws(text: str) -> str:
+    """Colapsa espacios/saltos de línea (el wrapping del prompt no debe romper un match multi-palabra)."""
+    return " ".join(text.split())
+
+
+def _resolve_m5_questions_prompt(state: dict) -> str:
+    """Replica la cadena de resolución de prompt de m5_questions_generator."""
+    prompt = _resolve_family_prompt(
+        state, M5_QUESTIONS_PROMPT_BY_FAMILY, M5_QUESTIONS_GENERATOR_PROMPT
+    )
+    return _maybe_business_classification_prompt(
+        state, prompt, M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+    )
+
+
+def test_m5_questions_business_clasificacion_resolves_business_prompt() -> None:
+    """business + clasificación → M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION (no genérico, no ml_ds)."""
+    state = _make_state_mode(
+        student_profile="business", algoritmos=["Logistic Regression"], algorithm_mode="single"
+    )
+    result = _resolve_m5_questions_prompt(state)
+    assert result is M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+    assert result is not M5_QUESTIONS_GENERATOR_PROMPT
+    assert result is not M5_QUESTIONS_PROMPT_BY_FAMILY["clasificacion"]  # no el prompt ml_ds
+
+
+def test_m5_questions_business_regresion_stays_generic() -> None:
+    """business + regresión → genérico (el swap es no-op fuera de clasificación)."""
+    state = _make_state_mode(
+        student_profile="business", algoritmos=["Linear Regression"], algorithm_mode="single"
+    )
+    result = _resolve_m5_questions_prompt(state)
+    assert result is M5_QUESTIONS_GENERATOR_PROMPT
+    assert result is not M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+
+
+def test_m5_questions_business_clustering_stays_generic() -> None:
+    """business + clustering → genérico (el swap es no-op fuera de clasificación)."""
+    state = _make_state_mode(
+        student_profile="business", algoritmos=["K-Means"], algorithm_mode="single"
+    )
+    result = _resolve_m5_questions_prompt(state)
+    assert result is M5_QUESTIONS_GENERATOR_PROMPT
+    assert result is not M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+
+
+def test_m5_questions_mlds_clasificacion_unchanged() -> None:
+    """ml_ds + clasificación → prompt ml_ds intacto (swap no-op para ml_ds → byte-idéntico)."""
+    state = _make_state_mode(
+        student_profile="ml_ds", algoritmos=["Logistic Regression"], algorithm_mode="single"
+    )
+    result = _resolve_m5_questions_prompt(state)
+    assert result is M5_QUESTIONS_PROMPT_BY_FAMILY["clasificacion"]
+    assert result is not M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+
+
+def test_m5_questions_mlds_regresion_unchanged() -> None:
+    """ml_ds + regresión → genérico (familias no-clasificación intactas)."""
+    state = _make_state_mode(
+        student_profile="ml_ds", algoritmos=["Linear Regression"], algorithm_mode="single"
+    )
+    result = _resolve_m5_questions_prompt(state)
+    assert result is M5_QUESTIONS_GENERATOR_PROMPT
+    assert result is not M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
+
+
+def test_m5_questions_generator_node_wires_business_swap() -> None:
+    """m5_questions_generator debe llamar _maybe_business_classification_prompt con el prompt business."""
+    from case_generator import graph as _graph
+
+    source = _inspect.getsource(_graph.m5_questions_generator)
+    assert "_maybe_business_classification_prompt" in source, (
+        "m5_questions_generator must apply the business+clasificación swap"
+    )
+    assert "M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION" in source, (
+        "m5_questions_generator must swap to M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION"
+    )
+
+
+def test_m5_questions_business_prompt_no_ds_jargon() -> None:
+    """El render business+clasificación NO expone jerga DS a la Junta Directiva."""
+    rendered = _normalize_ws(
+        M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION.format(**_M5_QUESTIONS_CONTEXT).lower()
+    )
+    leaked = [t for t in _QUESTIONS_DS_JARGON if t in rendered]
+    assert not leaked, f"business M5 questions render leaked DS jargon: {leaked}"
+    assert not _re.search(r"\broc\b", rendered), "business M5 questions render leaked 'roc'"
+
+
+def test_m5_questions_business_prompt_keeps_priorization_framing() -> None:
+    """El bloque #329 vuelve el memorándum clasificación-aware sin perder la audiencia gerencial."""
+    rendered = _normalize_ws(M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION.lower())
+    assert "probabilidad de evento" in rendered
+    assert "valor en riesgo" in rendered
+    assert "junta directiva" in rendered  # audiencia business (presente en base + bloque)
+
+
+def test_m5_questions_business_prompt_placeholder_contract() -> None:
+    """El bloque #329 NO añade placeholders y se ensambla sobre el GENÉRICO (no el prompt ml_ds)."""
+    assert _placeholders(M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION) == _placeholders(
+        M5_QUESTIONS_GENERATOR_PROMPT
+    ), "M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION must not add/remove placeholders vs the generic base"
+    assert _placeholders(M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION) != _placeholders(
+        M5_QUESTIONS_PROMPT_CLASSIFICATION
+    ), "must be assembled over the GENERIC base, not the ml_ds clasificación prompt"
+
+
+def test_m5_questions_business_prompt_format_smoke() -> None:
+    """.format(**context) no lanza KeyError/ValueError (caza llaves literales sin escapar)."""
+    assert M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION.format(**_M5_QUESTIONS_CONTEXT)


### PR DESCRIPTION
## Resumen

Cierra la incoherencia **contenido↔preguntas** del perfil **business + clasificación**.

> ⚠️ **Diagnóstico del #329 corregido.** El issue afirmaba que las preguntas M4/M5 business reciben el prompt ml_ds (concept drift / monitoreo de AUC / *"Architect Engineers"*). **No es así.** `_resolve_family_prompt` (`backend/src/case_generator/graph.py:5311`) despacha por familia **solo para `ml_ds`**; cualquier perfil no-ml_ds recibe el prompt **GENÉRICO** (`M4/M5_QUESTIONS_GENERATOR_PROMPT`), que es jargon-free y ya enmarca el memo a la **"Junta Directiva"** (`_shared.py:457`). La jerga drift/AUC/"Architect Engineers" vive solo en `M4/M5_QUESTIONS_PROMPT_CLASSIFICATION`, que business **nunca alcanza** (despacho ml_ds-only). **No existía leak de jerga.**

El gap real es de **coherencia**: el CONTENIDO business de clasificación es clasificación-aware (lógica LR *"probabilidad de evento × valor en riesgo"*, #306/#319) pero las PREGUNTAS quedaban genérico-gerenciales. Esta PR las alinea con el **mismo patrón aditivo y el mismo gate** del contenido.

## Cambios
- **`prompts/__init__.py`**: 2 bloques estáticos `M4/M5_QUESTIONS_LR_BUSINESS_BLOCK` (brace-free, jargon-free, estilo `M4_CHART_LR_BUSINESS_BLOCK`: framing gerencial positivo, sin nombrar jerga ni para prohibirla) + los prompts `M4/M5_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION` ensamblados **sobre el base GENÉRICO** (no el ml_ds); 4 símbolos nuevos en `__all__`.
- **`graph.py`**: `_maybe_business_classification_prompt(...)` en `m4_questions_generator` y `m5_questions_generator` (2 wraps de 1 línea + 2 imports). **ml_ds byte-idéntico** (el swap es business+clasificacion-only, mismo gate que el contenido).
- **Tests**: dispatch compuesto (business→variante, **ml_ds `is`-identity**, no-clf genérico), framing presente (`probabilidad de evento` / `valor en riesgo` / `junta directiva`), **ausencia de jerga sobre el render completo** (`\broc\b` word-boundary para evitar falsos positivos con "proceso"), contrato de placeholders == base genérico + **guard anti-trampa** (≠ set del ml_ds), format-smoke, wiring `getsource`; live opt-in extendido a `m4/m5_questions` con tokens DS-específicos.

## Validación
- `pytest -q tests/test_m4_clasificacion_dispatch.py tests/test_m5_clasificacion_dispatch.py` → **84 passed**
- `pytest -q` (suite completa) → **1573 passed, 22 skipped**
- `mypy src` → **Success, no issues (88 files)**

## Líneas rojas respetadas
- ml_ds **byte-idéntico**; bloques **estáticos** sobre el base **genérico**; diff **funcional y mínimo** (+399 / −0, 5 archivos); `regresion`/`clustering`/`serie_temporal` y demás perfiles intactos; sin hash congelado tocado.

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)