### PR TITLE
feat(teacher-grading): UX de la vista de revisión de entregas (sidebar/topbar, puntos totales, estado por calificar)

### DIFF
--- a/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
@@ -146,6 +146,13 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
     const gradeMap = useMemo(() => buildGradeMap(detail), [detail]);
     const gradeProgress = useMemo(() => buildGradeProgress(detail), [detail]);
     const visibleModules = useMemo(() => getVisibleModules(detail), [detail]);
+    const moduleLabelById = useMemo(() => {
+        const labels: Partial<Record<ModuleId, string>> = {};
+        for (const module of getModuleConfig(canonicalOutput.studentProfile ?? "business", canonicalOutput.caseType)) {
+            labels[module.id] = module.name;
+        }
+        return labels;
+    }, [canonicalOutput]);
     const membershipId = detail.student.membership_id;
     const saveGrade = useSaveQuestionGrade(assignmentId, membershipId);
     const clearGrade = useClearQuestionGrade(assignmentId, membershipId);
@@ -207,8 +214,19 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                     className="hidden h-full w-[280px] shrink-0 flex-col border-r border-slate-900/60 bg-slate-950 text-slate-100 md:flex"
                     data-testid="teacher-submission-preview-sidebar"
                 >
-                    <div className="shrink-0 border-b border-slate-800 px-5 py-4">
-                        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                    <div className="shrink-0 px-3 pt-3">
+                        <button
+                            type="button"
+                            onClick={() => navigate(`/teacher/cases/${assignmentId}/entregas`)}
+                            className="inline-flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-slate-300 transition hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                            Volver
+                        </button>
+                    </div>
+
+                    <div className="shrink-0 border-b border-slate-800 px-5 pt-2 pb-4">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
                             Revisión docente
                         </p>
                         <h1 className="mt-1.5 text-base font-semibold leading-snug text-white">{detail.student.full_name}</h1>
@@ -227,19 +245,19 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
 
                     <div className="shrink-0 border-t border-slate-800 px-5 py-3 text-xs text-slate-200">
                         <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5" data-testid="teacher-submission-preview-summary">
-                            <dt className="text-[10px] uppercase tracking-wider text-slate-500">Estado</dt>
+                            <dt className="text-[10px] uppercase tracking-wider text-slate-400">Estado</dt>
                             <dd className="text-right text-[11px] font-semibold text-white">{statusLabel}</dd>
 
-                            <dt className="text-[10px] uppercase tracking-wider text-slate-500">Versión</dt>
+                            <dt className="text-[10px] uppercase tracking-wider text-slate-400">Versión</dt>
                             <dd className="text-right text-[11px]">{snapshotLabel}</dd>
 
-                            <dt className="text-[10px] uppercase tracking-wider text-slate-500">Respondidas</dt>
-                            <dd className="text-right text-[11px]">{answeredQuestions}/{totalQuestions}</dd>
+                            <dt className="text-[10px] uppercase tracking-wider text-slate-400">Respondidas</dt>
+                            <dd className="text-right text-[11px] tabular-nums">{answeredQuestions}/{totalQuestions}</dd>
 
-                            <dt className="text-[10px] uppercase tracking-wider text-slate-500">Calificación</dt>
-                            <dd className="text-right text-[11px]">{getGradeSummary(detail)}</dd>
+                            <dt className="text-[10px] uppercase tracking-wider text-slate-400">Calificación</dt>
+                            <dd className="text-right text-[11px] tabular-nums">{getGradeSummary(detail)}</dd>
 
-                            <dt className="text-[10px] uppercase tracking-wider text-slate-500">Entrega</dt>
+                            <dt className="text-[10px] uppercase tracking-wider text-slate-400">Entrega</dt>
                             <dd className="truncate text-right text-[11px]" title={formatTimestamp(detail.response_state.submitted_at, "Sin entrega")}>
                                 {formatTimestamp(detail.response_state.submitted_at, "Sin entrega")}
                             </dd>
@@ -249,26 +267,16 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
 
                 <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
                     <header
-                        className="flex h-16 shrink-0 items-center justify-between gap-4 border-b border-slate-200 bg-white px-4 md:px-6"
+                        className="flex h-12 shrink-0 items-center justify-between gap-4 border-b border-slate-200 bg-white px-4 md:px-6"
                         data-testid="teacher-submission-preview-header"
                     >
                         <div className="min-w-0">
-                            <div className="flex items-center gap-3">
-                                <button
-                                    type="button"
-                                    onClick={() => navigate(`/teacher/cases/${assignmentId}/entregas`)}
-                                    className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
-                                >
-                                    <ArrowLeft className="h-4 w-4" />
-                                    Volver
-                                </button>
-                                <div className="min-w-0">
-                                    <p className="truncate text-sm font-semibold text-slate-900">{detail.case.title}</p>
-                                    <p className="truncate text-xs text-slate-500">
-                                        {detail.case.course_code} · {detail.case.course_name} · {detail.student.email}
-                                    </p>
-                                </div>
-                            </div>
+                            <p
+                                className="truncate text-xs text-slate-500"
+                                title={`${detail.case.course_code} · ${detail.case.course_name} · ${detail.student.email}`}
+                            >
+                                {detail.case.course_code} · {detail.case.course_name} · {detail.student.email}
+                            </p>
                         </div>
 
                         <div className="flex items-center gap-3">
@@ -278,18 +286,18 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                                     data-testid="teacher-submission-grading-progress"
                                 >
                                     <span
-                                        className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700 ring-1 ring-inset ring-slate-200"
+                                        className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700 ring-1 ring-inset ring-slate-200"
                                         title="Preguntas calificadas"
                                     >
                                         <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">Calificadas</span>
-                                        <span data-testid="grading-progress-count">{gradeProgress.graded}/{gradeProgress.total}</span>
+                                        <span data-testid="grading-progress-count" className="tabular-nums">{gradeProgress.graded}/{gradeProgress.total}</span>
                                     </span>
                                     <span
-                                        className="inline-flex items-center gap-1.5 rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-200"
+                                        className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-200"
                                         title="Puntos otorgados sobre el total de las preguntas calificadas"
                                     >
                                         <span className="text-[10px] font-bold uppercase tracking-wider text-indigo-400">Puntos</span>
-                                        <span data-testid="grading-progress-points">
+                                        <span data-testid="grading-progress-points" className="whitespace-nowrap tabular-nums">
                                             {formatPoints(gradeProgress.earned)} / {formatPoints(gradeProgress.max)}
                                         </span>
                                     </span>
@@ -302,16 +310,27 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                                 type="button"
                                 onClick={onRefresh}
                                 disabled={isRefreshing}
-                                className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-70"
+                                className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-slate-200 px-2.5 py-1.5 text-xs font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
                                 aria-label={refreshLabel}
+                                title={refreshLabel}
                             >
                                 <RefreshCcw className={`h-4 w-4${isRefreshing ? " animate-spin" : ""}`} />
-                                {refreshLabel}
+                                <span className="hidden sm:inline">Actualizar</span>
                             </button>
                         </div>
                     </header>
 
                     <div className="border-b border-slate-200 bg-white px-4 py-3 md:hidden" data-testid="teacher-submission-preview-mobile-modules">
+                        <div className="mb-2 flex items-center">
+                            <button
+                                type="button"
+                                onClick={() => navigate(`/teacher/cases/${assignmentId}/entregas`)}
+                                className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+                            >
+                                <ArrowLeft className="h-4 w-4" />
+                                Volver
+                            </button>
+                        </div>
                         <div className="flex gap-2 overflow-x-auto pb-1">
                             {visibleModules.map((moduleId) => (
                                 <button
@@ -319,11 +338,11 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                                     type="button"
                                     onClick={() => setActiveModule(moduleId)}
                                     className={moduleId === activeModule
-                                        ? "rounded-full bg-slate-900 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] text-white"
-                                        : "rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] text-slate-600"
+                                        ? "shrink-0 whitespace-nowrap rounded-full bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white"
+                                        : "shrink-0 whitespace-nowrap rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600"
                                     }
                                 >
-                                    {moduleId}
+                                    {moduleLabelById[moduleId] ?? moduleId}
                                 </button>
                             ))}
                         </div>

--- a/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
@@ -12,7 +12,6 @@ import { useClearQuestionGrade, useSaveQuestionGrade } from "./useQuestionGradeM
 
 import {
     formatTeacherCourseTimestamp,
-    formatTeacherGradebookCellStatus,
     formatTeacherGradebookScore,
 } from "@/features/teacher-course/teacherCourseModel";
 import type {
@@ -67,6 +66,10 @@ function formatPoints(value: number): string {
     return POINTS_FORMATTER.format(value);
 }
 
+// Default points a question is worth until the teacher edits its "Valor de la pregunta".
+// Keep in sync with the QuestionGradingPanel `defaultMaxPoints` prop passed below.
+const DEFAULT_QUESTION_MAX_POINTS = 10;
+
 interface GradeProgress {
     graded: number;
     total: number;
@@ -84,10 +87,13 @@ function buildGradeProgress(detail: TeacherCaseSubmissionDetailResponse): GradeP
         for (const question of module.questions) {
             total += 1;
             const grade = question.grade;
+            // Denominator = the FULL points possible across every question: a graded question
+            // contributes its (teacher-editable) max_points, an ungraded one the default value the
+            // grading panel seeds. So editing a question's "Valor de la pregunta" moves the total.
+            max += grade ? grade.max_points : DEFAULT_QUESTION_MAX_POINTS;
             if (grade) {
                 graded += 1;
                 earned += grade.points_awarded;
-                max += grade.max_points;
             }
         }
     }
@@ -120,11 +126,36 @@ function getGradeSummary(detail: TeacherCaseSubmissionDetailResponse): string {
     return `${formatTeacherGradebookScore(detail.grade_summary.score)} / ${formatTeacherGradebookScore(detail.grade_summary.max_score)}`;
 }
 
-function getStatusBadgeClasses(status: string): string {
-    switch (status) {
-        case "submitted":
+type ReviewStatusTone = "graded" | "pending" | "in_progress" | "not_started";
+
+interface ReviewStatus {
+    label: string;
+    tone: ReviewStatusTone;
+}
+
+/**
+ * Status framed for the GRADING view: a submitted-but-ungraded entry reads "Por calificar" and a
+ * fully graded one "Calificado", so the teacher sees their own pending work at a glance. The raw
+ * submission state is still conveyed by the "Entrega" timestamp and "Versión" rows.
+ */
+function getReviewStatus(detail: TeacherCaseSubmissionDetailResponse): ReviewStatus {
+    if (detail.grade_summary.status === "graded") {
+        return { label: "Calificado", tone: "graded" };
+    }
+    if (detail.response_state.status === "submitted" || detail.response_state.status === "graded") {
+        return { label: "Por calificar", tone: "pending" };
+    }
+    if (detail.response_state.status === "in_progress") {
+        return { label: "En progreso", tone: "in_progress" };
+    }
+    return { label: "Sin iniciar", tone: "not_started" };
+}
+
+function getReviewStatusBadgeClasses(tone: ReviewStatusTone): string {
+    switch (tone) {
         case "graded":
             return "bg-emerald-100 text-emerald-800 ring-1 ring-inset ring-emerald-200";
+        case "pending":
         case "in_progress":
             return "bg-amber-100 text-amber-800 ring-1 ring-inset ring-amber-200";
         default:
@@ -164,7 +195,7 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
             <QuestionGradingPanel
                 questionId={args.questionId}
                 initialGrade={gradeMap[args.questionId] ?? null}
-                defaultMaxPoints={10}
+                defaultMaxPoints={DEFAULT_QUESTION_MAX_POINTS}
                 disabled={isRefreshing}
                 onSave={(payload) =>
                     saveGrade.mutateAsync({ questionId: args.questionId, payload }).then(() => undefined)
@@ -181,8 +212,9 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
     const totalQuestions = countSubmissionQuestions(detail);
     const refreshLabel = isRefreshing ? "Actualizando entrega" : "Actualizar entrega";
     const snapshotLabel = getSnapshotLabel(detail);
-    const statusLabel = formatTeacherGradebookCellStatus(detail.response_state.status).toUpperCase();
-    const statusBadgeClasses = getStatusBadgeClasses(detail.response_state.status);
+    const reviewStatus = getReviewStatus(detail);
+    const statusLabel = reviewStatus.label.toUpperCase();
+    const statusBadgeClasses = getReviewStatusBadgeClasses(reviewStatus.tone);
 
     useEffect(() => {
         if (visibleModules.length === 0) {
@@ -257,10 +289,12 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                             <dt className="text-[10px] uppercase tracking-wider text-slate-400">Calificación</dt>
                             <dd className="text-right text-[11px] tabular-nums">{getGradeSummary(detail)}</dd>
 
-                            <dt className="text-[10px] uppercase tracking-wider text-slate-400">Entrega</dt>
-                            <dd className="truncate text-right text-[11px]" title={formatTimestamp(detail.response_state.submitted_at, "Sin entrega")}>
-                                {formatTimestamp(detail.response_state.submitted_at, "Sin entrega")}
-                            </dd>
+                            <div className="col-span-2 flex items-baseline justify-between gap-3">
+                                <dt className="text-[10px] uppercase tracking-wider text-slate-400">Entrega</dt>
+                                <dd className="whitespace-nowrap text-right text-[11px] tabular-nums" title={formatTimestamp(detail.response_state.submitted_at, "Sin entrega")}>
+                                    {formatTimestamp(detail.response_state.submitted_at, "Sin entrega")}
+                                </dd>
+                            </div>
                         </dl>
                     </div>
                 </aside>
@@ -272,7 +306,7 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                     >
                         <div className="min-w-0">
                             <p
-                                className="truncate text-xs text-slate-500"
+                                className="truncate text-xs font-semibold text-slate-600"
                                 title={`${detail.case.course_code} · ${detail.case.course_name} · ${detail.student.email}`}
                             >
                                 {detail.case.course_code} · {detail.case.course_name} · {detail.student.email}
@@ -294,7 +328,7 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                                     </span>
                                     <span
                                         className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-200"
-                                        title="Puntos otorgados sobre el total de las preguntas calificadas"
+                                        title="Puntos otorgados sobre el total de puntos de todas las preguntas"
                                     >
                                         <span className="text-[10px] font-bold uppercase tracking-wider text-indigo-400">Puntos</span>
                                         <span data-testid="grading-progress-points" className="whitespace-nowrap tabular-nums">

--- a/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/TeacherSubmissionPreview.tsx
@@ -337,7 +337,10 @@ export function TeacherSubmissionPreview({ assignmentId, detail, isRefreshing, o
                                     </span>
                                 </div>
                             ) : null}
-                            <span className={`hidden rounded-full px-3 py-1 text-xs font-semibold lg:inline-flex ${statusBadgeClasses}`}>
+                            <span
+                                data-testid="teacher-submission-status-badge"
+                                className={`hidden rounded-full px-3 py-1 text-xs font-semibold lg:inline-flex ${statusBadgeClasses}`}
+                            >
                                 {statusLabel}
                             </span>
                             <button

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
@@ -155,6 +155,50 @@ describe("TeacherSubmissionPreview", () => {
         expect(screen.queryByTestId("question-grading-panel")).toBeNull();
         // no grading progress chips when the response is not gradeable
         expect(screen.queryByTestId("teacher-submission-grading-progress")).toBeNull();
+        // ESTADO reflects the in-progress branch with an amber (pending-tone) badge
+        const summary = screen.getByTestId("teacher-submission-preview-summary");
+        expect(within(summary).getByText("EN PROGRESO")).toBeTruthy();
+        expect(screen.getByTestId("teacher-submission-status-badge").className).toContain("amber");
+    });
+
+    it("shows SIN INICIAR with a neutral badge when the student has not started", async () => {
+        renderPreview({
+            detail: createSubmissionDetailResponse({
+                response_state: {
+                    status: "not_started",
+                    first_opened_at: null,
+                    last_autosaved_at: null,
+                    submitted_at: null,
+                    snapshot_id: null,
+                    snapshot_hash: null,
+                },
+            }),
+        });
+
+        const summary = await screen.findByTestId("teacher-submission-preview-summary");
+        expect(within(summary).getByText("SIN INICIAR")).toBeTruthy();
+        expect(screen.getByTestId("teacher-submission-status-badge").className).toContain("slate");
+    });
+
+    it("stays POR CALIFICAR until the grade rollup completes, even if response_state is graded", async () => {
+        renderPreview({
+            detail: createSubmissionDetailResponse({
+                response_state: {
+                    status: "graded",
+                    first_opened_at: "2026-06-02T12:00:00Z",
+                    last_autosaved_at: "2026-06-05T18:15:00Z",
+                    submitted_at: "2026-06-05T19:00:00Z",
+                    snapshot_id: "snapshot-1",
+                    snapshot_hash: "hash-123",
+                },
+                grade_summary: { status: null, score: null, max_score: 5, graded_at: null },
+            }),
+        });
+
+        const summary = await screen.findByTestId("teacher-submission-preview-summary");
+        // ESTADO keys "Calificado" off grade_summary.status, not response_state, so an
+        // unrolled-up summary still reads as pending.
+        expect(within(summary).getByText("POR CALIFICAR")).toBeTruthy();
     });
 
     it("shows live grading progress in the topbar (graded count + running points)", async () => {
@@ -283,6 +327,7 @@ describe("TeacherSubmissionPreview", () => {
         expect(within(summary).getByText("Borrador vigente")).toBeTruthy();
         expect(within(summary).getByText("CALIFICADO")).toBeTruthy();
         expect(within(summary).getByText(`${formatTeacherGradebookScore(4.5)} / ${formatTeacherGradebookScore(5)}`)).toBeTruthy();
+        expect(screen.getByTestId("teacher-submission-status-badge").className).toContain("emerald");
     });
 
     it("navigates back to the submissions list from the sidebar", async () => {

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
@@ -126,7 +126,9 @@ describe("TeacherSubmissionPreview", () => {
         expect(within(summary).getByText("Borrador vigente")).toBeTruthy();
         expect(within(summary).getByText("2/2")).toBeTruthy();
         expect(within(summary).getByText("Pendiente")).toBeTruthy();
-        expect(within(header).getByText("Caso Plataforma")).toBeTruthy();
+        // The case title now lives only in the sidebar; the topbar shows the course/student context line.
+        expect(within(header).queryByText("Caso Plataforma")).toBeNull();
+        expect(within(header).getByText(/ana\.student@example\.edu/)).toBeTruthy();
         // A submitted response is gradeable: the renderer receives renderQuestionFooter and a panel renders.
         const renderer = screen.getByTestId("case-content-renderer");
         expect(renderer.getAttribute("data-has-grading")).toBe("true");
@@ -252,12 +254,31 @@ describe("TeacherSubmissionPreview", () => {
         expect(within(summary).getByText(`${formatTeacherGradebookScore(4.5)} / ${formatTeacherGradebookScore(5)}`)).toBeTruthy();
     });
 
-    it("navigates back to the submissions list", async () => {
+    it("navigates back to the submissions list from the sidebar", async () => {
         renderPreview();
 
-        fireEvent.click(await screen.findByRole("button", { name: /Volver/i }));
+        const sidebar = await screen.findByTestId("teacher-submission-preview-sidebar");
+        fireEvent.click(within(sidebar).getByRole("button", { name: /Volver/i }));
 
         expect(await screen.findByTestId("submissions-list")).toBeTruthy();
+    });
+
+    it("navigates back from the mobile module bar", async () => {
+        renderPreview();
+
+        const mobileBar = await screen.findByTestId("teacher-submission-preview-mobile-modules");
+        fireEvent.click(within(mobileBar).getByRole("button", { name: /Volver/i }));
+
+        expect(await screen.findByTestId("submissions-list")).toBeTruthy();
+    });
+
+    it("labels the mobile module pills with readable names instead of raw ids", async () => {
+        renderPreview();
+
+        const mobileBar = await screen.findByTestId("teacher-submission-preview-mobile-modules");
+        // business + harvard_only => m1 renders as "Case Reader", not the raw "m1" id.
+        expect(within(mobileBar).getByRole("button", { name: "Case Reader" })).toBeTruthy();
+        expect(within(mobileBar).queryByRole("button", { name: "m1" })).toBeNull();
     });
 
     it("forwards the refresh action", async () => {

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
@@ -122,7 +122,7 @@ describe("TeacherSubmissionPreview", () => {
 
         expect(within(sidebar).getByText("Ana Student")).toBeTruthy();
         expect(within(sidebar).getByText("Caso Plataforma")).toBeTruthy();
-        expect(within(summary).getByText("ENTREGADO")).toBeTruthy();
+        expect(within(summary).getByText("POR CALIFICAR")).toBeTruthy();
         expect(within(summary).getByText("Borrador vigente")).toBeTruthy();
         expect(within(summary).getByText("2/2")).toBeTruthy();
         expect(within(summary).getByText("Pendiente")).toBeTruthy();
@@ -193,8 +193,38 @@ describe("TeacherSubmissionPreview", () => {
 
         const progress = await screen.findByTestId("teacher-submission-grading-progress");
         expect(within(progress).getByTestId("grading-progress-count").textContent).toBe("2/3");
-        // 7 + 8,5 = 15,5 awarded out of 10 + 10 = 20 over the graded questions
-        expect(within(progress).getByTestId("grading-progress-points").textContent).toBe("15,5 / 20");
+        // 7 + 8,5 = 15,5 awarded; total = 10 + 10 (graded) + 10 (default for the ungraded M5-Q1) = 30
+        expect(within(progress).getByTestId("grading-progress-points").textContent).toBe("15,5 / 30");
+    });
+
+    it("totals max points across ALL questions (default 10 each; reflects per-question edits)", async () => {
+        renderPreview({
+            detail: createSubmissionDetailResponse({
+                modules: [
+                    {
+                        id: "M1",
+                        title: "Módulo 1",
+                        questions: [
+                            {
+                                id: "M1-Q1", order: 1, statement: "", context: null, expected_solution: "",
+                                student_answer: null, student_answer_chars: 0, is_answer_from_draft: false,
+                                // teacher raised this question's value to 20
+                                grade: { question_id: "M1-Q1", points_awarded: 4, max_points: 20, feedback: null, graded_at: "2026-06-06T18:00:00Z", graded_by_membership_id: "t" },
+                            },
+                            {
+                                id: "M1-Q2", order: 2, statement: "", context: null, expected_solution: "",
+                                student_answer: null, student_answer_chars: 0, is_answer_from_draft: false, grade: null,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        });
+
+        const progress = await screen.findByTestId("teacher-submission-grading-progress");
+        expect(within(progress).getByTestId("grading-progress-count").textContent).toBe("1/2");
+        // 4 awarded; total = 20 (edited) + 10 (default for the ungraded question) = 30
+        expect(within(progress).getByTestId("grading-progress-points").textContent).toBe("4 / 30");
     });
 
     it("passes canonical output, answers and read-only flags to the renderer", async () => {
@@ -251,6 +281,7 @@ describe("TeacherSubmissionPreview", () => {
         const summary = await screen.findByTestId("teacher-submission-preview-summary");
 
         expect(within(summary).getByText("Borrador vigente")).toBeTruthy();
+        expect(within(summary).getByText("CALIFICADO")).toBeTruthy();
         expect(within(summary).getByText(`${formatTeacherGradebookScore(4.5)} / ${formatTeacherGradebookScore(5)}`)).toBeTruthy();
     });
 


### PR DESCRIPTION
## Contexto

La vista de revisión/calificación de una entrega (`TeacherSubmissionPreview`) se sentía "amontonada": dos cabeceras apiladas (la barra azul global de 80px + el topbar local) y el chip de PUNTOS partía el número en dos líneas. Esta PR descongestiona el topbar, mueve la navegación e identidad al sidebar y corrige varios detalles de calidad y accesibilidad detectados en el camino. Solo frontend; sin backend, sin cambios de contrato/API.

## Cambios

- **Volver → sidebar** (arriba de "Revisión docente", estilo superficie oscura + focus ring) y **Volver en móvil** dentro de la barra de módulos (el sidebar se oculta en `<md`).
- **Topbar más limpio**: se quita el título (ya está en el sidebar) y se baja `h-16 → h-12`; queda solo la línea de contexto curso·correo (peso semibold, 12px).
- **Chip de PUNTOS** ya no se parte: `whitespace-nowrap` + `tabular-nums` + `shrink-0`.
- **PUNTOS = total del caso**: el denominador suma el valor de **todas** las preguntas (default 10 c/u vía `DEFAULT_QUESTION_MAX_POINTS`, refleja el "Valor de la pregunta" editado), no solo las calificadas.
- **ESTADO enfocado en calificación**: `POR CALIFICAR` / `CALIFICADO` (badge ámbar→verde) vía helper local `getReviewStatus`; **no** toca el formateador compartido del cuadernillo.
- **Botón "Actualizar" compacto** (ícono + etiqueta corta; `aria-label` preservado).
- **Defectos móviles**: las píldoras de módulo muestran el **nombre** (p. ej. "Case Reader") en vez de "m1".
- **Fila ENTREGA** a ancho completo (`col-span-2`) para ver la fecha completa sin recortar.
- **A11y**: contraste de etiquetas del footer (slate-500→slate-400), números tabulares, anillos `focus-visible`.

## Verificación

- `npm --prefix frontend run lint` ✓
- `npm --prefix frontend run test` ✓ (529/529)
- `npm --prefix frontend run build` ✓
- Review adversarial multiagente (testing, mantenibilidad, frontend/a11y, riesgo-producción, red-team): 0 críticos; los 2 hallazgos informativos (cobertura de ramas de `getReviewStatus` + tono del badge) quedaron cerrados con tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)