### PR TITLE
fix(case-preview): M1 exhibit tables always render — normalize <br> row separators (#356)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -99,6 +99,13 @@ MLDS_BINARY_TARGET_COERCE=true
 # Set to false to passthrough exactly (instant revert, no redeploy). The product is USD-only (#370).
 CASE_USD_CURRENCY_ENFORCE=true
 
+# -- M1 Exhibit <br> normalization (kill-switch, Issue #356) ------
+# When true (default), the architect's M1 Exhibit tables (doc1_anexo_*) have any literal
+# <br> row separators converted to real newlines at the case_architect return, so the
+# persisted table renders as a GFM table instead of raw markdown. An exhibit without <br>
+# is byte-identical. Set to false to passthrough exactly (instant revert, no redeploy).
+M1_EXHIBIT_NORMALIZE=true
+
 # -- Supabase auth perimeter (Issue 23 + Issue 30) ----------------
 # Required for JWT verification, activation flows and admin auth operations.
 # Local auth/session dev uses `supabase start` at http://localhost:54321.

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -483,6 +483,35 @@ def sanitize_markdown(text: str) -> str:
     return text
 
 
+_EXHIBIT_BR_RE = re.compile(r"<br\s*/?>", re.IGNORECASE)
+
+
+def normalize_exhibit_markdown(text: str) -> str:
+    """Convert literal ``<br>`` row separators to real newlines in M1 Exhibit tables (#356).
+
+    The architect emits ``CaseArchitectOutput`` as *structured output*, where multi-line
+    markdown is frequently written with literal ``<br>`` as row separators and ZERO real
+    newlines (a well-known LLM quirk for string fields). That breaks BOTH the frontend GFM
+    table parser (it collapses to one line → renders raw) and the backend ``.splitlines()``
+    anchor parser in ``m1_grounding``. This pure, deterministic relabel converts ``<br>`` /
+    ``<br/>`` / ``<br />`` (any case, optional inner spaces) to ``\\n``. Scoped to the three
+    ``doc1_anexo_*`` fields only — NOT the shared ``sanitize_markdown`` blast radius. A string
+    without ``<br>`` is byte-identical.
+    """
+    if not text:
+        return ""
+    normalized = _EXHIBIT_BR_RE.sub("\n", text)
+    if normalized == text:
+        # No <br> present → return the original verbatim. Strictly additive: this helper
+        # never touches an exhibit that already uses real newlines.
+        return text
+    # Only when a <br> was actually converted: collapse the 3+ newline runs a <br><br><br>…
+    # heading gap can produce (matches the repo's sanitize_untrusted_text newline-collapse
+    # convention). A single blank line between a heading and the table (\n\n) is the
+    # GFM-correct shape and is preserved.
+    return re.sub(r"\n{3,}", "\n\n", normalized)
+
+
 def _extract_text(response) -> str:
     """Extrae texto limpio del response de Gemini 2.5 o 3.x.
 
@@ -1044,9 +1073,18 @@ def case_architect(state: ADAMState, config: RunnableConfig) -> dict:
                 _enforce_usd_currency_field(pregunta_eje) if pregunta_eje else pregunta_eje
             ),
             "doc1_instrucciones": _enforce_usd_currency_field(result.instrucciones_estudiante),
-            "doc1_anexo_financiero": _enforce_usd_currency_field(result.anexo_financiero),
-            "doc1_anexo_operativo": _enforce_usd_currency_field(anexo_operativo_final),
-            "doc1_anexo_stakeholders": _enforce_usd_currency_field(result.anexo_stakeholders),
+            # #356 — normalize <br> row separators → real newlines BEFORE the USD relabel,
+            # so both the frontend GFM parser and the backend .splitlines() anchor parser see
+            # a real multi-line table (the architect structured output bypasses sanitize_markdown).
+            "doc1_anexo_financiero": _enforce_usd_currency_field(
+                _normalize_exhibit_field(result.anexo_financiero)
+            ),
+            "doc1_anexo_operativo": _enforce_usd_currency_field(
+                _normalize_exhibit_field(anexo_operativo_final)
+            ),
+            "doc1_anexo_stakeholders": _enforce_usd_currency_field(
+                _normalize_exhibit_field(result.anexo_stakeholders)
+            ),
             # downstream nodes leen state["dataset_schema_required"] y degradan
             # gracefully al comportamiento previo si es None.
             "dataset_schema_required": contract_dict,
@@ -1354,6 +1392,13 @@ def _enforce_usd_currency_field(text: str) -> str:
     if not settings.case_usd_currency_enforce:
         return text
     return enforce_usd_currency(text)
+
+
+def _normalize_exhibit_field(text: str) -> str:
+    """Normalize ``<br>`` → real newlines in one M1 exhibit field (kill-switch gated, #356)."""
+    if not settings.m1_exhibit_normalize:
+        return text
+    return normalize_exhibit_markdown(text)
 
 
 # ─────────────────────────────────────────────────────────

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -73,6 +73,15 @@ class Settings(BaseSettings):
     # env-only revert; no redeploy). The currency LABEL of `business_cost_matrix` stays coerced by
     # #370 regardless of this flag.
     case_usd_currency_enforce: bool = True
+    # Normalize M1 Exhibit tables that the architect emits with literal `<br>` row separators
+    # and zero real newlines (Issue #356). When true, `normalize_exhibit_markdown` converts
+    # `<br>`/`<br/>`/`<br />` → real newlines on the three `doc1_anexo_*` fields at the
+    # `case_architect` return, so the persisted canonical_output is a real multi-line GFM table
+    # (frontend renders it; `m1_grounding.splitlines()` parses it). Byte-identical for any exhibit
+    # without `<br>`. Kill-switch: set M1_EXHIBIT_NORMALIZE=false to passthrough exactly (instant
+    # env-only revert; no redeploy). The frontend `sanitizeExhibitMarkdown` repairs existing cases
+    # regardless of this flag.
+    m1_exhibit_normalize: bool = True
 
     model_config = SettingsConfigDict(env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/tests/test_issue356_m1_exhibit_normalization.py
+++ b/backend/tests/test_issue356_m1_exhibit_normalization.py
@@ -1,0 +1,207 @@
+"""Issue #356 — M1 Exhibit ``<br>`` normalization (deterministic backend layer).
+
+The architect emits ``CaseArchitectOutput`` as *structured output*, where the M1 Exhibit
+tables (``doc1_anexo_*``) are frequently written with literal ``<br>`` as row separators and
+ZERO real newlines. That collapses the whole table onto one line, which breaks both the
+frontend GFM table parser (renders raw) and the backend ``.splitlines()`` anchor parser.
+
+Two surfaces:
+
+* **Pure helper** ``normalize_exhibit_markdown`` — converts ``<br>`` / ``<br/>`` / ``<br />``
+  (any case, optional inner spaces) to ``\\n`` and collapses 3+ newline runs to 2. Scoped to
+  the three anexo fields only — byte-identical for any string without ``<br>``.
+* **Node wiring** — ``_normalize_exhibit_field`` (kill-switch ``M1_EXHIBIT_NORMALIZE``) is
+  applied to the three ``doc1_anexo_*`` fields at the ``case_architect`` return, INNER to the
+  #377 ``_enforce_usd_currency_field`` relabel (normalize newlines first, then USD relabel).
+
+The frontend ``sanitizeExhibitMarkdown`` is the render-time twin that repairs already-generated
+cases regardless of this flag; this layer cleans the persisted canonical_output at the source.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import case_generator.graph as graph_module
+from case_generator.graph import normalize_exhibit_markdown
+from case_generator.m1_grounding import parse_exhibit_anchors
+from case_generator.tools_and_schemas import CaseArchitectOutput
+
+# The exact single-line shape from the issue: <br> row separators, ZERO real newlines.
+ISSUE_EVIDENCE = (
+    "### Exhibit 1 — Datos Financieros<br><br>"
+    "| Métrica | Año N-1 | Año N |<br>"
+    "|---|---|---|<br>"
+    "| Ingresos | $40,000,000 | $45,000,000 |<br>"
+    "| Costos | $30,000,000 | $33,000,000 |<br>"
+    "| EBITDA | $10,000,000 | $12,000,000 |"
+)
+
+
+def _table_rows(text: str) -> list[str]:
+    """Lines that are markdown table rows (header / separator / data)."""
+    return [ln for ln in text.splitlines() if ln.lstrip().startswith("|")]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Pure helper — the deterministic core
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestNormalizeExhibitMarkdown:
+    def test_issue_evidence_becomes_real_multiline_table(self) -> None:
+        out = normalize_exhibit_markdown(ISSUE_EVIDENCE)
+        assert "<br" not in out.lower()
+        # header + separator + 3 data rows, each on its OWN line — was a single line.
+        assert len(_table_rows(out)) == 5
+        # contrast: pre-fix, the whole table is mashed onto the `###` heading line, so ZERO
+        # lines look like a table row — exactly why the GFM parser renders it raw.
+        assert len(_table_rows(ISSUE_EVIDENCE)) == 0
+        # The heading is separated from the table by a single blank line (GFM-correct).
+        assert (
+            "### Exhibit 1 — Datos Financieros\n\n| Métrica | Año N-1 | Año N |" in out
+        )
+
+    def test_anchors_parse_from_normalized_output(self) -> None:
+        anchors = parse_exhibit_anchors(normalize_exhibit_markdown(ISSUE_EVIDENCE))
+        for figure in (40_000_000.0, 45_000_000.0, 12_000_000.0):
+            assert figure in anchors
+
+    @pytest.mark.parametrize("br", ["<br>", "<br/>", "<br />", "<BR>", "<br >", "<BR/>"])
+    def test_all_br_variants_normalized(self, br: str) -> None:
+        src = f"| A | B |{br}|---|---|{br}| 1 | 2 |"
+        out = normalize_exhibit_markdown(src)
+        assert "<br" not in out.lower()
+        assert len(_table_rows(out)) == 3
+
+    def test_double_br_heading_gap_preserved_as_blank_line(self) -> None:
+        assert normalize_exhibit_markdown("### H<br><br>| a |") == "### H\n\n| a |"
+
+    def test_triple_plus_br_gap_collapsed_to_one_blank_line(self) -> None:
+        assert normalize_exhibit_markdown("### H<br><br><br><br>| a |") == "### H\n\n| a |"
+
+    def test_no_br_is_byte_identical(self) -> None:
+        src = "### Exhibit 1\n\n| Ingresos | $25M |\n|---|---|\n| EBITDA | $7M |"
+        assert normalize_exhibit_markdown(src) == src
+
+    def test_no_br_with_preexisting_blank_run_is_byte_identical(self) -> None:
+        # Strictly additive: a no-<br> exhibit is returned verbatim even if it already
+        # contains a 3+ newline run — the collapse only fires when a <br> was converted.
+        src = "### Exhibit 1\n\n\n| Ingresos | $25M |\n|---|---|\n| EBITDA | $7M |"
+        assert normalize_exhibit_markdown(src) == src
+
+    def test_empty_is_safe(self) -> None:
+        assert normalize_exhibit_markdown("") == ""
+
+    def test_magnitudes_preserved_verbatim(self) -> None:
+        out = normalize_exhibit_markdown(ISSUE_EVIDENCE)
+        for figure in ("$40,000,000", "$45,000,000", "$12,000,000"):
+            assert figure in out
+
+    def test_idempotent(self) -> None:
+        once = normalize_exhibit_markdown(ISSUE_EVIDENCE)
+        assert normalize_exhibit_markdown(once) == once
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Node wiring — case_architect source + kill-switch + composition with #377
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _arch_output(**overrides: str) -> CaseArchitectOutput:
+    base = dict(
+        titulo="NovaTech — Crisis de márgenes",
+        industria="retail B2B",
+        company_profile="Perfil con caja $1,200,000.",
+        dilema_brief="Inversión de $5,000 y revenue $80,000.",
+        instrucciones_estudiante="Eres analista de la firma.",
+        anexo_financiero=ISSUE_EVIDENCE,
+        anexo_operativo=(
+            "### Exhibit 2 — Indicadores Operativos<br>"
+            "| Indicador | Valor |<br>|---|---|<br>| Tickets | 14,500 |<br>| Activos | 52,000 |"
+        ),
+        anexo_stakeholders=(
+            "### Exhibit 3 — Mapa de Stakeholders<br>"
+            "| Actor | Interés |<br>|---|---|<br>| CFO | Caja |"
+        ),
+    )
+    base.update(overrides)
+    return CaseArchitectOutput(**base)
+
+
+def _patch_architect(
+    monkeypatch: pytest.MonkeyPatch,
+    arch_out: CaseArchitectOutput,
+    *,
+    profile: str = "business",
+    family: str = "regresion",
+) -> None:
+    monkeypatch.setattr(graph_module, "_get_architect_llm", lambda *a, **k: object())
+    monkeypatch.setattr(
+        graph_module, "_build_base_context", lambda state: {"student_profile": profile}
+    )
+    monkeypatch.setattr(graph_module, "_assemble_architect_prompt", lambda ctx: "")
+    monkeypatch.setattr(
+        graph_module,
+        "_invoke_case_architect_with_contract",
+        lambda **k: (arch_out, profile, family, None),
+    )
+    # Isolate from #372 — passthrough the operativo (its own tests cover the rate row).
+    monkeypatch.setattr(
+        graph_module, "_invoke_m1_exhibit2_coherence", lambda **k: k["anexo_operativo"]
+    )
+
+
+class TestCaseArchitectNormalization:
+    def test_br_normalized_in_all_three_returned_exhibits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(graph_module.settings, "m1_exhibit_normalize", True)
+        monkeypatch.setattr(graph_module.settings, "case_usd_currency_enforce", False)
+        _patch_architect(monkeypatch, _arch_output())
+        out = graph_module.case_architect({}, {"configurable": {}})
+        for key in (
+            "doc1_anexo_financiero",
+            "doc1_anexo_operativo",
+            "doc1_anexo_stakeholders",
+        ):
+            assert "<br" not in out[key].lower()
+            assert "\n" in out[key]
+        assert len(_table_rows(out["doc1_anexo_financiero"])) == 5
+
+    def test_kill_switch_off_preserves_br_byte_identical(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(graph_module.settings, "m1_exhibit_normalize", False)
+        monkeypatch.setattr(graph_module.settings, "case_usd_currency_enforce", False)
+        arch = _arch_output()
+        _patch_architect(monkeypatch, arch)
+        out = graph_module.case_architect({}, {"configurable": {}})
+        assert out["doc1_anexo_financiero"] == arch.anexo_financiero
+        assert "<br>" in out["doc1_anexo_financiero"]
+
+    def test_no_br_exhibit_byte_identical(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(graph_module.settings, "m1_exhibit_normalize", True)
+        monkeypatch.setattr(graph_module.settings, "case_usd_currency_enforce", False)
+        clean = "### Exhibit 1\n\n| Ingresos | $4,500,000 |\n|---|---|\n| EBITDA | $900,000 |"
+        arch = _arch_output(anexo_financiero=clean)
+        _patch_architect(monkeypatch, arch)
+        out = graph_module.case_architect({}, {"configurable": {}})
+        assert out["doc1_anexo_financiero"] == clean
+
+    def test_composes_inner_to_usd_relabel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Normalization (inner) runs before the #377 USD relabel (outer): a <br>-collapsed
+        table with a EUR figure ends up as a real multi-line table with the EUR relabeled."""
+        monkeypatch.setattr(graph_module.settings, "m1_exhibit_normalize", True)
+        monkeypatch.setattr(graph_module.settings, "case_usd_currency_enforce", True)
+        arch = _arch_output(
+            anexo_financiero=(
+                "### Exhibit 1<br><br>| Métrica | Valor |<br>|---|---|<br>| Caja | 5.000 EUR |"
+            ),
+        )
+        _patch_architect(monkeypatch, arch)
+        out = graph_module.case_architect({}, {"configurable": {}})
+        fin = out["doc1_anexo_financiero"]
+        assert "<br" not in fin.lower()          # normalized to real newlines
+        assert "5.000 USD" in fin and "EUR" not in fin  # USD relabel applied after
+        assert len(_table_rows(fin)) == 3

--- a/frontend/src/features/case-preview/sanitizeExhibit.test.ts
+++ b/frontend/src/features/case-preview/sanitizeExhibit.test.ts
@@ -187,6 +187,58 @@ describe("[8] inline table expansion", () => {
     });
 });
 
+// ── [9] HTML <br> row separators (issue #356) ──────────────────────────────────
+
+describe("[9] HTML <br> row separators", () => {
+    // The architect emits the whole table on a single line with literal <br> as row
+    // separators and zero real newlines — this is the exact shape from issue #356.
+    const ISSUE_EVIDENCE =
+        "### Exhibit 1 — Datos Financieros<br><br>" +
+        "| Métrica | Año N-1 | Año N |<br>" +
+        "|---|---|---|<br>" +
+        "| Ingresos | $40,000,000 | $45,000,000 |<br>" +
+        "| Costos | $30,000,000 | $33,000,000 |<br>" +
+        "| EBITDA | $10,000,000 | $12,000,000 |";
+
+    it("turns the issue-evidence single-line <br> table into a renderable GFM table", () => {
+        const result = sanitizeExhibitMarkdown(ISSUE_EVIDENCE);
+
+        expect(isRenderableAsTable(result)).toBe(true);
+        // heading separated from the table by a blank line, header row on its own line
+        expect(result).toContain(
+            "### Exhibit 1 — Datos Financieros\n\n| Métrica | Año N-1 | Año N |",
+        );
+        // header + separator + 3 data rows, each on its own line
+        expect(tableLines(result)).toHaveLength(5);
+        // no literal <br> survives
+        expect(result).not.toMatch(/<br/i);
+    });
+
+    it.each(["<br>", "<br/>", "<br />", "<BR>", "<br >", "<BR/>"])(
+        "normalizes the %s variant into a renderable table",
+        (br) => {
+            const input =
+                `| A | B |${br}|---|---|${br}| 1 | 2 |${br}| 3 | 4 |`;
+            const result = sanitizeExhibitMarkdown(input);
+
+            expect(isRenderableAsTable(result)).toBe(true);
+            expect(tableLines(result)).toHaveLength(4);
+            expect(result).not.toMatch(/<br/i);
+        },
+    );
+
+    it("is a no-op (byte-identical) for a well-formed table with no <br>", () => {
+        const input = [
+            "| Métrica | Valor |",
+            "|---|---|",
+            "| Ingresos | $25M |",
+            "| EBITDA | $7M |",
+        ].join("\n");
+
+        expect(sanitizeExhibitMarkdown(input)).toBe(input);
+    });
+});
+
 // ── Regression guards ──────────────────────────────────────────────────────────
 
 describe("regression: blank lines that must be preserved", () => {

--- a/frontend/src/shared/case-viewer/sanitizeExhibit.ts
+++ b/frontend/src/shared/case-viewer/sanitizeExhibit.ts
@@ -12,6 +12,7 @@
  *   [5] No blank line after the last table row (breaks next paragraph)
  *   [6] Heading immediately adjacent to table (### Exhibit\n| col |)
  *   [7] Blank line(s) trapped between two table rows (premature </table> close)
+ *   [9] Literal <br> row separators with zero real newlines (issue #356)
  */
 import { isMarkdownTableRow } from "./markdownTable";
 
@@ -91,6 +92,17 @@ export function sanitizeExhibitMarkdown(raw: string): string {
 
     // [2] Normalize line endings to \n only
     text = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+    // [9] HTML <br> normalization: the architect (case_architect) frequently emits
+    //     exhibit tables with literal <br> as row separators and ZERO real newlines
+    //     (a structured-output quirk — issue #356). marked / remark-gfm require real
+    //     newlines to detect a GFM table, so without this the whole table collapses to
+    //     one line and renders raw. Covers <br>, <br/>, <br /> (any case, optional inner
+    //     spaces). Runs BEFORE expandInlineTable so the row-split, separator-injection
+    //     and table-glue passes operate on real lines. Purely additive: a string with no
+    //     <br> is byte-identical. Scoped to exhibit fields (table-only), so a global
+    //     conversion is safe here.
+    text = text.replace(/<br\s*\/?>/gi, "\n");
 
     // [8] Inline table expansion: collapse a single-line GFM table into proper
     // multiline rows before the remaining passes run.


### PR DESCRIPTION
## Qué y por qué

Cierra **#356**. Los Exhibits del M1 (Exhibit 1 Financiero / Exhibit 2 Operativo / Exhibit 3 Stakeholders) **a veces** se renderizaban como **markdown crudo** (se veían los `|`, los separadores `---|---|---` y `<br>` literales en una sola línea) en vez de tablas — tanto en el preview en vivo como en el render final de `CasePreview`.

**Causa raíz (verificada):** `case_architect` emite los anexos como *structured output*, donde el LLM frecuentemente escribe el markdown multilínea con **`<br>` literales como separadores de fila y CERO saltos de línea reales** (quirk típico de structured output). `marked` / `remark-gfm` necesitan saltos reales para detectar una tabla GFM, así que toda la tabla colapsaba a una línea y se imprimía cruda. Pre-existente; el preview por módulo (#355) solo lo hizo más visible.

## Solución — dos capas deterministas (cada una garantiza por sí sola un render correcto)

1. **Frontend (render-time, cubre TODOS los casos existentes + nuevos, sin regenerar):** `sanitizeExhibitMarkdown` convierte `<br>` / `<br/>` / `<br />` (cualquier caja, espacios opcionales) → saltos reales **antes** de las pasadas de reparación de tabla existentes. Estrictamente aditivo (byte-idéntico si no hay `<br>`). Es el único chokepoint que comparten el preview en vivo y el render final → arregla **todos los casos ya generados en la DB** sin regenerar.

2. **Backend (raíz, casos nuevos):** `normalize_exhibit_markdown` (puro, determinista) limpia los tres campos `doc1_anexo_*` en el `return` de `case_architect`, **inner** al relabel USD de #377, de modo que el `canonical_output` persistido es una tabla GFM multilínea real (`m1_grounding.splitlines()` también se beneficia). Estrictamente aditivo: un anexo sin `<br>` se devuelve verbatim. **Kill-switch `M1_EXHIBIT_NORMALIZE`** (default `true`, forma de `CASE_USD_CURRENCY_ENFORCE`).

**Sin tocar el prompt del architect** → `_MLDS_ARCHITECT_PROMPT_SHA256` congelado intacto (el deep-dive determinista hace irrelevante la elección de `<br>` del LLM; un edit cosmético al prompt está desaconsejado por CLAUDE.md). Sin nueva clave canónica/state, sin entrada en `case_sanitization`. El render `marked` de narrativa (prosa) queda intacto a propósito.

## Archivos

| Archivo | Cambio |
|---|---|
| `frontend/src/shared/case-viewer/sanitizeExhibit.ts` | pasada `<br>`→`\n` (`[9]`) |
| `frontend/src/features/case-preview/sanitizeExhibit.test.ts` | bloque de test `[9]` |
| `backend/src/case_generator/graph.py` | `normalize_exhibit_markdown` + `_normalize_exhibit_field` gateado + aplicado a los 3 anexos |
| `backend/src/shared/database.py` | setting `m1_exhibit_normalize` |
| `backend/.env.example` | `M1_EXHIBIT_NORMALIZE=true` |
| `backend/tests/test_issue356_m1_exhibit_normalization.py` | test nuevo (helper puro + nodo + kill-switch + composición #377) |

## Verificación

- **Backend:** `uv run --directory backend pytest -q` → **1665 passed, 22 skipped**. Incluye `test_issue301_pr2b_architect::test_mlds_architect_prompt_frozen_hash` **VERDE** = prueba de que el prompt sensible NO se tocó. `mypy src` limpio (88 archivos).
- **Frontend:** `npm run test` → **537 passed** (65 files, sin churn de snapshots), `npm run lint` limpio, `npm run build` OK.
- **Contraste de regresión:** el shape pre-fix (`### Exhibit 1 …<br>| … |<br>…`) tiene **0 filas reconocibles como tabla** (todo mashed en la línea `###`) → render crudo; tras la normalización, 5 filas reales (header + separador + 3 datos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
