### PR TITLE
feat(case_generator): coherencia interna de opciones en M1 (clasificación, business + ml_ds)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -106,6 +106,14 @@ CASE_USD_CURRENCY_ENFORCE=true
 # is byte-identical. Set to false to passthrough exactly (instant revert, no redeploy).
 M1_EXHIBIT_NORMALIZE=true
 
+# -- M1 question option coherence (kill-switch) ------------------
+# When true (default), the M1 discussion questions are checked so a `solucion_esperada`
+# only recommends a strategic option that exists in the case (A/B/C, from dilema_brief) and
+# that its own enunciado presents; case_questions reprompts once then degrades. Gated to the
+# classification family (business + ml_ds); other cases are unaffected. Set to false to
+# passthrough exactly (instant revert, no redeploy).
+M1_OPTION_COHERENCE=true
+
 # -- Supabase auth perimeter (Issue 23 + Issue 30) ----------------
 # Required for JWT verification, activation flows and admin auth operations.
 # Local auth/session dev uses `supabase start` at http://localhost:54321.

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -171,6 +171,7 @@ from case_generator.m1_grounding import (
     enforce_usd_currency,
     validate_exhibit2_event_rate,
     validate_narrative_exhibit_coherence,
+    validate_question_option_coherence,
     validate_questions_exhibit_coherence,
 )
 from case_generator.m3_notebook_execution import (
@@ -1129,6 +1130,17 @@ _M1_QUESTIONS_EXHIBIT_REPROMPT_HEADER = (
     "cifras que aparezcan textualmente en el Exhibit referido; NUNCA aproximes ni "
     "redondees. Incoherencias detectadas:\n"
 )
+_M1_QUESTIONS_OPTION_REPROMPT_HEADER = (
+    "\n\n# CORRECCIÓN OBLIGATORIA DE COHERENCIA DE OPCIONES\n"
+    "Algunas preguntas recomiendan en `solucion_esperada` una opción estratégica que NO "
+    "existe en el caso, o que el propio enunciado de esa pregunta no presenta al estudiante. "
+    "El caso define un conjunto cerrado de opciones (A, B, C). Regenera EXACTAMENTE 3 "
+    "preguntas con el mismo schema: el enunciado de cada pregunta de decisión DEBE presentar "
+    "las opciones (A/B/C) entre las que el estudiante elige, y `solucion_esperada` SOLO puede "
+    "recomendar una de las opciones presentadas en su enunciado, nombrándola por su letra. "
+    "NUNCA recomiendes una opción inexistente ni ausente del enunciado. Incoherencias "
+    "detectadas:\n"
+)
 
 
 def _build_m1_exhibit_anexos(state: ADAMState) -> dict[str, str]:
@@ -1258,6 +1270,67 @@ def _apply_m1_questions_exhibit_coherence(
     except Exception as exc:  # best-effort — never fail M1
         logger.warning(
             "[case_questions] validador coherencia Exhibit M1 falló (best-effort): %s",
+            exc,
+            extra={"node": "case_questions", "case_id": state.get("case_id")},
+        )
+        return preguntas_dict
+
+
+def _apply_m1_questions_option_coherence(
+    *, llm: Any, prompt: str, state: ADAMState, preguntas_dict: list[dict]
+) -> list[dict]:
+    """Validate + reprompt-once-then-DEGRADE the M1 question option coherence.
+
+    Internal coherence: a ``solucion_esperada`` must only recommend a strategic option that
+    exists in the case (A/B/C, derived from ``dilema_brief``) and that its own ``enunciado``
+    presents. Gated to the classification family for BOTH profiles (business AND ml_ds) and
+    behind the ``m1_option_coherence`` kill-switch; a byte-identical no-op otherwise. The
+    reprompt re-invokes structured output (may raise ``ValidationError`` /
+    ``OutputParserException`` / ``ValueError``); any failure or a residual violation degrades
+    to the pass-1 questions. Best-effort: never raises (in particular never propagates
+    ``RuntimeError``), so the job always completes. Runs AFTER the Exhibit-coherence pass.
+    """
+    if not settings.m1_option_coherence or not _is_classification_family(state):
+        return preguntas_dict
+    try:
+        dilema_brief = str(state.get("dilema_brief") or "")
+        violations = validate_question_option_coherence(preguntas_dict, dilema_brief)
+        if not violations:
+            return preguntas_dict
+        bullet_list = "\n".join(f"- {violation}" for violation in violations)
+        print(
+            f"[case_questions] Incoherencias de opciones M1 detectadas: {violations}. "
+            "Reprompt explícito (1/1)."
+        )
+        reprompt = prompt + _M1_QUESTIONS_OPTION_REPROMPT_HEADER + bullet_list
+        try:
+            resultado: GeneradorPreguntasM1Output = llm.with_structured_output(
+                GeneradorPreguntasM1Output
+            ).invoke(reprompt)
+            corrected = [p.model_dump() for p in resultado.preguntas]
+        except (ValidationError, OutputParserException, ValueError) as exc:
+            logger.warning(
+                "[case_questions] reprompt coherencia de opciones inválido — degrada a pass-1: %s",
+                exc,
+                extra={"node": "case_questions", "case_id": state.get("case_id")},
+            )
+            return preguntas_dict
+        violations_2 = validate_question_option_coherence(corrected, dilema_brief)
+        if not violations_2:
+            print("[case_questions] Reprompt coherencia de opciones M1 OK")
+            return corrected
+        logger.warning(
+            "[case_questions] coherencia de opciones M1 degradada tras reprompt",
+            extra={
+                "node": "case_questions",
+                "violations": violations_2,
+                "case_id": state.get("case_id"),
+            },
+        )
+        return preguntas_dict
+    except Exception as exc:  # best-effort — never fail M1
+        logger.warning(
+            "[case_questions] validador coherencia de opciones M1 falló (best-effort): %s",
             exc,
             extra={"node": "case_questions", "case_id": state.get("case_id")},
         )
@@ -1522,6 +1595,11 @@ def case_questions(state: ADAMState, config: RunnableConfig) -> dict:
     # Issue #360 — best-effort Exhibit coherence (outside the try above so the existing
     # `except RuntimeError: raise` is untouched; this helper never raises).
     preguntas_dict = _apply_m1_questions_exhibit_coherence(
+        llm=llm, prompt=prompt, state=state, preguntas_dict=preguntas_dict
+    )
+    # Option coherence (clasificación, both profiles) — best-effort, runs after the Exhibit
+    # pass; the solución must only recommend options the case defines and the enunciado presents.
+    preguntas_dict = _apply_m1_questions_option_coherence(
         llm=llm, prompt=prompt, state=state, preguntas_dict=preguntas_dict
     )
     # No escribe current_agent — nodo paralelo (evita race condition)
@@ -5257,6 +5335,20 @@ def _is_ml_ds_classification(
         default_unresolved_ml_ds_to_classification=default_unresolved_ml_ds_to_classification,
     )
     return profile == "ml_ds" and family == "clasificacion"
+
+
+def _is_classification_family(state: ADAMState) -> bool:
+    """True for ANY profile (business OR ml_ds) when the resolved family is clasificación.
+
+    Mirrors the family resolution `_build_base_context` uses for ``primary_family``
+    (``default_unresolved_ml_ds_to_classification=True``), so this fires exactly when the
+    classification M1 questions prompt was selected — covering BOTH ``business+clf`` and
+    ``ml_ds+clf``. (Contrast with `_is_ml_ds_classification`, which is ml_ds-only.)
+    """
+    _profile, family = _resolve_generation_focus(
+        state, default_unresolved_ml_ds_to_classification=True
+    )
+    return family == "clasificacion"
 
 
 def _sanitize_pregunta_eje(

--- a/backend/src/case_generator/m1_grounding.py
+++ b/backend/src/case_generator/m1_grounding.py
@@ -164,6 +164,35 @@ _COMPLETENESS_KEYWORD_RE = re.compile(
     re.IGNORECASE,
 )
 
+# ── M1 question option coherence (internal) ───────────────────────────────────
+# Internal coherence of the M1 discussion questions: a `solucion_esperada` must never
+# recommend a strategic option that does NOT exist in the case, nor one its own
+# `enunciado` does not present. The case's options live ONLY as free text labeled A/B/C
+# in `dilema_brief` (there is no structured `opciones` field), so the check is textual.
+# Scope is gated by the caller to the classification family for BOTH profiles
+# (business + ml_ds); this module is profile-agnostic and never imports the graph.
+#
+# Detection precision (zero-FP doctrine, mirrors #360/#372):
+#  * The option letter is UPPERCASE-only, so the Spanish prepositions "a"/"o" in
+#    "opción a corto plazo" / "Opción A o B" are never read as labels.
+#  * The keyword anchor ("opción"/"opciones"/"alternativa") means a stray capital
+#    ("plan B", "modelo B2B") is never mistaken for an option label.
+#  * Each option letter must be a STANDALONE token — the `(?![\w/-])` guard rejects a
+#    letter glued to a compound term by a hyphen or slash, so Spanish/ML collocations like
+#    "opción E-commerce", "opción C-suite", "opción C-level" or "opción A/B testing" are
+#    never read as option labels E / C / A / B. A spaced enumeration ("Opción A / Opción B")
+#    still parses (the slash there is surrounded by whitespace, not glued to the letter).
+#  * The enumeration tail captures runs like "Opciones A, B y C" / "Opción A o B" so the
+#    universe and enunciado label sets are complete.
+#  * All quantifiers are bounded (no unbounded `+` over a letter run) → LINEAR matching,
+#    no catastrophic backtracking (ReDoS).
+_VALID_OPTION_LABELS = frozenset({"A", "B", "C"})  # architect contract: SIEMPRE 3 (A, B, C)
+_OPTION_REF_RE = re.compile(
+    r"(?:[Oo]pci[oó]n|[Aa]lternativa)\w*\s+"
+    r"(?P<labels>[A-F](?![\w/-])(?:\s*(?:,|/|&|y|o)\s*[A-F](?![\w/-]))*)"
+)
+_OPTION_LETTER_RE = re.compile(r"[A-F]")
+
 
 # ── Public API ────────────────────────────────────────────────────────────────
 
@@ -356,7 +385,104 @@ def detect_exhibit2_completeness_row(anexo_operativo: str) -> list[str]:
     ]
 
 
+def validate_question_option_coherence(
+    preguntas: list[dict], dilema_brief: str = ""
+) -> list[str]:
+    """Return option-coherence violations for the M1 discussion questions.
+
+    Pure, deterministic, total on well-typed input (never raises; the caller still wraps
+    it best-effort). Two independent rules per question, evaluated over both ``enunciado``
+    and ``solucion_esperada``:
+
+    * ``OPTION_NONEXISTENT`` (PRIMARY) — an option label cited that is OUTSIDE the case's
+      option universe. The universe is the floor ``{A, B, C}`` plus any extra label the
+      ``dilema_brief`` (the case's authority) actually defines, so a legitimate 4th option
+      never false-positives while an invented "Opción D" always flags. The enunciados are
+      deliberately NOT part of the universe — a question that invents an option must not
+      self-justify; it must be flagged.
+    * ``OPTION_NOT_PRESENTED`` (SECONDARY) — when a question's ``enunciado`` enumerates ≥2
+      distinct option labels (it presents a closed choice set) and the ``solucion_esperada``
+      recommends an in-universe label that the enunciado does not present. The ≥2 guard
+      avoids flagging when the enunciado merely names one option in passing. This is the
+      literal reported defect: the answer key picks an option the question never offered.
+
+    Zero false positives by construction: detection is uppercase keyword-anchored, and
+    over-capturing the universe only relaxes the check. Returns a deduplicated, ordered
+    list of human-readable violation strings; ``[]`` means coherent.
+    """
+    if not isinstance(preguntas, list):
+        return []
+    universe = _option_universe(dilema_brief)
+    universe_label = _format_universe(universe)
+    violations: list[str] = []
+    for index, pregunta in enumerate(preguntas):
+        if not isinstance(pregunta, Mapping):
+            continue
+        numero = pregunta.get("numero")
+        num = numero if isinstance(numero, int) else index + 1
+        enunciado = pregunta.get("enunciado")
+        solucion = pregunta.get("solucion_esperada")
+        enunciado_labels = _extract_option_labels(
+            enunciado if isinstance(enunciado, str) else ""
+        )
+        enunciado_set = set(enunciado_labels)
+        solucion_labels = _extract_option_labels(
+            solucion if isinstance(solucion, str) else ""
+        )
+        # PRIMARY — an enunciado that itself cites an invented option is a defect.
+        for opt in dict.fromkeys(enunciado_labels):
+            if opt not in universe:
+                violations.append(
+                    f"OPTION_NONEXISTENT: el enunciado de la pregunta {num} cita la opción "
+                    f"{opt}, que no existe en el caso (opciones: {universe_label})"
+                )
+        for opt in dict.fromkeys(solucion_labels):
+            if opt not in universe:
+                violations.append(
+                    f"OPTION_NONEXISTENT: la solución de la pregunta {num} recomienda la "
+                    f"opción {opt}, que no existe en el caso (opciones: {universe_label})"
+                )
+                continue
+            # SECONDARY — in-universe but not presented by this question's enunciado.
+            if len(enunciado_set) >= 2 and opt not in enunciado_set:
+                violations.append(
+                    f"OPTION_NOT_PRESENTED: la solución de la pregunta {num} recomienda la "
+                    f"opción {opt}, que su enunciado no presenta al estudiante"
+                )
+    return violations
+
+
 # ── Internals ─────────────────────────────────────────────────────────────────
+
+def _extract_option_labels(text: str) -> list[str]:
+    """Ordered option letters referenced via 'Opción/Opciones/alternativa X' (with dups).
+
+    Handles singletons ("Opción A") and enumerations ("Opciones A, B y C", "Opción A o B").
+    Returns letters in source order; the caller dedups for deterministic messages.
+    """
+    if not isinstance(text, str) or not text:
+        return []
+    labels: list[str] = []
+    for match in _OPTION_REF_RE.finditer(text):
+        labels.extend(_OPTION_LETTER_RE.findall(match.group("labels")))
+    return labels
+
+
+def _option_universe(dilema_brief: str) -> set[str]:
+    """Valid option labels for the case: floor {A, B, C} ∪ labels the brief defines.
+
+    The ``dilema_brief`` is the case's authority on which options exist; over-capturing a
+    legitimate 4th option (e.g. a future grad case with A–D) only relaxes the check, so it
+    can never create a false positive. The enunciados are NOT consulted here on purpose.
+    """
+    universe = set(_VALID_OPTION_LABELS)
+    if isinstance(dilema_brief, str) and dilema_brief:
+        universe.update(_extract_option_labels(dilema_brief))
+    return universe
+
+
+def _format_universe(universe: set[str]) -> str:
+    return ", ".join(sorted(universe))
 
 def _iter_table_cells(text: str) -> list[str]:
     """Yield the cell strings of every markdown-table data row in ``text`` (skips

--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/questions.py
@@ -64,6 +64,16 @@ de costo EXCLUSIVAMENTE de la matriz de costos del caso provista a continuación
   CUALITATIVA (a quién priorizar bajo incertidumbre), SIN exigir ni inventar cifras.
   (La instrucción de hipótesis inicial ya está en el bloque base — no duplicar.)
 
+## Coherencia obligatoria de opciones (P3)
+El caso define un conjunto CERRADO de opciones estratégicas etiquetadas A, B y C (las del
+`dilema_brief` y la narrativa). Respeta estas reglas sin excepción:
+- El enunciado de P3 DEBE presentar al estudiante las opciones (A, B, C) entre las que elige,
+  usando las MISMAS etiquetas del caso. NO inventes una "Opción D", ni renombres ni reordenes
+  las opciones.
+- `solucion_esperada` de P3 DEBE nombrar la opción recomendada por su LETRA (A, B o C) y SOLO
+  puede recomendar una de las opciones presentadas en el enunciado de P3. NUNCA recomiendes una
+  opción inexistente en el caso ni una que el enunciado no haya presentado al estudiante.
+
 Referencia para contextualizar las preguntas — pregunta eje del caso:
 {pregunta_eje}
 """

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -82,6 +82,14 @@ class Settings(BaseSettings):
     # env-only revert; no redeploy). The frontend `sanitizeExhibitMarkdown` repairs existing cases
     # regardless of this flag.
     m1_exhibit_normalize: bool = True
+    # Internal coherence of M1 discussion-question options (clasificación, both profiles).
+    # When true, `validate_question_option_coherence` checks that each `solucion_esperada`
+    # only recommends a strategic option that (a) exists in the case (A/B/C, derived from
+    # `dilema_brief`) and (b) its own `enunciado` presents; `case_questions` reprompts once
+    # then degrades to the pass-1 questions. Best-effort + gated to the classification family,
+    # so business/other-family/non-clf cases are unaffected. Kill-switch: set
+    # M1_OPTION_COHERENCE=false to passthrough exactly (instant env-only revert; no redeploy).
+    m1_option_coherence: bool = True
 
     model_config = SettingsConfigDict(env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/tests/test_m1_option_coherence.py
+++ b/backend/tests/test_m1_option_coherence.py
@@ -1,0 +1,382 @@
+"""M1 question option coherence — deterministic internal coherence guard.
+
+Covers the reported defect: an M1 ``solucion_esperada`` recommending a strategic option
+that does not exist in the case, or one its own ``enunciado`` never presented. Scope is the
+classification family for BOTH profiles (business + ml_ds).
+
+Two layers under test:
+  1. The pure validator ``m1_grounding.validate_question_option_coherence`` (+ its extractor /
+     universe helpers) — an adversarial matrix proving zero false positives and the
+     ``dilema_brief``-as-authority universe (lesson #377: run the function against adversarial
+     inputs, don't reason about the regex).
+  2. The graph wrapper ``graph._apply_m1_questions_option_coherence`` — reprompt-once-then-
+     DEGRADE, gated to the classification family + kill-switch, best-effort.
+
+Pure-Python: no DB, no real LLM, no network.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from case_generator.m1_grounding import (
+    _extract_option_labels,
+    _option_universe,
+    validate_question_option_coherence,
+)
+from case_generator.prompts import (
+    CASE_QUESTIONS_PROMPT,
+    CASE_QUESTIONS_PROMPT_CLASSIFICATION,
+)
+from case_generator.tools_and_schemas import (
+    GeneradorPreguntasM1Output,
+    PreguntaMinimalista,
+)
+
+graph_module = importlib.import_module("case_generator.graph")
+
+# A dilema_brief that defines exactly options A, B, C (the architect contract).
+_BRIEF_ABC = "Opción A: expandir. Opción B: retener selectivamente. Opción C: desinvertir."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Extractor — enumeration-aware, uppercase-only (zero-FP)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestExtractOptionLabels:
+    def test_singleton(self) -> None:
+        assert _extract_option_labels("La Opción A es viable.") == ["A"]
+
+    def test_enumeration_comma_and_y(self) -> None:
+        assert _extract_option_labels("Opciones A, B y C") == ["A", "B", "C"]
+
+    def test_enumeration_o(self) -> None:
+        assert _extract_option_labels("Opción A o B") == ["A", "B"]
+
+    def test_alternativa_keyword(self) -> None:
+        assert _extract_option_labels("la alternativa C conviene") == ["C"]
+
+    def test_stops_at_non_letter_continuation(self) -> None:
+        # "Opción A, la cual…" must capture only A (", la" is not ", <LETTER>").
+        assert _extract_option_labels("Opción A, la cual conviene") == ["A"]
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Diseña un plan B de contingencia",       # no keyword before B
+            "evalúa el modelo B2B del mercado",        # B2B is not a bare label
+            "la opción a corto plazo es razonable",    # lowercase preposition "a"
+            "elige A, B o C según convenga",           # no keyword before the run
+            "sin opciones explícitas en el texto",     # no letters at all
+            # Compound terms glued by hyphen/slash are not option labels (zero-FP guard).
+            "considera la opción E-commerce frente al canal físico",
+            "la opción E-learning para capacitación",
+            "la opción C-suite debe liderar la ejecución",
+            "evalúa la alternativa C-level del comité",
+            "despliega una opción A/B testing para confirmar",
+        ],
+    )
+    def test_false_positive_guards_return_empty(self, text: str) -> None:
+        assert _extract_option_labels(text) == []
+
+    def test_spaced_slash_enumeration_still_parses(self) -> None:
+        # A slash surrounded by whitespace is a real enumeration, not a compound.
+        assert _extract_option_labels("elige Opción A / Opción B") == ["A", "B"]
+
+    def test_non_string_safe(self) -> None:
+        assert _extract_option_labels(None) == []  # type: ignore[arg-type]
+
+    def test_long_input_is_linear_no_redos(self) -> None:
+        # Bounded quantifiers → linear; a long contiguous run must not hang.
+        labels = _extract_option_labels("Opción " + "A," * 4000 + "A")
+        assert labels and set(labels) == {"A"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Universe — dilema_brief is the authority; floor {A,B,C}
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestOptionUniverse:
+    def test_empty_brief_floor(self) -> None:
+        assert _option_universe("") == {"A", "B", "C"}
+
+    def test_brief_extends_universe(self) -> None:
+        assert _option_universe("Opciones A, B, C y D del caso") == {"A", "B", "C", "D"}
+
+    def test_brief_without_keyword_keeps_floor(self) -> None:
+        # No "Opción/alternativa" keyword → nothing parsed → floor only.
+        assert _option_universe("estrategias A, B, C") == {"A", "B", "C"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Validator — PRIMARY (nonexistent) / SECONDARY (not presented)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _pq(numero: int, *, enunciado: str = "", solucion: str = "") -> dict:
+    return {
+        "numero": numero,
+        "titulo": "T",
+        "enunciado": enunciado,
+        "solucion_esperada": solucion,
+    }
+
+
+class TestValidator:
+    def test_clean_when_solution_picks_presented_option(self) -> None:
+        q = _pq(
+            3,
+            enunciado="Elige entre la Opción A, la Opción B y la Opción C.",
+            solucion="La Opción B es la mejor por la caja.",
+        )
+        assert validate_question_option_coherence([q], _BRIEF_ABC) == []
+
+    def test_clean_when_enunciado_delegates_to_narrative(self) -> None:
+        # Enunciado lists no labels (delegates to the narrative). Solution names B
+        # (in-universe) → SECONDARY skipped (no closed set), PRIMARY ok → no violation.
+        q = _pq(
+            3,
+            enunciado="Elige la mejor estrategia del caso con la evidencia disponible.",
+            solucion="La Opción B es la más sólida.",
+        )
+        assert validate_question_option_coherence([q], _BRIEF_ABC) == []
+
+    def test_compound_term_does_not_false_positive(self) -> None:
+        # "opción E-commerce" must NOT be read as an invented "Opción E".
+        q = _pq(
+            3,
+            enunciado="Considera la opción E-commerce frente al canal físico.",
+            solucion="La Opción A es la mejor por la caja.",
+        )
+        assert validate_question_option_coherence([q], _BRIEF_ABC) == []
+
+    def test_primary_nonexistent_option_in_solution(self) -> None:
+        q = _pq(
+            3,
+            enunciado="Elige entre la Opción A, la Opción B y la Opción C.",
+            solucion="Recomiendo la Opción D por su retorno.",
+        )
+        out = validate_question_option_coherence([q], _BRIEF_ABC)
+        assert len(out) == 1 and out[0].startswith("OPTION_NONEXISTENT")
+        assert "pregunta 3" in out[0]
+
+    def test_secondary_option_not_presented(self) -> None:
+        # Enunciado presents only A and B; solution recommends C (in-universe but absent).
+        q = _pq(
+            3,
+            enunciado="Compara la Opción A con la Opción B para la decisión.",
+            solucion="La Opción C es preferible.",
+        )
+        out = validate_question_option_coherence([q], _BRIEF_ABC)
+        assert len(out) == 1 and out[0].startswith("OPTION_NOT_PRESENTED")
+
+    def test_enunciado_inventing_option_is_flagged_not_self_justified(self) -> None:
+        # The brief defines only A/B/C; an enunciado that invents "Opción D" must be flagged
+        # (enunciados are NOT part of the universe — anti self-justification).
+        q = _pq(
+            3,
+            enunciado="Elige entre la Opción A, la Opción B y la Opción D.",
+            solucion="La Opción A es la mejor.",
+        )
+        out = validate_question_option_coherence([q], _BRIEF_ABC)
+        assert any(v.startswith("OPTION_NONEXISTENT") and "enunciado" in v for v in out)
+
+    def test_brief_defining_fourth_option_suppresses_primary(self) -> None:
+        q = _pq(3, solucion="Recomiendo la Opción D.")
+        with_d = "Opciones A, B, C y D: cuatro caminos posibles."
+        assert validate_question_option_coherence([q], with_d) == []
+        # Control: without D in the brief, the same solution is flagged.
+        out = validate_question_option_coherence([q], _BRIEF_ABC)
+        assert out and out[0].startswith("OPTION_NONEXISTENT")
+
+    def test_dedupe_repeated_label(self) -> None:
+        q = _pq(3, solucion="Opción D, insisto en la Opción D y de nuevo la Opción D.")
+        out = validate_question_option_coherence([q], _BRIEF_ABC)
+        assert len(out) == 1
+
+    def test_empty_brief_uses_floor(self) -> None:
+        assert validate_question_option_coherence([_pq(3, solucion="Opción C.")], "") == []
+        assert validate_question_option_coherence([_pq(3, solucion="Opción D.")], "")
+
+    def test_non_list_safe(self) -> None:
+        assert validate_question_option_coherence(None, _BRIEF_ABC) == []  # type: ignore[arg-type]
+
+    def test_p1_p2_without_options_are_ignored(self) -> None:
+        qs = [
+            _pq(1, enunciado="¿De qué trata el caso?", solucion="La causa raíz es X."),
+            _pq(2, enunciado="Cruza dos stakeholders.", solucion="El CFO y el COO chocan."),
+            _pq(3, enunciado="Elige Opción A, B o C.", solucion="La Opción B conviene."),
+        ]
+        assert validate_question_option_coherence(qs, _BRIEF_ABC) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Prompt layer — the classification anchor carries the option-coherence block
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPromptAnchor:
+    _SENTINEL = "Coherencia obligatoria de opciones"
+
+    def test_classification_prompt_has_option_block(self) -> None:
+        assert self._SENTINEL in CASE_QUESTIONS_PROMPT_CLASSIFICATION
+
+    def test_generic_prompt_unchanged(self) -> None:
+        assert self._SENTINEL not in CASE_QUESTIONS_PROMPT
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Graph wrapper — reprompt-once-then-DEGRADE, gated, best-effort
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FakeStructuredLLM:
+    """Mimics the case_questions LLM: queue of outputs (or exceptions). Raises if over-called."""
+
+    def __init__(self, outputs: list[object] | None = None) -> None:
+        self._outputs = list(outputs or [])
+        self.calls = 0
+
+    def with_structured_output(self, _schema: object) -> "_FakeStructuredLLM":
+        return self
+
+    def invoke(self, _prompt: str) -> object:
+        self.calls += 1
+        if not self._outputs:
+            raise AssertionError("LLM invoked more times than expected")
+        result = self._outputs.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _state(
+    *,
+    profile: str = "ml_ds",
+    algoritmos: list[str] | None = None,
+    dilema_brief: str = _BRIEF_ABC,
+) -> dict:
+    return {
+        "studentProfile": profile,
+        "algoritmos": algoritmos if algoritmos is not None else ["Logistic Regression"],
+        "algorithm_mode": "single",
+        "dilema_brief": dilema_brief,
+        "case_id": "case_option_coherence",
+        "output_language": "es",
+    }
+
+
+def _questions(p3_enunciado: str, p3_solucion: str) -> list[dict]:
+    return [
+        _pq(1, enunciado="¿De qué trata el caso?", solucion="La causa raíz es X."),
+        _pq(2, enunciado="Cruza dos stakeholders.", solucion="El CFO y el COO chocan."),
+        _pq(3, enunciado=p3_enunciado, solucion=p3_solucion),
+    ]
+
+
+# A pass-1 set with a violating P3 (solution recommends a nonexistent option D).
+_BAD = _questions("Elige entre la Opción A, la Opción B y la Opción C.", "Recomiendo la Opción D.")
+# A clean P3 the reprompt can return.
+_CLEAN_RESULT = GeneradorPreguntasM1Output(
+    preguntas=[
+        PreguntaMinimalista(numero=1, titulo="T", enunciado="¿De qué trata?", solucion_esperada="Causa X."),
+        PreguntaMinimalista(numero=2, titulo="T", enunciado="Stakeholders.", solucion_esperada="CFO vs COO."),
+        PreguntaMinimalista(
+            numero=3,
+            titulo="T",
+            enunciado="Elige entre la Opción A, la Opción B y la Opción C.",
+            solucion_esperada="La Opción B es la mejor.",
+        ),
+    ]
+)
+# A reprompt that still violates (still recommends D).
+_STILL_BAD_RESULT = GeneradorPreguntasM1Output(
+    preguntas=[
+        PreguntaMinimalista(numero=1, titulo="T", enunciado="¿De qué trata?", solucion_esperada="Causa X."),
+        PreguntaMinimalista(numero=2, titulo="T", enunciado="Stakeholders.", solucion_esperada="CFO vs COO."),
+        PreguntaMinimalista(
+            numero=3,
+            titulo="T",
+            enunciado="Elige entre la Opción A, la Opción B y la Opción C.",
+            solucion_esperada="Insisto en la Opción D.",
+        ),
+    ]
+)
+
+
+def _invoke(fake: _FakeStructuredLLM, state: dict, preguntas: list[dict]) -> list[dict]:
+    return graph_module._apply_m1_questions_option_coherence(
+        llm=fake, prompt="PROMPT", state=state, preguntas_dict=preguntas
+    )
+
+
+class TestWrapper:
+    def test_happy_path_no_reprompt(self) -> None:
+        clean = _questions("Elige Opción A, B o C.", "La Opción B conviene.")
+        fake = _FakeStructuredLLM()  # would raise if invoked
+        out = _invoke(fake, _state(), clean)
+        assert fake.calls == 0
+        assert out == clean
+
+    def test_reprompt_corrects(self) -> None:
+        fake = _FakeStructuredLLM([_CLEAN_RESULT])
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 1
+        assert validate_question_option_coherence(out, _BRIEF_ABC) == []
+        assert "Opción D" not in out[2]["solucion_esperada"]
+
+    def test_degrade_when_reprompt_still_violates(self) -> None:
+        fake = _FakeStructuredLLM([_STILL_BAD_RESULT])
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 1
+        assert out == _BAD  # degrade to pass-1
+
+    def test_degrade_when_structured_output_raises(self) -> None:
+        fake = _FakeStructuredLLM([ValueError("bad json")])
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 1
+        assert out == _BAD
+
+    def test_gate_fires_for_business_clf(self) -> None:
+        fake = _FakeStructuredLLM([_CLEAN_RESULT])
+        out = _invoke(fake, _state(profile="business"), _BAD)
+        assert fake.calls == 1  # gate fired for business + clasificación
+        assert validate_question_option_coherence(out, _BRIEF_ABC) == []
+
+    def test_gate_fires_for_mlds_clf(self) -> None:
+        fake = _FakeStructuredLLM([_CLEAN_RESULT])
+        out = _invoke(fake, _state(profile="ml_ds"), _BAD)
+        assert fake.calls == 1
+
+    def test_gate_noop_for_non_classification_family(self) -> None:
+        fake = _FakeStructuredLLM()  # would raise if invoked
+        out = _invoke(fake, _state(algoritmos=["Linear Regression"]), _BAD)
+        assert fake.calls == 0
+        assert out == _BAD
+
+    def test_gate_noop_for_business_without_algorithms(self) -> None:
+        fake = _FakeStructuredLLM()
+        out = _invoke(fake, _state(profile="business", algoritmos=[]), _BAD)
+        assert fake.calls == 0
+        assert out == _BAD
+
+    def test_kill_switch_off_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(graph_module.settings, "m1_option_coherence", False)
+        fake = _FakeStructuredLLM()
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 0
+        assert out == _BAD
+
+    def test_best_effort_when_validator_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(*_a: object, **_k: object) -> list[str]:
+            raise RuntimeError("validator bug")
+
+        monkeypatch.setattr(graph_module, "validate_question_option_coherence", _boom)
+        fake = _FakeStructuredLLM()
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 0
+        assert out == _BAD


### PR DESCRIPTION
## Qué y por qué

Garantiza de forma **determinista** que en el **Módulo 1** de los casos de **clasificación** (perfiles **business** y **ml_ds**) la `solucion_esperada` solo recomiende una opción estratégica que **(a)** exista en el caso (A/B/C, derivadas de `dilema_brief`) y **(b)** el propio enunciado presente.

Cierra el defecto reportado: *la solución esperada proponía una opción que no existía en la pregunta de ese módulo*. Hasta ahora los validadores de M1 (#360 cifras↔Exhibit, #372 fila de tasa) solo revisaban **números**; ninguno verificaba la coherencia opción↔enunciado↔solución.

## Diseño (replica el patrón #360/#372 — sin tocar el grafo ni otros módulos)

- **Validador puro** `validate_question_option_coherence` (`m1_grounding.py`):
  - PRIMARIA → `OPTION_NONEXISTENT`: etiqueta fuera del universo `{A,B,C} ∪ dilema_brief`.
  - SECUNDARIA → `OPTION_NOT_PRESENTED`: opción in-universe que un enunciado con ≥2 etiquetas no presenta.
  - **Zero-FP**: detección keyword-anclada, letra MAYÚSCULA, guarda `(?![\w/-])` que descarta compuestos (`opción E-commerce`/`C-suite`/`A/B testing`); cuantificadores acotados (sin ReDoS). El `dilema_brief` es la autoridad del universo; los enunciados no se auto-justifican.
- **Wrapper** `_apply_m1_questions_option_coherence` en `case_questions`: reprompt-once-then-DEGRADE, best-effort (nunca levanta), gateado a clasificación para **ambos perfiles** vía `_is_classification_family` (espeja la selección de prompt de `_build_base_context`). Corre tras el paso de Exhibits.
- **Refuerzo de prompt** en el ancla de preguntas de clasificación (P3 presenta A/B/C; la solución nombra la opción por su letra). Base genérico intacto → otras familias byte-idénticas. **Architect SHA256 sin tocar.**
- **Kill-switch** `M1_OPTION_COHERENCE` (default `true`) → revert instantáneo sin redeploy.

## Configuración de agentes / costo

**Sin cambio de tier de modelo.** `case_questions` sigue en Flash + `thinking=low`. El guardia determinista da la garantía a costo marginal ~cero (el reprompt LLM solo se dispara ante una violación real). Palanca de override por-nodo documentada para canary futuro.

## No-breakage

- Architect intacto → `_MLDS_ARCHITECT_PROMPT_SHA256` congelado.
- Base genérico de preguntas intacto → regresion/clustering/serie_temporal y `business`-no-clf byte-idénticos.
- Sin cambios de schema → renderer M1 y contratos `studentProfile`/`M1..M6` intactos.
- Código aditivo, gateado, kill-switched, best-effort, nunca levanta → topología `case_architect → [case_writer ∥ case_questions] → doc1_complete` sin tocar.

## Verificación

- `test_m1_option_coherence.py` (44 casos): matriz adversarial FP/FN + universo + wiring del nodo + ambos perfiles + kill-switch + best-effort.
- Suite completa: **1710 passed, 22 skipped**. `mypy src`: limpio.
- `/review` exhaustivo (integración + adversarial): SHIP-READY; el pase adversarial encontró 1 FP real (compuestos `E-commerce`/`C-suite`/`A/B`) → **corregido y con tests de regresión**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)