### PR TITLE
feat(case_generator): coherencia interna de preguntas M3 (clasificación, business + ml_ds)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -122,6 +122,14 @@ M1_OPTION_COHERENCE=true
 # unaffected. Set to false to passthrough exactly (instant revert, no redeploy).
 M2_QUESTION_COHERENCE=true
 
+# -- M3 question coherence (kill-switch) ------------------------
+# When true (default), each M3 socratic question is checked so its `m3_section_ref` exists in
+# the section taxonomy for its profile (business -> 3.1-3.5; ml_ds -> exp.*) and single-model
+# questions (lr_only / rf_only) do not name the unselected model; m3_questions_generator
+# reprompts once then degrades. Gated to the classification family (business + ml_ds); other
+# cases are unaffected. Set to false to passthrough exactly (instant revert, no redeploy).
+M3_QUESTION_COHERENCE=true
+
 # -- Supabase auth perimeter (Issue 23 + Issue 30) ----------------
 # Required for JWT verification, activation flows and admin auth operations.
 # Local auth/session dev uses `supabase start` at http://localhost:54321.

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -175,6 +175,10 @@ from case_generator.m1_grounding import (
     validate_questions_exhibit_coherence,
 )
 from case_generator.m2_grounding import validate_eda_questions_coherence
+from case_generator.m3_grounding import (
+    allowed_sections_for,
+    validate_m3_questions_coherence,
+)
 from case_generator.m3_notebook_execution import (
     M3NotebookExecutionError,
     _bounded_diagnostic,
@@ -6048,6 +6052,151 @@ def m3_content_generator(state: ADAMState, config: RunnableConfig) -> dict:
 
 
 # Issue 4.3 — M3 QUESTIONS GENERATOR
+# ─────────────────────────────────────────────────────────
+# M3 question coherence — reprompt-once-then-DEGRADE (M3 sibling of #412/#413).
+# Mirrors `_apply_eda_questions_coherence`. The pure validator lives in m3_grounding.py;
+# this gates it to the classification family for BOTH profiles behind the
+# `m3_question_coherence` kill-switch and reprompts once on a violation.
+# ─────────────────────────────────────────────────────────
+
+_M3_VIOLATION_CODES = (
+    ("M3_SECTION_REF_NONEXISTENT", "section_ref"),
+    ("MODELO_NO_SELECCIONADO", "unselected_model"),
+)
+
+
+def _m3_violation_types(violations: list[str]) -> list[str]:
+    """Enumerated short codes for structured logging — never the raw message (no PII)."""
+    codes: list[str] = []
+    for violation in violations:
+        for prefix, code in _M3_VIOLATION_CODES:
+            if violation.startswith(prefix) and code not in codes:
+                codes.append(code)
+    return codes
+
+
+def _build_m3_coherence_reprompt(
+    violations: list[str], *, profile: str, variant: str | None, numeros: list[Any]
+) -> str:
+    """Focused reprompt (CONCATENATED, never ``.format`` — the already-formatted prompt and
+    this suffix both carry ``{}`` from the JSON schema). Carries the concrete fix (the valid
+    section tokens for the profile + the forbidden model when single-model) and demands the
+    SAME questions with the SAME ``numero`` so the downstream ``M3-Q{numero}`` answer/grading
+    key is preserved — load-bearing because ``GeneradorPreguntasOutput`` does NOT bound length.
+    """
+    bullet_list = "\n".join(f"- {violation}" for violation in violations)
+    valid_sections = ", ".join(sorted(allowed_sections_for(profile)))
+    forbidden_line = ""
+    if variant == CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY:
+        forbidden_line = "NO menciones Random Forest (el modelo seleccionado es Logistic Regression).\n"
+    elif variant == CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY:
+        forbidden_line = "NO menciones Logistic Regression (el modelo seleccionado es Random Forest).\n"
+    numeros_str = ", ".join(str(numero) for numero in numeros)
+    return (
+        "\n\n# CORRECCIÓN OBLIGATORIA DE COHERENCIA (Módulo 3)\n"
+        "Algunas preguntas citan una sección inexistente en `m3_section_ref` o nombran un "
+        "modelo no seleccionado. "
+        f"Regenera EXACTAMENTE {len(numeros)} preguntas con el MISMO schema y los MISMOS "
+        f"`numero` ({numeros_str}): cada `m3_section_ref` debe ser una sección válida del "
+        "Módulo 3 y ninguna pregunta debe nombrar el modelo no seleccionado.\n"
+        f"Secciones válidas: {valid_sections}.\n"
+        f"{forbidden_line}"
+        "Incoherencias detectadas:\n" + bullet_list
+    )
+
+
+def _apply_m3_questions_coherence(
+    *,
+    llm: Any,
+    prompt: str,
+    state: ADAMState,
+    preguntas_dict: list[dict],
+    profile: str,
+    variant: str | None,
+) -> list[dict]:
+    """Validate + reprompt-once-then-DEGRADE the M3 question coherence.
+
+    Gated to the classification family for BOTH profiles (business + ml_ds) via
+    ``_is_classification_family`` (the SAME gate M1/M2 use) behind the
+    ``m3_question_coherence`` kill-switch; a byte-identical no-op otherwise. On a violation
+    it reprompts ONCE (one Flash call) with the concrete fix; the corrected set is accepted
+    ONLY if it preserves the question count AND the ``numero`` sequence (the answer/grading
+    key ``M3-Q{numero}``) AND is now coherent — otherwise it degrades to the pass-1 questions.
+    Best-effort: ANY throw (including a reprompt ``RuntimeError``, which the node would
+    otherwise re-raise and fail the job) degrades to pass-1. Never raises.
+
+    ``prompt`` is the ALREADY-formatted string; the reprompt is built by CONCATENATION (never
+    re-``.format``). ``profile``/``variant`` are resolved by the caller and feed the two checks.
+    ``state`` is read ONLY for the gate and ``case_id`` logging — never ``m3_content`` /
+    ``m3_metrics_summary`` / the notebook branch — so the parallel notebook fan-out stays independent.
+    """
+    log_extra = {"node": "m3_questions_generator", "case_id": state.get("case_id")}
+    try:
+        if not settings.m3_question_coherence or not _is_classification_family(state):
+            return preguntas_dict
+        violations = validate_m3_questions_coherence(
+            preguntas_dict, profile=profile, variant=variant
+        )
+        if not violations:
+            return preguntas_dict
+        numeros = [q.get("numero") for q in preguntas_dict]
+        logger.info(
+            "[m3_questions] reprompt de coherencia M3 disparado",
+            extra={
+                **log_extra,
+                "violation_count": len(violations),
+                "violation_types": _m3_violation_types(violations),
+            },
+        )
+        reprompt = prompt + _build_m3_coherence_reprompt(
+            violations, profile=profile, variant=variant, numeros=numeros
+        )
+        try:
+            resultado: GeneradorPreguntasOutput = llm.with_structured_output(
+                GeneradorPreguntasOutput
+            ).invoke(reprompt)
+            corrected = [p.model_dump() for p in resultado.preguntas]
+        except (ValidationError, OutputParserException, ValueError) as exc:
+            logger.warning(
+                "[m3_questions] reprompt de coherencia M3 inválido — degrada a pass-1: %s",
+                exc,
+                extra=log_extra,
+            )
+            return preguntas_dict
+        # Identity guard: a reprompt that drops/adds/renumbers a question would corrupt the
+        # `M3-Q{numero}` answer/grading key — reject it. List equality = count + order + values,
+        # and is the ONLY count protection because `GeneradorPreguntasOutput` is unbounded.
+        if [q.get("numero") for q in corrected] != numeros:
+            logger.warning(
+                "[m3_questions] reprompt M3 alteró conteo/numero — degrada a pass-1",
+                extra=log_extra,
+            )
+            return preguntas_dict
+        residual = validate_m3_questions_coherence(corrected, profile=profile, variant=variant)
+        if not residual:
+            logger.info(
+                "[m3_questions] coherencia M3 corregida por reprompt",
+                extra={**log_extra, "degraded": False},
+            )
+            return corrected
+        logger.warning(
+            "[m3_questions] coherencia M3 degradada tras reprompt",
+            extra={
+                **log_extra,
+                "violation_types": _m3_violation_types(residual),
+                "degraded": True,
+            },
+        )
+        return preguntas_dict
+    except Exception as exc:  # best-effort — a coherence pass must never fail the job
+        logger.warning(
+            "[m3_questions] validador de coherencia M3 falló (best-effort): %s",
+            exc,
+            extra=log_extra,
+        )
+        return preguntas_dict
+
+
 def m3_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
     """Genera preguntas de M3 bifurcadas por perfil:
     - business: M3_AUDIT_QUESTIONS_PROMPT    (3 preguntas, refs 3.1–3.5, auditoría de evidencia)
@@ -6064,6 +6213,11 @@ def m3_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
         })
 
         profile, family = _resolve_generation_focus(state)
+        # `resolved_variant` is None for every cohort EXCEPT ml_ds+clf (set below); the M3
+        # coherence wrapper passes it to the unselected-model guard (no-op when None), so
+        # business / ml_ds-non-clf never enter Check B. Initialized here so the call site
+        # below always has it defined (no NameError on the else branches).
+        resolved_variant: str | None = None
         if profile == "ml_ds":
             if family == "clasificacion":
                 _algoritmos_raw = _extract_state_algoritmos(state)
@@ -6080,6 +6234,7 @@ def m3_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
                         _algoritmos_raw,
                         _q_variant_warning,
                     )
+                resolved_variant = _variant
                 prompt = M3_CLASSIFICATION_QUESTIONS_BY_VARIANT.get(
                     _variant,
                     M3_CLASSIFICATION_QUESTIONS_BY_VARIANT["lr_rf_contrast"],
@@ -6092,11 +6247,22 @@ def m3_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
             prompt = M3_AUDIT_QUESTIONS_PROMPT
             tag = "m3_audit_questions"
 
+        # Capture the formatted prompt so the coherence wrapper can CONCATENATE its
+        # correction suffix onto it (never a second `.format()` — JSON schema braces).
+        formatted = prompt.format(**context)
         resultado: GeneradorPreguntasOutput = llm.with_structured_output(
             GeneradorPreguntasOutput
-        ).invoke(prompt.format(**context))
+        ).invoke(formatted)
 
         preguntas = [p.model_dump() for p in resultado.preguntas]
+        preguntas = _apply_m3_questions_coherence(
+            llm=llm,
+            prompt=formatted,
+            state=state,
+            preguntas_dict=preguntas,
+            profile=profile,
+            variant=resolved_variant,
+        )
         print(f"[{tag}] {len(preguntas)} preguntas")
         return {"m3_questions": preguntas, "current_agent": "m3_questions_generator"}
     except RuntimeError:

--- a/backend/src/case_generator/m3_grounding.py
+++ b/backend/src/case_generator/m3_grounding.py
@@ -1,0 +1,169 @@
+"""M3 (Module 3) question coherence validator.
+
+Deterministic, pure, best-effort checker that anchors the M3 socratic questions to
+(a) the section taxonomy that actually exists for the case's profile and (b) the
+selected model for single-model classification variants. It is the M3 sibling of
+``m1_grounding`` (#412) and ``m2_grounding`` (#413): same zero-false-positive
+doctrine, same "never imports the graph" rule, same ``[] == coherent`` contract.
+
+Why M3 needs its OWN validator instead of reusing the M1/M2 ones: M3 questions use
+``PreguntaMinimalista`` — open socratic prompts with NO ``opciones`` field, so there is
+no A/B/C option universe (M1) and no chart manifest / event rate (M2) to anchor
+against. The analogous M3 defect (a ``solucion_esperada`` citing something the module
+never presents) takes two concrete, deterministic shapes:
+
+* **M3_SECTION_REF_NONEXISTENT** — a question's ``m3_section_ref`` cites a section
+  outside the module's taxonomy for its profile (business → ``3.1..3.5``; ml_ds →
+  ``exp.*``). Direct analog of "recommends an option that does not exist": the answer
+  key points the student at a section that was never produced.
+* **MODELO_NO_SELECCIONADO** — (ml_ds single-model ``lr_only`` / ``rf_only``) a P1/P2
+  question/solution names the UNSELECTED model. Reuses the asymmetric prose guard
+  ``narrative_grounding.detect_unselected_model_mentions`` (#337) — the SAME one M4/M5
+  use — over the question text. No-op for ``lr_rf_contrast`` / business (``variant`` is
+  ``None``), so Check B never fires for business by construction. The **P3 synthesis/discard
+  question (``exp.descarte``) is exempt**: its single-model prompt explicitly asks the student
+  to "propón una alternativa" after discarding the selected model, so naming an alternative
+  model there is prompt-sanctioned, not a leak — flagging it would be a false positive.
+
+Deliberately NOT checked (FP-prone, documented honest false negative): the P3 verdict
+colour (Verde/Amarillo/Rojo). The business §3.5 narrative always prints all three
+labels and the P3 enunciado template literally contains ``[Verde/Amarillo/Rojo]``, so
+any presence/difference check would false-positive on prompt-sanctioned output.
+
+Detection precision (zero-FP doctrine, mirrors #360/#372/#377):
+
+* **Profile-keyed taxonomy** — the allowed section set is selected by ``profile``
+  (NOT family), so the ml_ds generic-experiment cohort (exp.* refs, no variant) and the
+  ml_ds+clf variant cohort (exp.* refs, variant set) are both validated against the SAME
+  exp.* set the prompt emitted. business → the 3.x audit set.
+* **Anchored tokenization** — only well-formed ``exp.<word>`` / ``<d>.<d>`` tokens are
+  extracted, so a compound ref (``"3.2 o 3.3"``, ``"exp.hipotesis/exp.sesgo"`` — both
+  prompt-sanctioned) is accepted when ANY token is valid; a sentinel / blank / prose ref
+  is skipped. Bounded quantifiers → LINEAR matching, no catastrophic backtracking (ReDoS).
+* **Word-boundary model guard** — ``detect_unselected_model_mentions`` matches only the
+  full model names (never the bare ``RF`` / ``LR`` acronyms), so ``surf`` / ``perfil`` /
+  ``performance`` never false-positive.
+
+Honest, documented false negatives (the accepted cost of zero-FP): a section ref with
+one valid token mixed with garbage (``"3.2 o 9.9"``) is accepted (over-acceptance never
+degrades a good case), and a bare-acronym model leak (``"usa RF"``) is not caught (mirrors
+the existing narrative guard's limitation).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+from case_generator.narrative_grounding import detect_unselected_model_mentions
+
+# ── section taxonomies (per profile) ────────────────────────────────────────────
+# Business audit sections (``M3_AUDIT_QUESTIONS_PROMPT``) vs ml_ds experiment sections
+# (``M3_EXPERIMENT_QUESTIONS_PROMPT`` + the lr_only/rf_only/lr_rf_contrast variant blocks,
+# which only ever emit ``exp.*`` refs). Frozen literals: a future taxonomy change in the
+# prompt must update this set in the SAME change (the golden oracle guards it).
+_BUSINESS_SECTIONS = frozenset({"3.1", "3.2", "3.3", "3.4", "3.5"})
+_MLDS_SECTIONS = frozenset({"exp.hipotesis", "exp.sesgo", "exp.validacion", "exp.descarte"})
+
+# The P3 synthesis/discard section. Check B (unselected-model leak) is SKIPPED for this one
+# question: its lr_only/rf_only prompt explicitly invites "propón una alternativa" after
+# discarding the selected model, so naming an alternative model there is prompt-sanctioned,
+# not a leak (see Check B note below).
+_SECTION_DESCARTE = "exp.descarte"
+
+# Values the LLM emits to mean "no section reference" — skipped, never flagged (mirror
+# ``m2_grounding._CHART_REF_SENTINELS``). Compared after ``.strip().lower()``.
+_SECTION_REF_SENTINELS = frozenset({"", "null", "none", "ninguno", "n/a", "na", "-"})
+
+# Only well-formed section tokens: ``exp.<1-20 letters>`` or ``<digit>.<1-2 digits>``.
+# Bounded quantifiers → linear (no ReDoS). The business taxonomy is 3.1..3.5 so
+# ``\d\.\d{1,2}`` covers it; a future section ≥ 3.10 would need this regex AND
+# ``_BUSINESS_SECTIONS`` updated together (the golden oracle catches the drift).
+_SECTION_TOKEN_RE = re.compile(r"exp\.[a-z]{1,20}|\d\.\d{1,2}")
+
+
+def allowed_sections_for(profile: str) -> frozenset[str]:
+    """The M3 section taxonomy for a profile (``business`` → 3.x; otherwise ``exp.*``).
+
+    Single source of truth shared by the validator and the graph reprompt builder, so the
+    "valid sections" hint the model is given never drifts from what is enforced.
+    """
+    return _BUSINESS_SECTIONS if profile == "business" else _MLDS_SECTIONS
+
+
+def validate_m3_questions_coherence(
+    preguntas: list[dict], *, profile: str, variant: str | None
+) -> list[str]:
+    """Return coherence violations for the M3 socratic questions. ``[]`` == coherent.
+
+    Pure, deterministic, total on well-typed input (never raises; the caller still wraps
+    it best-effort). Two independent checks per question:
+
+    * ``M3_SECTION_REF_NONEXISTENT`` — ``m3_section_ref`` has well-formed tokens but none
+      belongs to the profile's section taxonomy. Sentinel / blank / token-less refs are
+      skipped. Both profiles.
+    * ``MODELO_NO_SELECCIONADO`` — (variant ``lr_only`` / ``rf_only``) a P1/P2 question's text
+      (``titulo`` + ``enunciado`` + ``solucion_esperada``) names the unselected model. No-op for
+      ``lr_rf_contrast`` / ``None`` (business and ml_ds contrast), and for the P3 synthesis/discard
+      question (``exp.descarte``), whose prompt sanctions naming an alternative model.
+
+    ``profile`` selects the taxonomy ('business' → 3.x; otherwise exp.*). ``variant`` is the
+    resolved classification notebook variant (or ``None``) — passed in by the caller, never
+    re-derived here (avoids drift with the prompt that was actually selected).
+    """
+    if not isinstance(preguntas, list):
+        return []
+    allowed = allowed_sections_for(profile)
+    violations: list[str] = []
+    for index, pregunta in enumerate(preguntas):
+        if not isinstance(pregunta, Mapping):
+            continue
+        numero = pregunta.get("numero")
+        num = numero if isinstance(numero, int) else index + 1
+        ref = pregunta.get("m3_section_ref")
+        normalized = _normalize_section_ref(ref)
+        tokens = _SECTION_TOKEN_RE.findall(normalized) if normalized is not None else []
+
+        # ── Check A — m3_section_ref must exist in the profile's taxonomy ────────
+        if tokens and not any(token in allowed for token in tokens):
+            violations.append(
+                f"M3_SECTION_REF_NONEXISTENT: la pregunta {num} referencia la sección "
+                f"'{ref}', que no existe en el Módulo 3 "
+                f"(secciones válidas: {_format_sections(allowed)})"
+            )
+
+        # ── Check B — single-model question must not name the unselected model ───
+        # EXCEPTION: the P3 synthesis/discard question (`exp.descarte`) is SKIPPED — its
+        # lr_only/rf_only prompt explicitly asks the student to "propón una alternativa"
+        # after discarding the selected model, so naming an alternative model there is
+        # prompt-sanctioned, not a leak. Check B stays active for P1 (`exp.hipotesis`) and
+        # P2 (`exp.sesgo`), where the question is squarely about the selected model and the
+        # other model's name IS an incoherent leak. Each leak is question-numbered (mirrors
+        # Check A / M2) so cross-question mentions never collapse into indistinguishable dupes.
+        if _SECTION_DESCARTE not in tokens:
+            prose = "\n".join(
+                str(pregunta.get(key, "")) for key in ("titulo", "enunciado", "solucion_esperada")
+            )
+            for leak in detect_unselected_model_mentions(prose, variant):
+                model = leak.split(": ", 1)[-1]
+                violations.append(
+                    f"MODELO_NO_SELECCIONADO: la pregunta {num} nombra el modelo no "
+                    f"seleccionado ({model})"
+                )
+    return violations
+
+
+# ── Internals ───────────────────────────────────────────────────────────────────
+
+def _normalize_section_ref(value: object) -> str | None:
+    """A real section ref (stripped, lowercased), or ``None`` for a non-reference."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip().lower()
+    if stripped in _SECTION_REF_SENTINELS:
+        return None
+    return stripped
+
+
+def _format_sections(sections: frozenset[str]) -> str:
+    return ", ".join(sorted(sections))

--- a/backend/src/case_generator/m3_grounding.py
+++ b/backend/src/case_generator/m3_grounding.py
@@ -133,13 +133,15 @@ def validate_m3_questions_coherence(
             )
 
         # ── Check B — single-model question must not name the unselected model ───
-        # EXCEPTION: the P3 synthesis/discard question (`exp.descarte`) is SKIPPED — its
-        # lr_only/rf_only prompt explicitly asks the student to "propón una alternativa"
-        # after discarding the selected model, so naming an alternative model there is
-        # prompt-sanctioned, not a leak. Check B stays active for P1 (`exp.hipotesis`) and
-        # P2 (`exp.sesgo`), where the question is squarely about the selected model and the
-        # other model's name IS an incoherent leak. Each leak is question-numbered (mirrors
-        # Check A / M2) so cross-question mentions never collapse into indistinguishable dupes.
+        # EXCEPTION (token-driven): a question is exempted ONLY when its `m3_section_ref`
+        # tokenizes to `exp.descarte` (the P3 synthesis/discard question). Its lr_only/rf_only
+        # prompt explicitly asks the student to "propón una alternativa" after discarding the
+        # selected model, so naming an alternative model there is prompt-sanctioned, not a leak.
+        # Check B stays active for P1 (`exp.hipotesis`) and P2 (`exp.sesgo`), AND for any P3
+        # whose ref is a sentinel/blank/garbage (no `exp.descarte` token) — that still gets the
+        # model-leak scan, which is the safe direction (the only cost is a rare reprompt on a
+        # mislabeled synthesis question, never a shipped leak). Each leak is question-numbered
+        # (mirrors Check A / M2) so cross-question mentions never collapse into indistinguishable dupes.
         if _SECTION_DESCARTE not in tokens:
             prose = "\n".join(
                 str(pregunta.get(key, "")) for key in ("titulo", "enunciado", "solucion_esperada")

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -99,6 +99,15 @@ class Settings(BaseSettings):
     # are unaffected. Kill-switch: set M2_QUESTION_COHERENCE=false to passthrough exactly
     # (instant env-only revert; no redeploy).
     m2_question_coherence: bool = True
+    # Internal coherence of the M3 socratic questions (clasificación, both profiles).
+    # When true, `validate_m3_questions_coherence` checks that each question's
+    # `m3_section_ref` exists in the section taxonomy for its profile (business → 3.1–3.5;
+    # ml_ds → exp.*) and that single-model questions (lr_only / rf_only) do not name the
+    # unselected model; `m3_questions_generator` reprompts once then degrades to the
+    # pass-1 questions. Best-effort + gated to the classification family, so
+    # business/other-family/non-clf cases are unaffected. Kill-switch: set
+    # M3_QUESTION_COHERENCE=false to passthrough exactly (instant env-only revert; no redeploy).
+    m3_question_coherence: bool = True
 
     model_config = SettingsConfigDict(env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/tests/golden_eval.py
+++ b/backend/tests/golden_eval.py
@@ -58,6 +58,13 @@ class NodeEvalInputs:
     # prevalence). True (n/a) for non-classification jobs. Computed via
     # ``check_eda_questions_coherence`` (reuses the production validator).
     eda_questions_coherence_ok: bool = True
+    # M3 question coherence: every classification golden job's M3 questions must be coherent
+    # (m3_section_ref exists in the profile's taxonomy; single-model questions do not name the
+    # unselected model). True (n/a) for non-classification jobs. Computed via
+    # ``check_m3_questions_coherence`` (reuses the production validator). The M3 questions prompt
+    # embeds ``{m3_content}``, so a future m3_content_generator Pro→Flash downgrade that induced
+    # incoherent questions is blocked here (anti-regression invariant, like the M2 oracle).
+    m3_questions_coherence_ok: bool = True
 
 
 @dataclass
@@ -86,6 +93,8 @@ def evaluate_downgrade_gate(r: NodeEvalInputs) -> GateResult:
         reasons.append("domain coherence failure: churn-coupled target on ml_ds non-churn job")
     if not r.eda_questions_coherence_ok:
         reasons.append("M2 EDA question coherence failure: chart_ref or event-rate mismatch")
+    if not r.m3_questions_coherence_ok:
+        reasons.append("M3 question coherence failure: section_ref or unselected-model leak")
     if r.judge_baseline_mean is not None and r.judge_candidate_mean is not None:
         drop = r.judge_baseline_mean - r.judge_candidate_mean
         if drop > JUDGE_MAX_DROP:
@@ -143,6 +152,21 @@ def check_eda_questions_coherence(
     from case_generator.m2_grounding import validate_eda_questions_coherence
 
     return not validate_eda_questions_coherence(preguntas, chart_ids, target_event_rate)
+
+
+def check_m3_questions_coherence(
+    preguntas: list[dict], *, profile: str, variant: str | None
+) -> bool:
+    """Pure oracle: are the M3 questions coherent (no nonexistent section_ref / model leak)?
+
+    Reuses the production validator ``m3_grounding.validate_m3_questions_coherence`` (single
+    source of truth), so a future M3-prompt or m3_content downgrade regression that reintroduces
+    an out-of-taxonomy ``m3_section_ref`` or an unselected-model leak fails the golden gate.
+    Function-level import keeps this support module lightweight.
+    """
+    from case_generator.m3_grounding import validate_m3_questions_coherence
+
+    return not validate_m3_questions_coherence(preguntas, profile=profile, variant=variant)
 
 
 # ── frozen golden set ────────────────────────────────────

--- a/backend/tests/test_m3_question_coherence.py
+++ b/backend/tests/test_m3_question_coherence.py
@@ -186,6 +186,24 @@ class TestUnselectedModelLeak:
         assert "pregunta 1" in out[0] and "pregunta 2" in out[1]
         assert out[0] != out[1]  # distinct, not collapsed duplicates
 
+    @pytest.mark.parametrize("benign", ["evaluar el performance del perfil", "surf de datos", "rendimiento del bosque local"])
+    def test_word_boundary_benign_prose_no_false_positive(self, benign: str) -> None:
+        # M3-layer zero-FP lock for the word-boundary class the docstring claims: benign Spanish
+        # prose that merely contains substrings of model names must NOT trigger Check B.
+        q = _q(section="exp.hipotesis", enunciado=benign)
+        assert validate_m3_questions_coherence([q], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY) == []
+
+    def test_bare_acronym_is_documented_honest_fn(self) -> None:
+        # Documented honest FN (zero-FP cost): the bare acronym 'RF' is intentionally NOT matched.
+        q = _q(section="exp.hipotesis", enunciado="usa RF en su lugar")
+        assert validate_m3_questions_coherence([q], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY) == []
+
+    def test_p1_mislabeled_descarte_leak_documented_fn(self) -> None:
+        # The exp.descarte exemption is token-driven: a P1 leak mislabeled exp.descarte bypasses
+        # Check B (documented defense-in-depth FN; #233/#337 are the primary leak guards).
+        q = _q(numero=1, section="exp.descarte", enunciado="¿y Random Forest?")
+        assert validate_m3_questions_coherence([q], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY) == []
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 3. Malformed inputs — never raise
@@ -366,6 +384,62 @@ class TestWrapperReprompt:
         out = _invoke(fake, _state(), pass1, variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY)
         assert fake.calls == 1
         assert validate_m3_questions_coherence(out, profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY) == []
+
+    def test_reprompt_corrects_model_leak_rf_only(self) -> None:
+        # rf_only pass-1 leaks Logistic Regression; reprompt removes it (exercises the rf_only branch).
+        pass1 = [
+            _q(numero=1, section="exp.hipotesis", enunciado="¿y la Regresión Logística?"),
+            _q(numero=2, section="exp.sesgo"),
+            _q(numero=3, section="exp.descarte"),
+        ]
+        corrected = _result(
+            _pm(1, section="exp.hipotesis", enunciado="Random Forest favorece la clase mayoritaria"),
+            _pm(2, section="exp.sesgo"),
+            _pm(3, section="exp.descarte"),
+        )
+        fake = _FakeStructuredLLM([corrected])
+        out = _invoke(
+            fake, _state(algoritmos=["Random Forest"]), pass1, variant=CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY
+        )
+        assert fake.calls == 1
+        assert validate_m3_questions_coherence(out, profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY) == []
+
+
+class TestRepromptBuilderAndCodes:
+    def test_reprompt_includes_profile_sections_and_numeros(self) -> None:
+        rp = graph_module._build_m3_coherence_reprompt(
+            ["M3_SECTION_REF_NONEXISTENT: x"], profile="ml_ds", variant=None, numeros=[1, 2, 3]
+        )
+        for section in ("exp.hipotesis", "exp.sesgo", "exp.validacion", "exp.descarte"):
+            assert section in rp
+        assert "1, 2, 3" in rp
+
+    def test_reprompt_business_sections(self) -> None:
+        rp = graph_module._build_m3_coherence_reprompt([], profile="business", variant=None, numeros=[1])
+        assert "3.1" in rp and "3.5" in rp
+        assert "exp.hipotesis" not in rp
+
+    def test_reprompt_lr_only_forbids_random_forest(self) -> None:
+        rp = graph_module._build_m3_coherence_reprompt(
+            [], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY, numeros=[1]
+        )
+        assert "NO menciones Random Forest" in rp
+
+    def test_reprompt_rf_only_forbids_logistic_regression(self) -> None:
+        rp = graph_module._build_m3_coherence_reprompt(
+            [], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY, numeros=[1]
+        )
+        assert "NO menciones Logistic Regression" in rp
+
+    def test_violation_types_maps_both_prefixes_deduped(self) -> None:
+        codes = graph_module._m3_violation_types(
+            [
+                "M3_SECTION_REF_NONEXISTENT: a",
+                "M3_SECTION_REF_NONEXISTENT: b",
+                "MODELO_NO_SELECCIONADO: la pregunta 1 nombra el modelo no seleccionado (Random Forest)",
+            ]
+        )
+        assert codes == ["section_ref", "unselected_model"]
 
 
 class TestWrapperIdentityGuard:

--- a/backend/tests/test_m3_question_coherence.py
+++ b/backend/tests/test_m3_question_coherence.py
@@ -1,0 +1,497 @@
+"""M3 (Module 3) question coherence — deterministic internal coherence guard.
+
+Covers the M3 analog of the reported defect: an M3 ``solucion_esperada`` (or its question)
+that cites a section which does not exist in the module's taxonomy, or — for a single-model
+classification variant — names the model that was NOT selected. Scope is the classification
+family for BOTH profiles (business + ml_ds).
+
+Three layers under test:
+  1. The pure validator ``m3_grounding.validate_m3_questions_coherence`` — section-ref +
+     unselected-model checks, zero false positives by construction (composite refs, sentinels,
+     ReDoS-bounded tokenization). Lesson #377: run the function against adversarial inputs.
+  2. The graph wrapper ``graph._apply_m3_questions_coherence`` — reprompt-once-then-DEGRADE,
+     gated to the classification family + kill-switch, identity-guarded, best-effort.
+  3. The golden oracle ``golden_eval.check_m3_questions_coherence`` + downgrade-gate wiring.
+
+Pure-Python: no DB, no real LLM, no network.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from case_generator.m3_grounding import (
+    allowed_sections_for,
+    validate_m3_questions_coherence,
+)
+from case_generator.prompts import (
+    CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY,
+    CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY,
+)
+from case_generator.tools_and_schemas import GeneradorPreguntasOutput, PreguntaMinimalista
+
+graph_module = importlib.import_module("case_generator.graph")
+
+_VARIANT_CONTRAST = "lr_rf_contrast"
+
+
+def _q(
+    numero: int = 1,
+    *,
+    titulo: str = "T",
+    enunciado: str = "E",
+    solucion: str = "S",
+    section: object = None,
+) -> dict:
+    return {
+        "numero": numero,
+        "titulo": titulo,
+        "enunciado": enunciado,
+        "solucion_esperada": solucion,
+        "bloom_level": "analysis",
+        "m3_section_ref": section,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Check A — section_ref tokenization (composite-safe, sentinel-safe, zero-FP)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestM3SectionRefTokenization:
+    @pytest.mark.parametrize(
+        "section, profile",
+        [
+            ("3.2", "business"),
+            ("3.5", "business"),
+            ("3.2 o 3.3", "business"),       # prompt-sanctioned compound
+            ("3.2/3.3", "business"),
+            ("3.5.", "business"),            # trailing punctuation
+            ("exp.hipotesis", "ml_ds"),
+            ("exp.hipotesis/exp.sesgo", "ml_ds"),   # prompt-sanctioned compound
+            ("exp.hipotesis; exp.validacion", "ml_ds"),
+            ("Exp.Hipotesis", "ml_ds"),      # casing normalized
+            ("exp.descarte/invalida", "ml_ds"),  # one valid token → accepted (over-acceptance)
+        ],
+    )
+    def test_valid_refs_no_violation(self, section: str, profile: str) -> None:
+        out = validate_m3_questions_coherence([_q(section=section)], profile=profile, variant=None)
+        assert out == []
+
+    @pytest.mark.parametrize("section", ["", None, "ninguno", "N/A", "-", "null", 123, "ver el análisis"])
+    def test_sentinel_or_tokenless_refs_skipped(self, section: object) -> None:
+        out = validate_m3_questions_coherence([_q(section=section)], profile="ml_ds", variant=None)
+        assert out == []
+
+    def test_business_emitting_mlds_ref_is_flagged(self) -> None:
+        out = validate_m3_questions_coherence(
+            [_q(numero=2, section="exp.hipotesis")], profile="business", variant=None
+        )
+        assert len(out) == 1
+        assert out[0].startswith("M3_SECTION_REF_NONEXISTENT")
+        assert "pregunta 2" in out[0]
+
+    def test_mlds_emitting_business_ref_is_flagged(self) -> None:
+        out = validate_m3_questions_coherence([_q(section="3.5")], profile="ml_ds", variant=None)
+        assert len(out) == 1
+        assert out[0].startswith("M3_SECTION_REF_NONEXISTENT")
+
+    def test_out_of_taxonomy_numeric_ref_is_flagged(self) -> None:
+        out = validate_m3_questions_coherence([_q(section="9.9")], profile="business", variant=None)
+        assert len(out) == 1
+
+    def test_redos_bounded_long_ref_is_linear(self) -> None:
+        # A pathological long ref must not hang (bounded quantifiers). Token-less → skipped.
+        out = validate_m3_questions_coherence([_q(section="x" * 100_000)], profile="ml_ds", variant=None)
+        assert out == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Check B — unselected-model leak (ml_ds single-model only; business no-op)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestUnselectedModelLeak:
+    def test_lr_only_naming_random_forest_is_flagged(self) -> None:
+        q = _q(section="exp.hipotesis", enunciado="¿Cómo se compara con Random Forest?")
+        out = validate_m3_questions_coherence([q], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY)
+        assert any(v.startswith("MODELO_NO_SELECCIONADO") for v in out)
+
+    def test_lr_only_naming_bosques_aleatorios_is_flagged(self) -> None:
+        q = _q(section="exp.hipotesis", solucion="usar bosques aleatorios")
+        out = validate_m3_questions_coherence([q], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY)
+        assert any(v.startswith("MODELO_NO_SELECCIONADO") for v in out)
+
+    def test_rf_only_naming_logistic_regression_is_flagged(self) -> None:
+        q = _q(section="exp.sesgo", solucion="compararlo contra Logistic Regression")
+        out = validate_m3_questions_coherence([q], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY)
+        assert any(v.startswith("MODELO_NO_SELECCIONADO") for v in out)
+
+    def test_lr_only_naming_selected_model_is_clean(self) -> None:
+        # Naming the SELECTED model (LR for lr_only) is legitimate → no violation.
+        q = _q(section="exp.hipotesis", enunciado="la regresión logística asume independencia")
+        out = validate_m3_questions_coherence([q], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY)
+        assert out == []
+
+    def test_contrast_naming_both_models_is_clean(self) -> None:
+        q = _q(section="exp.hipotesis", enunciado="contrasta Logistic Regression y Random Forest")
+        out = validate_m3_questions_coherence([q], profile="ml_ds", variant=_VARIANT_CONTRAST)
+        assert out == []
+
+    def test_business_with_model_name_is_noop(self) -> None:
+        # business → variant None → Check B never fires (model name is harmless prose here).
+        q = _q(section="3.2", enunciado="menciona Random Forest")
+        out = validate_m3_questions_coherence([q], profile="business", variant=None)
+        assert out == []
+
+    def test_mlds_non_clf_variant_none_is_noop(self) -> None:
+        q = _q(section="exp.hipotesis", enunciado="menciona Random Forest")
+        out = validate_m3_questions_coherence([q], profile="ml_ds", variant=None)
+        assert out == []
+
+    def test_p3_descarte_naming_alternative_is_clean_lr_only(self) -> None:
+        # The lr_only P3 prompt invites "propón una alternativa" → naming Random Forest as the
+        # alternative is prompt-sanctioned (NOT a leak). Must be clean (M3-FP-1 regression).
+        q = _q(
+            section="exp.descarte",
+            enunciado="¿Cuándo descartar Logistic Regression y qué alternativa usarías?",
+            solucion="Con VIF>5 se justifica descartar LR y adoptar un modelo no lineal como un Random Forest.",
+        )
+        out = validate_m3_questions_coherence([q], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY)
+        assert out == []
+
+    def test_p3_descarte_naming_alternative_is_clean_rf_only(self) -> None:
+        q = _q(
+            section="exp.descarte",
+            solucion="Por interpretabilidad regulatoria, la alternativa es una Regresión Logística.",
+        )
+        out = validate_m3_questions_coherence([q], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY)
+        assert out == []
+
+    def test_p1_p2_still_flag_the_other_model(self) -> None:
+        # Check B stays active on P1/P2 (the question is about the selected model).
+        p1 = _q(numero=1, section="exp.hipotesis", enunciado="¿y Random Forest?")
+        p2 = _q(numero=2, section="exp.sesgo", solucion="comparar con Random Forest")
+        out = validate_m3_questions_coherence([p1, p2], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY)
+        assert len(out) == 2
+        assert all(v.startswith("MODELO_NO_SELECCIONADO") for v in out)
+
+    def test_model_leak_violations_carry_question_number_and_are_distinct(self) -> None:
+        # M3-B-DUP-NOID regression: per-question identifier (mirrors Check A / M2), no cross-question dupes.
+        p1 = _q(numero=1, section="exp.hipotesis", enunciado="Random Forest")
+        p2 = _q(numero=2, section="exp.sesgo", enunciado="Random Forest")
+        out = validate_m3_questions_coherence([p1, p2], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY)
+        assert "pregunta 1" in out[0] and "pregunta 2" in out[1]
+        assert out[0] != out[1]  # distinct, not collapsed duplicates
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Malformed inputs — never raise
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMalformedInputsM3:
+    def test_empty_list(self) -> None:
+        assert validate_m3_questions_coherence([], profile="ml_ds", variant=None) == []
+
+    def test_non_list(self) -> None:
+        assert validate_m3_questions_coherence(None, profile="ml_ds", variant=None) == []  # type: ignore[arg-type]
+        assert validate_m3_questions_coherence("x", profile="ml_ds", variant=None) == []  # type: ignore[arg-type]
+
+    def test_non_mapping_elements_skipped(self) -> None:
+        out = validate_m3_questions_coherence(
+            [42, _q(section="3.5")], profile="ml_ds", variant=None  # type: ignore[list-item]
+        )
+        assert len(out) == 1  # only the dict with the bad ml_ds ref is flagged
+
+    def test_missing_keys_are_safe(self) -> None:
+        assert validate_m3_questions_coherence([{"numero": 1}], profile="ml_ds", variant=None) == []
+
+    def test_non_string_section_ref_is_safe(self) -> None:
+        assert validate_m3_questions_coherence([_q(section=123)], profile="ml_ds", variant=None) == []
+
+    def test_missing_numero_uses_index_fallback(self) -> None:
+        out = validate_m3_questions_coherence(
+            [{"m3_section_ref": "3.5", "titulo": "T", "enunciado": "E", "solucion_esperada": "S"}],
+            profile="ml_ds",
+            variant=None,
+        )
+        assert len(out) == 1
+        assert "pregunta 1" in out[0]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Non-tautology — the validator discriminates (not a no-op)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestNonTautology:
+    def test_validator_discriminates(self) -> None:
+        # Red-control intent (revert the fix → these flip): a coherent question passes and an
+        # incoherent one is flagged. If `allowed` were emptied / Check B removed, the TP below
+        # would stop firing — proving the guard is load-bearing (mirrors #348/#350).
+        good = _q(section="exp.hipotesis", enunciado="la regresión logística asume independencia")
+        bad = _q(section="3.5", enunciado="¿y Random Forest?")
+        assert validate_m3_questions_coherence([good], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY) == []
+        assert validate_m3_questions_coherence([bad], profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY) != []
+
+    def test_taxonomy_sets_are_disjoint(self) -> None:
+        assert allowed_sections_for("business").isdisjoint(allowed_sections_for("ml_ds"))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Graph wrapper — reprompt-once-then-DEGRADE, gated, identity-guarded, best-effort
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FakeStructuredLLM:
+    """Mimics the m3_questions LLM: queue of outputs (or exceptions). Raises if over-called."""
+
+    def __init__(self, outputs: list[object] | None = None) -> None:
+        self._outputs = list(outputs or [])
+        self.calls = 0
+
+    def with_structured_output(self, _schema: object) -> "_FakeStructuredLLM":
+        return self
+
+    def invoke(self, _prompt: str) -> object:
+        self.calls += 1
+        if not self._outputs:
+            raise AssertionError("LLM invoked more times than expected")
+        result = self._outputs.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _state(*, profile: str = "ml_ds", algoritmos: list[str] | None = None) -> dict:
+    return {
+        "studentProfile": profile,
+        "algoritmos": algoritmos if algoritmos is not None else ["Logistic Regression"],
+        "algorithm_mode": "single",
+        "dataset_schema_required": {},
+        "case_id": "case_m3_coherence",
+        "output_language": "es",
+    }
+
+
+def _pm(numero: int, *, section: str | None = None, enunciado: str = "E", solucion: str = "S") -> PreguntaMinimalista:
+    return PreguntaMinimalista(
+        numero=numero,
+        titulo="T",
+        enunciado=enunciado,
+        solucion_esperada=solucion,
+        bloom_level="analysis",
+        m3_section_ref=section,
+    )
+
+
+def _result(*preguntas: PreguntaMinimalista) -> GeneradorPreguntasOutput:
+    return GeneradorPreguntasOutput(preguntas=list(preguntas))
+
+
+# A 3-question pass-1 set with a violating P1 (ml_ds ref pointing at a business section).
+def _bad_pass1() -> list[dict]:
+    return [
+        _q(numero=1, section="3.5"),
+        _q(numero=2, section="exp.sesgo"),
+        _q(numero=3, section="exp.descarte"),
+    ]
+
+
+def _invoke(
+    fake: _FakeStructuredLLM,
+    state: dict,
+    preguntas: list[dict],
+    *,
+    profile: str = "ml_ds",
+    variant: str | None = None,
+) -> list[dict]:
+    return graph_module._apply_m3_questions_coherence(
+        llm=fake,
+        prompt="PROMPT",
+        state=state,
+        preguntas_dict=preguntas,
+        profile=profile,
+        variant=variant,
+    )
+
+
+class TestWrapperReprompt:
+    def test_happy_path_no_reprompt(self) -> None:
+        clean = [_q(numero=1, section="exp.hipotesis"), _q(numero=2, section="exp.sesgo")]
+        fake = _FakeStructuredLLM()  # would raise if invoked
+        out = _invoke(fake, _state(), clean)
+        assert fake.calls == 0
+        assert out == clean
+
+    def test_reprompt_corrects(self) -> None:
+        corrected = _result(
+            _pm(1, section="exp.hipotesis"),
+            _pm(2, section="exp.sesgo"),
+            _pm(3, section="exp.descarte"),
+        )
+        fake = _FakeStructuredLLM([corrected])
+        out = _invoke(fake, _state(), _bad_pass1())
+        assert fake.calls == 1
+        assert validate_m3_questions_coherence(out, profile="ml_ds", variant=None) == []
+
+    def test_degrade_when_reprompt_still_violates(self) -> None:
+        still_bad = _result(
+            _pm(1, section="3.5"),  # still a business ref under ml_ds
+            _pm(2, section="exp.sesgo"),
+            _pm(3, section="exp.descarte"),
+        )
+        fake = _FakeStructuredLLM([still_bad])
+        pass1 = _bad_pass1()
+        out = _invoke(fake, _state(), pass1)
+        assert fake.calls == 1
+        assert out == pass1
+
+    def test_reprompt_corrects_model_leak(self) -> None:
+        # lr_only pass-1 leaks Random Forest; reprompt removes it.
+        pass1 = [
+            _q(numero=1, section="exp.hipotesis", enunciado="¿y Random Forest?"),
+            _q(numero=2, section="exp.sesgo"),
+            _q(numero=3, section="exp.descarte"),
+        ]
+        corrected = _result(
+            _pm(1, section="exp.hipotesis", enunciado="la regresión logística asume independencia"),
+            _pm(2, section="exp.sesgo"),
+            _pm(3, section="exp.descarte"),
+        )
+        fake = _FakeStructuredLLM([corrected])
+        out = _invoke(fake, _state(), pass1, variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY)
+        assert fake.calls == 1
+        assert validate_m3_questions_coherence(out, profile="ml_ds", variant=CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY) == []
+
+
+class TestWrapperIdentityGuard:
+    def test_degrade_on_count_drift(self) -> None:
+        # A coherent but SHORTER reprompt (2 vs 3 questions) → reject (numero/count guard).
+        two = _result(_pm(1, section="exp.hipotesis"), _pm(2, section="exp.sesgo"))
+        fake = _FakeStructuredLLM([two])
+        pass1 = _bad_pass1()
+        out = _invoke(fake, _state(), pass1)
+        assert fake.calls == 1
+        assert out == pass1
+
+    def test_degrade_on_numero_drift(self) -> None:
+        renum = _result(_pm(1, section="exp.hipotesis"), _pm(3, section="exp.sesgo"), _pm(4, section="exp.descarte"))
+        fake = _FakeStructuredLLM([renum])
+        pass1 = _bad_pass1()
+        out = _invoke(fake, _state(), pass1)
+        assert fake.calls == 1
+        assert out == pass1
+
+    def test_degrade_on_order_scramble(self) -> None:
+        scrambled = _result(_pm(3, section="exp.descarte"), _pm(1, section="exp.hipotesis"), _pm(2, section="exp.sesgo"))
+        fake = _FakeStructuredLLM([scrambled])
+        pass1 = _bad_pass1()
+        out = _invoke(fake, _state(), pass1)
+        assert fake.calls == 1
+        assert out == pass1
+
+
+class TestWrapperBestEffort:
+    def test_runtime_error_from_reprompt_is_swallowed(self) -> None:
+        # CRITICAL: a reprompt RuntimeError must NOT escape (the node's `except RuntimeError: raise`
+        # would fail the job). The wrapper's outer `except Exception` degrades to pass-1.
+        fake = _FakeStructuredLLM([RuntimeError("LLM quota")])
+        pass1 = _bad_pass1()
+        out = _invoke(fake, _state(), pass1)
+        assert fake.calls == 1
+        assert out == pass1
+
+    def test_degrade_when_structured_output_raises(self) -> None:
+        fake = _FakeStructuredLLM([ValueError("bad json")])
+        pass1 = _bad_pass1()
+        out = _invoke(fake, _state(), pass1)
+        assert fake.calls == 1
+        assert out == pass1
+
+    def test_best_effort_when_validator_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(*_a: object, **_k: object) -> list[str]:
+            raise RuntimeError("validator bug")
+
+        monkeypatch.setattr(graph_module, "validate_m3_questions_coherence", _boom)
+        fake = _FakeStructuredLLM()
+        pass1 = _bad_pass1()
+        out = _invoke(fake, _state(), pass1)
+        assert fake.calls == 0
+        assert out == pass1
+
+
+class TestWrapperGate:
+    def test_kill_switch_off_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(graph_module.settings, "m3_question_coherence", False)
+        fake = _FakeStructuredLLM()
+        pass1 = _bad_pass1()
+        out = _invoke(fake, _state(), pass1)
+        assert fake.calls == 0
+        assert out == pass1
+
+    def test_gate_noop_for_non_classification_family(self) -> None:
+        fake = _FakeStructuredLLM()  # would raise if invoked
+        out = _invoke(fake, _state(algoritmos=["Linear Regression"]), _bad_pass1())
+        assert fake.calls == 0
+        assert out == _bad_pass1()
+
+    def test_gate_fires_for_business_clf(self) -> None:
+        # business ref taxonomy is 3.x; an exp.* ref is the business violation.
+        pass1 = [_q(numero=1, section="exp.hipotesis"), _q(numero=2, section="3.2")]
+        corrected = _result(_pm(1, section="3.4"), _pm(2, section="3.2"))
+        fake = _FakeStructuredLLM([corrected])
+        out = _invoke(fake, _state(profile="business"), pass1, profile="business", variant=None)
+        assert fake.calls == 1
+        assert validate_m3_questions_coherence(out, profile="business", variant=None) == []
+
+    def test_gate_fires_for_mlds_clf(self) -> None:
+        corrected = _result(_pm(1, section="exp.hipotesis"), _pm(2, section="exp.sesgo"), _pm(3, section="exp.descarte"))
+        fake = _FakeStructuredLLM([corrected])
+        out = _invoke(fake, _state(), _bad_pass1())
+        assert fake.calls == 1
+
+    def test_gate_fires_for_mlds_without_algorithms(self) -> None:
+        corrected = _result(_pm(1, section="exp.hipotesis"), _pm(2, section="exp.sesgo"), _pm(3, section="exp.descarte"))
+        fake = _FakeStructuredLLM([corrected])
+        # ml_ds + unresolved family defaults to clasificación (mirrors M1/M2 gate).
+        out = _invoke(fake, _state(profile="ml_ds", algoritmos=[]), _bad_pass1())
+        assert fake.calls == 1
+
+    def test_gate_noop_for_business_without_algorithms(self) -> None:
+        fake = _FakeStructuredLLM()
+        out = _invoke(fake, _state(profile="business", algoritmos=[]), _bad_pass1(), profile="business")
+        assert fake.calls == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Golden oracle + downgrade-gate wiring (anti-regression lock)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestGoldenOracle:
+    def test_oracle_coherent_true(self) -> None:
+        from tests.golden_eval import check_m3_questions_coherence
+
+        q = _q(section="exp.hipotesis")
+        assert check_m3_questions_coherence([q], profile="ml_ds", variant=None) is True
+
+    def test_oracle_incoherent_false(self) -> None:
+        from tests.golden_eval import check_m3_questions_coherence
+
+        q = _q(section="3.5")  # business ref under ml_ds
+        assert check_m3_questions_coherence([q], profile="ml_ds", variant=None) is False
+
+    def test_gate_blocks_on_incoherence(self) -> None:
+        from tests.golden_eval import NodeEvalInputs, evaluate_downgrade_gate
+
+        ok = evaluate_downgrade_gate(NodeEvalInputs(node="x", deterministic_pass=True))
+        assert ok.passed
+        blocked = evaluate_downgrade_gate(
+            NodeEvalInputs(node="x", deterministic_pass=True, m3_questions_coherence_ok=False)
+        )
+        assert not blocked.passed
+        assert any("M3 question coherence" in reason for reason in blocked.reasons)


### PR DESCRIPTION
## Qué y por qué

El **Módulo 3** podía shipear una `solucion_esperada` que cita algo inexistente en la pregunta — la misma clase de defecto que se blindó en **M1 (#412)** y **M2 (#413)**, pero que **M3 no tenía validador**. Alcance: `business + clasificación` y `ml_ds + clasificación`.

Como las preguntas M3 usan `PreguntaMinimalista` (sin campo `opciones`), el defecto exacto de M1 no recurre, pero sí su análogo determinista:
- **A — sección inexistente** (`M3_SECTION_REF_NONEXISTENT`): `m3_section_ref` fuera de la taxonomía del perfil (business `3.1–3.5`; ml_ds `exp.*`).
- **B — modelo no seleccionado** (`MODELO_NO_SELECCIONADO`): una pregunta single-model (`lr_only`/`rf_only`) que nombra el modelo NO elegido (reusa la guarda de prosa probada de #337). **Exenta la P3 "propón una alternativa"** (`exp.descarte`), donde nombrar el otro modelo es la respuesta correcta.

## Cómo

- **Nuevo** `m3_grounding.py`: `validate_m3_questions_coherence(preguntas, *, profile, variant)` — puro, total, zero-FP (tokenización acotada anti-ReDoS, sentinelas, compuestos `"3.2 o 3.3"` aceptados, taxonomía por perfil).
- `graph.py`: wrapper `_apply_m3_questions_coherence` en `m3_questions_generator` — **reprompt-once-then-DEGRADE**, gateado a clasificación (ambos perfiles) tras el kill-switch, identity-guard sobre la secuencia de `numero` (única protección dado que `GeneradorPreguntasOutput` no acota longitud), outer `except` best-effort (nunca falla un job). Espejo exacto de `_apply_eda_questions_coherence` (M2).
- `database.py` + `.env.example`: kill-switch `M3_QUESTION_COHERENCE` (default `true`).
- `golden_eval.py`: oráculo `check_m3_questions_coherence` + criterio del downgrade gate (la prompt de M3 embebe `{m3_content}`, así que blinda un futuro Pro→Flash de `m3_content_generator`).

## Garantías

- **Cero colateral**: sin editar prompts (SHA pins intactos), sin cambio de edges del grafo / `m3_sync` / rama paralela del notebook, sin nueva clave de state, sin entrada en `case_sanitization`, sin cambio de tier. Kill-switch off = passthrough byte-idéntico.
- **Costo**: validador determinista (~\$0); el reprompt (1 llamada Flash) solo dispara si hay violación real.

## Validación

- `uv run --directory backend pytest -q`: **1868 passed**, 22 skipped (+1 flake de auth no relacionado, pasa en aislamiento).
- `tests/test_m3_question_coherence.py`: **60 passed** (validador FP/TP + wrapper degrade/identity/best-effort + kill-switch + oráculo golden + no-tautología).
- `mypy src`: limpio. `git diff prompts/`: vacío.

## Revisión adversarial

Dos workflows de subagentes (plan + implementación, con probing **ejecutable** del validador, lección #377). El segundo encontró y corrigió **pre-merge**: un **FP real** en la P3 de descarte (Check B ahora exenta `exp.descarte`) y la falta de identificador de pregunta en las violaciones de Check B. Dimensión graph-safety: **cero defectos** (6 invariantes verificados por ejecución, incl. que el outer `except` traga el `RuntimeError` del reprompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)