### PR TITLE
feat(case_generator): coherencia opción↔solución en preguntas M4 (clasificación, business + ml_ds)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -122,6 +122,14 @@ M1_OPTION_COHERENCE=true
 # unaffected. Set to false to passthrough exactly (instant revert, no redeploy).
 M2_QUESTION_COHERENCE=true
 
+# -- M4 question option coherence (kill-switch) -----------------
+# When true (default), each M4 (Impacto) decision question is checked so its `solucion_esperada`
+# only recommends an option that exists in the case (A/B/C) and that its own `enunciado`
+# presents; m4_questions_generator reprompts once then degrades (preserving count + numero).
+# Gated to the classification family (business + ml_ds); other cases are unaffected. Set to
+# false to passthrough exactly (instant revert, no redeploy).
+M4_QUESTION_COHERENCE=true
+
 # -- Supabase auth perimeter (Issue 23 + Issue 30) ----------------
 # Required for JWT verification, activation flows and admin auth operations.
 # Local auth/session dev uses `supabase start` at http://localhost:54321.

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -1142,6 +1142,17 @@ _M1_QUESTIONS_OPTION_REPROMPT_HEADER = (
     "NUNCA recomiendes una opción inexistente ni ausente del enunciado. Incoherencias "
     "detectadas:\n"
 )
+_M4_QUESTIONS_OPTION_REPROMPT_HEADER = (
+    "\n\n# CORRECCIÓN OBLIGATORIA DE COHERENCIA DE OPCIONES (Módulo 4)\n"
+    "Algunas preguntas recomiendan en `solucion_esperada` una opción estratégica que NO "
+    "existe en el caso, o que el propio enunciado de esa pregunta no presenta al estudiante. "
+    "El caso define un conjunto cerrado de opciones (A, B, C). Regenera EXACTAMENTE 3 "
+    "preguntas con el MISMO schema y los MISMOS `numero` (1, 2, 3): el enunciado de cada "
+    "pregunta de decisión DEBE presentar las opciones (A/B/C) entre las que el estudiante "
+    "elige, y `solucion_esperada` SOLO puede recomendar una de las opciones presentadas en "
+    "su enunciado, nombrándola por su letra. NUNCA recomiendes una opción inexistente ni "
+    "ausente del enunciado. Incoherencias detectadas:\n"
+)
 
 
 def _build_m1_exhibit_anexos(state: ADAMState) -> dict[str, str]:
@@ -1334,6 +1345,106 @@ def _apply_m1_questions_option_coherence(
             "[case_questions] validador coherencia de opciones M1 falló (best-effort): %s",
             exc,
             extra={"node": "case_questions", "case_id": state.get("case_id")},
+        )
+        return preguntas_dict
+
+
+# ─────────────────────────────────────────────────────────
+# M4 (Impacto) question option coherence — reuses the M1 validator with the FLOOR
+# universe {A,B,C} (M4 has no dilema_brief). See m1_grounding.validate_question_option_coherence.
+# ─────────────────────────────────────────────────────────
+_M4_VIOLATION_CODES = (
+    ("OPTION_NONEXISTENT", "option_nonexistent"),
+    ("OPTION_NOT_PRESENTED", "option_not_presented"),
+)
+
+
+def _m4_violation_types(violations: list[str]) -> list[str]:
+    """Enumerated short codes for structured logging — never the raw message (no PII)."""
+    codes: list[str] = []
+    for violation in violations:
+        for prefix, code in _M4_VIOLATION_CODES:
+            if violation.startswith(prefix) and code not in codes:
+                codes.append(code)
+    return codes
+
+
+def _apply_m4_questions_option_coherence(
+    *, llm: Any, prompt: str, state: ADAMState, preguntas_dict: list[dict]
+) -> list[dict]:
+    """Validate + reprompt-once-then-DEGRADE the M4 (Impacto) question option coherence.
+
+    Reuses the M1 option validator with the FLOOR universe (M4 has no ``dilema_brief``): a
+    ``solucion_esperada`` may only recommend an option the case defines (A/B/C) and that its
+    own ``enunciado`` presents. Gated to the classification family for BOTH profiles
+    (business + ml_ds) behind the ``m4_question_coherence`` kill-switch; a byte-identical
+    no-op otherwise. On a violation it reprompts ONCE (one Flash call); the corrected set is
+    accepted ONLY if it preserves the question count AND the ``numero`` sequence (the grading
+    key ``M4-Q{numero}`` in shared.student_reads/teacher_reads) AND is now coherent —
+    otherwise it degrades to the pass-1 questions. ``GeneradorPreguntasOutput`` (unlike M1's
+    schema) does NOT enforce count/numbering, so the identity guard is load-bearing.
+    Best-effort: ANY throw (including a reprompt ``RuntimeError``) degrades to pass-1. Never
+    raises, so the job always completes.
+
+    Known coverage limit (same trade-off as M1, zero false positives): only A/B/C LETTER
+    options are checked. Options named as models/prose ("desplegar Random Forest") or an
+    enunciado that names a single option are not flagged; the M4 questions prompt boundary
+    nudges the LLM to the letter form so the validator covers the reported defect.
+    """
+    log_extra = {"node": "m4_questions_generator", "case_id": state.get("case_id")}
+    try:
+        if not settings.m4_question_coherence or not _is_classification_family(state):
+            return preguntas_dict
+        violations = validate_question_option_coherence(preguntas_dict, "")
+        if not violations:
+            return preguntas_dict
+        logger.info(
+            "[m4_questions] reprompt de coherencia de opciones M4 disparado",
+            extra={
+                **log_extra,
+                "violation_count": len(violations),
+                "violation_types": _m4_violation_types(violations),
+            },
+        )
+        bullet_list = "\n".join(f"- {violation}" for violation in violations)
+        reprompt = prompt + _M4_QUESTIONS_OPTION_REPROMPT_HEADER + bullet_list
+        try:
+            resultado: GeneradorPreguntasOutput = llm.with_structured_output(
+                GeneradorPreguntasOutput
+            ).invoke(reprompt)
+            corrected = [p.model_dump() for p in resultado.preguntas]
+        except (ValidationError, OutputParserException, ValueError) as exc:
+            logger.warning(
+                "[m4_questions] reprompt coherencia de opciones M4 inválido — degrada a pass-1: %s",
+                exc,
+                extra=log_extra,
+            )
+            return preguntas_dict
+        # Identity guard: a reprompt that drops/adds/renumbers a question would corrupt the
+        # ``M4-Q{numero}`` grading key (shared.student_reads) — reject it, keep pass-1.
+        if [q.get("numero") for q in corrected] != [q.get("numero") for q in preguntas_dict]:
+            logger.warning(
+                "[m4_questions] reprompt M4 alteró conteo/numero — degrada a pass-1",
+                extra=log_extra,
+            )
+            return preguntas_dict
+        residual = validate_question_option_coherence(corrected, "")
+        if not residual:
+            logger.info(
+                "[m4_questions] coherencia de opciones M4 corregida por reprompt",
+                extra={**log_extra, "degraded": False},
+            )
+            return corrected
+        logger.warning(
+            "[m4_questions] coherencia de opciones M4 degradada tras reprompt",
+            extra={**log_extra, "violation_types": _m4_violation_types(residual), "degraded": True},
+        )
+        return preguntas_dict
+    except Exception as exc:  # best-effort — a coherence pass must never fail the job
+        logger.warning(
+            "[m4_questions] validador coherencia de opciones M4 falló (best-effort): %s",
+            exc,
+            extra=log_extra,
         )
         return preguntas_dict
 
@@ -5145,6 +5256,12 @@ def m4_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
 
         preguntas = [p.model_dump() for p in resultado.preguntas]
         print(f"[m4_questions_generator] {len(preguntas)} preguntas")
+        # Option coherence (clasificación, both profiles) — best-effort, reprompt-once-then-
+        # degrade. Pass the RENDERED prompt (the node inlines .format above) so the reprompt
+        # re-grounds on the same text; the wrapper concatenates (never re-.format, cifras `{}`).
+        preguntas = _apply_m4_questions_option_coherence(
+            llm=llm, prompt=prompt.format(**context), state=state, preguntas_dict=preguntas
+        )
         return {"m4_questions": preguntas, "current_agent": "m4_questions_generator"}
     except Exception as e:
         logger.error("[m4_questions_generator] ERROR: %s", e, exc_info=True)

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -5250,17 +5250,19 @@ def m4_questions_generator(state: ADAMState, config: RunnableConfig) -> dict:
         prompt = _maybe_business_classification_prompt(
             state, prompt, M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION
         )
+        # Render once; the coherence reprompt below reuses this verbatim so it re-grounds on
+        # the SAME text the model first saw (mirrors the M1/M2 single-render pattern).
+        rendered_prompt = prompt.format(**context)
         resultado: GeneradorPreguntasOutput = llm.with_structured_output(
             GeneradorPreguntasOutput
-        ).invoke(prompt.format(**context))
+        ).invoke(rendered_prompt)
 
         preguntas = [p.model_dump() for p in resultado.preguntas]
         print(f"[m4_questions_generator] {len(preguntas)} preguntas")
         # Option coherence (clasificación, both profiles) — best-effort, reprompt-once-then-
-        # degrade. Pass the RENDERED prompt (the node inlines .format above) so the reprompt
-        # re-grounds on the same text; the wrapper concatenates (never re-.format, cifras `{}`).
+        # degrade. The wrapper concatenates onto the rendered prompt (never re-.format, cifras `{}`).
         preguntas = _apply_m4_questions_option_coherence(
-            llm=llm, prompt=prompt.format(**context), state=state, preguntas_dict=preguntas
+            llm=llm, prompt=rendered_prompt, state=state, preguntas_dict=preguntas
         )
         return {"m4_questions": preguntas, "current_agent": "m4_questions_generator"}
     except Exception as e:

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -1120,6 +1120,10 @@ negocio.
   probabilidad puede dirigir el presupuesto al lugar equivocado; pide una mitigación concreta en
   términos de negocio (a quién priorizar, con qué presupuesto, cómo confirmar el supuesto), no una
   receta técnica del modelo.
+- **Coherencia opción↔solución:** si una pregunta plantea opciones, enúncialas con letras
+  (A/B/C) y en `solucion_esperada` recomienda SOLO una de las letras presentadas en ese mismo
+  enunciado, nombrándola por su letra; nunca una opción ausente del enunciado ni una letra fuera
+  de A/B/C.
 - **Honestidad:** usa únicamente cifras del caso (Exhibits, M2, M4). NO inventes probabilidades,
   tasas ni valores nuevos; razona sobre la lógica de priorización, no sobre métricas del modelo.
 """

--- a/backend/src/case_generator/prompts/clasificacion/M4_clasificacion/questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M4_clasificacion/questions.py
@@ -62,6 +62,10 @@ riesgos de producción específicos de modelos de clasificación.
 # Your Boundaries
 - Solo JSON schema. Las preguntas DEBEN citar métricas numéricas del M4 y del
   bloque de métricas verificadas (si disponibles), y opciones A/B/C.
+- COHERENCIA OPCIÓN↔SOLUCIÓN: cuando una pregunta presente opciones, el enunciado DEBE
+  listarlas con sus letras (A/B/C) y `solucion_esperada` SOLO puede recomendar una de esas
+  letras presentadas en ese mismo enunciado, nombrándola por su letra. NUNCA recomiendes una
+  opción que el enunciado no presenta, ni una letra fuera de A/B/C.
 - Citar SOLO números que aparezcan en {m4_content} o en {computed_metrics_block}.
   No fabricar métricas que no figuren en esas fuentes.
 - **Idioma de salida: {output_language}**

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -99,6 +99,15 @@ class Settings(BaseSettings):
     # are unaffected. Kill-switch: set M2_QUESTION_COHERENCE=false to passthrough exactly
     # (instant env-only revert; no redeploy).
     m2_question_coherence: bool = True
+    # Internal coherence of the M4 (Impacto) decision-question options (clasificación, both
+    # profiles). When true, `validate_question_option_coherence` (reused from m1_grounding with
+    # the floor universe A/B/C — M4 has no `dilema_brief`) checks that each `solucion_esperada`
+    # only recommends an option the case defines (A/B/C) and that its own `enunciado` presents;
+    # `m4_questions_generator` reprompts once then degrades to the pass-1 questions (identity-
+    # guarded on `numero`). Best-effort + gated to the classification family, so
+    # business/other-family/non-clf cases are unaffected. Kill-switch: set
+    # M4_QUESTION_COHERENCE=false to passthrough exactly (instant env-only revert; no redeploy).
+    m4_question_coherence: bool = True
 
     model_config = SettingsConfigDict(env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/tests/golden_eval.py
+++ b/backend/tests/golden_eval.py
@@ -58,6 +58,11 @@ class NodeEvalInputs:
     # prevalence). True (n/a) for non-classification jobs. Computed via
     # ``check_eda_questions_coherence`` (reuses the production validator).
     eda_questions_coherence_ok: bool = True
+    # M4 (Impacto) question option coherence: every classification golden job's M4 questions must be
+    # coherent (no `solucion_esperada` recommending an option absent from / nonexistent in its own
+    # enunciado). True (n/a) for non-classification jobs. Computed via
+    # ``check_m4_question_option_coherence`` (reuses the production validator).
+    m4_questions_coherence_ok: bool = True
 
 
 @dataclass
@@ -86,6 +91,8 @@ def evaluate_downgrade_gate(r: NodeEvalInputs) -> GateResult:
         reasons.append("domain coherence failure: churn-coupled target on ml_ds non-churn job")
     if not r.eda_questions_coherence_ok:
         reasons.append("M2 EDA question coherence failure: chart_ref or event-rate mismatch")
+    if not r.m4_questions_coherence_ok:
+        reasons.append("M4 question option coherence failure: nonexistent or unpresented option")
     if r.judge_baseline_mean is not None and r.judge_candidate_mean is not None:
         drop = r.judge_baseline_mean - r.judge_candidate_mean
         if drop > JUDGE_MAX_DROP:
@@ -143,6 +150,19 @@ def check_eda_questions_coherence(
     from case_generator.m2_grounding import validate_eda_questions_coherence
 
     return not validate_eda_questions_coherence(preguntas, chart_ids, target_event_rate)
+
+
+def check_m4_question_option_coherence(preguntas: list[dict]) -> bool:
+    """Pure oracle: are the M4 questions coherent (no nonexistent / unpresented option)?
+
+    Reuses the production validator ``m1_grounding.validate_question_option_coherence`` with an
+    empty ``dilema_brief`` (M4 has no case-options authority → floor universe A/B/C), so a future
+    M4-prompt regression that lets ``solucion_esperada`` recommend an option absent from its own
+    enunciado fails the golden gate. Function-level import keeps this support module lightweight.
+    """
+    from case_generator.m1_grounding import validate_question_option_coherence
+
+    return not validate_question_option_coherence(preguntas, "")
 
 
 # ── frozen golden set ────────────────────────────────────

--- a/backend/tests/test_m4_question_coherence.py
+++ b/backend/tests/test_m4_question_coherence.py
@@ -1,0 +1,368 @@
+"""M4 (Impacto) question option coherence — deterministic internal coherence guard.
+
+Covers the reported defect for Module 4: an ``solucion_esperada`` recommending an option that
+does not exist in the case, or one its own ``enunciado`` never presented. Scope is the
+classification family for BOTH profiles (business + ml_ds).
+
+Three layers under test:
+  1. The REUSED pure validator ``m1_grounding.validate_question_option_coherence(preguntas, "")``
+     with the FLOOR universe {A,B,C} (M4 has no ``dilema_brief``). The validator internals are
+     exhaustively covered by ``test_m1_option_coherence.py``; here we only assert the floor-universe
+     behaviour and the M4-shape false-positive controls.
+  2. The prompt layer (defense-in-depth, #M4-coherence): both classification question prompts carry
+     an option↔solution coherence boundary; the generic prompt does not (non-clf unaffected).
+  3. The graph wrapper ``graph._apply_m4_questions_option_coherence`` — reprompt-once-then-DEGRADE,
+     gated to the classification family + kill-switch, identity-guarded on ``numero`` (the
+     ``M4-Q{numero}`` grading key), best-effort.
+
+Pure-Python: no DB, no real LLM, no network.
+"""
+
+from __future__ import annotations
+
+import importlib
+import string
+
+import pytest
+
+from case_generator.m1_grounding import validate_question_option_coherence
+from case_generator.prompts import (
+    M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION,
+    M4_QUESTIONS_GENERATOR_PROMPT,
+)
+from case_generator.prompts.clasificacion.M4_clasificacion import (
+    M4_QUESTIONS_PROMPT_CLASSIFICATION,
+)
+from case_generator.tools_and_schemas import (
+    GeneradorPreguntasOutput,
+    PreguntaMinimalista,
+)
+
+graph_module = importlib.import_module("case_generator.graph")
+
+# Defense-in-depth boundary sentinel (case-folded) added to both classification question prompts.
+_COHERENCE_SENTINEL = "opción↔solución"
+
+
+def _pq(numero: int, *, enunciado: str = "", solucion: str = "") -> dict:
+    return {
+        "numero": numero,
+        "titulo": "T",
+        "enunciado": enunciado,
+        "solucion_esperada": solucion,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Validator reuse — floor universe {A,B,C} (no dilema_brief) + M4-shape FP controls
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestValidatorFloorUniverse:
+    def test_clean_when_solution_picks_presented_option(self) -> None:
+        q = _pq(
+            2,
+            enunciado="Elige entre la Opción A, la Opción B y la Opción C de despliegue.",
+            solucion="La Opción B ofrece mejor ROI dado el costo de reentrenamiento.",
+        )
+        assert validate_question_option_coherence([q], "") == []
+
+    def test_primary_nonexistent_option_floor(self) -> None:
+        q = _pq(
+            2,
+            enunciado="Elige entre la Opción A, la Opción B y la Opción C.",
+            solucion="Recomiendo la Opción D, un esquema híbrido.",
+        )
+        out = validate_question_option_coherence([q], "")
+        assert len(out) == 1 and out[0].startswith("OPTION_NONEXISTENT")
+
+    def test_secondary_option_not_presented_floor(self) -> None:
+        q = _pq(
+            2,
+            enunciado="Compara la Opción A con la Opción B para el despliegue.",
+            solucion="La Opción C es preferible.",
+        )
+        out = validate_question_option_coherence([q], "")
+        assert len(out) == 1 and out[0].startswith("OPTION_NOT_PRESENTED")
+
+    def test_m4_shapes_without_letters_are_ignored(self) -> None:
+        # The real M4 question shapes: P1 analysis, P2 contrast naming "los dos modelos", P3
+        # synthesis mentioning "A/B testing". None uses a keyword-anchored A/B/C label → no check.
+        qs = [
+            _pq(
+                1,
+                enunciado="¿Cómo impacta la tasa del evento (8%) la línea de ingresos al aplicar el modelo?",
+                solucion="Reduce la pérdida priorizando los casos de mayor probabilidad × valor.",
+            ),
+            _pq(
+                2,
+                enunciado="Entre los dos modelos (Logistic Regression con AUC 0.82 y Random Forest 0.88), ¿cuál?",
+                solucion="Random Forest ofrece mejor trade-off ROI/riesgo tras amortizar el reentrenamiento.",
+            ),
+            _pq(
+                3,
+                enunciado="¿Cómo mitigar el concept drift en producción?",
+                solucion="Reentrenamiento trimestral y un A/B testing controlado del umbral de alerta.",
+            ),
+        ]
+        assert validate_question_option_coherence(qs, "") == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Prompt layer — defense-in-depth boundary (capa B), contract-safe
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _placeholders(template: str) -> set[str]:
+    """Placeholder names of a ``.format()`` template (técnica de M2)."""
+    return {
+        fname.split(".")[0].split("[")[0]
+        for _, fname, _, _ in string.Formatter().parse(template)
+        if fname
+    }
+
+
+class TestPromptBoundary:
+    def test_mlds_classification_prompt_has_boundary(self) -> None:
+        assert _COHERENCE_SENTINEL in M4_QUESTIONS_PROMPT_CLASSIFICATION.lower()
+
+    def test_business_classification_prompt_has_boundary(self) -> None:
+        assert _COHERENCE_SENTINEL in M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION.lower()
+
+    def test_generic_prompt_has_no_boundary(self) -> None:
+        # Non-classification families render the generic prompt unchanged.
+        assert _COHERENCE_SENTINEL not in M4_QUESTIONS_GENERATOR_PROMPT.lower()
+
+    def test_mlds_prompt_adds_no_placeholder_and_renders(self) -> None:
+        # A new {placeholder} or an unescaped literal brace would KeyError/ValueError at .format.
+        ctx = {p: "X" for p in _placeholders(M4_QUESTIONS_PROMPT_CLASSIFICATION)}
+        assert M4_QUESTIONS_PROMPT_CLASSIFICATION.format(**ctx)
+
+    def test_business_block_adds_no_placeholder_vs_generic(self) -> None:
+        # The business block stays placeholder-free: same set as the generic base it composes on.
+        assert _placeholders(M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION) == _placeholders(
+            M4_QUESTIONS_GENERATOR_PROMPT
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Graph wrapper — reprompt-once-then-DEGRADE, gated, identity-guarded, best-effort
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FakeStructuredLLM:
+    """Mimics the m4_questions LLM: queue of outputs (or exceptions). Raises if over-called."""
+
+    def __init__(self, outputs: list[object] | None = None) -> None:
+        self._outputs = list(outputs or [])
+        self.calls = 0
+
+    def with_structured_output(self, _schema: object) -> "_FakeStructuredLLM":
+        return self
+
+    def invoke(self, _prompt: str) -> object:
+        self.calls += 1
+        if not self._outputs:
+            raise AssertionError("LLM invoked more times than expected")
+        result = self._outputs.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _state(*, profile: str = "ml_ds", algoritmos: list[str] | None = None) -> dict:
+    # M4 has NO dilema_brief — the wrapper validates against the floor universe {A,B,C}.
+    return {
+        "studentProfile": profile,
+        "algoritmos": algoritmos if algoritmos is not None else ["Logistic Regression"],
+        "algorithm_mode": "single",
+        "case_id": "case_m4_option_coherence",
+        "output_language": "es",
+    }
+
+
+def _questions(p2_enunciado: str, p2_solucion: str) -> list[dict]:
+    return [
+        _pq(1, enunciado="¿Cómo impacta el hallazgo del M2 los ingresos?", solucion="Reduce la pérdida."),
+        _pq(2, enunciado=p2_enunciado, solucion=p2_solucion),
+        _pq(3, enunciado="¿Cómo mitigar el concept drift?", solucion="Reentrenamiento trimestral."),
+    ]
+
+
+def _output(preguntas: list[dict]) -> GeneradorPreguntasOutput:
+    return GeneradorPreguntasOutput(preguntas=[PreguntaMinimalista(**p) for p in preguntas])
+
+
+# A pass-1 set with a violating P2 (solution recommends a nonexistent option D).
+_BAD = _questions(
+    "Elige entre la Opción A, la Opción B y la Opción C de despliegue.",
+    "Recomiendo la Opción D por su retorno.",
+)
+# A clean P2 the reprompt can return (recommends a presented option).
+_CLEAN = _questions(
+    "Elige entre la Opción A, la Opción B y la Opción C de despliegue.",
+    "La Opción B es la mejor por el ROI.",
+)
+_CLEAN_RESULT = _output(_CLEAN)
+# A reprompt that still violates (still recommends D).
+_STILL_BAD_RESULT = _output(
+    _questions(
+        "Elige entre la Opción A, la Opción B y la Opción C.",
+        "Insisto en la Opción D.",
+    )
+)
+# A reprompt that fixes P2 but introduces a NEW violation in P1 (recommends an absent C).
+_FIX_ONE_BREAK_ANOTHER_RESULT = _output(
+    [
+        _pq(1, enunciado="Compara la Opción A con la Opción B.", solucion="La Opción C es mejor."),
+        _pq(2, enunciado="Elige entre la Opción A, la Opción B y la Opción C.", solucion="La Opción A."),
+        _pq(3, enunciado="¿Cómo mitigar el concept drift?", solucion="Reentrenamiento trimestral."),
+    ]
+)
+# Identity-guard breakers: shorter (2 questions) and renumbered ([2,1,3]).
+_SHORTER_RESULT = _output(
+    [
+        _pq(1, enunciado="¿Cómo impacta el hallazgo del M2?", solucion="Reduce la pérdida."),
+        _pq(2, enunciado="Elige entre la Opción A, la Opción B y la Opción C.", solucion="La Opción A."),
+    ]
+)
+_RENUMBERED_RESULT = _output(
+    [
+        _pq(2, enunciado="¿Cómo impacta el hallazgo del M2?", solucion="Reduce la pérdida."),
+        _pq(1, enunciado="Elige entre la Opción A, la Opción B y la Opción C.", solucion="La Opción A."),
+        _pq(3, enunciado="¿Cómo mitigar el concept drift?", solucion="Reentrenamiento trimestral."),
+    ]
+)
+
+
+def _invoke(fake: _FakeStructuredLLM, state: dict, preguntas: list[dict]) -> list[dict]:
+    return graph_module._apply_m4_questions_option_coherence(
+        llm=fake, prompt="PROMPT", state=state, preguntas_dict=preguntas
+    )
+
+
+class TestWrapper:
+    def test_validator_detects_bad_fixture_so_tests_are_not_vacuous(self) -> None:
+        # Negative control: prove the bad pass-1 fixture genuinely violates, so a green
+        # "no reprompt" elsewhere means the gate/validator worked — not that the bug is silent.
+        assert validate_question_option_coherence(_BAD, "") != []
+
+    def test_happy_path_no_reprompt(self) -> None:
+        fake = _FakeStructuredLLM()  # would raise if invoked
+        out = _invoke(fake, _state(), _CLEAN)
+        assert fake.calls == 0
+        assert out == _CLEAN
+
+    def test_reprompt_corrects(self) -> None:
+        fake = _FakeStructuredLLM([_CLEAN_RESULT])
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 1
+        assert out != _BAD  # corrected, not degraded
+        assert validate_question_option_coherence(out, "") == []
+        assert "Opción D" not in out[1]["solucion_esperada"]
+
+    def test_degrade_when_reprompt_still_violates(self) -> None:
+        fake = _FakeStructuredLLM([_STILL_BAD_RESULT])
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 1
+        assert out == _BAD  # degrade to pass-1
+
+    def test_degrade_when_reprompt_fixes_one_breaks_another(self) -> None:
+        fake = _FakeStructuredLLM([_FIX_ONE_BREAK_ANOTHER_RESULT])
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 1
+        assert out == _BAD  # residual (new) violation → degrade
+
+    def test_degrade_when_structured_output_raises(self) -> None:
+        fake = _FakeStructuredLLM([ValueError("bad json")])
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 1
+        assert out == _BAD
+
+    def test_degrade_on_count_drift(self) -> None:
+        # A coherent but SHORTER reprompt (2 questions) must be rejected (identity guard).
+        fake = _FakeStructuredLLM([_SHORTER_RESULT])
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 1
+        assert out == _BAD
+
+    def test_degrade_on_numero_drift(self) -> None:
+        # A coherent but RENUMBERED reprompt ([2,1,3]) corrupts the M4-Q{numero} key → reject.
+        fake = _FakeStructuredLLM([_RENUMBERED_RESULT])
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 1
+        assert out == _BAD
+
+    def test_gate_fires_for_business_clf(self) -> None:
+        fake = _FakeStructuredLLM([_CLEAN_RESULT])
+        out = _invoke(fake, _state(profile="business"), _BAD)
+        assert fake.calls == 1  # gate fired for business + clasificación
+        assert validate_question_option_coherence(out, "") == []
+
+    def test_gate_fires_for_mlds_clf(self) -> None:
+        fake = _FakeStructuredLLM([_CLEAN_RESULT])
+        out = _invoke(fake, _state(profile="ml_ds"), _BAD)
+        assert fake.calls == 1
+
+    def test_gate_fires_for_mlds_without_algorithms(self) -> None:
+        # ml_ds with empty algoritmos resolves to clasificación (default) → gate ON.
+        fake = _FakeStructuredLLM([_CLEAN_RESULT])
+        out = _invoke(fake, _state(profile="ml_ds", algoritmos=[]), _BAD)
+        assert fake.calls == 1
+
+    def test_gate_noop_for_non_classification_family(self) -> None:
+        fake = _FakeStructuredLLM()  # would raise if invoked
+        out = _invoke(fake, _state(algoritmos=["Linear Regression"]), _BAD)
+        assert fake.calls == 0
+        assert out == _BAD
+
+    def test_gate_noop_for_business_without_algorithms(self) -> None:
+        fake = _FakeStructuredLLM()
+        out = _invoke(fake, _state(profile="business", algoritmos=[]), _BAD)
+        assert fake.calls == 0
+        assert out == _BAD
+
+    def test_kill_switch_off_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(graph_module.settings, "m4_question_coherence", False)
+        fake = _FakeStructuredLLM()
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 0
+        assert out == _BAD
+
+    def test_best_effort_when_validator_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(*_a: object, **_k: object) -> list[str]:
+            raise RuntimeError("validator bug")
+
+        monkeypatch.setattr(graph_module, "validate_question_option_coherence", _boom)
+        fake = _FakeStructuredLLM()
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 0
+        assert out == _BAD
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Golden oracle — anti-regression lock on the downgrade gate
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestGoldenOracle:
+    def test_oracle_coherent_true(self) -> None:
+        from tests.golden_eval import check_m4_question_option_coherence
+
+        assert check_m4_question_option_coherence(_CLEAN) is True
+
+    def test_oracle_incoherent_false(self) -> None:
+        from tests.golden_eval import check_m4_question_option_coherence
+
+        assert check_m4_question_option_coherence(_BAD) is False
+
+    def test_gate_blocks_on_incoherence(self) -> None:
+        from tests.golden_eval import NodeEvalInputs, evaluate_downgrade_gate
+
+        ok = evaluate_downgrade_gate(NodeEvalInputs(node="x", deterministic_pass=True))
+        assert ok.passed
+        blocked = evaluate_downgrade_gate(
+            NodeEvalInputs(node="x", deterministic_pass=True, m4_questions_coherence_ok=False)
+        )
+        assert not blocked.passed
+        assert any("M4 question option coherence" in reason for reason in blocked.reasons)

--- a/backend/tests/test_m4_question_coherence.py
+++ b/backend/tests/test_m4_question_coherence.py
@@ -279,6 +279,15 @@ class TestWrapper:
         assert fake.calls == 1
         assert out == _BAD
 
+    def test_degrade_when_reprompt_raises_runtime_error(self) -> None:
+        # A non-(Validation/Parser/Value)Error from the reprompt (e.g. an LLM RuntimeError
+        # on rate-limit/timeout) must hit the OUTER except Exception → degrade to pass-1,
+        # never propagate (the job must not fail).
+        fake = _FakeStructuredLLM([RuntimeError("llm exploded")])
+        out = _invoke(fake, _state(), _BAD)
+        assert fake.calls == 1
+        assert out == _BAD
+
     def test_degrade_on_count_drift(self) -> None:
         # A coherent but SHORTER reprompt (2 questions) must be rejected (identity guard).
         fake = _FakeStructuredLLM([_SHORTER_RESULT])


### PR DESCRIPTION
## Objetivo
Garantizar la **coherencia interna del Módulo 4 (Impacto)** para `ml_ds + clasificación` y `business + clasificación`: que la `solucion_esperada` de cada pregunta solo recomiende una opción (A/B/C) que su **propio enunciado presenta**. Es el mismo defecto ya cerrado en M1 ([#412](https://github.com/4Tech-Labs/ADAM-EDU/pull/412)) y M2 ([#414](https://github.com/4Tech-Labs/ADAM-EDU/pull/414)), que M4 no tenía cubierto (antes una solución podía recomendar una opción inexistente en la pregunta).

## Diseño (mínimo, aditivo, reversible)
- **Reusa el validador probado** `m1_grounding.validate_question_option_coherence(preguntas, "")` con universo piso `{A,B,C}` (M4 no tiene `dilema_brief`). Cero validador nuevo.
- **Nuevo wrapper** `_apply_m4_questions_option_coherence` en `m4_questions_generator`: reprompt-once-then-**DEGRADE**, **guard de identidad** sobre `numero` (protege la clave de calificación `M4-Q{numero}`), **best-effort** (`except Exception` externo → nunca falla el job), gateado a clasificación para **ambos perfiles** (`_is_classification_family`).
- **Kill-switch** `m4_question_coherence` (Settings + `.env.example`) → `M4_QUESTION_COHERENCE=false` = passthrough byte-idéntico, revert sin redeploy.
- **Defensa en profundidad (prompt):** una frontera opción↔solución en los 2 prompts de preguntas de clasificación (ml_ds + business), **sin nuevos placeholders** (contratos verdes).
- **Observabilidad sin PII:** log de *tipos* de violación. **Anti-regresión:** `check_m4_question_option_coherence` + `m4_questions_coherence_ok` en `golden_eval`.

## No-regresión / cero-FP
- Byte-idéntico no-op para familias no-clf, `business` sin algoritmos, kill-switch off, o validador que lanza.
- **Sin cambios** al grafo, a los demás módulos (M1/M2/M3/M5), a `case_sanitization`/`teacher_reads`, al SHA del architect, ni a la **configuración de modelos de M4** (content=Pro/thinking-medium, questions/charts=Flash; ya óptimo). El guard agrega ≤1 reprompt Flash solo ante incoherencia → costo marginal ≈ 0.

## Calidad / verificación
- **1836 passed, 22 skipped**; `mypy src` limpio.
- Plan endurecido por **revisión adversarial multi-agente** (orquestación, FP/FN, contratos cross-módulo, resiliencia, tests) + **probing EJECUTABLE** del código real: zero-FP en shapes M4 reales, sin ReDoS (<1ms en 100KB), gate alineado, guard de identidad load-bearing, nunca lanza → **SHIP sin defectos**.
- Tests: `backend/tests/test_m4_question_coherence.py` (validador piso, capa B de prompts, matriz completa del wrapper con control negativo anti-tautología, oráculo golden).

## Límite conocido (mismo trade-off que M1, cero FP)
Solo se valida la forma de **letras A/B/C** (la que el prompt M4 manda y la capa B refuerza). Opciones nombradas como modelos/prosa sin letra no se marcan; documentado en código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)