### PR TITLE
fix(case_generator): "Mapa de valores faltantes" honesto + colorbar 0..1 (ml_ds + clasificación)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -147,6 +147,16 @@ M4_QUESTION_COHERENCE=true
 # passthrough exactly (instant revert, no redeploy).
 M5_QUESTION_COHERENCE=true
 
+# -- M2 missingness-map honest text (kill-switch, ml_ds + clasificación) --
+# When true (default), the M2 "Mapa de valores faltantes" chart gets deterministic, honest text
+# from the python builder describing the REAL missingness of the sample (and a centered empty-state
+# annotation when there are 0 nulls), and the chart is excluded from LLM annotation so the LLM can
+# no longer invent an MNAR pattern the de-churned ml_ds+clf dataset (#382) never has. Scoped to the
+# classification python path; business/other-family/non-clf cases are unaffected. Set to false to
+# restore the prior behavior byte-identically (empty builder text + LLM annotates; instant revert,
+# no redeploy). The frontend colorbar fix applies regardless of this flag.
+M2_MISSINGNESS_HONEST_TEXT=true
+
 # -- Supabase auth perimeter (Issue 23 + Issue 30) ----------------
 # Required for JWT verification, activation flows and admin auth operations.
 # Local auth/session dev uses `supabase start` at http://localhost:54321.

--- a/backend/src/case_generator/datagen/eda_charts_classification.py
+++ b/backend/src/case_generator/datagen/eda_charts_classification.py
@@ -92,7 +92,7 @@ def _build_class_distribution(
 
 
 def _build_missingness_heatmap(
-    df: pd.DataFrame, target_col: str, source: str
+    df: pd.DataFrame, target_col: str, source: str, *, honest_text: bool = True
 ) -> dict[str, Any]:
     n_rows = len(df)
     if n_rows == 0:
@@ -116,18 +116,88 @@ def _build_missingness_heatmap(
             source,
         )
     # 1 = missing, 0 = present. Transpose so columns are y-axis (más legible).
-    matrix = sample[cols].isna().astype(int).T.values.tolist()
+    na = sample[cols].isna()
+    matrix = na.astype(int).T.values.tolist()
+
+    n_sample = len(sample)
+    base_subtitle = f"Muestra aleatoria de {n_sample} filas (random_state=42)"
+    subtitle = base_subtitle
+    description = ""
+    notes = ""
+    layout: dict[str, Any] = {
+        "template": "plotly_white",
+        "xaxis": {"title": "Filas (muestra)"},
+        "yaxis": {"title": "Columnas"},
+    }
+
+    # El builder conoce la verdad EXACTA de la muestra → escribe texto determinista
+    # y honesto en lugar de dejar que el LLM anotador (que no ve los datos) invente
+    # un patrón MNAR inexistente. Para los casos ml_ds+clf de dominio (de-churned,
+    # Issue #382) el dataset no tiene nulos por construcción, así que el mapa es
+    # uniforme y el texto debe DECIRLO en vez de afirmar missingness que no existe.
+    # `honest_text=False` (kill-switch) restaura el comportamiento previo byte-idéntico.
+    if honest_text:
+        total_missing = int(na.values.sum())
+        n_cols = len(cols)
+        if total_missing == 0:
+            subtitle = f"{base_subtitle} · sin valores faltantes"
+            description = (
+                f"Mapa de completitud de {n_cols} variables sobre {n_sample} "
+                "registros de la muestra. El dataset está COMPLETO (0 valores "
+                "faltantes), por eso el mapa se ve uniforme; en datos reales "
+                "esperarías huecos y el paso es confirmar la completitud antes "
+                "de modelar."
+            )
+            notes = (
+                "Sin nulos en esta muestra: no hay que imputar. En un caso real "
+                "evaluarías si los faltantes son MCAR/MAR/MNAR antes de eliminar "
+                "filas o imputar."
+            )
+            # Estado vacío explícito: que el panel uniforme no se lea como un bug.
+            # `buildLayout` (frontend) preserva `layout.annotations` vía spread.
+            layout["annotations"] = [
+                {
+                    "text": "Sin valores faltantes en la muestra",
+                    "xref": "paper",
+                    "yref": "paper",
+                    "x": 0.5,
+                    "y": 0.5,
+                    "showarrow": False,
+                    "font": {"size": 13, "color": "#94a3b8"},
+                }
+            ]
+        else:
+            cols_with_nulls = [c for c in cols if int(na[c].sum()) > 0]
+            k = len(cols_with_nulls)
+            top_cols = sorted(
+                cols_with_nulls, key=lambda c: int(na[c].sum()), reverse=True
+            )[:3]
+            subtitle = (
+                f"{base_subtitle} · {total_missing} celdas faltantes en {k} "
+                f"{'columna' if k == 1 else 'columnas'}"
+            )
+            description = (
+                f"Mapa de completitud de {n_cols} variables sobre {n_sample} "
+                f"registros. Hay {total_missing} celdas faltantes concentradas "
+                f"en: {', '.join(top_cols)}. Las franjas rojas marcan los nulos."
+            )
+            notes = (
+                "Observa si los nulos se concentran en ciertas columnas o filas. "
+                "¿La ausencia sigue un patrón MNAR que sesgaría el modelo si solo "
+                "eliminas filas?"
+            )
+
     return {
         "id": "missingness_heatmap",
         "title": "Mapa de valores faltantes",
-        "subtitle": f"Muestra aleatoria de {len(sample)} filas (random_state=42)",
+        "subtitle": subtitle,
         "library": "plotly",
         "chart_type": "heatmap",
         "traces": [
             {
                 "type": "heatmap",
                 "z": matrix,
-                "x": list(range(len(sample))),
+                "x": list(range(n_sample)),
                 "y": cols,
                 "colorscale": [[0, "#f5f5f5"], [1, "#d62728"]],
                 "showscale": True,
@@ -135,14 +205,10 @@ def _build_missingness_heatmap(
                 "zmax": 1,
             }
         ],
-        "layout": {
-            "template": "plotly_white",
-            "xaxis": {"title": "Filas (muestra)"},
-            "yaxis": {"title": "Columnas"},
-        },
+        "layout": layout,
         "source": source,
-        "description": "",
-        "notes": "",
+        "description": description,
+        "notes": notes,
         "data_source": "python_builder",
     }
 
@@ -226,12 +292,22 @@ def _build_mutual_info_top8(
 
 
 def generate_classification_eda_charts(
-    df: pd.DataFrame, target_col: str, contract: dict | None
+    df: pd.DataFrame,
+    target_col: str,
+    contract: dict | None,
+    *,
+    honest_text: bool = True,
 ) -> list[dict[str, Any]]:
     """Build the 3-chart EDA panel deterministically.
 
     Returns a list of dicts shaped like ``EDAChartSpec`` (with
-    ``data_source="python_builder"`` and empty ``description``/``notes``).
+    ``data_source="python_builder"``). All charts emit empty ``description``/
+    ``notes`` (the LLM annotates them) EXCEPT ``missingness_heatmap``, whose text
+    is deterministic and honest about the real missingness when ``honest_text`` is
+    True (the builder knows the truth; the LLM annotator does not see the data and
+    would otherwise invent an MNAR pattern that the de-churned ml_ds+clf dataset,
+    Issue #382, never has). ``honest_text=False`` (kill-switch
+    ``m2_missingness_honest_text``) restores the previous byte-identical behaviour.
     The caller validates with the Pydantic model and merges LLM annotations.
 
     On hard failure (empty df, missing target) returns ``[]`` so the caller
@@ -252,7 +328,7 @@ def generate_classification_eda_charts(
 
     builders: list[tuple[str, Any]] = [
         ("class_distribution", lambda: _build_class_distribution(df, target_col, source)),
-        ("missingness_heatmap", lambda: _build_missingness_heatmap(df, target_col, source)),
+        ("missingness_heatmap", lambda: _build_missingness_heatmap(df, target_col, source, honest_text=honest_text)),
         ("mutual_info_top8", lambda: _build_mutual_info_top8(df, target_col, source)),
     ]
     for cid, fn in builders:

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2122,6 +2122,8 @@ def _annotate_validate_emit(
     state: ADAMState,
     config: RunnableConfig,
     annotate_prompt: str,
+    *,
+    deterministic_text_ids: frozenset[str] = frozenset(),
 ) -> dict | None:
     """Cola compartida de los paths EDA Python-deterministas (clasif + business).
 
@@ -2131,6 +2133,12 @@ def _annotate_validate_emit(
     validó. El boundary del LLM nunca tumba el panel: si la anotación falla, se
     sirven los charts sin texto LLM (preservando los `notes` del builder, p. ej.
     el aviso anti-overclaim del chart de drivers).
+
+    ``deterministic_text_ids`` son los charts cuyo `description`/`notes` los escribe
+    el builder de forma determinista (p. ej. `missingness_heatmap`): se EXCLUYEN de
+    la petición al LLM y se descartan de sus anotaciones, de modo que el texto del
+    builder se conserva (el merge ya prefiere el texto del builder cuando el id no
+    está en `ann_by_id`). Default vacío → no-op byte-idéntico (path business).
     """
     # Cap defensivo: el contrato son ≤5 charts.
     if len(charts) > 5:
@@ -2147,6 +2155,7 @@ def _annotate_validate_emit(
                 "chart_type": c.get("chart_type", ""),
             }
             for c in charts
+            if c.get("id", "") not in deterministic_text_ids
         ]
         prompt = annotate_prompt.format(
             charts_context_json=json.dumps(charts_context, ensure_ascii=False),
@@ -2172,6 +2181,12 @@ def _annotate_validate_emit(
             ann_err,
         )
         ann_by_id = {}
+
+    # Charts con texto determinista: descartar cualquier anotación LLM (incl. una
+    # que un modelo díscolo devuelva sin habérsela pedido) para preservar el texto
+    # honesto del builder en el merge de abajo.
+    for _det_id in deterministic_text_ids:
+        ann_by_id.pop(_det_id, None)
 
     # Merge defensivo: solo description/notes; preservamos data_source y los
     # `notes` factuales del builder (p. ej. el caveat anti-overclaim). El caveat va
@@ -2237,15 +2252,30 @@ def _eda_classification_python_path(
             )
             return None
 
-        charts = generate_classification_eda_charts(df, target_col, contract)
+        # Kill-switch `m2_missingness_honest_text` (default true): el builder escribe
+        # texto determinista y honesto para `missingness_heatmap` (que el LLM no debe
+        # pisar). Off → texto vacío + el LLM lo anota (comportamiento previo).
+        honest_text = settings.m2_missingness_honest_text
+        charts = generate_classification_eda_charts(
+            df, target_col, contract, honest_text=honest_text
+        )
         if not charts:
             logger.warning(
                 "[eda_chart_generator/py] builder devolvió 0 charts — fallback a path LLM"
             )
             return None
 
+        # El id está acoplado al builder (`_build_missingness_heatmap`); el test E2E
+        # de coherencia de texto lo bloquea contra un rename silencioso.
+        deterministic_text_ids = (
+            frozenset({"missingness_heatmap"}) if honest_text else frozenset()
+        )
         return _annotate_validate_emit(
-            charts, state, config, EDA_ANNOTATE_ONLY_PROMPT_CLASSIFICATION
+            charts,
+            state,
+            config,
+            EDA_ANNOTATE_ONLY_PROMPT_CLASSIFICATION,
+            deterministic_text_ids=deterministic_text_ids,
         )
     except Exception as e:  # noqa: BLE001
         logger.error(

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -126,6 +126,17 @@ class Settings(BaseSettings):
     # are unaffected. Kill-switch: set M5_QUESTION_COHERENCE=false to passthrough exactly (instant
     # env-only revert; no redeploy).
     m5_question_coherence: bool = True
+    # Honest, deterministic text for the M2 "Mapa de valores faltantes" chart (ml_ds +
+    # clasificación). When true, `_build_missingness_heatmap` writes the real missingness
+    # summary into `subtitle`/`description`/`notes` (and a centered empty-state annotation
+    # when the sample has 0 nulls), and `_eda_classification_python_path` excludes the chart
+    # from LLM annotation so the LLM can no longer invent an MNAR pattern the de-churned
+    # dataset (#382) never has. Best-effort + scoped to the classification python path, so
+    # business/other-family/non-clf cases are unaffected. Kill-switch: set
+    # M2_MISSINGNESS_HONEST_TEXT=false to restore the prior behavior byte-identically (empty
+    # builder text + LLM annotates the chart; instant env-only revert, no redeploy). The
+    # frontend colorbar fix (constant-matrix range) applies regardless of this flag.
+    m2_missingness_honest_text: bool = True
 
     model_config = SettingsConfigDict(env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/tests/test_issue237_eda_charts_classification.py
+++ b/backend/tests/test_issue237_eda_charts_classification.py
@@ -64,7 +64,8 @@ CONTRACT = {"case_id": "test_case_237"}
 
 def test_happy_path_invariants(df_binary: pd.DataFrame) -> None:
     """El happy path emite EXACTAMENTE 3 charts en el orden esperado, todos
-    con `data_source=python_builder` y descriptions/notes vacías (anti-LLM).
+    con `data_source=python_builder`. Solo `missingness_heatmap` lleva texto
+    determinista del builder (honest_text); los otros dos siguen vacíos (anti-LLM).
     """
     charts = generate_classification_eda_charts(df_binary, "churn", CONTRACT)
     assert len(charts) == 3
@@ -77,10 +78,17 @@ def test_happy_path_invariants(df_binary: pd.DataFrame) -> None:
     for c in charts:
         assert c["library"] == "plotly"
         assert c["data_source"] == "python_builder"
-        # Anti-LLM-fabricated: el builder NO escribe textos pedagógicos.
-        assert c["description"] == ""
-        assert c["notes"] == ""
         assert c["source"].startswith("Dataset ADAM")
+        if c["id"] == "missingness_heatmap":
+            # Texto determinista y honesto del builder (no LLM): df_binary no tiene
+            # nulos → describe completitud, no deja que el LLM invente un MNAR.
+            assert "faltantes" in c["subtitle"]
+            assert c["description"] != ""
+            assert c["notes"] != ""
+        else:
+            # Anti-LLM-fabricated: los demás builders NO escriben textos pedagógicos.
+            assert c["description"] == ""
+            assert c["notes"] == ""
 
 
 def test_target_multiclass(df_multiclass: pd.DataFrame) -> None:
@@ -146,6 +154,59 @@ def test_snapshot_mutual_info_top8_features(df_binary: pd.DataFrame) -> None:
 
 
 # ─────────────────────────────────────────────────────────
+# Texto honesto del mapa de valores faltantes (Cambio 1)
+# ─────────────────────────────────────────────────────────
+
+
+def test_missingness_text_complete_dataset(df_binary: pd.DataFrame) -> None:
+    """Dataset sin nulos (caso de-churned ml_ds+clf): el chart de missingness DICE
+    que el dataset está completo y trae una annotation de estado vacío — NO inventa
+    un patrón MNAR inexistente."""
+    charts = generate_classification_eda_charts(df_binary, "churn", CONTRACT)
+    mh = next(c for c in charts if c["id"] == "missingness_heatmap")
+    assert "sin valores faltantes" in mh["subtitle"]
+    assert "COMPLETO" in mh["description"]
+    # El texto del estado-completo no afirma que hay missingness concentrada.
+    assert "concentradas" not in mh["description"]
+    anns = mh["layout"].get("annotations") or []
+    assert any("Sin valores faltantes" in (a.get("text", "") or "") for a in anns)
+
+
+def test_missingness_text_with_real_nulls() -> None:
+    """Dataset CON nulos (caso churn/retención): describe el conteo real + pregunta
+    MNAR legítima y NO añade la annotation de estado vacío."""
+    rng = np.random.default_rng(7)
+    n = 120
+    df = pd.DataFrame(
+        {
+            "age": rng.integers(18, 70, size=n).astype(float),
+            "income": rng.normal(50_000, 15_000, size=n),
+            "churn": rng.choice([0, 1], size=n, p=[0.7, 0.3]),
+        }
+    )
+    df.loc[:9, "age"] = np.nan  # 10 celdas faltantes en una columna feature
+    charts = generate_classification_eda_charts(df, "churn", CONTRACT)
+    mh = next(c for c in charts if c["id"] == "missingness_heatmap")
+    assert "celdas faltantes" in mh["subtitle"]
+    assert "age" in mh["description"]
+    assert "MNAR" in mh["notes"]
+    assert "annotations" not in mh["layout"]
+
+
+def test_missingness_honest_text_off_is_byte_identical(df_binary: pd.DataFrame) -> None:
+    """Kill-switch OFF (`honest_text=False`): comportamiento previo byte-idéntico —
+    description/notes vacías, sin annotation, subtitle base."""
+    charts = generate_classification_eda_charts(
+        df_binary, "churn", CONTRACT, honest_text=False
+    )
+    mh = next(c for c in charts if c["id"] == "missingness_heatmap")
+    assert mh["description"] == ""
+    assert mh["notes"] == ""
+    assert mh["subtitle"] == "Muestra aleatoria de 200 filas (random_state=42)"
+    assert "annotations" not in mh["layout"]
+
+
+# ─────────────────────────────────────────────────────────
 # Boundary del LLM stub (annotate-only path)
 # ─────────────────────────────────────────────────────────
 
@@ -198,6 +259,12 @@ def test_boundary_llm_cannot_alter_traces(df_binary: pd.DataFrame) -> None:
         .tolist()
     ]
     assert cd["data_source"] == "python_builder"
+    # El chart de missingness CONSERVA el texto determinista del builder: el stub
+    # LLM ("d2"/"n2") se descarta por `deterministic_text_ids` (Cambio 2).
+    mh = next(c for c in charts if c["id"] == "missingness_heatmap")
+    assert mh["description"] != "d2"
+    assert mh["notes"] != "n2"
+    assert "faltantes" in mh["subtitle"]
 
 
 def test_llm_ghost_chart_id_is_silently_dropped(df_binary: pd.DataFrame) -> None:

--- a/frontend/src/shared/case-viewer/plotlyChartUtils.test.ts
+++ b/frontend/src/shared/case-viewer/plotlyChartUtils.test.ts
@@ -65,3 +65,82 @@ describe("sanitizeTraces — dense heatmap per-cell text handling", () => {
         expect(out.texttemplate).toBeUndefined();
     });
 });
+
+describe("sanitizeTraces — heatmap zmin/zmax range", () => {
+    it("respects the backend zmin/zmax on a constant (all-zero) missingness matrix", () => {
+        const [out] = sanitizeTraces([
+            {
+                type: "heatmap",
+                z: [
+                    [0, 0, 0],
+                    [0, 0, 0],
+                ],
+                zmin: 0,
+                zmax: 1,
+                colorscale: [
+                    [0, "#f5f5f5"],
+                    [1, "#d62728"],
+                ],
+            },
+        ]);
+
+        // Sin el fix, un rango degenerado [0,0] colapsaba la colorbar (Plotly caía a −1..1).
+        expect(out.zmin).toBe(0);
+        expect(out.zmax).toBe(1);
+        expect(out.zauto).toBe(false);
+    });
+
+    it("forces −1..1 on a correlation-like matrix without a backend range", () => {
+        const [out] = sanitizeTraces([
+            {
+                type: "heatmap",
+                z: [
+                    [1, -0.8],
+                    [0.3, 0.5],
+                ],
+                colorscale: "RdBu",
+            },
+        ]);
+
+        expect(out.zmin).toBe(-1);
+        expect(out.zmax).toBe(1);
+    });
+
+    it("uses data min/max on a cohort-like matrix without a backend range", () => {
+        const [out] = sanitizeTraces([
+            {
+                type: "heatmap",
+                z: [
+                    [0.95, 0.5],
+                    [0.8, 0.2],
+                ],
+                colorscale: "YlOrRd",
+            },
+        ]);
+
+        expect(out.zmin).toBe(0.2);
+        expect(out.zmax).toBe(0.95);
+    });
+
+    it("uses 0..1 on a missingness matrix that has real nulls (non-degenerate)", () => {
+        const [out] = sanitizeTraces([
+            {
+                type: "heatmap",
+                z: [
+                    [0, 1, 0],
+                    [1, 0, 0],
+                ],
+                zmin: 0,
+                zmax: 1,
+                colorscale: [
+                    [0, "#f5f5f5"],
+                    [1, "#d62728"],
+                ],
+            },
+        ]);
+
+        // dataMin=0 ≠ dataMax=1 → rama else (sin cambio), mismo 0..1.
+        expect(out.zmin).toBe(0);
+        expect(out.zmax).toBe(1);
+    });
+});

--- a/frontend/src/shared/case-viewer/plotlyChartUtils.ts
+++ b/frontend/src/shared/case-viewer/plotlyChartUtils.ts
@@ -137,12 +137,32 @@ export function sanitizeTraces(traces: Record<string, unknown>[]): Record<string
 
                 const dataMin = validation.zMin!;
                 const dataMax = validation.zMax!;
+                const backendZmin =
+                    typeof trace.zmin === "number" && Number.isFinite(trace.zmin)
+                        ? (trace.zmin as number)
+                        : null;
+                const backendZmax =
+                    typeof trace.zmax === "number" && Number.isFinite(trace.zmax)
+                        ? (trace.zmax as number)
+                        : null;
                 const isCorrelationLike =
                     dataMin >= -1 - 1e-6 &&
                     dataMax <= 1 + 1e-6 &&
                     dataMin < -1e-6;
 
-                if (isCorrelationLike) {
+                if (
+                    dataMin === dataMax &&
+                    backendZmin !== null &&
+                    backendZmax !== null
+                ) {
+                    // Matriz constante (p.ej. el mapa de missingness sin nulos): un
+                    // rango [v, v] colapsa la colorbar a una escala degenerada. Respetar
+                    // el rango declarado por el backend (0..1) para una leyenda correcta.
+                    // Solo el heatmap de missingness fija zmin/zmax en el backend, así que
+                    // cohort (YlOrRd) y correlación (RdBu) no entran por esta rama.
+                    sanitized.zmin = backendZmin;
+                    sanitized.zmax = backendZmax;
+                } else if (isCorrelationLike) {
                     sanitized.zmin = -1;
                     sanitized.zmax = 1;
                 } else {


### PR DESCRIPTION
## Problema

En un caso **ml_ds + clasificación de dominio NO-retención** (de-churned, #382), el chart M2 EDA **"Mapa de valores faltantes"** sale roto:

- Heatmap **uniformemente gris** → 0 valores faltantes en TODO el dataset (por construcción).
- Colorbar degenerada **−1..1** (estilo correlación) en vez de leyenda 0..1 presente/faltante.
- Descripción y pie (escritos por el **LLM anotador**, que NO ve los datos) **afirman** missingness, nulos correlacionados y un **patrón MNAR** que el dataset **nunca tiene**.

### Causa raíz

El dataset de un caso no-retención no tiene nulos: las únicas columnas `nullable=True` del contrato ml_ds (`customer_ltv`, `engagement_score`) las elimina el de-churn de #382 (`_enforce_mlds_classification_schema`); todo lo demás se inyecta `nullable=False`. → `df.isna()` siempre `False` → heatmap en blanco. El defecto es de **coherencia** (texto que inventa MNAR) + **render** (colorbar degenerada), no de números. (En churn/retención el de-churn es no-op → el chart sí funciona.)

## Enfoque (bajo riesgo): honestidad + colorbar — **sin tocar la capa de datos (#382)**

Cero cambio del dataset → cero riesgo de AUC / notebook M3 / señal / prevalencia. Coherente en ambos cohortes: de-churned → "dataset completo"; churn → nulos reales + MNAR legítimo.

- **Cambio 1 (builder)** `_build_missingness_heatmap`: texto determinista y honesto según la missingness REAL de la muestra (subtitle/description/notes) + annotation central de estado vacío cuando hay 0 nulos.
- **Cambio 2 (graph)** `_eda_classification_python_path`: excluye `missingness_heatmap` de la anotación LLM (`deterministic_text_ids`) para que no pise el texto del builder. Business/otras familias: no-op byte-idéntico.
- **Cambio 3 (frontend)** `sanitizeTraces`: respeta el `zmin/zmax` del backend en matriz constante → leyenda 0..1. Solo el heatmap de missingness fija `zmin/zmax` → cohort/correlación intactos. Mejora también casos viejos (render-time).
- **Cambio 4** kill-switch `m2_missingness_honest_text` (default true) → revert sin redeploy.

## Tests / verificación

- Backend `test_issue237_eda_charts_classification.py`: happy-path actualizado, boundary reforzado (el chart conserva el texto del builder, no el stub LLM), +3 nuevos (completo / con-nulos / kill-switch-off).
- Frontend `plotlyChartUtils.test.ts`: +4 (matriz constante respeta backend 0..1; correlación −1..1; cohort data-min/max; missingness-con-nulos 0..1).
- ✅ Backend `pytest -q`: **1953 passed, 22 skipped**. ✅ `mypy src` limpio. ✅ Frontend lint / test (10/10) / build verdes.

## Notas

- Estrictamente aditivo; sin migración de datos, sin cambio de tier, sin tocar el generador determinista ni el architect (hash `_MLDS_ARCHITECT_PROMPT_SHA256` intacto). Sin nueva clave canónica ni entrada en `case_sanitization`.
- Casos previos: el colorbar se corrige solo (render-time); el texto persistido solo se corrige regenerando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)