### PR TITLE
fix(case_generator): excluir índice temporal/IDs del chart M2 "Top features por Mutual Information" (ml_ds+clf)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -157,6 +157,17 @@ M5_QUESTION_COHERENCE=true
 # no redeploy). The frontend colorbar fix applies regardless of this flag.
 M2_MISSINGNESS_HONEST_TEXT=true
 
+# -- M2 Mutual-Information model-ready feature filter (kill-switch, ml_ds + clasificación) --
+# When true (default), the M2 "Top features por Mutual Information" chart excludes columns that
+# inflate MI through high-cardinality discrete encoding: the temporal index `period` ("2023-01",
+# always all-unique → MI≈H(Y) artifact), IDs, free-text and other high-cardinality categoricals,
+# plus constants and >50%-null columns — mirroring the M3 notebook's modeled feature universe.
+# Continuous numerics (financial base + the real driver) are kept (k-NN MI does not inflate with
+# cardinality). Scoped to the classification python path; business/other-family/non-clf cases are
+# unaffected. Set to false to restore the prior behavior byte-identically (all columns except the
+# target enter the ranking; instant revert, no redeploy).
+M2_MI_EXCLUDE_INDEX=true
+
 # -- Supabase auth perimeter (Issue 23 + Issue 30) ----------------
 # Required for JWT verification, activation flows and admin auth operations.
 # Local auth/session dev uses `supabase start` at http://localhost:54321.

--- a/backend/src/case_generator/datagen/eda_charts_classification.py
+++ b/backend/src/case_generator/datagen/eda_charts_classification.py
@@ -36,6 +36,7 @@ Failure policy:
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import pandas as pd
@@ -47,6 +48,95 @@ logger = logging.getLogger("adam.graph")
 # ── Defensive caps (keep payloads small for FE/Plotly) ────────────────
 _MISSINGNESS_SAMPLE_ROWS = 500
 _MI_TOP_K = 8
+
+# ── Model-ready feature filter for the Mutual Information chart ────────
+# Mirror of the M3 notebook "dummy_baseline" feature recipe so the M2 MI
+# ranking matches the universe the notebook actually models.
+_MI_CAT_MAX_CARD = 20  # espejo del notebook M3 (_cat_cols: nunique <= 20)
+_MI_MAX_NULL_FRAC = 0.5  # espejo del notebook M3 (isna().mean() <= 0.5)
+
+
+def _normalize_colname(name: str) -> str:
+    """Lowercase + colapsa todo no-alfanumérico a ``_`` (espejo barato del
+    ``normalize_colname`` del notebook M3). Solo se usa para el chequeo del
+    token ``id`` por igualdad de token (no substring)."""
+    return re.sub(r"[^a-z0-9]+", "_", str(name).lower()).strip("_")
+
+
+def _select_mi_feature_columns(df: pd.DataFrame, target_col: str) -> list[str]:
+    """Columnas elegibles para el ranking de Mutual Information.
+
+    Replica el universo de features "model-ready" del notebook M3 (numérica +
+    categórica de baja cardinalidad; sin target, IDs, constantes ni columnas con
+    >50%% de nulos) para ALINEAR el chart M2 con el universo que M3 modela (con
+    una divergencia deliberada documentada abajo) y, sobre todo, para eliminar el
+    ARTEFACTO de alta cardinalidad: una columna discreta con valores casi-únicos
+    (p. ej. ``period`` = "2023-01", IDs, texto libre) se ``LabelEncoder``-ea y
+    entra a ``mutual_info_classif`` con ``discrete_features=True``; ahí cada valor
+    único fuerza ``H(Y|X)=0`` → MI≈H(Y) (memorización in-sample) y la columna
+    domina el ranking sin ser predictiva.
+
+    Reglas por columna ``c`` (sobre ``sorted(df.columns)``, ``c != target_col``):
+      * índice temporal (nombre ``period`` o dtype fecha)  → descartar SIEMPRE,
+            con independencia de la cardinalidad. El generador SIEMPRE nombra la
+            columna de tiempo ``period`` (es un índice, no una feature); esto cierra
+            el borde de datasets pequeños donde ``nunique(period) <= _MI_CAT_MAX_CARD``
+            y la sola regla de cardinalidad no bastaría.
+      * valores no-hasheables (list/dict)                  → descartar (no es una
+            feature de MI; defensivo — el generador determinista solo emite escalares)
+      * constante (``nunique(dropna=True) <= 1``)          → descartar (MI=0)
+      * >``_MI_MAX_NULL_FRAC`` de nulos                     → descartar
+      * NUMÉRICA (``is_numeric_dtype`` y NO ``bool``)       → conservar, salvo que
+            el nombre normalizado tenga el token ``id``. El estimador k-NN de MI
+            NO se infla por cardinalidad → es seguro conservar continuas de
+            cualquier cardinalidad (base financiera ``revenue``/``costs``/
+            ``margin_pct`` y el driver real incluidos).
+      * NO numérica (object/str/category/bool → discreta)  → conservar SOLO si
+            ``nunique(dropna=True) <= _MI_CAT_MAX_CARD`` (la alta cardinalidad
+            discreta es la ÚNICA clase que produce el artefacto).
+
+    Divergencia DELIBERADA vs. M3: el notebook también descarta numéricas con
+    ``nunique == n`` (regla anti-ID). Aquí NO se aplica a numéricas porque son
+    k-NN-seguras y descartarlas escondería señal real; la divergencia queda en la
+    dirección segura (M2 puede mostrar una numérica continua que M3 descarta,
+    nunca una columna causante del artefacto). Mantener en sync con la receta
+    ``dummy_baseline`` de ``prompts/clasificacion/notebooks`` si esa cambia.
+    """
+    n_rows = len(df)
+    feature_cols: list[str] = []
+    for c in sorted(df.columns):
+        if c == target_col:
+            continue
+        s = df[c]
+        # Índice temporal: el generador SIEMPRE nombra la columna de tiempo
+        # `period` (graph.py `_generate_dataset_from_schema`) y un dtype fecha es
+        # igualmente un índice, NUNCA una feature. Se excluyen por nombre/dtype con
+        # independencia de la cardinalidad → el artefacto no reaparece en datasets
+        # chicos donde nunique(period) <= _MI_CAT_MAX_CARD.
+        if _normalize_colname(c) == "period" or pd.api.types.is_datetime64_any_dtype(s):
+            continue
+        try:
+            nunique = int(s.nunique(dropna=True))
+        except TypeError:
+            # Valores no-hasheables (list/dict): no es una feature de MI. El path
+            # legacy los habría LabelEncoded como string (otro artefacto), así que
+            # excluirlos es estrictamente más correcto. Defensivo: el generador
+            # determinista solo emite escalares (no debería ocurrir en producción).
+            continue
+        if nunique <= 1:
+            continue  # constante → MI=0, ruido visual
+        if n_rows and float(s.isna().mean()) > _MI_MAX_NULL_FRAC:
+            continue  # demasiados nulos → no es una feature model-ready
+        is_numeric = pd.api.types.is_numeric_dtype(s) and not pd.api.types.is_bool_dtype(s)
+        if is_numeric:
+            if "id" in _normalize_colname(c).split("_"):
+                continue  # ID numérico → no es feature
+            feature_cols.append(c)
+        elif nunique <= _MI_CAT_MAX_CARD:
+            # Discreta de baja cardinalidad (se LabelEncode + discrete=True):
+            # categorías reales (region/plan), no el artefacto de memorización.
+            feature_cols.append(c)
+    return feature_cols
 
 
 # ───────────────────────────────────────────────────────────────────────
@@ -214,12 +304,18 @@ def _build_missingness_heatmap(
 
 
 def _build_mutual_info_top8(
-    df: pd.DataFrame, target_col: str, source: str
+    df: pd.DataFrame, target_col: str, source: str, *, exclude_index: bool = True
 ) -> dict[str, Any]:
     from sklearn.feature_selection import mutual_info_classif
     from sklearn.preprocessing import LabelEncoder
 
-    feature_cols = [c for c in sorted(df.columns) if c != target_col]
+    # `exclude_index` (kill-switch `m2_mi_exclude_index`): filtra columnas que
+    # inflan el MI por alta cardinalidad discreta (period/IDs/texto). Off →
+    # comportamiento legacy byte-idéntico (todas las columnas salvo el target).
+    if exclude_index:
+        feature_cols = _select_mi_feature_columns(df, target_col)
+    else:
+        feature_cols = [c for c in sorted(df.columns) if c != target_col]
     if not feature_cols:
         return empty_chart(
             "mutual_info_top8",
@@ -297,6 +393,7 @@ def generate_classification_eda_charts(
     contract: dict | None,
     *,
     honest_text: bool = True,
+    exclude_index: bool = True,
 ) -> list[dict[str, Any]]:
     """Build the 3-chart EDA panel deterministically.
 
@@ -329,7 +426,7 @@ def generate_classification_eda_charts(
     builders: list[tuple[str, Any]] = [
         ("class_distribution", lambda: _build_class_distribution(df, target_col, source)),
         ("missingness_heatmap", lambda: _build_missingness_heatmap(df, target_col, source, honest_text=honest_text)),
-        ("mutual_info_top8", lambda: _build_mutual_info_top8(df, target_col, source)),
+        ("mutual_info_top8", lambda: _build_mutual_info_top8(df, target_col, source, exclude_index=exclude_index)),
     ]
     for cid, fn in builders:
         try:

--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -2256,8 +2256,12 @@ def _eda_classification_python_path(
         # texto determinista y honesto para `missingness_heatmap` (que el LLM no debe
         # pisar). Off → texto vacío + el LLM lo anota (comportamiento previo).
         honest_text = settings.m2_missingness_honest_text
+        # Kill-switch `m2_mi_exclude_index` (default true): filtra del chart de MI las
+        # columnas que inflan la métrica por alta cardinalidad discreta (period/IDs/texto).
+        # Off → todas las columnas salvo el target (comportamiento legacy byte-idéntico).
+        exclude_index = settings.m2_mi_exclude_index
         charts = generate_classification_eda_charts(
-            df, target_col, contract, honest_text=honest_text
+            df, target_col, contract, honest_text=honest_text, exclude_index=exclude_index
         )
         if not charts:
             logger.warning(

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -137,6 +137,18 @@ class Settings(BaseSettings):
     # builder text + LLM annotates the chart; instant env-only revert, no redeploy). The
     # frontend colorbar fix (constant-matrix range) applies regardless of this flag.
     m2_missingness_honest_text: bool = True
+    # Model-ready feature filter for the M2 "Top features por Mutual Information" chart
+    # (ml_ds + clasificación). When true, `_build_mutual_info_top8` excludes columns that
+    # inflate Mutual Information through high-cardinality discrete encoding — the temporal
+    # index `period` ("2023-01", always all-unique → MI≈H(Y) memorization artifact), IDs,
+    # free-text and other high-cardinality categoricals, plus constants and >50%-null
+    # columns — mirroring the M3 notebook's modeled feature universe. Continuous numerics
+    # (incl. the financial base revenue/costs/margin_pct and the real driver) are kept:
+    # the k-NN MI estimator does not inflate with cardinality. Scoped to the classification
+    # python path; business/other-family/non-clf cases are unaffected. Kill-switch: set
+    # M2_MI_EXCLUDE_INDEX=false to restore the prior behavior byte-identically (all columns
+    # except the target enter the ranking; instant env-only revert, no redeploy).
+    m2_mi_exclude_index: bool = True
 
     model_config = SettingsConfigDict(env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/tests/test_issue237_eda_charts_classification.py
+++ b/backend/tests/test_issue237_eda_charts_classification.py
@@ -306,3 +306,199 @@ def test_llm_ghost_chart_id_is_silently_dropped(df_binary: pd.DataFrame) -> None
     # La annotation real sí se aplicó.
     cd = next(c for c in charts if c["id"] == "class_distribution")
     assert cd["description"] == "real"
+
+
+# ─────────────────────────────────────────────────────────
+# Filtro model-ready del chart de Mutual Information
+# (kill-switch `m2_mi_exclude_index`) — fix del artefacto `period`
+# ─────────────────────────────────────────────────────────
+
+
+from case_generator.datagen.eda_charts_classification import (  # noqa: E402
+    _select_mi_feature_columns,
+)
+
+
+def _periods_monthly(n: int) -> list[str]:
+    """Espejo del generador determinista (_generate_time_periods, monthly):
+    el año incrementa cada 12 → etiquetas all-unique ("2023-01", "2023-02", ...)."""
+    return [f"{2023 + i // 12}-{(i % 12) + 1:02d}" for i in range(n)]
+
+
+def _mi_features(df: pd.DataFrame, target: str, **kwargs: Any) -> list[str]:
+    charts = generate_classification_eda_charts(df, target, CONTRACT, **kwargs)
+    mi = next(c for c in charts if c["id"] == "mutual_info_top8")
+    return list(mi["traces"][0]["y"]) if mi["traces"] else []
+
+
+def test_mi_excludes_period_index(df_binary: pd.DataFrame) -> None:
+    """El artefacto reportado: `period` (fecha 'YYYY-MM', all-unique) ya NO entra
+    al ranking de MI; las features numéricas reales siguen presentes."""
+    df = df_binary.copy()
+    df["period"] = _periods_monthly(len(df))
+    feats = _mi_features(df, "churn")
+    assert "period" not in feats
+    assert {"age", "income", "tenure_months"} <= set(feats)
+
+
+def test_mi_keeps_financial_base() -> None:
+    """Candado anti-regresión del bug de 'restricción por contrato': la base
+    financiera (revenue/costs/margin_pct) NO está en feature_columns pero SÍ debe
+    aparecer en el chart (son numéricas legítimas, k-NN-seguras). `period` fuera."""
+    rng = np.random.default_rng(11)
+    n = 120
+    df = pd.DataFrame(
+        {
+            "period": _periods_monthly(n),
+            "revenue": rng.normal(200_000, 50_000, size=n).round(2),
+            "costs": rng.normal(120_000, 30_000, size=n).round(2),
+            "margin_pct": rng.uniform(0.05, 0.4, size=n).round(3),
+            "churn": rng.choice([0, 1], size=n, p=[0.7, 0.3]),
+        }
+    )
+    feats = _mi_features(df, "churn")
+    assert {"revenue", "costs", "margin_pct"} <= set(feats)
+    assert "period" not in feats
+
+
+def test_mi_excludes_high_cardinality_string_id(df_binary: pd.DataFrame) -> None:
+    """Una categórica string de alta cardinalidad (quasi-ID) produce el mismo
+    artefacto de memorización que `period` → se excluye; las categóricas de baja
+    cardinalidad (region/plan) se conservan."""
+    df = df_binary.copy()
+    df["customer_ref"] = [f"CUST-{i:05d}" for i in range(len(df))]  # all-unique
+    feats = _mi_features(df, "churn")
+    assert "customer_ref" not in feats
+    assert {"region", "plan"} <= set(feats)
+
+
+def test_mi_excludes_numeric_id_token(df_binary: pd.DataFrame) -> None:
+    """Un ID numérico se excluye por el token `id` del nombre (defensa en
+    profundidad; aunque k-NN no lo infle, no es una feature)."""
+    df = df_binary.copy()
+    df["account_id"] = np.arange(len(df))
+    assert "account_id" not in _select_mi_feature_columns(df, "churn")
+
+
+def test_mi_id_token_no_false_positive(df_binary: pd.DataFrame) -> None:
+    """El chequeo por igualdad de token (no substring) no descarta numéricas
+    legítimas cuyo nombre contiene 'id' como subcadena."""
+    df = df_binary.copy()
+    df["paid_amount"] = np.linspace(0.0, 1000.0, len(df))
+    df["covid_cases"] = np.arange(len(df))
+    feats = _select_mi_feature_columns(df, "churn")
+    assert "paid_amount" in feats
+    assert "covid_cases" in feats
+
+
+def test_mi_excludes_constant_and_high_null(df_binary: pd.DataFrame) -> None:
+    """Constantes (MI=0, ruido) y columnas con >50%% de nulos se descartan
+    (espejo de la receta model-ready de M3)."""
+    df = df_binary.copy()
+    df["constant_col"] = 7
+    df["mostly_null"] = np.nan
+    df.loc[df.index[:10], "mostly_null"] = np.arange(10).astype(float)  # 10/200 no-nulos
+    feats = _select_mi_feature_columns(df, "churn")
+    assert "constant_col" not in feats
+    assert "mostly_null" not in feats
+
+
+def test_mi_only_index_returns_empty_chart() -> None:
+    """df sin ninguna feature model-ready (solo `period` + target) → placeholder
+    vacío (`traces == []`), nunca un crash ni un ranking de un índice temporal."""
+    n = 24
+    df = pd.DataFrame(
+        {"period": _periods_monthly(n), "churn": [0, 1] * (n // 2)}
+    )
+    charts = generate_classification_eda_charts(df, "churn", CONTRACT)
+    mi = next(c for c in charts if c["id"] == "mutual_info_top8")
+    assert mi["traces"] == []
+
+
+def test_mi_exclude_index_off_is_byte_identical(df_binary: pd.DataFrame) -> None:
+    """Kill-switch OFF (`exclude_index=False`): comportamiento legacy — `period`
+    vuelve a entrar al ranking (revert exacto sin redeploy)."""
+    df = df_binary.copy()
+    df["period"] = _periods_monthly(len(df))
+    feats = _mi_features(df, "churn", exclude_index=False)
+    assert "period" in feats
+
+
+def test_mi_no_index_df_unchanged(df_binary: pd.DataFrame) -> None:
+    """Un df sin índice/ID/alta-card (las fixtures actuales) produce EXACTAMENTE
+    el mismo set de features que antes del fix (promesa byte-idéntica)."""
+    assert set(_mi_features(df_binary, "churn")) == {
+        "age",
+        "income",
+        "tenure_months",
+        "region",
+        "plan",
+    }
+
+
+def test_mi_exclude_index_kill_switch_default_is_true() -> None:
+    from shared.database import Settings
+
+    assert Settings.model_fields["m2_mi_exclude_index"].default is True
+
+
+def test_mi_excludes_period_small_n() -> None:
+    """Borde de dataset pequeño: con <=20 períodos la regla de cardinalidad NO
+    bastaría (nunique(period) <= _MI_CAT_MAX_CARD); el drop por NOMBRE garantiza
+    que `period` queda fuera a CUALQUIER n (cierra el hueco hallado en review)."""
+    n = 12
+    rng = np.random.default_rng(3)
+    df = pd.DataFrame(
+        {
+            "period": _periods_monthly(n),  # 12 valores únicos ≤ 20
+            "income": rng.normal(50_000, 15_000, size=n).round(2),
+            "score": rng.uniform(0.0, 1.0, size=n).round(3),
+            "churn": [0, 1] * (n // 2),
+        }
+    )
+    feats = _select_mi_feature_columns(df, "churn")
+    assert "period" not in feats
+    assert "income" in feats
+
+
+def test_mi_excludes_datetime_column(df_binary: pd.DataFrame) -> None:
+    """Una columna dtype fecha es un índice temporal, nunca una feature de MI →
+    excluida con independencia de su cardinalidad."""
+    df = df_binary.copy()
+    df["signup_date"] = pd.to_datetime("2023-01-01") + pd.to_timedelta(
+        np.arange(len(df)), unit="D"
+    )
+    feats = _select_mi_feature_columns(df, "churn")
+    assert "signup_date" not in feats
+    assert {"age", "income"} <= set(feats)
+
+
+def test_mi_unhashable_column_does_not_crash(df_binary: pd.DataFrame) -> None:
+    """Defensivo: una columna con valores no-hasheables (list/dict) no rompe el
+    filtro (el `nunique` lanzaría TypeError) — se omite y el resto del chart sigue."""
+    df = df_binary.copy()
+    df["tags"] = [[1, 2] for _ in range(len(df))]  # valores no-hasheables
+    feats = _select_mi_feature_columns(df, "churn")  # no debe lanzar
+    assert "tags" not in feats
+    assert {"age", "income", "tenure_months"} <= set(feats)
+
+
+def test_mi_keeps_bool_low_cardinality(df_binary: pd.DataFrame) -> None:
+    """Una columna bool es discreta de baja cardinalidad (no numérica para el MI):
+    se conserva, igual que la rama `discrete_mask` del builder la trataría."""
+    df = df_binary.copy()
+    rng = np.random.default_rng(5)
+    df["is_active"] = rng.choice([True, False], size=len(df))
+    assert "is_active" in _select_mi_feature_columns(df, "churn")
+
+
+def test_mi_cardinality_boundary(df_binary: pd.DataFrame) -> None:
+    """Frontera load-bearing del filtro (_MI_CAT_MAX_CARD=20): una categórica con
+    exactamente 20 valores se conserva; con 21 se descarta."""
+    df = df_binary.copy()
+    n = len(df)
+    df["cat20"] = [f"v{i % 20}" for i in range(n)]  # 20 únicos → conservar
+    df["cat21"] = [f"w{i % 21}" for i in range(n)]  # 21 únicos → descartar
+    feats = _select_mi_feature_columns(df, "churn")
+    assert "cat20" in feats
+    assert "cat21" not in feats


### PR DESCRIPTION
## Problema

El gráfico EDA de M2 **"Top 8 features por Mutual Information"** (combinación `studentProfile=ml_ds` + family `clasificacion`) mostraba `period` (una fecha `2023-01`) como la feature #1, por encima de cualquier predictor real, mientras el driver de dominio del target quedaba casi en cero. Reportado por el usuario tras obtener un ranking distinto al computar MI por su cuenta.

## Causa raíz (auditoría verificada en código)

- El chart se computa en **Python determinista** (`_build_mutual_info_top8`, sklearn), no lo alucina el LLM (solo anota `description`/`notes`).
- `period` se genera SIEMPRE all-unique (`nunique == n_rows`; el año incrementa cada 12 meses) y se `LabelEncoder`-ea + entra a `mutual_info_classif` con `discrete_features=True`. Para una discreta con cada valor único, el estimador fuerza `H(Y|X)=0` → **MI≈H(Y)** (memorización in-sample). Es un artefacto de alta cardinalidad, NO señal.
- Las numéricas continuas usan el estimador k-NN, que **no** se infla por cardinalidad → no producen el artefacto.
- `period` nunca es el driver real del target → su dominancia era 100% artefacto. Afecta a **todos** los casos ml_ds+clf (churn y no-churn).

## Fix

Nuevo filtro puro `_select_mi_feature_columns` (espejo del universo "model-ready" del notebook M3) aplicado antes del cómputo de MI:
- excluye el índice temporal por **nombre** (`period`) y **dtype fecha**, a cualquier `n` (cierra el borde de datasets pequeños);
- excluye categóricas de alta cardinalidad (`nunique > 20`: IDs string, texto libre), constantes, columnas con `>50%` de nulos, e IDs numéricos (token `id`);
- **conserva** las numéricas continuas (base financiera `revenue`/`costs`/`margin_pct` + driver real) — k-NN-seguras;
- defensivo ante columnas no-hasheables (no rompe el chart).

Detrás de kill-switch **`m2_mi_exclude_index`** (default `true`); off → comportamiento legacy byte-idéntico (revert sin redeploy). Solo toca el path `ml_ds + clasificación`; **business y otras familias intactas** (dispatch verificado). Sin nueva clave canónica/state, sin entrada en `case_sanitization`.

## Por qué arreglar el input y no reemplazar el chart

MI es una herramienta EDA válida (el pie del chart pide detectar leakage). El defecto era higiene de columnas, no el tipo de gráfico — un chart alternativo con `period` LabelEncoded sufriría lo mismo.

## Tests / verificación

- 15 tests nuevos en `test_issue237_eda_charts_classification.py`: artefacto `period`, `n` pequeño (drop por nombre), datetime, base financiera (candado anti-regresión del enfoque "restricción por contrato" descartado), IDs string/numéricos, FP del token `id`, constantes/nulos, bool, frontera de cardinalidad (20 vs 21), chart vacío, kill-switch off byte-idéntico, default del setting.
- Suite completa: **1974 passed, 22 skipped**. `mypy src`: limpio.
- Revisión: army de 3 especialistas (correctness, testing, red-team adversarial) → SHIP, 0 P0/P1; los 2 P2 reales (borde `n` pequeño + columna no-hasheable) endurecidos en esta rama.

## Follow-up (fuera de alcance, issue separado)

La señal del driver de dominio queda con MI modesta (~0.11) incluso tras el fix: investigar `noise_factor` / calibración top-k del target binario en `_generate_dataset_from_schema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)