### PR TITLE
feat(case-viewer): títulos descriptivos en español para el sidebar de módulos

### DIFF
--- a/backend/src/case_generator/m6_grounding.py
+++ b/backend/src/case_generator/m6_grounding.py
@@ -29,16 +29,14 @@ _ABSENT_MODULE_MARKERS: dict[str, tuple[str, ...]] = {
         "EDA",
         "Análisis Exploratorio",
         "Exploración de Datos",
-        "Data Analyst",
-        "Insight Analyst",
+        "Lectura de los Datos",
     ),
     "m3": (
         "notebook",
-        "Experiment Validator",
+        "Diseño del Experimento",
         "Validación Experimental",
-        "Decision Evidence Reviewer",
+        "Auditoría de la Evidencia",
         "Evaluación de Evidencia",
-        "Auditor de Evidencia",
     ),
 }
 

--- a/backend/src/case_generator/prompts/teaching_note/module_guide_block.py
+++ b/backend/src/case_generator/prompts/teaching_note/module_guide_block.py
@@ -58,18 +58,18 @@ M4_VERDICT_MLDS = "Desplegar / No desplegar / Desplegar con restricciones"
 # Canonical bilingual labels — copied verbatim from getModuleConfig (caseViewerConfig.ts).
 # A drift test asserts these stay equal to the TS literals.
 _LABELS_BUSINESS: dict[str, str] = {
-    "m1": "Case Reader — Comprensión Gerencial",
-    "m2": "Insight Analyst — Interpretación Visual",
-    "m3": "Decision Evidence Reviewer — Evaluación de Evidencia",
-    "m4": "Business Impact Evaluator — Impacto Comercial",
-    "m5": "Executive Recommendation Writer — Recomendación Ejecutiva",
+    "m1": "El Caso y el Dilema — Comprende la situación gerencial",
+    "m2": "Lectura de los Datos — Interpreta la evidencia visual",
+    "m3": "Auditoría de la Evidencia — Evalúa qué tan sólida es la evidencia",
+    "m4": "Impacto en el Negocio — Cuantifica el valor y los trade-offs",
+    "m5": "Recomendación Ejecutiva — Redacta el memorándum a la junta",
 }
 _LABELS_MLDS: dict[str, str] = {
-    "m1": "Problem Framer — Formulación Analítica",
-    "m2": "Data Analyst — Exploración de Datos",
-    "m3": "Experiment Validator — Validación Experimental",
-    "m4": "Value & Impact Translator — Traducción a Valor",
-    "m5": "Technical-Executive Writer — Informe Técnico-Ejecutivo",
+    "m1": "Planteamiento del Problema — Traduce el reto a un problema de datos",
+    "m2": "Exploración de Datos — Analiza el dataset y sus patrones",
+    "m3": "Diseño del Experimento — Valida el modelo con rigor experimental",
+    "m4": "Impacto y Valor — Convierte el modelo en valor de negocio",
+    "m5": "Decisión Ejecutiva — Redacta el memorándum final a la dirección",
 }
 
 _EDA_CASE_TYPE = "harvard_with_eda"

--- a/backend/tests/test_m6_module_guide.py
+++ b/backend/tests/test_m6_module_guide.py
@@ -32,18 +32,18 @@ _FRONTEND_CONFIG = (
 )
 
 _BUSINESS_NAMES = [
-    "Case Reader", "Comprensión Gerencial",
-    "Insight Analyst", "Interpretación Visual",
-    "Decision Evidence Reviewer", "Evaluación de Evidencia",
-    "Business Impact Evaluator", "Impacto Comercial",
-    "Executive Recommendation Writer", "Recomendación Ejecutiva",
+    "El Caso y el Dilema", "Comprende la situación gerencial",
+    "Lectura de los Datos", "Interpreta la evidencia visual",
+    "Auditoría de la Evidencia", "Evalúa qué tan sólida es la evidencia",
+    "Impacto en el Negocio", "Cuantifica el valor y los trade-offs",
+    "Recomendación Ejecutiva", "Redacta el memorándum a la junta",
 ]
 _MLDS_NAMES = [
-    "Problem Framer", "Formulación Analítica",
-    "Data Analyst", "Exploración de Datos",
-    "Experiment Validator", "Validación Experimental",
-    "Value & Impact Translator", "Traducción a Valor",
-    "Technical-Executive Writer", "Informe Técnico-Ejecutivo",
+    "Planteamiento del Problema", "Traduce el reto a un problema de datos",
+    "Exploración de Datos", "Analiza el dataset y sus patrones",
+    "Diseño del Experimento", "Valida el modelo con rigor experimental",
+    "Impacto y Valor", "Convierte el modelo en valor de negocio",
+    "Decisión Ejecutiva", "Redacta el memorándum final a la dirección",
 ]
 
 
@@ -72,18 +72,18 @@ def test_roster_ids_harvard_only_renumber():
     # No EDA: M2/M3 absent, M4→Módulo 2, M5→Módulo 3.
     assert module_guide_roster_ids(False, "harvard_only") == ["m1", "m4", "m5"]
     block = _block(case_type="harvard_only", notebook_present=False)
-    assert "Módulo 2 · Value & Impact Translator" in block
-    assert "Módulo 3 · Technical-Executive Writer" in block
-    for absent in ("Data Analyst", "Experiment Validator", "Exploración de Datos", "notebook"):
+    assert "Módulo 2 · Impacto y Valor" in block
+    assert "Módulo 3 · Decisión Ejecutiva" in block
+    for absent in ("Exploración de Datos", "Diseño del Experimento", "notebook"):
         assert absent not in block
 
 
 def test_labels_business_vs_mlds():
     b = _block(is_business=True)
     m = _block(is_business=False)
-    assert "Problem Framer — Formulación Analítica" in m
-    assert "Case Reader — Comprensión Gerencial" in b
-    assert "Case Reader" not in m and "Problem Framer" not in b
+    assert "Planteamiento del Problema — Traduce el reto a un problema de datos" in m
+    assert "El Caso y el Dilema — Comprende la situación gerencial" in b
+    assert "El Caso y el Dilema" not in m and "Planteamiento del Problema" not in b
 
 
 def test_unknown_caseType_defaults_to_three_modules():

--- a/frontend/src/features/case-preview/CasePreview.test.tsx
+++ b/frontend/src/features/case-preview/CasePreview.test.tsx
@@ -72,7 +72,7 @@ describe("CasePreview lazy modules", () => {
 
         expect(screen.getByTestId("m1-module")).toBeTruthy();
 
-        fireEvent.click(screen.getByText("Data Analyst"));
+        fireEvent.click(screen.getByText("Exploración de Datos"));
 
         expect(screen.getByTestId("case-preview-module-loading")).toBeTruthy();
         expect(screen.getByText("Cargando módulo...")).toBeTruthy();

--- a/frontend/src/features/student-runtime/StudentCaseResolutionPage.test.tsx
+++ b/frontend/src/features/student-runtime/StudentCaseResolutionPage.test.tsx
@@ -14,8 +14,8 @@ vi.mock("@/shared/case-viewer", () => ({
         {
             id: "m1",
             number: 1,
-            name: "Case Reader",
-            subLabel: "Comprension Gerencial",
+            name: "El Caso y el Dilema",
+            subLabel: "Comprende la situacion gerencial",
             iconColor: "#3b82f6",
         },
         {

--- a/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
+++ b/frontend/src/features/teacher-case-submission-detail/__tests__/TeacherSubmissionPreview.test.tsx
@@ -352,8 +352,8 @@ describe("TeacherSubmissionPreview", () => {
         renderPreview();
 
         const mobileBar = await screen.findByTestId("teacher-submission-preview-mobile-modules");
-        // business + harvard_only => m1 renders as "Case Reader", not the raw "m1" id.
-        expect(within(mobileBar).getByRole("button", { name: "Case Reader" })).toBeTruthy();
+        // business + harvard_only => m1 renders as "El Caso y el Dilema", not the raw "m1" id.
+        expect(within(mobileBar).getByRole("button", { name: "El Caso y el Dilema" })).toBeTruthy();
         expect(within(mobileBar).queryByRole("button", { name: "m1" })).toBeNull();
     });
 

--- a/frontend/src/shared/case-viewer/caseViewerConfig.ts
+++ b/frontend/src/shared/case-viewer/caseViewerConfig.ts
@@ -17,16 +17,16 @@ export function getModuleConfig(studentProfile: string, caseType: string): Modul
         {
             id: "m1",
             number: 1,
-            name: isBusiness ? "Case Reader" : "Problem Framer",
-            subLabel: isBusiness ? "Comprensión Gerencial" : "Formulación Analítica",
+            name: isBusiness ? "El Caso y el Dilema" : "Planteamiento del Problema",
+            subLabel: isBusiness ? "Comprende la situación gerencial" : "Traduce el reto a un problema de datos",
             iconColor: "#3b82f6",
         },
         ...(isEDA
             ? [{
                 id: "m2" as ModuleId,
                 number: 2,
-                name: isBusiness ? "Insight Analyst" : "Data Analyst",
-                subLabel: isBusiness ? "Interpretación Visual" : "Exploración de Datos",
+                name: isBusiness ? "Lectura de los Datos" : "Exploración de Datos",
+                subLabel: isBusiness ? "Interpreta la evidencia visual" : "Analiza el dataset y sus patrones",
                 iconColor: "#8b5cf6",
             }]
             : []),
@@ -34,23 +34,23 @@ export function getModuleConfig(studentProfile: string, caseType: string): Modul
             ? [{
                 id: "m3" as ModuleId,
                 number: 3,
-                name: isBusiness ? "Decision Evidence Reviewer" : "Experiment Validator",
-                subLabel: isBusiness ? "Evaluación de Evidencia" : "Validación Experimental",
+                name: isBusiness ? "Auditoría de la Evidencia" : "Diseño del Experimento",
+                subLabel: isBusiness ? "Evalúa qué tan sólida es la evidencia" : "Valida el modelo con rigor experimental",
                 iconColor: "#ec4899",
             }]
             : []),
         {
             id: "m4",
             number: isEDA ? 4 : 2,
-            name: isBusiness ? "Business Impact Evaluator" : "Value & Impact Translator",
-            subLabel: isBusiness ? "Impacto Comercial" : "Traducción a Valor",
+            name: isBusiness ? "Impacto en el Negocio" : "Impacto y Valor",
+            subLabel: isBusiness ? "Cuantifica el valor y los trade-offs" : "Convierte el modelo en valor de negocio",
             iconColor: "#f59e0b",
         },
         {
             id: "m5",
             number: isEDA ? 5 : 3,
-            name: isBusiness ? "Executive Recommendation Writer" : "Technical-Executive Writer",
-            subLabel: isBusiness ? "Recomendación Ejecutiva" : "Informe Técnico-Ejecutivo",
+            name: isBusiness ? "Recomendación Ejecutiva" : "Decisión Ejecutiva",
+            subLabel: isBusiness ? "Redacta el memorándum a la junta" : "Redacta el memorándum final a la dirección",
             iconColor: "#10b981",
         },
         {

--- a/frontend/src/shared/case-viewer/modules/M2Eda.tsx
+++ b/frontend/src/shared/case-viewer/modules/M2Eda.tsx
@@ -8,7 +8,7 @@ export function M2Eda({ result, content, md, isMLDS, renderPreguntas }: CaseModu
     return (
         <>
             <div className="mb-8">
-                <p className="running-header mb-2">Módulo 2 · {isMLDS ? "Data Analyst" : "Insight Analyst"} · {
+                <p className="running-header mb-2">Módulo 2 · {isMLDS ? "Exploración de Datos" : "Lectura de los Datos"} · {
                     result.outputDepth === "visual_plus_notebook" ? "Gráficos + Código" : "Gráficos + Análisis"
                 }</p>
                 <h1 className="type-h1 text-slate-900 mb-2">

--- a/frontend/src/shared/case-viewer/modules/M3AuditSection.test.tsx
+++ b/frontend/src/shared/case-viewer/modules/M3AuditSection.test.tsx
@@ -76,3 +76,20 @@ describe("M3AuditSection — graceful degradation", () => {
         expect(screen.queryByText("Notebook no disponible")).toBeNull();
     });
 });
+
+describe("M3AuditSection — profile-aware heading", () => {
+    it("uses the ml_ds title when isMLDS", () => {
+        renderSection({ m3NotebookDegraded: true }, { isMLDS: true });
+
+        expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Diseño del Experimento");
+        // Regression lock: the old hardcoded English title must be gone for both profiles.
+        expect(screen.queryByText("Experiment Validator")).toBeNull();
+    });
+
+    it("uses the business title when not ml_ds", () => {
+        renderSection({ m3NotebookDegraded: true }, { isMLDS: false });
+
+        expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Auditoría de la Evidencia");
+        expect(screen.queryByText("Experiment Validator")).toBeNull();
+    });
+});

--- a/frontend/src/shared/case-viewer/modules/M3AuditSection.tsx
+++ b/frontend/src/shared/case-viewer/modules/M3AuditSection.tsx
@@ -14,10 +14,10 @@ export function M3AuditSection({ result, content, md, isMLDS, renderPreguntas, o
         <>
             <div className="mb-8">
                 <p className="running-header mb-2">
-                    Módulo 3 · {isMLDS ? "Experiment Validator" : "Decision Evidence Reviewer"} · Auditoría de Evidencia
+                    Módulo 3 · {isMLDS ? "Diseño del Experimento" : "Auditoría de la Evidencia"} · {isMLDS ? "Validación Experimental" : "Evaluación de Evidencia"}
                 </p>
                 <h1 className="type-h1 text-slate-900 mb-2">
-                    Experiment Validator
+                    {isMLDS ? "Diseño del Experimento" : "Auditoría de la Evidencia"}
                 </h1>
                 <hr style={{ border: "none", height: "1.5px", background: "linear-gradient(to right, #cbd5e1, transparent)", margin: "1.5rem 0" }} />
             </div>


### PR DESCRIPTION
## Qué cambia

El sidebar de la vista del caso mostraba como título principal un **nombre de persona en inglés** (Problem Framer, Data Analyst, Experiment Validator, …) mientras el producto es 100% en español, así que el elemento más visible no comunicaba qué es cada módulo. Este PR los reemplaza por **títulos descriptivos en español** (título = qué es, subtítulo = qué haces), en ambos perfiles.

| Mód | ml_ds | business |
|----|-------|----------|
| M1 | Planteamiento del Problema | El Caso y el Dilema |
| M2 | Exploración de Datos | Lectura de los Datos |
| M3 | Diseño del Experimento | Auditoría de la Evidencia |
| M4 | Impacto y Valor | Impacto en el Negocio |
| M5 | Decisión Ejecutiva | Recomendación Ejecutiva |

## Detalles

- **`caseViewerConfig.ts`**: fuente de verdad (`name`/`subLabel` de M1–M5). M6 "Solución Maestra" sin cambios.
- **`M2Eda.tsx` / `M3AuditSection.tsx`**: encabezados internos alineados. Corrige un bug latente: el `<h1>` de M3 mostraba "Experiment Validator" hasta en el perfil business; ahora es profile-aware.
- **M6 "Solución Maestra"**: las etiquetas deterministas (`module_guide_block._LABELS_*`) y el allowlist del LLM salen de la misma fuente → su "Recorrido por Módulo" muestra los títulos nuevos. Atado por el drift test `test_labels_match_getmoduleconfig_literals`.
- **`m6_grounding.py`**: markers de módulo ausente actualizados a los nombres nuevos (guard logger-only, best-effort).
- **Fuera de alcance (decisión de producto)**: los alias internos de los prompts de generación (`_writer_base.py`, etc.) quedan intactos — invisibles para el usuario; la lógica de ramas usa `"business"`/`"ml_ds"`, no el alias.

## Verificación

- Frontend: suite completa **548 tests ✓** (incl. 2 de regresión nuevos para el `<h1>` de M3 por perfil), `lint` limpio, `build` (tsc) ✓.
- Backend: `test_m6_module_guide.py` **36 ✓** + chequeo del contrato de drift backend↔frontend y del grounding.
- Sin cambios de SQL, auth, migraciones, schema ni API. Cambio de capa de presentación + etiquetas de M6 en sync.

## Review

`/review` ultra-exhaustivo: 4 especialistas en paralelo (coupling sweep, grounding backend, i18n/UX, cobertura) + pase crítico. **0 hallazgos críticos, 0 acoplamientos rotos.** PR Quality Score 9.0/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)