### PR TITLE
chore(agents): comparte el plugin andrej-karpathy-skills vía project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "karpathy-skills": {
+      "source": {
+        "source": "github",
+        "repo": "multica-ai/andrej-karpathy-skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "andrej-karpathy-skills@karpathy-skills": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -204,7 +204,8 @@ backend/.data/
 .python-version
 backend/.python-version
 skills-lock.json
-.claude/
+.claude/*
+!.claude/settings.json
 .agents/*
 !.agents/skills/
 .agents/skills/*


### PR DESCRIPTION
## Qué

Añade un `.claude/settings.json` **versionado** que declara el marketplace `karpathy-skills` (fork `multica-ai/andrej-karpathy-skills`) y habilita el plugin `andrej-karpathy-skills` a **scope de proyecto**.

## Por qué

Para que **todos los developers del repo** obtengan el plugin automáticamente: al confiar en la carpeta del repo, Claude Code les **ofrece instalar** el marketplace + plugin, en lugar de que cada quien corra los comandos `/plugin` a mano.

El plugin aporta guías de comportamiento estilo Karpathy (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution).

## Cambios

- **Nuevo** `.claude/settings.json` con `extraKnownMarketplaces` + `enabledPlugins` (mismo formato ya usado a nivel usuario para `chrome-devtools-plugins`).
- **`.gitignore`**: `.claude/` estaba ignorado por completo. Se cambia a `.claude/*` + `!.claude/settings.json` (mismo patrón "ignorar dir + re-incluir" que ya usan `.agents/` y `.codex/`), de modo que **solo** se versiona `settings.json`. `settings.local.json` (per-usuario) y `skills/` (runtime generado) **siguen ignorados** — verificado con `git check-ignore`.

## Verificación

- `python -c "import json;json.load(open('.claude/settings.json'))"` → JSON válido.
- `git check-ignore .claude/settings.json` → vacío (ya no ignorado); `settings.local.json` y `skills/` siguen ignorados.
- El diff stageado contiene **solo** `settings.json` + `.gitignore`.
- Prueba de equipo (post-merge): en un clon fresco, abrir el repo en Claude Code y confiar en la carpeta → debe aparecer la oferta de instalar `karpathy-skills` + `andrej-karpathy-skills`.

## Nota

Per-usuario (para proyectos **fuera** de ADAM-EDU) sigue siendo manual:
```
/plugin marketplace add multica-ai/andrej-karpathy-skills
/plugin install andrej-karpathy-skills@karpathy-skills
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)