### PR TITLE
fix(docker): node:22-alpine for pnpm 11 (Cloud Run build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the frontend assets that will be served with the backend image.
-FROM node:20-alpine AS frontend-builder
+# Node 22+ is required: pnpm 11 uses the built-in node:sqlite module (Node 22.13+).
+FROM node:22-alpine AS frontend-builder
 
 # Pinned pnpm (matches frontend/package.json "packageManager"). A direct npm
 # global install avoids Corepack signature pitfalls on the alpine base.


### PR DESCRIPTION
El build de la imagen de Cloud Run fallaba en `pnpm install` porque pnpm 11 requiere Node ≥ 22.13 (usa `node:sqlite`) y el `frontend-builder` seguía en `node:20-alpine`. CI ya usa Node 22; solo faltaba alinear el Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)