### PR TITLE
docs(agents): guías Karpathy siempre-activas en CLAUDE.md + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,3 +352,52 @@ Cuando el cambio toque setup local o auth:
   - auth/session local por `supabase start` en `54321`
 - no documentes `5432` como puerto host local por defecto del repo
 - no permitas ejemplos donde `DATABASE_URL` apunte al Postgres interno de Supabase local en `54322`
+
+## Coding Guidelines (Karpathy Skills)
+
+These cross-cutting working principles mirror the `andrej-karpathy-skills` plugin (`karpathy-guidelines`) enabled for this repo via `.claude/settings.json`. They are restated here so they stay **always-active** for every session and agent, even when the skill is not explicitly invoked. They bias toward caution over speed; for trivial tasks, use judgment. Merge with the project-specific rules above — where a repo rule and a guideline conflict, the repo rule wins. (Kept in sync with `CLAUDE.md`.)
+
+### Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+- Remove imports/variables/functions that YOUR changes made unused; don't remove pre-existing dead code unless asked.
+
+The test: every changed line should trace directly to the user's request.
+
+### Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan with a verify check per step. Strong success criteria let you loop independently; weak criteria ("make it work") require constant clarification.
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,3 +384,52 @@ uv run python -m shared.app
 
 `docker compose up` starts PostgreSQL, but does not apply migrations. Alembic bootstrap is required before using the API locally.
 `DATABASE_URL` stays on `localhost:5434`. Do not point it at the Supabase local database on `54322`.
+
+## Coding Guidelines (Karpathy Skills)
+
+These cross-cutting working principles mirror the `andrej-karpathy-skills` plugin (`karpathy-guidelines`) enabled for this repo via `.claude/settings.json`. They are restated here so they stay **always-active** for every session and agent, even when the skill is not explicitly invoked. They bias toward caution over speed; for trivial tasks, use judgment. Merge with the project-specific rules above — where a repo rule and a guideline conflict, the repo rule wins.
+
+### Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+- Remove imports/variables/functions that YOUR changes made unused; don't remove pre-existing dead code unless asked.
+
+The test: every changed line should trace directly to the user's request.
+
+### Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan with a verify check per step. Strong success criteria let you loop independently; weak criteria ("make it work") require constant clarification.
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
## Qué

Incorpora las guías de comportamiento del plugin `andrej-karpathy-skills` (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution) a las superficies de instrucciones **siempre-cargadas** del repo: `CLAUDE.md` y `AGENTS.md`.

## Por qué

El plugin que mergeamos en [#432](https://github.com/4Tech-Labs/ADAM-EDU/pull/432) expone las guías como una **skill** (`karpathy-guidelines`), que es **invocada por el modelo** (se activa cuando juzga que la tarea encaja), no en cada turno. Para que las guías apliquen **siempre**, en toda sesión y para todos los devs/agentes, su contenido debe vivir en `CLAUDE.md`/`AGENTS.md`, que se cargan en cada sesión.

## Cambios

- **`CLAUDE.md`** y **`AGENTS.md`**: nueva sección `## Coding Guidelines (Karpathy Skills)` al final de cada uno (append puro, +49 líneas, sin tocar contenido existente).
- Se actualizan **ambos en el mismo PR** según la regla *Instruction Canon* del repo (AGENTS.md = superficie Codex, CLAUDE.md = superficie Claude).
- Las cuatro sub-guías se anidan como `###` bajo un único `##` para no contaminar el árbol de encabezados.
- La nota inicial deja explícito que **ante conflicto, la regla del repo gana** sobre la guía.

## Verificación

- `git diff --stat` → solo `CLAUDE.md` + `AGENTS.md`, 98 inserciones, 0 borrados.
- Sección presente exactamente 1× en cada archivo.
- Append puro: ninguna línea preexistente modificada.

## Relación

Complementa #432: ese PR habilita el plugin (skill model-invoked + instalación de equipo); este lo hace **always-active** vía el canon de instrucciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)