### PR TITLE
fix(m471): M6 teaching note clustering-aware (M1/M2/M3 segmentación)

### DIFF
--- a/backend/src/case_generator/prompts/teaching_note/module_guide_block.py
+++ b/backend/src/case_generator/prompts/teaching_note/module_guide_block.py
@@ -29,6 +29,9 @@ Wiring notes for the caller (see ``teaching_note_part1`` in ``graph.py``):
   ``"desconocida"`` fallback — never ``None``), reused from the ``_build_base_context`` the node
   already calls. ``state.get("primary_family")`` does NOT exist (always ``None``). ``is_clf``
   compares the resolved value strictly to ``"clasificacion"``, so ``"desconocida"`` → generic M2 line.
+  ``is_clustering`` (Issue #471) compares strictly to ``"clustering"`` and is consumed ml_ds-ONLY
+  (M1/M3 are nested in the ml_ds branch; M2 guards with ``and not is_business``) — mirroring the
+  strict ``_is_ml_ds_clustering`` gate, so business+clustering stays byte-identical/generic.
 * ``notebook_present = bool(state.get("m3_notebook_code")) and not state.get("m3_notebook_degraded")``
   — REALIZED state. The M3 notebook GENERATOR (graph.py) is family-AGNOSTIC (ml_ds regresión/
   clustering ship a real notebook too); only the EXECUTOR is clasificación-gated. So gating the
@@ -74,6 +77,7 @@ _LABELS_MLDS: dict[str, str] = {
 
 _EDA_CASE_TYPE = "harvard_with_eda"
 _CLASSIFICATION_FAMILY = "clasificacion"
+_CLUSTERING_FAMILY = "clustering"
 
 # Issue #437 Fase 3 — the M4 module synopsis value frame per Impact Lens. CURATED + CURRENCY-TOKEN-FREE
 # (no ``$``/``€``/ISO adjacent to a figure — ``test_block_byte_identical_through_usd_enforce`` requires
@@ -134,6 +138,7 @@ def _module_lines(
     *,
     is_business: bool,
     is_clf: bool,
+    is_clustering: bool,
     notebook_present: bool,
     lens: str | None = None,
 ) -> list[str]:
@@ -141,19 +146,34 @@ def _module_lines(
 
     ``lens`` (Issue #437 Fase 3) reframes ONLY the M4 ``aprende`` value noun; ``None``/``financial_roi``
     keeps today's exact wording (byte-identical). It never touches the drift-locked LABELS or verdict.
+
+    ``is_clustering`` (Issue #471) reframes M1/M2/M3 for the unsupervised clustering family. It is
+    ml_ds-ONLY: M1/M3 are nested in the ``else`` of ``is_business`` (so business+clustering never
+    reaches them), and M2 guards explicitly with ``and not is_business`` — mirroring the strict
+    ``_is_ml_ds_clustering`` gate (graph.py), so business+clustering stays byte-identical/generic.
     """
     if mod_id == "m1":
         ve = (
             f"Una narrativa de {M1_NARRATIVE_WORDS} palabras con el dilema central, "
             "3 opciones estratégicas (A/B/C) y 3 Exhibits (financiero, operativo y de stakeholders)."
         )
-        aprende = (
-            "Identifica el dilema gerencial real, mapea a los stakeholders y lee los Exhibits "
-            "para formarse una hipótesis inicial."
-            if is_business
-            else "Traduce el problema de negocio a un problema de datos: define la variable "
-            "objetivo, plantea hipótesis analíticas y reconoce los límites de la información."
-        )
+        if is_business:
+            aprende = (
+                "Identifica el dilema gerencial real, mapea a los stakeholders y lee los Exhibits "
+                "para formarse una hipótesis inicial."
+            )
+        elif is_clustering:
+            # Unsupervised: no target variable. Frame the segmentation decision instead (#455/#471).
+            aprende = (
+                "Traduce el problema de negocio a un problema de datos: descubre segmentos latentes "
+                "en datos sin etiquetar (aprendizaje no supervisado), plantea hipótesis de "
+                "segmentación y reconoce los límites de la información."
+            )
+        else:
+            aprende = (
+                "Traduce el problema de negocio a un problema de datos: define la variable "
+                "objetivo, plantea hipótesis analíticas y reconoce los límites de la información."
+            )
         formato = (
             "3 preguntas de discusión (comprensión → análisis → evaluación); la última exige "
             "elegir A/B/C con información incompleta y nombrar el supuesto más frágil."
@@ -172,13 +192,24 @@ def _module_lines(
             else "Examina distribuciones, valores atípicos y correlaciones para confirmar o "
             "refutar la hipótesis del Módulo 1 con rigor técnico."
         )
-        formato = (
-            "2 preguntas socráticas abiertas: la Paradoja de la Exactitud (desbalance de clases) "
-            "y el equilibrio entre precisión y exhaustividad."
-            if is_clf
-            else "2 preguntas socráticas abiertas: el sesgo de confirmación en los datos y la "
-            "diferencia entre correlación y causalidad."
-        )
+        if is_clf:
+            formato = (
+                "2 preguntas socráticas abiertas: la Paradoja de la Exactitud (desbalance de clases) "
+                "y el equilibrio entre precisión y exhaustividad."
+            )
+        elif is_clustering and not is_business:
+            # Mirror EDA_QUESTIONS_GENERATOR_PROMPT_CLUSTERING (#456): P1 escala/distancia, P2
+            # correlación + silhouette. ml_ds-only (business+clustering keeps the generic line).
+            formato = (
+                "2 preguntas socráticas abiertas: por qué estandarizar las features antes de "
+                "aplicar K-Means (escala y distancia) y cómo juzgar la validez de los segmentos "
+                "(correlación entre features y lectura del coeficiente de silhouette)."
+            )
+        else:
+            formato = (
+                "2 preguntas socráticas abiertas: el sesgo de confirmación en los datos y la "
+                "diferencia entre correlación y causalidad."
+            )
         return [ve, aprende, formato]
 
     if mod_id == "m3":
@@ -189,16 +220,28 @@ def _module_lines(
             )
             aprende = "Aprende a dudar de forma constructiva de los hallazgos del Módulo 2 antes de decidir."
         else:
-            ve = (
-                f"Un diseño experimental ({M3_EXPERIMENT_WORDS} palabras) que conecta los datos "
-                "con la arquitectura de la solución y prueba la causalidad."
-            )
+            if is_clustering:
+                # Unsupervised segmentation, not a supervised experiment / causality (#457/#471).
+                ve = (
+                    f"Un diseño de segmentación ({M3_EXPERIMENT_WORDS} palabras) que conecta los "
+                    "datos con la elección del número de grupos y la validación de su cohesión."
+                )
+                aprende = (
+                    "Aprende a elegir el número de segmentos, validar su cohesión (silhouette) y "
+                    "traducir cada grupo en un perfil accionable."
+                )
+            else:
+                ve = (
+                    f"Un diseño experimental ({M3_EXPERIMENT_WORDS} palabras) que conecta los datos "
+                    "con la arquitectura de la solución y prueba la causalidad."
+                )
+                aprende = (
+                    "Aprende a diseñar experimentos rigurosos, anticipar sesgos y definir criterios "
+                    "de validación."
+                )
+            # Notebook clause is family-agnostic for ml_ds (DRY: applies to clustering + clf/reg).
             if notebook_present:
                 ve += " Incluye un notebook de Python (Jupyter) con la implementación."
-            aprende = (
-                "Aprende a diseñar experimentos rigurosos, anticipar sesgos y definir criterios "
-                "de validación."
-            )
         formato = "3 preguntas de discusión (análisis, evaluación y síntesis)."
         return [ve, aprende, formato]
 
@@ -260,6 +303,7 @@ def build_module_guide_block(
     kill-switch is off, keeping the OFF path byte-identical).
     """
     is_clf = (family or "") == _CLASSIFICATION_FAMILY
+    is_clustering = (family or "") == _CLUSTERING_FAMILY
     anchors = anchors or {}
 
     out: list[str] = ["## Recorrido por Módulo", ""]
@@ -268,6 +312,7 @@ def build_module_guide_block(
             mod_id,
             is_business=is_business,
             is_clf=is_clf,
+            is_clustering=is_clustering,
             notebook_present=notebook_present,
             lens=lens,
         )

--- a/backend/tests/test_m6_module_guide.py
+++ b/backend/tests/test_m6_module_guide.py
@@ -98,14 +98,16 @@ def test_unknown_caseType_defaults_to_three_modules():
 # ─────────────────────────────────────────────────────────────
 
 def test_notebook_clause_present_for_mlds_regression():
-    # The M3 notebook GENERATOR is family-agnostic — regresión ships a real notebook too.
-    block = _block(family="regresion", notebook_present=True)
-    assert "notebook" in block
+    # The M3 notebook GENERATOR is family-agnostic — regresión AND clustering ship a real notebook.
+    assert "notebook" in _block(family="regresion", notebook_present=True)
+    # The clustering M3 branch must keep the DRY notebook clause working.
+    assert "notebook" in _block(family="clustering", notebook_present=True)
 
 
 def test_notebook_clause_suppressed_when_degraded_or_absent():
     assert "notebook" not in _block(family="clasificacion", notebook_present=False)
     assert "notebook" not in _block(family="regresion", notebook_present=False)
+    assert "notebook" not in _block(family="clustering", notebook_present=False)
 
 
 def test_notebook_clause_never_for_business():
@@ -123,15 +125,84 @@ def test_m2_line_classification_topics():
 
 
 def test_m2_line_generic_for_non_classification():
-    block = _block(family="clustering")
-    assert "correlación y causalidad" in block
-    assert "Paradoja de la Exactitud" not in block
+    # regresión / serie_temporal are the GENERIC-else families (clustering now has its OWN line).
+    for fam in ("regresion", "serie_temporal"):
+        block = _block(family=fam)
+        assert "correlación y causalidad" in block
+        assert "Paradoja de la Exactitud" not in block
+        assert "silhouette" not in block  # must NOT pick up the clustering line either
 
 
 def test_m4_verdict_profile_aware():
     assert M4_VERDICT_BUSINESS in _block(is_business=True, case_type="harvard_only")
     assert M4_VERDICT_MLDS not in _block(is_business=True, case_type="harvard_only")
     assert M4_VERDICT_MLDS in _block(is_business=False, case_type="harvard_only")
+
+
+# ─────────────────────────────────────────────────────────────
+# 3b. Clustering family (ml_ds-only, Issue #471): M1/M2/M3 segmentation framing
+#     mirrors _is_ml_ds_clustering — business+clustering stays byte-identical/generic.
+# ─────────────────────────────────────────────────────────────
+
+def test_m1_clustering_drops_target_variable():
+    # Unsupervised clustering has NO target → the M1 "define la variable objetivo" claim is wrong.
+    block = _block(family="clustering")
+    assert "variable objetivo" not in block
+    assert "segmentos latentes" in block
+    assert "no supervisado" in block
+    assert "datos sin etiquetar" in block
+    # clf / regression keep the supervised wording (byte-identical).
+    assert "define la variable objetivo" in _block(family="clasificacion")
+    assert "define la variable objetivo" in _block(family="regresion")
+
+
+def test_m2_clustering_mirrors_issue456():
+    # M2 line must mirror EDA_QUESTIONS_GENERATOR_PROMPT_CLUSTERING (#456): P1 standardize-before-
+    # K-Means (scale/distance), P2 feature correlation + silhouette reading.
+    block = _block(family="clustering")
+    assert "estandarizar" in block
+    assert "K-Means" in block
+    assert "silhouette" in block
+    assert "correlación y causalidad" not in block   # not the generic else
+    assert "Paradoja de la Exactitud" not in block   # not the clf line
+
+
+def test_m3_clustering_segmentation_framing():
+    # M3 must NOT describe a supervised experiment for unsupervised clustering (#457 is segmentation).
+    block = _block(family="clustering")
+    assert "diseño de segmentación" in block
+    assert "cohesión" in block
+    assert "prueba la causalidad" not in block
+    assert "experimentos rigurosos" not in block
+    # clf / regression keep the supervised experiment wording (byte-identical).
+    for fam in ("clasificacion", "regresion"):
+        assert "prueba la causalidad" in _block(family=fam)
+        assert "experimentos rigurosos" in _block(family=fam)
+
+
+def test_business_clustering_stays_generic():
+    # #456/#455/#457 are ml_ds-only (mirror _is_ml_ds_clustering); business+clustering keeps the
+    # generic M2 line + the business M1/M3 branches → byte-identical to today.
+    block = _block(is_business=True, family="clustering")
+    assert "correlación y causalidad" in block          # generic M2, not the clustering line
+    assert "silhouette" not in block and "K-Means" not in block
+    assert "segmentos latentes" not in block            # M1 is the business branch
+    assert "datos sin etiquetar" not in block
+    assert "diseño de segmentación" not in block        # M3 is the business audit branch
+
+
+def test_clustering_block_placeholder_and_currency_free():
+    # The clustering copy must stay placeholder-free and introduce no currency token
+    # (enforce_usd_currency, #377, must be a byte-identical no-op).
+    from case_generator.m1_grounding import enforce_usd_currency
+
+    for is_business in (False, True):
+        block = build_module_guide_block(
+            is_business=is_business, case_type="harvard_with_eda", family="clustering",
+            notebook_present=True, anchors=None,
+        )
+        assert "{" not in block and "}" not in block
+        assert enforce_usd_currency(block) == block
 
 
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Qué

Cierra #471. El §2 "Recorrido por Módulo" de la teaching note **M6** (teacher-only, `content.teachingNote`) se ensambla en Python (`build_module_guide_block`, determinista, sin LLM) y solo distinguía `is_business` / `is_clf` — **sin rama clustering**. Para un caso **ml_ds + K-Means** (EPIC #458, primer test con usuarios) el docente leía 3 descripciones supervisado-céntricas incoherentes:

| Módulo | Antes (incoherente) | Ahora (clustering) |
|---|---|---|
| **M1** `aprende` | "…define **la variable objetivo**…" | "…descubre **segmentos latentes** en datos sin etiquetar (aprendizaje no supervisado)…" |
| **M2** `formato` | genérico: "sesgo de confirmación / correlación y causalidad" | espeja #456: "estandarizar antes de **K-Means** (escala/distancia) + correlación entre features y lectura del **silhouette**" |
| **M3** `ve`/`aprende` | "diseño experimental que **prueba la causalidad**" / "experimentos rigurosos" | "diseño de **segmentación**: elección del número de grupos + validación de **cohesión** (silhouette) + perfilado" |

M3 no estaba en el alcance literal de la issue, pero tiene el **mismo defecto de raíz**; incluirlo deja el M6 de clustering **internamente coherente** (M1 segmentos + M2 silhouette + M3 segmentación).

## Cómo

- `_CLUSTERING_FAMILY` + flag `is_clustering` enhebrado a `_module_lines`; ramas clustering en M1 (`elif`), M2 (`elif … and not is_business`) y M3 (anidado en el `else` ml_ds; la cláusula notebook se aplica DRY después).
- **ml_ds-only** (mirror del gate STRICT `_is_ml_ds_clustering`): **business+clustering queda byte-idéntico** en el texto genérico, igual que clasificación/regresión/serie_temporal.
- **Sin kill-switch nuevo** (texto determinista; `teaching_note_module_guide` #422 ya es la sombrilla de revert del §2). Sin cambios de state/schema/migración/frontend/architect. Casos ya generados no se reprocesan.

## Tests

- 5 nuevos en `test_m6_module_guide.py`: M1 sin "variable objetivo", M2 espeja #456, M3 segmentación, **business+clustering genérico** (lock del gate ml_ds-only), placeholder/currency-free (`enforce_usd_currency` no-op #377).
- Re-apuntado `test_m2_line_generic_for_non_classification` (`clustering` → `regresion`/`serie_temporal`, que sí son el branch genérico) y extendido el notebook-clause a `clustering`.
- `test_m6_module_guide.py`: **45 passed**. Suite completa (excl. notebook-executor que cuelga en Windows/zmq, verde en CI Linux): **2514 passed, 23 skipped**. `mypy src` limpio.

## Coherencia con el diff (byte-idéntico para no-clustering)

Cada string existente se conserva verbatim (los ternarios pasaron a `if/elif/else`; en M3 la cláusula notebook solo se movió tras el inner if/else — la lista devuelta es idéntica). Verificado por diff + tests.

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)