### PR TITLE
fix(m481): preguntas M4 abiertas — sin answer-choices A/B/C que colisionan/cross-mapean

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -232,6 +232,7 @@ from case_generator.m5_grounding import validate_m5_questions_coherence
 from case_generator.m6_grounding import log_out_of_roster_mentions
 from case_generator.m4_grounding import (
     build_m4_chart_grounding_reprompt,
+    detect_embedded_mcq_options,
     drop_sensitivity_charts,
     log_chart_benchmark_fabrication,
     log_duplicate_deployment_sections,
@@ -1544,14 +1545,13 @@ _M1_QUESTIONS_OPTION_REPROMPT_HEADER = (
 )
 _M4_QUESTIONS_OPTION_REPROMPT_HEADER = (
     "\n\n# CORRECCIÓN OBLIGATORIA DE COHERENCIA DE OPCIONES (Módulo 4)\n"
-    "Algunas preguntas recomiendan en `solucion_esperada` una opción estratégica que NO "
-    "existe en el caso, o que el propio enunciado de esa pregunta no presenta al estudiante. "
-    "El caso define un conjunto cerrado de opciones (A, B, C). Regenera EXACTAMENTE 3 "
-    "preguntas con el MISMO schema y los MISMOS `numero` (1, 2, 3): el enunciado de cada "
-    "pregunta de decisión DEBE presentar las opciones (A/B/C) entre las que el estudiante "
-    "elige, y `solucion_esperada` SOLO puede recomendar una de las opciones presentadas en "
-    "su enunciado, nombrándola por su letra. NUNCA recomiendes una opción inexistente ni "
-    "ausente del enunciado. Incoherencias detectadas:\n"
+    "Las preguntas del Módulo 4 son ABIERTAS: el enunciado NO debe incrustar opciones de "
+    "respuesta etiquetadas A/B/C (colisionan con las opciones estratégicas A/B/C del caso). "
+    "Regenera EXACTAMENTE 3 preguntas con el MISMO schema y los MISMOS `numero` (1, 2, 3): "
+    "reescribe cada enunciado como pregunta abierta SIN answer-choices A/B/C. Si "
+    "`solucion_esperada` recomienda una opción estratégica del caso, nómbrala por su LETRA "
+    "REAL tal como aparece en el análisis del Módulo 4 (§4.5), sin inventar ni cruzar una "
+    "letra de respuesta. NUNCA recomiendes una opción inexistente. Incoherencias detectadas:\n"
 )
 
 
@@ -1756,6 +1756,7 @@ def _apply_m1_questions_option_coherence(
 _M4_VIOLATION_CODES = (
     ("OPTION_NONEXISTENT", "option_nonexistent"),
     ("OPTION_NOT_PRESENTED", "option_not_presented"),
+    ("MCQ_OPCIONES_EMBEBIDAS", "mcq_opciones_embebidas"),
 )
 
 
@@ -1769,33 +1770,50 @@ def _m4_violation_types(violations: list[str]) -> list[str]:
     return codes
 
 
+def _m4_question_violations(preguntas_dict: list[dict]) -> list[str]:
+    """All M4 question option-coherence violations (#481).
+
+    Two pure rules over the same set, so the pass-1 check and the post-reprompt re-validation apply the
+    SAME contract: (1) the shared #416 validator with the FLOOR universe (``dilema_brief=""``) — a
+    ``solucion_esperada`` that recommends a nonexistent / unpresented A/B/C option; (2) the embedded-MCQ
+    detector — an ``enunciado`` that incrusta its OWN answer-choices ("A) … B) … C) …"), which collide
+    and historically cross-map with the strategic Opción A/B/C. The validator is letter-agnostic on the
+    WORD "Opción X"; the detector covers the answer-letter "X)" form it cannot see.
+    """
+    violations = list(validate_question_option_coherence(preguntas_dict, ""))
+    for pregunta in preguntas_dict:
+        if isinstance(pregunta, dict):
+            violations.extend(detect_embedded_mcq_options(pregunta.get("enunciado")))
+    return violations
+
+
 def _apply_m4_questions_option_coherence(
     *, llm: Any, prompt: str, state: ADAMState, preguntas_dict: list[dict]
 ) -> list[dict]:
     """Validate + reprompt-once-then-DEGRADE the M4 (Impacto) question option coherence.
 
-    Reuses the M1 option validator with the FLOOR universe (M4 has no ``dilema_brief``): a
-    ``solucion_esperada`` may only recommend an option the case defines (A/B/C) and that its
-    own ``enunciado`` presents. Gated to the classification family for BOTH profiles
-    (business + ml_ds) behind the ``m4_question_coherence`` kill-switch; a byte-identical
-    no-op otherwise. On a violation it reprompts ONCE (one Flash call); the corrected set is
-    accepted ONLY if it preserves the question count AND the ``numero`` sequence (the grading
-    key ``M4-Q{numero}`` in shared.student_reads/teacher_reads) AND is now coherent —
-    otherwise it degrades to the pass-1 questions. ``GeneradorPreguntasOutput`` (unlike M1's
-    schema) does NOT enforce count/numbering, so the identity guard is load-bearing.
-    Best-effort: ANY throw (including a reprompt ``RuntimeError``) degrades to pass-1. Never
-    raises, so the job always completes.
+    The M4 questions are OPEN (#481): the only A/B/C in a case are the M1 *strategic* options, named by
+    their REAL letter in ``solucion_esperada``. ``_m4_question_violations`` flags both a recommended
+    option that is nonexistent/unpresented (the shared #416 validator) AND an ``enunciado`` that
+    embeds its own answer-choices A/B/C (the #481 detector). Runs for ALL families (the defect is
+    general, not classification-only) behind the ``m4_question_coherence`` kill-switch; a no-op when the
+    switch is off. On a violation it reprompts ONCE (one Flash call); the corrected set is accepted ONLY
+    if it preserves the question count AND the ``numero`` sequence (the grading key ``M4-Q{numero}`` in
+    shared.student_reads/teacher_reads) AND is now coherent — otherwise it degrades to the pass-1
+    questions. ``GeneradorPreguntasOutput`` (unlike M1's schema) does NOT enforce count/numbering, so
+    the identity guard is load-bearing. Best-effort: ANY throw (including a reprompt ``RuntimeError``)
+    degrades to pass-1. Never raises, so the job always completes.
 
-    Known coverage limit (same trade-off as M1, zero false positives): only A/B/C LETTER
-    options are checked. Options named as models/prose ("desplegar Random Forest") or an
-    enunciado that names a single option are not flagged; the M4 questions prompt boundary
-    nudges the LLM to the letter form so the validator covers the reported defect.
+    Known coverage limit (zero false negatives are not promised): only UPPERCASE A/B/C letter forms are
+    checked. A lowercase MCQ, or a pure-``solucion_esperada`` cross-map with no enunciado markers, is
+    not flagged; the prompt fix (open questions, name the real letter) is the primary defense and a
+    detector false positive only degrades to the already-good pass-1 question (never fails a job).
     """
     log_extra = {"node": "m4_questions_generator", "case_id": state.get("case_id")}
     try:
-        if not settings.m4_question_coherence or not _is_classification_family(state):
+        if not settings.m4_question_coherence:
             return preguntas_dict
-        violations = validate_question_option_coherence(preguntas_dict, "")
+        violations = _m4_question_violations(preguntas_dict)
         if not violations:
             return preguntas_dict
         logger.info(
@@ -1828,7 +1846,7 @@ def _apply_m4_questions_option_coherence(
                 extra=log_extra,
             )
             return preguntas_dict
-        residual = validate_question_option_coherence(corrected, "")
+        residual = _m4_question_violations(corrected)
         if not residual:
             logger.info(
                 "[m4_questions] coherencia de opciones M4 corregida por reprompt",

--- a/backend/src/case_generator/m4_grounding.py
+++ b/backend/src/case_generator/m4_grounding.py
@@ -468,3 +468,46 @@ def build_m4_chart_grounding_reprompt(
         "\nMétricas verificadas del modelo (única fuente válida para métricas del modelo):\n"
         f"{metrics_block}\n"
     )
+
+
+# ── Issue #481 — embedded-MCQ answer-choice backstop (M4 questions, ALL families) ──────────────────
+# The PROMPT fix (the 5 M4-question prompt surfaces) is the CURE — it stops mandating embedded
+# "opciones A/B/C" answer-choices in the question ``enunciado``. This is the deterministic BACKSTOP:
+# M4 questions are meant to be OPEN, and the only A/B/C in a case are the M1 *strategic* options (cited
+# by their REAL letter in ``solucion_esperada``). A question whose ``enunciado`` still embeds its OWN
+# answer-choice markers ("A) … B) … C) …") collides — and historically CROSS-MAPS — with the strategic
+# Opción A/B/C (the #481 LIVE defect). The #416 validator cannot see it (it captures the word
+# "Opción X", not the answer-letter "X)" form). Wired into the existing reprompt-once-then-DEGRADE M4
+# guard (``graph._apply_m4_questions_option_coherence``); a residual violation only degrades to the
+# pass-1 question, so a FALSE POSITIVE costs one wasted reprompt and NEVER degrades quality or fails a
+# job.
+#
+# Marker shape: an UPPERCASE letter A-D immediately followed by ")" at the start of a line or after
+# whitespace (so a parenthetical cross-reference "(A)" — preceded by "(" — and an inline "wordA)" are
+# NOT markers). The defect needs an enumerated answer set, so the rule fires only on >=2 DISTINCT such
+# letters. Scans the ``enunciado`` ONLY (the solucion's "Opción C" word-form is the legit strategic
+# reference, covered by ``validate_question_option_coherence``). Bounded quantifiers → no ReDoS.
+_MCQ_OPTION_MARKER_RE = re.compile(r"(?:^|(?<=\s))([A-D])\)", re.MULTILINE)
+
+
+def detect_embedded_mcq_options(enunciado: str | None) -> list[str]:
+    """Return ``["MCQ_OPCIONES_EMBEBIDAS: …"]`` when *enunciado* embeds an A/B/C answer-choice set.
+
+    Pure and total: any non-str / None / internal error degrades to ``[]`` (never raises). Fires only
+    when >=2 DISTINCT uppercase ``A)``/``B)``/``C)``/``D)`` markers appear, so a single parenthetical
+    reference never trips it. Near-zero false positives; a false positive is degrade-safe at the call
+    site (reprompt-once-then-keep-pass-1).
+    """
+    if not isinstance(enunciado, str) or not enunciado:
+        return []
+    try:
+        letters = {m.group(1) for m in _MCQ_OPTION_MARKER_RE.finditer(enunciado)}
+        if len(letters) >= 2:
+            joined = ", ".join(f"{letter})" for letter in sorted(letters))
+            return [
+                "MCQ_OPCIONES_EMBEBIDAS: el enunciado incrusta opciones de respuesta "
+                f"etiquetadas ({joined}) que colisionan con las opciones estratégicas A/B/C del caso"
+            ]
+        return []
+    except Exception:  # pragma: no cover - defensive; never fail a job
+        return []

--- a/backend/src/case_generator/prompts/__init__.py
+++ b/backend/src/case_generator/prompts/__init__.py
@@ -1190,7 +1190,7 @@ conecta hallazgos con impacto real y sopesa trade-offs ejecutivos.
   {{
     "numero": 1,
     "titulo": "string corto (≤8 palabras)",
-    "enunciado": "string (pregunta con métricas numéricas y opciones A/B/C explícitas)",
+    "enunciado": "string (pregunta ABIERTA con métricas numéricas; SIN opciones de respuesta etiquetadas A/B/C)",
     "solucion_esperada": "string (máx 60 palabras)",
     "bloom_level": "analysis|evaluation|synthesis",
     "m4_section_ref": "4.1|4.2|4.3|4.4|4.5"
@@ -1205,7 +1205,10 @@ conecta hallazgos con impacto real y sopesa trade-offs ejecutivos.
    por el M4 y el razonamiento esperado del estudiante para llegar a ella.
 
 # Your Boundaries
-- Solo JSON schema. Las preguntas DEBEN citar métricas numéricas del M4 y opciones A/B/C.
+- Solo JSON schema. Las preguntas DEBEN citar métricas numéricas del M4. Son preguntas ABIERTAS:
+  NO incrustes opciones de respuesta etiquetadas A/B/C (colisionan con las Opción A/B/C estratégicas
+  del caso). Si recomiendas una opción estratégica en `solucion_esperada`, nómbrala por su LETRA REAL
+  del análisis del M4 (§4.5), sin inventar ni cruzar una letra de respuesta.
 - **Idioma de salida: {output_language}**
 
 # Perfil del estudiante: {student_profile}
@@ -1252,7 +1255,7 @@ conecta hallazgos con impacto real de VALOR (según el MARCO DE VALOR) y sopesa 
   {{
     "numero": 1,
     "titulo": "string corto (≤8 palabras)",
-    "enunciado": "string (pregunta con métricas numéricas y opciones A/B/C explícitas)",
+    "enunciado": "string (pregunta ABIERTA con métricas numéricas; SIN opciones de respuesta etiquetadas A/B/C)",
     "solucion_esperada": "string (máx 60 palabras)",
     "bloom_level": "analysis|evaluation|synthesis",
     "m4_section_ref": "4.1|4.2|4.3|4.4|4.5"
@@ -1267,7 +1270,10 @@ conecta hallazgos con impacto real de VALOR (según el MARCO DE VALOR) y sopesa 
    por el M4 y el razonamiento esperado del estudiante para llegar a ella.
 
 # Your Boundaries
-- Solo JSON schema. Las preguntas DEBEN citar métricas numéricas del M4 y opciones A/B/C.
+- Solo JSON schema. Las preguntas DEBEN citar métricas numéricas del M4. Son preguntas ABIERTAS:
+  NO incrustes opciones de respuesta etiquetadas A/B/C (colisionan con las Opción A/B/C estratégicas
+  del caso). Si recomiendas una opción estratégica en `solucion_esperada`, nómbrala por su LETRA REAL
+  del análisis del M4 (§4.5), sin inventar ni cruzar una letra de respuesta.
 - **Idioma de salida: {output_language}**
 
 # Perfil del estudiante: {student_profile}
@@ -1486,10 +1492,11 @@ negocio.
   probabilidad puede dirigir el presupuesto al lugar equivocado; pide una mitigación concreta en
   términos de negocio (a quién priorizar, con qué presupuesto, cómo confirmar el supuesto), no una
   receta técnica del modelo.
-- **Coherencia opción↔solución:** si una pregunta plantea opciones, enúncialas con letras
-  (A/B/C) y en `solucion_esperada` recomienda SOLO una de las letras presentadas en ese mismo
-  enunciado, nombrándola por su letra; nunca una opción ausente del enunciado ni una letra fuera
-  de A/B/C.
+- **Coherencia opción↔solución:** las preguntas son ABIERTAS — NO incrustes opciones de respuesta
+  etiquetadas A/B/C (colisionan con las Opción A/B/C estratégicas del caso). Si `solucion_esperada`
+  recomienda una opción estratégica del caso, nómbrala por su LETRA REAL tal como aparece en el M4;
+  PROHIBIDO crear answer-choices A/B/C nuevos, barajar las estratégicas bajo otras letras, o cruzar
+  una letra de respuesta con la estratégica.
 - **Honestidad:** usa únicamente cifras del caso (Exhibits, M2, M4). NO inventes probabilidades,
   tasas ni valores nuevos; razona sobre la lógica de priorización, no sobre métricas del modelo.
 """

--- a/backend/src/case_generator/prompts/clasificacion/M4_clasificacion/questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M4_clasificacion/questions.py
@@ -45,7 +45,7 @@ riesgos de producción específicos de modelos de clasificación.
   {{
     "numero": 1,
     "titulo": "string corto (≤8 palabras)",
-    "enunciado": "string (pregunta con métricas numéricas y opciones A/B/C explícitas)",
+    "enunciado": "string (pregunta ABIERTA con métricas numéricas; SIN opciones de respuesta etiquetadas A/B/C)",
     "solucion_esperada": "string (máx 60 palabras)",
     "bloom_level": "analysis|evaluation|synthesis",
     "m4_section_ref": "4.1|4.2|4.3|4.4|4.5"
@@ -61,11 +61,12 @@ riesgos de producción específicos de modelos de clasificación.
 
 # Your Boundaries
 - Solo JSON schema. Las preguntas DEBEN citar métricas numéricas del M4 y del
-  bloque de métricas verificadas (si disponibles), y opciones A/B/C.
-- COHERENCIA OPCIÓN↔SOLUCIÓN: cuando una pregunta presente opciones, el enunciado DEBE
-  listarlas con sus letras (A/B/C) y `solucion_esperada` SOLO puede recomendar una de esas
-  letras presentadas en ese mismo enunciado, nombrándola por su letra. NUNCA recomiendes una
-  opción que el enunciado no presenta, ni una letra fuera de A/B/C.
+  bloque de métricas verificadas (si disponibles). Son preguntas ABIERTAS, sin opciones de respuesta A/B/C.
+- COHERENCIA OPCIÓN↔SOLUCIÓN: las preguntas son ABIERTAS — NO incrustes opciones de respuesta
+  etiquetadas A/B/C (colisionan con las Opción A/B/C estratégicas del caso). Si `solucion_esperada`
+  recomienda una opción estratégica, nómbrala por su LETRA REAL tal como aparece en el M4 §4.5
+  (p.ej. «la Opción A»); PROHIBIDO crear answer-choices A/B/C nuevos, barajar las estratégicas bajo
+  otras letras, o cruzar una letra de respuesta con la estratégica.
 - Citar SOLO números que aparezcan en {m4_content} o en {computed_metrics_block}.
   No fabricar métricas que no figuren en esas fuentes.
 - **Idioma de salida: {output_language}**
@@ -132,7 +133,7 @@ DE VALOR) y con los riesgos de producción específicos de modelos de clasificac
   {{
     "numero": 1,
     "titulo": "string corto (≤8 palabras)",
-    "enunciado": "string (pregunta con métricas numéricas y opciones A/B/C explícitas)",
+    "enunciado": "string (pregunta ABIERTA con métricas numéricas; SIN opciones de respuesta etiquetadas A/B/C)",
     "solucion_esperada": "string (máx 60 palabras)",
     "bloom_level": "analysis|evaluation|synthesis",
     "m4_section_ref": "4.1|4.2|4.3|4.4|4.5"
@@ -148,11 +149,12 @@ DE VALOR) y con los riesgos de producción específicos de modelos de clasificac
 
 # Your Boundaries
 - Solo JSON schema. Las preguntas DEBEN citar métricas numéricas del M4 y del
-  bloque de métricas verificadas (si disponibles), y opciones A/B/C.
-- COHERENCIA OPCIÓN↔SOLUCIÓN: cuando una pregunta presente opciones, el enunciado DEBE
-  listarlas con sus letras (A/B/C) y `solucion_esperada` SOLO puede recomendar una de esas
-  letras presentadas en ese mismo enunciado, nombrándola por su letra. NUNCA recomiendes una
-  opción que el enunciado no presenta, ni una letra fuera de A/B/C.
+  bloque de métricas verificadas (si disponibles). Son preguntas ABIERTAS, sin opciones de respuesta A/B/C.
+- COHERENCIA OPCIÓN↔SOLUCIÓN: las preguntas son ABIERTAS — NO incrustes opciones de respuesta
+  etiquetadas A/B/C (colisionan con las Opción A/B/C estratégicas del caso). Si `solucion_esperada`
+  recomienda una opción estratégica, nómbrala por su LETRA REAL tal como aparece en el M4 §4.5
+  (p.ej. «la Opción A»); PROHIBIDO crear answer-choices A/B/C nuevos, barajar las estratégicas bajo
+  otras letras, o cruzar una letra de respuesta con la estratégica.
 - Citar SOLO números que aparezcan en {m4_content} o en {computed_metrics_block}.
   No fabricar métricas que no figuren en esas fuentes.
 - **Idioma de salida: {output_language}**

--- a/backend/src/case_generator/prompts/teaching_note/module_guide_block.py
+++ b/backend/src/case_generator/prompts/teaching_note/module_guide_block.py
@@ -260,7 +260,7 @@ def _module_lines(
         )
         verdict = M4_VERDICT_BUSINESS if is_business else M4_VERDICT_MLDS
         formato = (
-            "3 preguntas que citan métricas concretas y opciones A/B/C; la recomendación cierra "
+            "3 preguntas abiertas que citan métricas concretas; la recomendación cierra "
             f"con un veredicto {verdict}."
         )
         return [ve, aprende, formato]

--- a/backend/tests/golden_eval.py
+++ b/backend/tests/golden_eval.py
@@ -70,6 +70,13 @@ class NodeEvalInputs:
     # enunciado). True (n/a) for non-classification jobs. Computed via
     # ``check_m4_question_option_coherence`` (reuses the production validator).
     m4_questions_coherence_ok: bool = True
+    # M4 questions are OPEN (#481): no question ``enunciado`` may embed its own answer-choices A/B/C
+    # (which collide / cross-map with the strategic Opción A/B/C). True (n/a) when a job carries no M4
+    # questions. Computed via ``check_m4_questions_no_embedded_mcq`` (reuses the production
+    # ``m4_grounding.detect_embedded_mcq_options``), so a future M4-questions prompt or tier regression
+    # that re-embeds MCQ answer-choices fails the golden gate. Applies to ALL families (the defect is
+    # general, not classification-only).
+    m4_questions_no_embedded_mcq_ok: bool = True
     # M5 memorándum coherence: every classification golden job's M5 memo must be coherent (does not
     # name the unselected model; cites no model metric absent from the executed M3 metrics; does not
     # recommend a strategic option that does not exist in the case). True (n/a) for non-classification
@@ -236,6 +243,8 @@ def evaluate_downgrade_gate(r: NodeEvalInputs) -> GateResult:
         reasons.append("M3 question coherence failure: section_ref or unselected-model leak")
     if not r.m4_questions_coherence_ok:
         reasons.append("M4 question option coherence failure: nonexistent or unpresented option")
+    if not r.m4_questions_no_embedded_mcq_ok:
+        reasons.append("M4 question coherence failure: enunciado embeds MCQ answer-choices A/B/C")
     if not r.m5_questions_coherence_ok:
         reasons.append(
             "M5 memorándum coherence failure: unselected-model leak, unanchored metric, or "
@@ -404,6 +413,22 @@ def check_m4_question_option_coherence(preguntas: list[dict]) -> bool:
     from case_generator.m1_grounding import validate_question_option_coherence
 
     return not validate_question_option_coherence(preguntas, "")
+
+
+def check_m4_questions_no_embedded_mcq(preguntas: list[dict]) -> bool:
+    """Pure oracle: do the M4 questions avoid embedding MCQ answer-choices A/B/C (#481)?
+
+    Reuses the production detector ``m4_grounding.detect_embedded_mcq_options`` (single source of
+    truth), so a future M4-questions prompt or tier regression that re-embeds answer-choices A/B/C in an
+    ``enunciado`` (colliding / cross-mapping with the strategic Opción A/B/C) fails the golden gate.
+    Applies to ALL families. Function-level import keeps this support module lightweight.
+    """
+    from case_generator.m4_grounding import detect_embedded_mcq_options
+
+    for pregunta in preguntas:
+        if isinstance(pregunta, dict) and detect_embedded_mcq_options(pregunta.get("enunciado")):
+            return False
+    return True
 
 
 def check_m4_deployment_section_unique(m4_content: str) -> bool:

--- a/backend/tests/test_issue481_m4_open_questions.py
+++ b/backend/tests/test_issue481_m4_open_questions.py
@@ -1,0 +1,215 @@
+"""Issue #481 — M4 questions are OPEN; no embedded A/B/C answer-choices.
+
+The M4 ("Impacto y Finanzas") question prompts used to MANDATE embedding answer-choices A/B/C in the
+``enunciado``. Those answer-letters collided — and historically CROSS-MAPPED — with the M1 *strategic*
+Opción A/B/C (the LIVE defect in "LogiFlow" / "EduVanguard"). The fix makes the questions genuinely
+open: the only A/B/C in a case are the strategic options, named by their REAL letter in
+``solucion_esperada``.
+
+This module locks three things:
+  1. The deterministic backstop ``m4_grounding.detect_embedded_mcq_options`` (the GUARANTEE) — fires on
+     an enunciado that embeds ``A)``/``B)``/``C)`` markers, near-zero false positives, degrade-safe.
+  2. The prompt drift-locks across all 6 surfaces (the 5 question prompts + the M6 teaching-note
+     synopsis) — the old "opciones A/B/C explícitas" mandate is gone, the open instruction is present,
+     and the ``opción↔solución`` sentinel stays only on the classification/business prompts.
+  3. The golden oracle ``check_m4_questions_no_embedded_mcq`` + its downgrade-gate wiring.
+
+Pure-Python: no DB, no real LLM, no network.
+"""
+
+from __future__ import annotations
+
+import string
+
+from case_generator.m4_grounding import detect_embedded_mcq_options
+from case_generator.prompts import (
+    M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION,
+    M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION_NEUTRAL,
+    M4_QUESTIONS_GENERATOR_PROMPT,
+    M4_QUESTIONS_GENERATOR_PROMPT_NEUTRAL,
+    M4_QUESTIONS_PROMPT_CLASSIFICATION,
+    M4_QUESTIONS_PROMPT_CLASSIFICATION_NEUTRAL,
+)
+from case_generator.prompts.teaching_note.module_guide_block import (
+    build_module_guide_block,
+)
+
+_OLD_MANDATE = "opciones A/B/C explícitas"
+_SENTINEL = "opción↔solución"
+
+_GENERIC = (M4_QUESTIONS_GENERATOR_PROMPT, M4_QUESTIONS_GENERATOR_PROMPT_NEUTRAL)
+_CLF = (M4_QUESTIONS_PROMPT_CLASSIFICATION, M4_QUESTIONS_PROMPT_CLASSIFICATION_NEUTRAL)
+_BUSINESS = (
+    M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION,
+    M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION_NEUTRAL,
+)
+_ALL = _GENERIC + _CLF + _BUSINESS
+
+
+def _placeholders(template: str) -> set[str]:
+    return {
+        fname.split(".")[0].split("[")[0]
+        for _, fname, _, _ in string.Formatter().parse(template)
+        if fname
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Detector — RED/GREEN + FP/FN matrix
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDetector:
+    def test_reshuffle_shape_flags(self) -> None:
+        # The exact LIVE defect (LogiFlow Q2): strategic options shuffled under answer-letters.
+        out = detect_embedded_mcq_options(
+            "Elige: A) Opción C  B) Opción B  C) Opción A de despliegue."
+        )
+        assert len(out) == 1 and out[0].startswith("MCQ_OPCIONES_EMBEBIDAS")
+
+    def test_decoupled_distractors_flag(self) -> None:
+        # LogiFlow Q1: answer-choices that are metric interpretations (still embedded A/B/C).
+        out = detect_embedded_mcq_options(
+            "Interpreta el AUC: A) el modelo es perfecto, B) hay overfitting."
+        )
+        assert out and out[0].startswith("MCQ_OPCIONES_EMBEBIDAS")
+
+    def test_newline_separated_markers_flag(self) -> None:
+        out = detect_embedded_mcq_options("Opciones:\nA) reentrenar\nB) ajustar umbral\nC) no actuar")
+        assert out
+
+    def test_open_question_naming_strategic_letter_is_clean(self) -> None:
+        # The DESIRED shape: open question + solution naming the real strategic letter (word form).
+        assert detect_embedded_mcq_options(
+            "¿El valor proyectado del modelo (AUC 0.82) justifica el costo de despliegue?"
+        ) == []
+
+    def test_word_form_option_reference_is_clean(self) -> None:
+        # "Opción A" word form (the legit strategic reference) has no answer-letter marker.
+        assert detect_embedded_mcq_options("Se recomienda la Opción A según el análisis §4.5.") == []
+
+    def test_single_parenthetical_is_clean(self) -> None:
+        # "(A)" parenthetical (preceded by "(") is never a marker; a single marker never trips it.
+        assert detect_embedded_mcq_options("El panel (A) del gráfico muestra el payback.") == []
+        assert detect_embedded_mcq_options("La opción A) sería viable en el escenario base.") == []
+
+    def test_non_str_and_empty_are_clean(self) -> None:
+        assert detect_embedded_mcq_options(None) == []
+        assert detect_embedded_mcq_options("") == []
+        assert detect_embedded_mcq_options(123) == []  # type: ignore[arg-type]
+
+    def test_lowercase_mcq_is_accepted_fn(self) -> None:
+        # Documented accepted false NEGATIVE: lowercase markers are not flagged (zero-FP bias).
+        assert detect_embedded_mcq_options("opciones: a) uno b) dos c) tres") == []
+
+    def test_documented_fp_two_parenthetical_panels_flags(self) -> None:
+        # Documented residual false POSITIVE (degrade-safe): two "(... A)" / "(... B)" parentheticals
+        # where the letter sits after a space. The call site only reprompts-then-keeps-pass-1, so this
+        # FP costs one wasted reprompt and never degrades quality. Pinned so the behavior is honest.
+        assert detect_embedded_mcq_options("Ver el panel A) y el panel B) del exhibit.")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Prompt drift-locks — all 6 surfaces (the open contract)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPromptDriftLocks:
+    def test_old_mandate_removed_everywhere(self) -> None:
+        for prompt in _ALL:
+            assert _OLD_MANDATE not in prompt
+
+    def test_open_instruction_present_everywhere(self) -> None:
+        for prompt in _ALL:
+            assert "ABIERTA" in prompt
+
+    def test_clf_and_business_keep_sentinel(self) -> None:
+        for prompt in _CLF + _BUSINESS:
+            assert _SENTINEL in prompt.lower()
+
+    def test_generic_has_no_sentinel(self) -> None:
+        # Non-classification families render the generic prompt; it must stay sentinel-free
+        # (preserves test_m4_question_coherence::test_generic_prompt_has_no_boundary).
+        for prompt in _GENERIC:
+            assert _SENTINEL not in prompt.lower()
+
+    def test_old_clf_listing_mandate_removed(self) -> None:
+        for prompt in _CLF:
+            assert "listarlas con sus letras" not in prompt
+
+    def test_old_business_listing_mandate_removed(self) -> None:
+        for prompt in _BUSINESS:
+            assert "enúncialas con letras" not in prompt
+
+    def test_neutral_twins_preserve_placeholders(self) -> None:
+        # Brace-free edits → placeholder parity intact (mirrors test_issue437).
+        assert _placeholders(M4_QUESTIONS_GENERATOR_PROMPT_NEUTRAL) == _placeholders(
+            M4_QUESTIONS_GENERATOR_PROMPT
+        )
+        assert _placeholders(M4_QUESTIONS_PROMPT_CLASSIFICATION_NEUTRAL) == _placeholders(
+            M4_QUESTIONS_PROMPT_CLASSIFICATION
+        )
+
+    def test_prompts_still_render(self) -> None:
+        # No new {placeholder} / unescaped literal brace introduced by the edits.
+        for prompt in _GENERIC + _CLF:
+            ctx = {p: "X" for p in _placeholders(prompt)}
+            assert prompt.format(**ctx)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. M6 teaching-note synopsis (surface #6) — coherent with open M4 questions
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestM6Synopsis:
+    def _block(self, *, is_business: bool) -> str:
+        return build_module_guide_block(
+            is_business=is_business,
+            case_type="harvard_with_eda",
+            family="clasificacion",
+            notebook_present=not is_business,
+        )
+
+    def test_m4_synopsis_says_open_questions(self) -> None:
+        for is_business in (True, False):
+            block = self._block(is_business=is_business)
+            assert "3 preguntas abiertas" in block
+
+    def test_m4_synopsis_drops_abc_options(self) -> None:
+        for is_business in (True, False):
+            block = self._block(is_business=is_business)
+            assert "opciones A/B/C" not in block
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Golden oracle — anti-regression lock on the downgrade gate
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestGoldenOracle:
+    def test_oracle_clean_true(self) -> None:
+        from tests.golden_eval import check_m4_questions_no_embedded_mcq
+
+        clean = [
+            {"numero": 1, "enunciado": "¿El valor del modelo justifica el costo de despliegue?"},
+            {"numero": 2, "enunciado": "Se recomienda la Opción A según §4.5."},
+        ]
+        assert check_m4_questions_no_embedded_mcq(clean) is True
+
+    def test_oracle_embedded_mcq_false(self) -> None:
+        from tests.golden_eval import check_m4_questions_no_embedded_mcq
+
+        bad = [{"numero": 1, "enunciado": "Elige: A) Opción C  B) Opción B  C) Opción A."}]
+        assert check_m4_questions_no_embedded_mcq(bad) is False
+
+    def test_gate_blocks_on_embedded_mcq(self) -> None:
+        from tests.golden_eval import NodeEvalInputs, evaluate_downgrade_gate
+
+        ok = evaluate_downgrade_gate(NodeEvalInputs(node="x", deterministic_pass=True))
+        assert ok.passed
+        blocked = evaluate_downgrade_gate(
+            NodeEvalInputs(node="x", deterministic_pass=True, m4_questions_no_embedded_mcq_ok=False)
+        )
+        assert not blocked.passed
+        assert any("embeds MCQ" in reason for reason in blocked.reasons)

--- a/backend/tests/test_m4_question_coherence.py
+++ b/backend/tests/test_m4_question_coherence.py
@@ -1,8 +1,9 @@
 """M4 (Impacto) question option coherence — deterministic internal coherence guard.
 
 Covers the reported defect for Module 4: an ``solucion_esperada`` recommending an option that
-does not exist in the case, or one its own ``enunciado`` never presented. Scope is the
-classification family for BOTH profiles (business + ml_ds).
+does not exist in the case, or one its own ``enunciado`` never presented. Since #481 the wrapper is
+GENERAL (all families, both profiles) — the embedded-MCQ defect is not classification-specific; the
+#481 detector layer + its drift-locks live in ``test_issue481_m4_open_questions.py``.
 
 Three layers under test:
   1. The REUSED pure validator ``m1_grounding.validate_question_option_coherence(preguntas, "")``
@@ -12,8 +13,8 @@ Three layers under test:
   2. The prompt layer (defense-in-depth, #M4-coherence): both classification question prompts carry
      an option↔solution coherence boundary; the generic prompt does not (non-clf unaffected).
   3. The graph wrapper ``graph._apply_m4_questions_option_coherence`` — reprompt-once-then-DEGRADE,
-     gated to the classification family + kill-switch, identity-guarded on ``numero`` (the
-     ``M4-Q{numero}`` grading key), best-effort.
+     general (all families) behind the ``m4_question_coherence`` kill-switch, identity-guarded on
+     ``numero`` (the ``M4-Q{numero}`` grading key), best-effort.
 
 Pure-Python: no DB, no real LLM, no network.
 """
@@ -26,6 +27,7 @@ import string
 import pytest
 
 from case_generator.m1_grounding import validate_question_option_coherence
+from case_generator.m4_grounding import detect_embedded_mcq_options
 from case_generator.prompts import (
     M4_QUESTIONS_BUSINESS_PROMPT_CLASSIFICATION,
     M4_QUESTIONS_GENERATOR_PROMPT,
@@ -319,17 +321,32 @@ class TestWrapper:
         out = _invoke(fake, _state(profile="ml_ds", algoritmos=[]), _BAD)
         assert fake.calls == 1
 
-    def test_gate_noop_for_non_classification_family(self) -> None:
-        fake = _FakeStructuredLLM()  # would raise if invoked
+    def test_gate_fires_for_non_classification_family(self) -> None:
+        # #481: the guard is now GENERAL (not classification-only) — the defect is general (M4 of
+        # every family). A non-clf family with a violating pass-1 now reprompts.
+        fake = _FakeStructuredLLM([_CLEAN_RESULT])
         out = _invoke(fake, _state(algoritmos=["Linear Regression"]), _BAD)
-        assert fake.calls == 0
-        assert out == _BAD
+        assert fake.calls == 1
+        assert validate_question_option_coherence(out, "") == []
 
-    def test_gate_noop_for_business_without_algorithms(self) -> None:
-        fake = _FakeStructuredLLM()
+    def test_gate_fires_for_business_without_algorithms(self) -> None:
+        # #481: general gate — business without algorithms also gets the coherence guard now.
+        fake = _FakeStructuredLLM([_CLEAN_RESULT])
         out = _invoke(fake, _state(profile="business", algoritmos=[]), _BAD)
-        assert fake.calls == 0
-        assert out == _BAD
+        assert fake.calls == 1
+
+    def test_embedded_mcq_triggers_reprompt(self) -> None:
+        # #481: an enunciado embedding answer-choices "A)/B)/C)" must trigger the guard even though
+        # the shared validator (word-form "Opción X") cannot see the answer-letter form.
+        bad_mcq = _questions(
+            "Interpreta el AUC: A) modelo perfecto, B) overfitting, C) sin señal.",
+            "La opción A es correcta.",
+        )
+        fake = _FakeStructuredLLM([_CLEAN_RESULT])
+        out = _invoke(fake, _state(), bad_mcq)
+        assert fake.calls == 1
+        assert out != bad_mcq  # corrected, not degraded to the MCQ-bad pass-1
+        assert all(not detect_embedded_mcq_options(q["enunciado"]) for q in out)
 
     def test_kill_switch_off_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(graph_module.settings, "m4_question_coherence", False)


### PR DESCRIPTION
Closes #481

## Problema (confirmado LIVE: "LogiFlow" + "EduVanguard")
Las 3 preguntas del Módulo 4 se muestran etiquetadas **"RESPUESTA ABIERTA"** pero el `enunciado` incrustaba opciones de respuesta **A/B/C** propias del LLM, que **colisionaban** —y a veces **cross-mapeaban**— con las "Opción A/B/C" **estratégicas** del caso (M1).

> LogiFlow Q2: enunciado `"A) Opción C  B) Opción B  C) Opción A"`, solución `"la opción C es correcta"` → en realidad recomienda la **Opción A estratégica**. Ambiguo y cruzado.

**Por qué #416 no lo atrapaba:** `validate_question_option_coherence` es *letter-agnostic* (captura la palabra "Opción X", no la forma answer-letter "X)"), y el guard M4 estaba **clf-gated** → clustering sin guard.

## Fix (general — clasificación, clustering y business)
Decisión de diseño (gate de plan): las preguntas M4 son **genuinamente ABIERTAS** (la opción estratégica no está en el contexto de `m4_questions_generator`; la letra real ya vive en `m4_content` §4.5). El prompt es la defensa; un detector determinista es la garantía.

**6 surfaces de prompt** dejan de mandar answer-choices A/B/C:
- `M4_QUESTIONS_GENERATOR_PROMPT` (+ `_NEUTRAL`) — genérico (regresion/clustering/serie_temporal + base business)
- `M4_QUESTIONS_PROMPT_CLASSIFICATION` (+ `_NEUTRAL`) — ml_ds+clf
- `M4_QUESTIONS_LR_BUSINESS_BLOCK` — business+clf
- `module_guide_block.py` — el M6 teaching note deja de describir M4 como "opciones A/B/C"

**Backstop determinista** `m4_grounding.detect_embedded_mcq_options` (near-zero-FP, degrade-safe) cableado al guard `reprompt-once-then-degrade` existente, **generalizado a todas las familias** detrás del kill-switch `m4_question_coherence`. El reprompt header M4 se reencuadra al contrato abierto (el header **M1** NO se toca: ahí A/B/C es el dilema estratégico legítimo). El validador **compartido** `validate_question_option_coherence` (M1/M4/M5) **no se modifica** → #412/#416/#417 intactos.

**Golden oracle** `check_m4_questions_no_embedded_mcq` + gate de downgrade.

## Evidencia (antes → después del enunciado)
```
ANTES:  "Elige: A) Opción C  B) Opción B  C) Opción A de despliegue."   (→ detector: MCQ_OPCIONES_EMBEBIDAS)
        solución "la opción C es correcta"  (cross-map: respuesta C = estrategia A)

DESPUÉS: "¿El valor proyectado del modelo (AUC 0.82) justifica el costo de despliegue?"
         solución "Se recomienda la Opción A según el análisis §4.5"  (letra REAL, sin cross-map)
```

## Blast-radius
Mejora de una vía (clf **no** byte-idéntico, esperado). Sin frontend/schema/migración/architect-SHA. Sin nueva clave canónica/state/`case_sanitization`. El guard ahora corre también para clustering/regresion/business-no-clf (antes no-op); un FP del detector solo cuesta un reprompt y conserva el pass-1 (nunca degrada calidad ni falla el job). Coexiste con los guards de veredicto clustering #467/#469 (esos guardan el M4 *content*, no las *questions*). Casos ya generados no se reprocesan.

## Tests
- `test_issue481_m4_open_questions.py` (NUEVO): detector RED/GREEN + matriz FP/FN, drift-locks de los 6 surfaces, M6 synopsis, golden oracle + gate.
- `test_m4_question_coherence.py`: los 2 gate-tests pasan de "no-op non-clf" a "fires (general)" + test de MCQ embebido.
- Verdes: `test_m4_clasificacion_dispatch`, `test_m1_option_coherence` (#412/#416), `test_m5_question_coherence` (#417), `test_issue437_impact_lens_dispatch`, `test_m6_module_guide`.

**Validación local:** `uv run --directory backend pytest -q` → 2725 passed (los 13 fallos/errores restantes son de subsistemas no relacionados —auth/catálogo/admin— y pasan en aislamiento: artefactos de aislamiento de DB local; CI usa DB efímera). `mypy src` limpio.

## Fase 4 — LIVE (pendiente)
Sin `GEMINI_API_KEY` real en este entorno, la verificación LIVE (regenerar 1 clustering + 1 clasificación) queda pendiente; el contrato determinista está cubierto por unit/drift-locks/golden. **merge ≠ deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)