### PR TITLE
fix(m482): clustering — filtrar warnings que nombran el target stripeado (M2/M3)

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -4950,6 +4950,49 @@ def _enforce_mlds_clustering_no_target(
     return new_schema
 
 
+def _filter_clustering_target_warnings(
+    warnings: list[str],
+    *,
+    profile: str,
+    primary_family: str | None,
+    enabled: bool = True,
+) -> list[str]:
+    """Issue #482 — drop data_gap_warnings que NOMBRAN un target supervisado en ml_ds+clustering.
+
+    Clustering es no supervisado: ``_enforce_mlds_clustering_no_target`` (#466) stripea la COLUMNA
+    target del CSV, pero DOS emisores upstream aún producen un warning que nombra ese target huérfano
+    (``contract.target_column.name``, p. ej. ``dummy_target_ignored_for_clustering``):
+      (1) el architect ``_validate_target_semantic_coherence`` (sembrado en ``data_gap_warnings`` en
+          ``case_architect``; ungated por familia — dispara cuando el TÍTULO trae un keyword de
+          ``_TITLE_TO_TARGET_TOKENS``), y
+      (2) el validador ``_validate_schema_against_contract`` (``"target '<name>' … no fue
+          producido…"``; determinista en todo caso stripeado).
+    Ambos terminan en el ``warnings_payload`` de ``schema_designer`` y de ahí a M2 EDA
+    (``{data_gap_warnings_block}``) y, vía ``contexto_m2``, a M3-content → el estudiante lee una
+    columna ausente del CSV (#482). Este filtro corre en el ÚNICO choke point de ``schema_designer``,
+    DESPUÉS de fusionar todos los warnings, así que cubre ambos emisores (y cualquier futuro).
+
+    Prefix-based sobre las DOS únicas formas que nombran el target en todo el código: ``"target '"``
+    (validador) y ``_TARGET_SEMANTIC_MISMATCH_TOKEN`` (architect). Los warnings de feature-missing
+    (``"feature '…'"``) y de leakage se PRESERVAN → cero falsos positivos (clustering nunca tiene un
+    target legítimo, así que cualquier warning de target es espurio). Fuera de ml_ds+clustering /
+    kill-switch off → devuelve el MISMO objeto (byte-idéntico). Reusa el switch ``MLDS_CLUSTERING_NO_TARGET``.
+    """
+    if not enabled or profile != "ml_ds" or primary_family != "clustering":
+        return warnings
+    return [
+        w
+        for w in warnings
+        if not (
+            isinstance(w, str)
+            and (
+                w.lstrip().startswith("target '")
+                or w.lstrip().startswith(_TARGET_SEMANTIC_MISMATCH_TOKEN)
+            )
+        )
+    ]
+
+
 def _contract_with_enforced_target(contract: dict | None, target_name: str | None) -> dict | None:
     """Reescribe ``target_column`` del contrato al target binario que el spine garantizó.
 
@@ -5188,6 +5231,13 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
                 warnings_payload.extend(leakage)
             if biz_notes:
                 warnings_payload.extend(biz_notes)
+            # Issue #482 — quita los warnings que nombran el target stripeado de clustering (architect
+            # coherence + validador) antes de persistir; M2 EDA y M3-content dejan de citar una columna
+            # ausente del CSV. No-op byte-idéntico fuera de ml_ds+clustering / switch off.
+            warnings_payload = _filter_clustering_target_warnings(
+                warnings_payload, profile=profile, primary_family=primary_family,
+                enabled=settings.mlds_clustering_no_target,
+            )
             node_out: dict[str, Any] = {
                 "dataset_schema": schema_result,
                 "data_gap_warnings": warnings_payload,
@@ -5243,6 +5293,12 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
         warnings_payload.extend(leakage)
     if biz_notes:
         warnings_payload.extend(biz_notes)
+    # Issue #482 — mismo filtro de warnings de target stripeado en el fallback. Clustering corre ESTE
+    # path (determinista por #477), así que este es el filtro que actúa en producción.
+    warnings_payload = _filter_clustering_target_warnings(
+        warnings_payload, profile=profile, primary_family=primary_family,
+        enabled=settings.mlds_clustering_no_target,
+    )
     node_out = {
         "dataset_schema": fallback_schema,
         "data_gap_warnings": warnings_payload,

--- a/backend/tests/golden_eval.py
+++ b/backend/tests/golden_eval.py
@@ -204,6 +204,15 @@ class NodeEvalInputs:
     # Computed via ``check_clustering_entity_index``; gate-protects against a data-layer regression that
     # reverts to the monthly period index. RED control: rows with a monthly `period` column fail.
     clustering_entity_index_ok: bool = True
+    # ml_ds + clustering data_gap_warnings NAME no supervised target (Issue #482): #466 strips the
+    # leaked target COLUMN from the CSV, but the architect coherence check and the schema validator
+    # still emit a warning naming the orphan target, which leaks into M2 EDA / M3-content (the student
+    # reads a column absent from the CSV). ``_filter_clustering_target_warnings`` drops both at the
+    # schema_designer choke point. True (n/a) for non-clustering jobs / empty warnings. Computed via
+    # ``check_clustering_no_target_warnings``; gate-protects against a regression that re-introduces a
+    # target-naming warning. RED control: a warnings list with a ``target '…'`` or
+    # ``target_semantic_mismatch`` entry fails.
+    clustering_no_target_warning_ok: bool = True
 
 
 @dataclass
@@ -304,6 +313,11 @@ def evaluate_downgrade_gate(r: NodeEvalInputs) -> GateResult:
         reasons.append(
             "clustering data failure: dataset is time-indexed (monthly `period`) instead of "
             "entity-level (`user_id`) — analysis unit contradicts the segmentation narrative"
+        )
+    if not r.clustering_no_target_warning_ok:
+        reasons.append(
+            "clustering narrative failure: a data_gap_warning names a stripped supervised target, "
+            "leaking a column absent from the CSV into M2 EDA / M3-content"
         )
     if r.judge_baseline_mean is not None and r.judge_candidate_mean is not None:
         drop = r.judge_baseline_mean - r.judge_candidate_mean
@@ -782,6 +796,28 @@ def check_clustering_no_target(rows: list | None) -> bool:
         if non_null and non_null <= {0, 1}:
             return False
     return True
+
+
+def check_clustering_no_target_warnings(data_gap_warnings: list | None) -> bool:
+    """Pure oracle (Issue #482): do the ml_ds+clustering data_gap_warnings NAME no supervised target?
+
+    #466 strips the leaked target COLUMN from the CSV, but two upstream emitters still produce a
+    warning that names the orphan ``contract.target_column.name`` — the architect coherence check
+    (``target_semantic_mismatch: … target_column.name='…'``) and the schema validator
+    (``target '<name>' … no fue producido…``). Both reach M2 EDA and, via ``contexto_m2``, M3-content,
+    so the student reads a column absent from the downloaded CSV. ``_filter_clustering_target_warnings``
+    drops both at the schema_designer choke point. True iff NO warning starts with ``target '``
+    (validator) nor ``target_semantic_mismatch`` (architect). Feature-missing / leakage warnings
+    (``feature '…'``) are NOT target warnings → never flagged. Pure, deterministic, no LLM/network/API
+    key. Empty/absent → True (n/a). RED control: a list with either target-warning shape fails.
+    """
+    if not data_gap_warnings:
+        return True
+    return not any(
+        isinstance(w, str)
+        and (w.lstrip().startswith("target '") or w.lstrip().startswith("target_semantic_mismatch"))
+        for w in data_gap_warnings
+    )
 
 
 def check_clustering_eda_no_target_charts(charts: list | None) -> bool:

--- a/backend/tests/test_issue466_clustering_no_target.py
+++ b/backend/tests/test_issue466_clustering_no_target.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import copy
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -578,3 +579,85 @@ def test_gate_blocks_on_clustering_target_warning_leak() -> None:
     res = evaluate_downgrade_gate(fail)
     assert res.passed is False
     assert any("names a stripped supervised target" in r for r in res.reasons)
+
+
+def test_filter_handles_whitespace_and_non_str_elements() -> None:
+    """Defensive branches: a leading-whitespace target warning is still dropped (`lstrip()`), and a
+    non-str element is kept without throwing (the `isinstance(w, str)` guard)."""
+    warnings: list = [
+        "  target 'dummy' no fue producido por schema_designer",  # leading ws → still dropped
+        "feature 'recency_days' no fue producido",                # kept
+        None,                                                      # non-str → kept, never throws
+    ]
+    out = _filter_clustering_target_warnings(
+        warnings, profile="ml_ds", primary_family="clustering", enabled=True
+    )
+    assert out == ["feature 'recency_days' no fue producido", None]
+    # The oracle shares the same defensive shape: a non-str / clean-feature list is n/a (True),
+    # a leading-whitespace target warning is still flagged.
+    assert check_clustering_no_target_warnings([None, "feature 'x' no fue producido"]) is True
+    assert check_clustering_no_target_warnings(["  target 'dummy' no fue producido"]) is False
+
+
+# ── Node-level integration: the REAL schema_designer wiring (closes the helper-isolation gap) ──
+#
+# The helper tests above exercise `_filter_clustering_target_warnings` and the two emitters in
+# isolation, then hand-build `warnings_payload`. These drive the ACTUAL `schema_designer` node
+# (deterministic clustering path, no LLM/DB per #477) to prove the production wiring: the architect
+# seed in `state["data_gap_warnings"]` is merged AND the call-site filter removes it before persist.
+
+
+def _clustering_node_state(seed_warning: str) -> dict:
+    """ml_ds+clustering state with an architect-seeded target warning (the #228 seed path)."""
+    return {
+        "studentProfile": "ml_ds",
+        "algoritmos": ["K-Means"],
+        "titulo": "Segmentación para reducir el churn",
+        "doc1_anexo_financiero": "",
+        "doc1_anexo_operativo": "",
+        "dataset_schema_required": _orphan_contract(),
+        "data_gap_warnings": [seed_warning],
+    }
+
+
+def test_schema_designer_node_filters_architect_seed_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GREEN: the real node persists data_gap_warnings with NO orphan target name — proving the
+    fallback-path call-site filter + the state-seed merge, not just the helper in isolation."""
+    monkeypatch.setattr(graph.settings, "mlds_clustering_structure", True)
+    monkeypatch.setattr(graph.settings, "mlds_clustering_no_target", True)
+    # Clustering skips the Pro LLM (#477); patch the class so an accidental construction is inert.
+    monkeypatch.setattr(graph, "ChatGoogleGenerativeAI", MagicMock())
+    # Use the REAL architect coherence warning (the seed the node merges from state).
+    seed = _validate_target_semantic_coherence(
+        "Segmentación para reducir el churn",
+        {"name": _ORPHAN_TARGET, "role": "classification_target"},
+    )[0]
+    assert _ORPHAN_TARGET in seed  # the seed genuinely names the orphan
+
+    out = graph.schema_designer(_clustering_node_state(seed), {"configurable": {}})
+
+    warnings = out.get("data_gap_warnings") or []
+    assert all(_ORPHAN_TARGET not in w for w in warnings)  # orphan gone from every channel
+    # The deterministic clustering schema also carries no target column (strip ran end-to-end).
+    assert _ORPHAN_TARGET not in {c["name"] for c in out["dataset_schema"]["columns"]}
+
+
+def test_schema_designer_node_red_control_switch_off_keeps_seed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED control: with MLDS_CLUSTERING_NO_TARGET off the filter is skipped, so the architect-seeded
+    target warning survives in the persisted data_gap_warnings (byte-identical to pre-#482)."""
+    monkeypatch.setattr(graph.settings, "mlds_clustering_structure", True)
+    monkeypatch.setattr(graph.settings, "mlds_clustering_no_target", False)
+    monkeypatch.setattr(graph, "ChatGoogleGenerativeAI", MagicMock())
+    seed = _validate_target_semantic_coherence(
+        "Segmentación para reducir el churn",
+        {"name": _ORPHAN_TARGET, "role": "classification_target"},
+    )[0]
+
+    out = graph.schema_designer(_clustering_node_state(seed), {"configurable": {}})
+
+    warnings = out.get("data_gap_warnings") or []
+    assert any(_ORPHAN_TARGET in w for w in warnings)  # seed survives (filter off)

--- a/backend/tests/test_issue466_clustering_no_target.py
+++ b/backend/tests/test_issue466_clustering_no_target.py
@@ -35,13 +35,17 @@ from case_generator.graph import (
     _enforce_business_classification_schema,
     _enforce_mlds_classification_schema,
     _enforce_mlds_clustering_no_target,
+    _filter_clustering_target_warnings,
     _generate_dataset_from_schema,
+    _validate_schema_against_contract,
+    _validate_target_semantic_coherence,
 )
 from case_generator.prompts import EDA_ANNOTATE_ONLY_PROMPT_CLUSTERING, M3_NOTEBOOK_BASE_TEMPLATE
 from golden_eval import (
     NodeEvalInputs,
     check_clustering_eda_no_target_charts,
     check_clustering_no_target,
+    check_clustering_no_target_warnings,
     evaluate_downgrade_gate,
 )
 
@@ -457,3 +461,120 @@ def test_gate_blocks_on_clustering_chart_leak() -> None:
 def test_gate_passes_clean_defaults() -> None:
     ok = NodeEvalInputs(node="schema_designer", deterministic_pass=True)
     assert evaluate_downgrade_gate(ok).passed is True
+
+
+# ─────────────────────────── Issue #482 — target-warning leak to M2/M3 ───────────────────────────
+#
+# #466 strips the leaked target COLUMN from the clustering CSV, but the orphan
+# `contract.target_column.name` still leaks into the M2 EDA / M3-content NARRATIVE via TWO
+# data_gap_warning emitters that both end up in schema_designer's warnings_payload:
+#   (1) ARCHITECT  — `_validate_target_semantic_coherence` (fires when the TITLE has a keyword)
+#   (2) VALIDATOR  — `_validate_schema_against_contract` ("target '<name>' … no fue producido…")
+# `_filter_clustering_target_warnings` drops BOTH at the single schema_designer choke point.
+
+_ORPHAN_TARGET = "dummy_target_ignored_for_clustering"
+
+
+def _orphan_contract() -> dict:
+    """A clustering contract carrying an LLM-hallucinated supervised target (the #482 root)."""
+    return {
+        "target_column": {
+            "name": _ORPHAN_TARGET, "role": "classification_target", "dtype": "int",
+        },
+        # features present in the clustering fallback schema → no spurious feature-missing warning.
+        "feature_columns": [{"name": "recency_days"}, {"name": "monetary_value"}],
+    }
+
+
+def test_filter_drops_both_target_channels_red_then_green() -> None:
+    """RED→GREEN over the TWO REAL emitters: a churn-titled clustering case triggers the architect
+    coherence warning AND the validator missing-target warning, both naming the orphan target; the
+    filter drops both so the name disappears from the narrative-facing warnings (name-based, decoupled
+    from the filter's prefix mechanism)."""
+    schema = _clustering_schema()  # no orphan target column (clustering fallback)
+    contract = _orphan_contract()
+
+    # Channel 2 (validator): the orphan target is absent from the schema → missing-target warning.
+    missing, _leak = _validate_schema_against_contract(schema, contract)
+    # Channel 1 (architect): a title keyword ("churn") + a non-matching target → coherence warning.
+    coherence = _validate_target_semantic_coherence(
+        "Segmentación para reducir el churn", contract["target_column"]
+    )
+    # schema_designer merges the architect seed first, then the validator output (graph.py:5184-5186).
+    warnings_payload = list(coherence) + list(missing)
+
+    # RED: BOTH channels are present and name the orphan before the filter.
+    assert any(w.startswith("target_semantic_mismatch") for w in warnings_payload), "architect channel"
+    assert any(w.startswith("target '") for w in warnings_payload), "validator channel"
+    assert any(_ORPHAN_TARGET in w for w in warnings_payload)
+    assert check_clustering_no_target_warnings(warnings_payload) is False
+
+    # GREEN: the filter removes every warning that names the target.
+    filtered = _filter_clustering_target_warnings(
+        warnings_payload, profile="ml_ds", primary_family="clustering", enabled=True
+    )
+    assert not any(_ORPHAN_TARGET in w for w in filtered)
+    assert check_clustering_no_target_warnings(filtered) is True
+
+
+def test_filter_preserves_feature_and_leakage_warnings() -> None:
+    """FP guard: feature-missing and leakage warnings (prefix `feature '`) are NOT target warnings →
+    they survive the filter even alongside the dropped target warnings."""
+    feature_warning = "feature 'recency_days' (dtype=int) no fue producido por schema_designer"
+    leakage_warning = (
+        "feature 'churn_flag' marcada con riesgo de leakage (temporal_offset_months=3, "
+        "is_leakage_risk=True). El notebook M3 debe excluirla del entrenamiento."
+    )
+    target_warning = (
+        f"target '{_ORPHAN_TARGET}' (rol=classification_target, dtype=int) "
+        "no fue producido por schema_designer"
+    )
+    out = _filter_clustering_target_warnings(
+        [feature_warning, target_warning, leakage_warning],
+        profile="ml_ds", primary_family="clustering", enabled=True,
+    )
+    assert out == [feature_warning, leakage_warning]  # target dropped, features preserved
+
+
+@pytest.mark.parametrize(
+    "profile,family,enabled",
+    [
+        ("ml_ds", "clustering", False),    # kill-switch off → byte-idéntico a pre-#466
+        ("business", "clustering", True),   # business+clustering (#317 lane)
+        ("ml_ds", "clasificacion", True),   # otra familia
+        ("ml_ds", "regresion", True),       # otra familia
+    ],
+)
+def test_filter_noop_returns_same_object(profile: str, family: str, enabled: bool) -> None:
+    warnings = [
+        f"target '{_ORPHAN_TARGET}' (rol=classification_target) no fue producido por schema_designer",
+        f"target_semantic_mismatch: el título sugiere [churn] … target_column.name='{_ORPHAN_TARGET}'.",
+        "feature 'x' (dtype=int) no fue producido por schema_designer",
+    ]
+    out = _filter_clustering_target_warnings(
+        warnings, profile=profile, primary_family=family, enabled=enabled
+    )
+    assert out is warnings  # mismo objeto → byte-idéntico
+
+
+def test_check_clustering_no_target_warnings_red_green() -> None:
+    assert check_clustering_no_target_warnings(None) is True
+    assert check_clustering_no_target_warnings([]) is True
+    assert check_clustering_no_target_warnings(
+        ["feature 'recency_days' (dtype=int) no fue producido por schema_designer"]
+    ) is True
+    assert check_clustering_no_target_warnings(
+        [f"target '{_ORPHAN_TARGET}' (rol=…) no fue producido por schema_designer"]
+    ) is False
+    assert check_clustering_no_target_warnings(
+        [f"target_semantic_mismatch: … target_column.name='{_ORPHAN_TARGET}' …"]
+    ) is False
+
+
+def test_gate_blocks_on_clustering_target_warning_leak() -> None:
+    fail = NodeEvalInputs(
+        node="schema_designer", deterministic_pass=True, clustering_no_target_warning_ok=False
+    )
+    res = evaluate_downgrade_gate(fail)
+    assert res.passed is False
+    assert any("names a stripped supervised target" in r for r in res.reasons)


### PR DESCRIPTION
## Qué y por qué

`Closes #482` (P3, follow-up de #466, epic #458 ml_ds+clustering).

En el caso live "LogiFlow", #466 ya elimina la columna target del CSV de clustering, pero la narrativa de **M2 EDA** y **M3-content** todavía mencionaba `dummy_target_ignored_for_clustering` («Brechas de datos detectadas: se detectó la variable …») → el estudiante leía una columna ausente del dataset que descarga.

## Root cause (verificado, NO el de la hipótesis del issue)

El nombre huérfano del contrato (`dataset_schema_required.target_column.name`, LLM-emitido porque el campo es **requerido** en Pydantic) llega a la narrativa por **DOS** emisores de `data_gap_warning`, ambos fusionados en el `warnings_payload` de `schema_designer`:

1. **Validador** `_validate_schema_against_contract` → `"target '<name>' … no fue producido…"` (determinista, todo caso stripeado).
2. **Architect** `_validate_target_semantic_coherence` → `"target_semantic_mismatch: … target_column.name='…'"` — **ungated por familia**, dispara cuando el TÍTULO trae un keyword (`churn`, `fraude`, `ventas`, `satisfacción`…). Una primera versión que solo limpiaba el validador habría dejado este canal abierto en producción.

M2 EDA recibe el nombre SOLO por `{data_gap_warnings_block}`; M3-content lo hereda vía `contexto_m2`; el notebook lee el mismo `data_gap_warnings` persistido.

## Fix

`_filter_clustering_target_warnings` en el **único choke point** de `schema_designer` (tras fusionar todos los warnings, en happy + fallback paths — clustering corre el fallback por #477). Cierra ambos canales a la vez.

- **Gateado** a `ml_ds + clustering` + kill-switch reutilizado `MLDS_CLUSTERING_NO_TARGET` (#466). Fuera del cohorte / switch off → devuelve el **mismo objeto** (byte-idéntico).
- **Prefix-based** sobre las dos únicas formas que nombran el target (`target '` / `target_semantic_mismatch`) → **cero FP**: los warnings de `feature '…'` / leakage se preservan.
- **Sin** clave canónica/state nueva, sin tocar el contrato (evita el riesgo del campo Pydantic requerido), sin migración/frontend/architect-SHA. Reusa `data_gap_warnings`, que `schema_designer` ya escribe → sin nueva superficie de resume/fan-out.

## Tests / verificación

- Golden oracle `check_clustering_no_target_warnings` + `NodeEvalInputs.clustering_no_target_warning_ok` cableado en `evaluate_downgrade_gate` (espeja el patrón #466).
- TEST-FIRST en `test_issue466_clustering_no_target.py`: RED→GREEN sobre los **dos emisores reales** (título con "churn" → architect; schema stripeado → validador), FP-guard (feature/leakage se conservan), noop byte-idéntico (otras familias + switch off), oracle RED/GREEN, gate.
- `uv run --directory backend pytest` sobre las superficies tocadas: **136 passed**. `mypy src`: **limpio**.

### Out of scope (documentado)
- El `{dataset_contract_block}` (JSON) del notebook M3 sigue mostrando el target → aceptado por el issue como belt-and-suspenders (el prompt ordena "IGNÓRALO").
- Hacer `target_column` Optional en el contrato (la raíz-raíz) → requiere ADR (blast-radius en clasificación/regresión).

### Verificación LIVE pendiente (merge ≠ deploy)
Regenerar 1 caso ml_ds+K-Means con un título con keyword (p.ej. "Segmentación para reducir el churn") y confirmar que M1/M2/M3-content y el CSV no mencionan la columna ausente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)