### PR TITLE
feat(m525): sube dataset ml_ds+clasificación de 600 → 1000 filas (LR/RF)

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -3648,6 +3648,12 @@ _CLUSTERING_SEGMENTATION_COLUMNS: tuple[dict, ...] = (
 # deterministic band-lock tests; gated by `MLDS_CLUSTERING_STRUCTURE` (OFF → 200 generic ml_ds).
 _MLDS_CLUSTERING_MAX_ROWS = 1000
 
+# Row count for the ml_ds + clasificación dataset (Issue #525; 600 → 1000). More rows give LR/RF more
+# signal (AUC equal-or-better, bounded above by the target's noise_factor → no "too-perfect" degeneration).
+# 1000 ≤ 2000, so the notebook GridSearchCV cascade (#240) stays on the full-tuning branch — no behaviour
+# change. Sibling of `_MLDS_CLUSTERING_MAX_ROWS`; monotonic-safe constant, revert = git (no kill-switch).
+_MLDS_CLASSIFICATION_MAX_ROWS = 1000
+
 
 def _build_clustering_fallback_schema(max_rows: int) -> dict:
     """Entity-level segmentation fallback schema for ml_ds + clustering (Issue #452).
@@ -5492,15 +5498,15 @@ def schema_designer(state: ADAMState, config: RunnableConfig) -> dict:
     # (the resolved family, not "") gates that spine.
     _effective_family = (primary_family or "clasificacion") if profile == "ml_ds" else ""
 
-    # ml_ds+clasificacion: 600 filas (Issue #240 cascade: 600 ≤ 2000 → full GridSearchCV).
+    # ml_ds+clasificacion: 1000 filas (Issue #525, antes 600; cascada #240: 1000 ≤ 2000 → full GridSearchCV).
     # ml_ds+clustering: 1000 filas (Issue #468 — entity-level segmentation needs more points than
     #   the 12-D K-Means fit had at 200; recalibrated band). Gated por el switch → OFF = 200 genérico.
     # ml_ds+otras familias: 200 filas — el GridSearchCV size cascade es exclusivo del
-    # notebook de clasificacion; regresion no necesita 600 filas.
+    # notebook de clasificacion; regresion no necesita 1000 filas.
     # business: 100 (midpoint de 80-120; el LLM elige n_rows estrictamente entre 80-120).
     _is_clasificacion_ml = profile == "ml_ds" and _effective_family == "clasificacion"
     if _is_clasificacion_ml:
-        max_rows = 600
+        max_rows = _MLDS_CLASSIFICATION_MAX_ROWS
     elif _effective_family == "clustering" and settings.mlds_clustering_structure:
         max_rows = _MLDS_CLUSTERING_MAX_ROWS
     elif profile == "ml_ds":

--- a/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/dataset.py
+++ b/backend/src/case_generator/prompts/clasificacion/M2_clasificacion/dataset.py
@@ -12,7 +12,7 @@ Specialised for binary classification — dilemma-aware (Issue #382 de-churn):
   and which omits the churn/SaaS template columns.
 - The binary target is always ``int`` (0/1) with a ``dependency`` so LR/RF receive a
   signal-bearing target (AUC-ROC ≥ 0.70) instead of a random categorical string.
-- n_rows = {max_rows} (600 for ml_ds) → Issue #240 cascade: 600 ≤ 2000 → full GridSearchCV.
+- n_rows = {max_rows} (1000 for ml_ds, Issue #525) → Issue #240 cascade: 1000 ≤ 2000 → full GridSearchCV.
 
 The deterministic post-LLM sibling ``_enforce_mlds_classification_schema`` (graph.py) is the
 GUARANTEE for the de-churned signal: for a non-retention ml_ds target it re-points the driver to

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -22,7 +22,7 @@ _MAX_BUSINESS_COST = 1_000_000_000.0
 _MAX_BUSINESS_COST_RATIO = 1_000.0
 
 # Issue F1 — prevalencia del evento objetivo anunciada en Exhibit 2. Un evento de
-# clasificación debe ser una minoría aprendible: piso 1% (≥1 positivo a n=600), techo 50%
+# clasificación debe ser una minoría aprendible: piso 1% (≥10 positivos a n=1000), techo 50%
 # (un evento "raro" no debería ser mayoría; > 0.5 sería el complemento).
 _MIN_TARGET_EVENT_RATE = 0.01
 _MAX_TARGET_EVENT_RATE = 0.50

--- a/backend/tests/test_issue347_mlds_target_signal_guard.py
+++ b/backend/tests/test_issue347_mlds_target_signal_guard.py
@@ -70,7 +70,8 @@ _FRAUD_CONTRACT = {
 
 _TARGET = "fraud_flag"
 _RATE = 0.08
-_N_ROWS = 600  # ml_ds + clasificación: cascada GridSearchCV #240 (no cambia).
+_N_ROWS = 600  # Fixture DESACOPLADO de la constante de producción `_MLDS_CLASSIFICATION_MAX_ROWS`
+# (=1000 desde #525). Los invariantes de de-churn/AUC de abajo son agnósticos al conteo de filas.
 _AUC_FLOOR = 0.55  # espeja el piso del gate del ejecutor (m3_notebook_execution.py:477).
 
 
@@ -139,8 +140,10 @@ def test_contract_target_is_binary_with_dependency() -> None:
     )
 
 
-def test_row_count_is_600_for_mlds_classification() -> None:
-    """Línea roja #347: el conteo de filas ml_ds+clf (cascada #240) no cambia."""
+def test_fallback_schema_honors_requested_row_count() -> None:
+    """Integridad del pipeline: `_build_fallback_schema` produce EXACTAMENTE las filas pedidas
+    (`_N_ROWS`). NO es un candado del conteo de PRODUCCIÓN — ese vive en
+    `_MLDS_CLASSIFICATION_MAX_ROWS` (=1000 desde #525), desacoplado de este fixture."""
     assert _build_mlds_nonchurn_schema()["n_rows"] == _N_ROWS
 
 

--- a/backend/tests/test_issueR2_mlds_target_identity.py
+++ b/backend/tests/test_issueR2_mlds_target_identity.py
@@ -208,7 +208,7 @@ def test_other_family_is_byte_identical_noop() -> None:
 
 
 def test_align_handles_none_family_for_ml_ds() -> None:
-    # schema_designer trata ml_ds+None como 'clasificacion' (categoria, 600 filas);
+    # schema_designer trata ml_ds+None como 'clasificacion' (categoria, 1000 filas);
     # _align DEBE reconciliar también con primary_family=None (si no, leakage duplicado).
     schema = _ml_ds_fixed_schema()
     aligned = _align_ml_ds_classification_target(


### PR DESCRIPTION
## Qué

Sube el dataset sintético de **ml_ds + clasificación** (el que entrenan LR y RF en el notebook M3) de **600 → 1000 filas**, vía el nuevo named constant `_MLDS_CLASSIFICATION_MAX_ROWS` en `schema_designer` (hermano de `_MLDS_CLUSTERING_MAX_ROWS`). Resuelve #525.

## Por qué es seguro (auditado contra el código, no asumido)

Único cambio funcional: una constante. Todo lo downstream lee el conteo en runtime, así que no hay `600` quemado que actualizar:

| Riesgo | Veredicto |
|---|---|
| Fuga de `600` a narrativa/EDA/charts/notebook | NO — `len(df)` / `{dataset_total_rows}` / muestra de 30 filas (cost-neutral) |
| Rompe un test | NO — todo test pasa su **propio** 600; ninguno lee la constante de producción |
| Cruza un umbral de tuning | NO — 600 y 1000 ambos `≤2000` → misma rama `cv=5, n_iter=10` (n_train=800) |
| Validador rechaza 1000 | NO — `_MIN_TARGET_EVENT_RATE` es por tasa; sin tope de filas |
| StratifiedKFold/split | Más seguro con más filas (min-class crece) |
| Frontend | Sin cambios (render genérico de `datasetRows`) |
| Golden fixtures (g13) | Sin assert de `n_rows`; rebuild verifica coherencia de dominio (agnóstica al conteo) |
| Determinismo/resume | OK — seed = hash del schema; prevalencia top-k por tasa; Exhibit 1 preservado por `scale=expected/actual` |

Más filas = más señal para LR/RF (AUC igual-o-mejor, acotada arriba por el `noise_factor` del target → sin degeneración "demasiado perfecta").

## Higiene en el mismo PR (cero deuda técnica)

- Comentarios stale `600`→`1000`: `graph.py` (bloque cascada #240), docstring de `dataset.py`, `tools_and_schemas.py`.
- Test `test_row_count_is_600_for_mlds_classification` → renombrado a `test_fallback_schema_honors_requested_row_count`; su `_N_ROWS` sigue en **600** como fixture DESACOPLADO (los invariantes de de-churn/AUC son agnósticos al conteo — bumpearlo arriesgaría el assert de banda AUC sin ganancia).
- Comentario stale en `test_issueR2`.

Sin nueva clave canónica/state, sin migración Alembic, sin cambio de frontend, sin tocar el SHA del architect. Solo afecta **casos NUEVOS**.

## Validación

- `uv run --directory backend pytest -q` → **3199 passed, 26 skipped**
- `uv run --directory backend mypy src` → **limpio** (114 archivos)
- `/review` (pre-landing) → **sin hallazgos**; pase adversarial independiente APPROVE (6 ejes verificados contra los bytes del diff)

## merge ≠ deploy (no-bloqueante)

Post-deploy: verificación LIVE de un caso ml_ds+clf con LR y con RF para confirmar AUC ∈ `[0.55, 0.99]`. El gate de AUC es **no-bloqueante** (degrada, no falla el job); más filas solo deberían ayudar.

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
