### PR TITLE
refactor(case_generator): consolidate accent-folding into one shared fold_accents helper

### DIFF
--- a/backend/src/case_generator/graph.py
+++ b/backend/src/case_generator/graph.py
@@ -63,7 +63,6 @@ import re
 import textwrap
 import threading
 import time
-import unicodedata
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -276,6 +275,7 @@ from case_generator.m3_notebook_execution import (
     scrub_notebook_for_safe_execution,
 )
 from case_generator.m3_notebook_repair import repair_locals_existence_guards
+from case_generator.text_normalize import fold_accents
 from case_generator.tools_and_schemas import (
     CaseArchitectOutput,
     EDAAnnotateOnlyOutput,
@@ -8564,11 +8564,7 @@ def _is_markdown_separator_row(cells: list[str]) -> bool:
 
 def _normalize_m5_matrix_header_cell(cell: str) -> str:
     compact = " ".join(cell.lower().split())
-    without_accents = "".join(
-        char
-        for char in unicodedata.normalize("NFKD", compact)
-        if not unicodedata.combining(char)
-    )
+    without_accents = fold_accents(compact)
     return _M5_DECISION_MATRIX_HEADER_ALIASES.get(without_accents, without_accents)
 
 

--- a/backend/src/case_generator/impact_lens.py
+++ b/backend/src/case_generator/impact_lens.py
@@ -28,8 +28,9 @@ test ``test_impact_lens`` asserts every value AND label maps.
 
 from __future__ import annotations
 
-import unicodedata
 from typing import Literal, cast
+
+from case_generator.text_normalize import fold_accents
 
 # ── Lens keys (the canonical catalog of 5, Issue #437 decision D-B + Issue #505) ─
 IMPACT_LENS_FINANCIAL_ROI = "financial_roi"
@@ -139,9 +140,7 @@ _INDUSTRY_LENS_BY_KEY: dict[str, str] = {
 
 def _normalize_industry(raw: str) -> str:
     """Casefold + strip diacritics so 'Salud & Medicina' / 'salud' / 'SALUD' match."""
-    decomposed = unicodedata.normalize("NFKD", raw)
-    stripped = "".join(c for c in decomposed if not unicodedata.combining(c))
-    return stripped.strip().casefold()
+    return fold_accents(raw).strip().casefold()
 
 
 def resolve_impact_lens_from_industry(raw: str | None) -> str:

--- a/backend/src/case_generator/m1_dataset_coherence.py
+++ b/backend/src/case_generator/m1_dataset_coherence.py
@@ -48,13 +48,13 @@ Design invariants (acceptance):
 from __future__ import annotations
 
 import re
-import unicodedata
 from collections.abc import Iterable, Mapping
 
 # Reuse the M1-grounding number primitives (single source of truth for the Spanish
 # thousands-vs-decimal grammar + magnitude scale). m1_grounding is pure and never
 # imports the graph, so this stays import-light and graph-free too.
 from case_generator.m1_grounding import _mag_scale, _normalize_core
+from case_generator.text_normalize import fold_accents
 
 # ── Violation prefixes ─────────────────────────────────────────────────────────
 ENTITY_MISMATCH = "ENTITY_MISMATCH:"
@@ -158,14 +158,6 @@ _DISTRIB_NOUN_RE = re.compile(
 )
 
 
-def _fold_accents(text: str) -> str:
-    """Strip combining accents (NFD), preserving case. ``región`` → ``region``."""
-    return "".join(
-        ch for ch in unicodedata.normalize("NFD", text)
-        if unicodedata.category(ch) != "Mn"
-    )
-
-
 def _entity_roots(entity_descriptor: Mapping[str, object] | None) -> list[str]:
     """Accent-folded, lowercased, non-empty {snake_prefix, singular, plural} roots."""
     if not isinstance(entity_descriptor, Mapping):
@@ -176,7 +168,7 @@ def _entity_roots(entity_descriptor: Mapping[str, object] | None) -> list[str]:
         if isinstance(value, str) and value.strip():
             # Use the first token (the head noun) so a multi-word entity
             # ("centro de distribución") still matches the captured single noun.
-            head = _fold_accents(value.strip().lower()).split()[0]
+            head = fold_accents(value.strip().lower()).split()[0]
             if len(head) >= 3 and head not in roots:
                 roots.append(head)
     return roots
@@ -318,7 +310,7 @@ def validate_m1_dataset_coherence(
     if not prose or not isinstance(prose, str):
         return []
     try:
-        folded = _fold_accents(prose)
+        folded = fold_accents(prose)
         violations: list[str] = []
         roots = _entity_roots(entity_descriptor)
         if roots:

--- a/backend/src/case_generator/m4_grounding.py
+++ b/backend/src/case_generator/m4_grounding.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import logging
 import re
-import unicodedata
 
 from case_generator.narrative_grounding import (
     _FALLBACK_MARKER,
@@ -34,6 +33,7 @@ from case_generator.narrative_grounding import (
     detect_unselected_model_mentions,
     has_metric_anchors,
 )
+from case_generator.text_normalize import fold_accents
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +53,7 @@ _LEADING_SECTION_NUM_RE = re.compile(r"^\d+(?:\.\d+)*[.)]?\s*")
 
 def _normalize_heading(title: str) -> str:
     """Lowercase, strip accents, drop closing-ATX hashes + a leading section number, collapse spaces."""
-    decomposed = unicodedata.normalize("NFKD", title)
-    no_accents = "".join(c for c in decomposed if not unicodedata.combining(c))
+    no_accents = fold_accents(title)
     # rstrip trailing closing-ATX hashes/spaces ("## Title ##" → "title"); harmless for our
     # Spanish deployment-heading substring match (no legitimate title ends in '#').
     cleaned = no_accents.lower().strip().rstrip("# \t").strip()
@@ -147,8 +146,7 @@ def _normalize_chart_text(value: object) -> str:
     """Lowercase + strip accents from a chart text field. Non-str / None → empty string."""
     if not isinstance(value, str):
         return ""
-    decomposed = unicodedata.normalize("NFKD", value)
-    return "".join(c for c in decomposed if not unicodedata.combining(c)).lower()
+    return fold_accents(value).lower()
 
 
 def is_sensitivity_chart(chart: object) -> bool:

--- a/backend/src/case_generator/narrative_grounding.py
+++ b/backend/src/case_generator/narrative_grounding.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import logging
 import math
 import re
-import unicodedata
 from collections.abc import Mapping, Sequence
 from numbers import Real
 from typing import Any
@@ -20,6 +19,7 @@ from case_generator.prompts import (
     CLASSIFICATION_NOTEBOOK_VARIANT_LR_ONLY,
     CLASSIFICATION_NOTEBOOK_VARIANT_RF_ONLY,
 )
+from case_generator.text_normalize import fold_accents
 
 logger = logging.getLogger(__name__)
 
@@ -693,11 +693,7 @@ def _is_markdown_separator_row(cells: list[str]) -> bool:
 
 def _normalize_table_cell(cell: str) -> str:
     compact = " ".join(cell.lower().split())
-    return "".join(
-        char
-        for char in unicodedata.normalize("NFKD", compact)
-        if not unicodedata.combining(char)
-    )
+    return fold_accents(compact)
 
 
 def _normalize_m5_decision_matrix_header_cell(cell: str) -> str:

--- a/backend/src/case_generator/text_normalize.py
+++ b/backend/src/case_generator/text_normalize.py
@@ -1,0 +1,28 @@
+"""Shared text-normalization helpers for ``case_generator`` (stdlib-only, cycle-free)."""
+
+from __future__ import annotations
+
+import unicodedata
+
+__all__ = ["fold_accents"]
+
+
+def fold_accents(text: str) -> str:
+    """Strip diacritical marks from ``text``, preserving case and every other character.
+
+    ``café`` -> ``cafe``, ``región`` -> ``region``, ``NIÑO`` -> ``NINO``. Non-Latin characters
+    (CJK, emoji) are kept untouched; callers that need a pure-ASCII result chain
+    ``.encode("ascii", "ignore")`` after this.
+
+    Uses NFKD decomposition followed by removal of combining marks. NFKD (not NFD) is deliberate:
+    it keeps the two ASCII-fold call sites that post-compose this with ``.encode("ascii", "ignore")``
+    byte-for-byte unchanged — the ascii-encode already drops every combining mark, and NFKD
+    reproduces the compatibility decomposition (``ﬁ`` -> ``fi``) those sites applied inline. For the
+    Spanish diacritics the project actually folds (á é í ó ú ñ ü) NFD and NFKD are identical; NFKD
+    additionally folds compatibility characters, which is inert for the fuzzy-matching callers (they
+    lower-case and compare against ASCII constants) and was already the form in 7 of the 8 inline
+    copies this consolidates.
+    """
+    return "".join(
+        ch for ch in unicodedata.normalize("NFKD", text) if not unicodedata.combining(ch)
+    )

--- a/backend/src/case_generator/tools_and_schemas.py
+++ b/backend/src/case_generator/tools_and_schemas.py
@@ -6,12 +6,12 @@ that feed the teacher preview and downstream synthesis steps.
 
 import math
 import re
-import unicodedata
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from case_generator.impact_lens import DEFAULT_IMPACT_LENS, normalize_impact_lens
+from case_generator.text_normalize import fold_accents
 
 
 # USD-only product (Issue #370): el producto opera exclusivamente en dólares. Este sigue siendo
@@ -365,9 +365,9 @@ def _sanitize_entity_prefix(raw: object) -> str | None:
     """
     if not isinstance(raw, str):
         return None
-    # NFKD → drop combining marks → ASCII (accent-fold), lowercase.
+    # fold_accents (NFKD) → drop remaining non-ASCII → lowercase (accent-fold to a safe stem).
     ascii_only = (
-        unicodedata.normalize("NFKD", raw)
+        fold_accents(raw)
         .encode("ascii", "ignore")
         .decode("ascii")
         .lower()

--- a/backend/tests/golden_eval.py
+++ b/backend/tests/golden_eval.py
@@ -25,7 +25,6 @@ executes only under RUN_LIVE_LLM_TESTS with a configured job runner.
 from __future__ import annotations
 
 import re
-import unicodedata
 from dataclasses import dataclass, field
 
 # ── gate thresholds (5A) ─────────────────────────────────
@@ -1075,12 +1074,9 @@ _ENTITY_ID_VALUE_RE = re.compile(r"^[a-z][a-z0-9_]*_\d{4,}$")
 
 def _fold_accents(text: str) -> str:
     """Lowercase + strip accents (NFKD → ASCII) for accent-insensitive narrative matching (#513)."""
-    return (
-        unicodedata.normalize("NFKD", text)
-        .encode("ascii", "ignore")
-        .decode("ascii")
-        .lower()
-    )
+    from case_generator.text_normalize import fold_accents
+
+    return fold_accents(text).encode("ascii", "ignore").decode("ascii").lower()
 
 
 def check_clustering_entity_index(rows: list) -> bool:

--- a/backend/tests/test_text_normalize.py
+++ b/backend/tests/test_text_normalize.py
@@ -1,0 +1,61 @@
+"""Characterization tests for the shared ``fold_accents`` helper.
+
+Locks the contract every call site depends on after the consolidation: strip diacritics,
+preserve case and non-accent characters, and the deliberate NFKD compatibility behavior
+(so the ``.encode("ascii","ignore")`` call sites stay byte-identical).
+"""
+
+import pytest
+
+from case_generator.text_normalize import fold_accents
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Spanish diacritics — the folding the project actually relies on.
+        ("café", "cafe"),
+        ("región", "region"),
+        ("millón", "millon"),
+        ("áéíóúüñ", "aeiouun"),
+        # Case is preserved (callers apply their own .lower()/.casefold()).
+        ("NIÑO", "NINO"),
+        ("Ñ", "N"),
+        # A pre-decomposed sequence (base + combining acute) folds to the base.
+        ("é", "e"),
+        # No-op on already-folded ASCII (incl. the m1 currency-shape that must stay inert).
+        ("", ""),
+        ("$135.000 por centro", "$135.000 por centro"),
+    ],
+)
+def test_fold_accents_strips_diacritics_preserving_case(raw: str, expected: str) -> None:
+    assert fold_accents(raw) == expected
+
+
+@pytest.mark.parametrize("text", ["日本", "☕", "café日本☕"])
+def test_fold_accents_preserves_non_latin_characters(text: str) -> None:
+    # NFKD + combining-mark removal keeps CJK/emoji (they carry no combining marks); only the
+    # accented "é" in the mixed string is folded.
+    assert fold_accents("café日本☕") == "cafe日本☕"
+    # Pure non-Latin input is returned unchanged.
+    if "café" not in text:
+        assert fold_accents(text) == text
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # NFKD (not NFD) deliberately folds compatibility characters too. This is what keeps the
+        # _sanitize_entity_prefix / golden_eval _fold_accents ascii-encode sites byte-identical.
+        ("²", "2"),
+        ("ﬁ", "fi"),
+    ],
+)
+def test_fold_accents_applies_nfkd_compatibility_folding(raw: str, expected: str) -> None:
+    assert fold_accents(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["café", "región", "NIÑO", "²", "ﬁ", "日本", "é", ""])
+def test_fold_accents_is_idempotent(raw: str) -> None:
+    once = fold_accents(raw)
+    assert fold_accents(once) == once


### PR DESCRIPTION
## What & why

Accent-folding (Unicode decompose + strip combining marks) was reimplemented inline in **8 places** across the backend (7 in `case_generator/` + `tests/golden_eval.py`), having drifted apart over time: some `NFD`, most `NFKD`; some filtered by `combining()`, one by `category != "Mn"`; two used `.encode("ascii","ignore")`. Pre-existing package-wide tech debt surfaced by the #515 pre-landing review and deliberately deferred to keep that PR surgical.

This extracts **one** pure, stdlib-only helper `case_generator/text_normalize.py::fold_accents` (NFKD + drop combining marks, case-preserving) and routes every site through it, removing the duplicate copies and the now-unused `import unicodedata`. Net **-23 lines**.

## Behavior preservation

| Sites | Form before | Result |
|---|---|---|
| 5 (`graph`, `impact_lens`, `m4_grounding` x2, `narrative_grounding`) | NFKD + `combining()` | **byte-identical** (brute-forced over the BMP) |
| 2 (`tools_and_schemas._sanitize_entity_prefix`, `golden_eval._fold_accents`) | NFKD + `.encode("ascii","ignore")` | **provably identical** (ascii-encode subsumes the combining filter) |
| 1 (`m1_dataset_coherence`) | **NFD** + `category!="Mn"` | NFKD widening (see below) |

**Honest disclosure (not literally "zero behavior change" at the m1 site):** consolidating the one NFD copy onto NFKD also normalizes compatibility/fullwidth forms. The only observable effect: the M1 currency-fabrication guard now also catches **fullwidth** currency glyphs (fullwidth `$`, fullwidth `USD`, fullwidth `,`) the NFD path missed. This is a deliberate, **gated** (ml_ds+clustering), **best-effort** (wrapped, never fails a job) widening that catches *more* of the fabrication it targets, with worst-case one extra reprompt — and it triggers only on glyphs realistic Spanish LLM prose does not produce. Verified end-to-end. Chosen NFKD because it is the form 7 of 8 copies already used and the only one that keeps the two ASCII-fold sites byte-identical.

## Scope

No prompt / contract / schema / migration / frontend change. No new canonical/state key, no `case_sanitization` entry, no kill-switch (a zero-runtime-config refactor; rollback = `git revert`). Adds `tests/test_text_normalize.py` locking the contract.

## Verification

- Full backend suite: **3280 passed, 26 skipped, 0 failed**
- `mypy src`: clean (116 files)
- `ruff` delta on touched files: **zero new** I001/F401/D; one pre-existing-pattern E402 in `graph.py` (its `case_generator` imports already sit below a `logger =` line; not CI-gated)
- Two independent fresh-context adversarial reviews (correctness + completeness): both "merge as-is"; the m1 NFKD finding above was surfaced by review and verified against ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
