### PR TITLE
fix(m3-questions): notebook rf_only cita importancias por impureza, no permutación (ml_ds+RF)

### DIFF
--- a/backend/src/case_generator/prompts/clasificacion/M3_clasificacion/notebook_questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M3_clasificacion/notebook_questions.py
@@ -15,7 +15,9 @@ single-model executor cell does not export it), injected by the node for Q4's "s
 Two variants, one per LIVE single-model path. Each template names ONLY its model (leak-safe by
 construction — the asymmetric output guard ``detect_unselected_model_mentions`` (#337) is the runtime
 backstop): ``lr_only`` frames the top features as odds ratios / coefficients (direction = sign);
-``rf_only`` frames them as permutation importances (magnitude). ``lr_rf_contrast`` is OUT OF SCOPE
+``rf_only`` frames them as impurity-based feature importances (``feature_importances_``; magnitude,
+no direction — this is what the executed RF cell actually computes, NOT permutation importance,
+which #353 removed from the notebook core). ``lr_rf_contrast`` is OUT OF SCOPE
 (replay-only; the node omits the 2 questions for it).
 
 Q4 (evaluation) reads the real AUC vs the ``DummyClassifier`` baseline and the confusion matrix
@@ -131,7 +133,7 @@ esperado, no contra una corrida desconocida.
 - AUC-ROC del baseline (DummyClassifier): {auc_dummy}
 - F1 (macro) del mejor modelo: {f1}
 - Prevalencia del evento (proporción de la clase positiva): {prevalence}
-- Top features por peso (importancias de permutación del Random Forest): {top_features_display}
+- Top features por peso (importancias por impureza / feature_importances_ del Random Forest): {top_features_display}
 
 # Matriz de costos del caso (premisa del enunciado — ancla de la P5)
 {cost_matrix_block}
@@ -166,7 +168,7 @@ esperado, no contra una corrida desconocida.
   confusión de forma CUALITATIVA: más falsos positivos = más acciones innecesarias; más falsos
   negativos = más omisiones. Cita el AUC REAL {auc} EXACTAMENTE; NUNCA inventes otro número de métrica.
 - **P5 (numero 5 — synthesis — top features → decisión de negocio):**
-  Pide al estudiante que, leyendo la tabla de importancias de permutación de SU notebook, identifique
+  Pide al estudiante que, leyendo la tabla de importancias por impureza de SU notebook, identifique
   cuál feature pesa más y, apoyándose en el EDA del Módulo 2, en qué SENTIDO se asocia con el evento;
   conecte esa palanca con la matriz de costos (costo de acción innecesaria vs. costo de omisión) y
   proponga una acción o un ajuste de umbral, ligándolo al dilema del Módulo 1.

--- a/backend/tests/test_issue493_clf_notebook_questions.py
+++ b/backend/tests/test_issue493_clf_notebook_questions.py
@@ -236,6 +236,30 @@ class TestVariantDispatch:
         assert "Random Forest" not in LR and "RandomForest" not in LR
         assert "Logistic" not in RF and "Regresión Logística" not in RF
 
+    def test_rf_prompt_names_impurity_importance_not_permutation(self) -> None:
+        """The rf_only question must describe the SAME feature-importance artifact the student sees.
+
+        The executed RF notebook cell (`pipeline_rf`) derives `perm_df` from
+        `feature_importances_` (impurity-based) and prints "Top feature importances (RF):" with the
+        note "importancia por impureza"; #353 REMOVED the `interp_rf` permutation-importance cell
+        from the notebook core (`test_m3_rf_notebook_production_quality.py` even forbids
+        "permutation importance" in the comparison cell). So the question prompt must frame the
+        table as impurity importances — never "importancias de permutación", a technique the
+        student's notebook no longer computes (the original #493 mislabel).
+        """
+        from case_generator.prompts import (
+            M3_NOTEBOOK_QUESTIONS_PROMPT_CLASSIFICATION_LR_ONLY as LR,
+            M3_NOTEBOOK_QUESTIONS_PROMPT_CLASSIFICATION_RF_ONLY as RF,
+        )
+
+        # RF: matches the notebook's real artifact, never the removed permutation cell.
+        assert "feature_importances_" in RF
+        assert "impureza" in RF.lower()
+        assert "permutaci" not in RF.lower() and "permutation" not in RF.lower()
+        # LR: still framed as odds ratios / coefficients (direction = sign), untouched.
+        assert "odds ratios" in LR.lower() and "coeficiente" in LR.lower()
+        assert "permutaci" not in LR.lower()
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 4. Context builder — strip + injection


### PR DESCRIPTION
## Qué

Corrige una **incoherencia student-facing** en las preguntas output-grounded de M3 (Issue #493) para la combinación **ml_ds + Random Forest** (variante `rf_only`). Alcance: solo M2/M3 questions + soluciones esperadas para ml_ds+RF.

## Por qué (root cause)

El prompt `M3_NOTEBOOK_QUESTIONS_PROMPT_CLASSIFICATION_RF_ONLY` le decía al estudiante que leyera *"la tabla de **importancias de permutación**"* de su notebook. Pero:

- La celda ejecutada `pipeline_rf` computa `_imp_rf = ...feature_importances_` (importancia por impureza/MDI) e **imprime** `"Top feature importances (RF):"` — con el comentario interno *"feature_importances_ del RF, sin permutation_importance"*.
- La nota de la tabla comparativa dice `"feature_importances_ del bosque (importancia por impureza)"`.
- La celda `permutation_importance` (`interp_rf`) fue **removida del núcleo por #353** (los tests de calidad del notebook RF incluso prohíben `"permutation importance"`).

El estudiante leía una técnica que su propio notebook ya no produce → incoherencia directa entre la pregunta y el artefacto que califica el docente.

## Qué cambia (prompt-only, solo `rf_only`)

- **Docstring** + **ancla de grounding "Resultados REALES"** (`:135`, contexto del LLM): `"importancias de permutación"` → `"importancias por impureza / feature_importances_"` — espejo de la nota de la tabla comparativa que el estudiante sí ve.
- **Guía del enunciado de P5** (student-facing): concepto limpio `"importancias por impureza"`, **simétrico con el LR** (`"odds ratios / coeficientes"`, sin atributo crudo) — la prosa del estudiante queda sin jerga sklearn, el término preciso vive en el ancla de grounding + docstring.
- `lr_only` **intacto** (sigue `"odds ratios / coeficientes"`).
- Drift-lock nuevo en `test_issue493_clf_notebook_questions.py`.

## Por qué es zero-risk

- **Prompt-string-only**: sin cambio de schema, claves canónicas/student-facing, `case_sanitization`, state, migración, frontend, ni el SHA del architect.
- Contrato de **12 placeholders intacto** (KeyError-proof); `.format()` brace-safe.
- Cero fuga de modelo (RF no nombra Logistic Regression); detectores de grounding (`detect_unanchored_adjacent_metrics`, `detect_unselected_model_mentions`) **inertes** a los tokens nuevos (verificado contra las regex reales).
- `feature_importances_` es exactamente lo que el notebook **ya muestra** al estudiante (no es jerga interna oculta como `num__`/`fp_cost`).
- Casos ya generados **NO** se reprocesan.

## Validación

- `pytest` (superficies afectadas + slice de grounding/coherencia): **330 + 254 passed, 0 failures** (el único fallo observado fue un `ModuleNotFoundError` de subproceso por un workaround `PYTHONPATH` local, resuelto con editable-install; no relacionado). Incluye el drift-lock nuevo + **ejecución real del notebook RF** (fraud/credit/environmental) confirmando `feature_importances_`.
- `mypy src`: clean (121 files).
- **Revisión adversarial multi-agente (6 agentes, 5 lentes independientes + árbitro): GO, cero issues P0/P1/P2.** El árbitro re-derivó cada claim del código fuente.

## Follow-ups documentados (fuera de alcance, pre-existentes)

- Conceptual P2 (`_M3_CLASSIFICATION_QUESTIONS_BLOCK_RF_ONLY`): la premisa *"RF tiende a favorecer la clase mayoritaria"* convive con `class_weight="balanced"` del notebook — defendible como pedagogía (el estudiante debe reconocer el balanceo como mitigación); no se toca.
- Variable interna `perm_df` (no student-visible) podría renombrarse a `imp_df` algún día.

🤖 Generated with [Claude Code](https://claude.com/claude-code)