### PR TITLE
chore(deploy): rutear nodos LLM a OpenRouter en prod (GLM + Gemini-3.1-pro)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,8 @@ jobs:
 
       - name: Deploy to Cloud Run
         run: |
+          # NODE_MODEL_OVERRIDES is JSON (contains commas) → use gcloud's custom '@' delimiter
+          # (^@^) for --set-env-vars so its value is not split on the JSON's internal commas.
           gcloud run deploy public-api \
             --image="$IMAGE:$GITHUB_SHA" \
             --region="$REGION" \
@@ -220,8 +222,8 @@ jobs:
             --max-instances=4 \
             --no-cpu-throttling \
             --memory=2Gi --cpu=2 --timeout=3600 \
-            --set-env-vars="ENVIRONMENT=production,SUPABASE_URL=https://pdnbjsrxgvxstjcqpxde.supabase.co,CORS_ALLOWED_ORIGIN=https://adamcampus.com" \
-            --set-secrets="DATABASE_URL=adam-database-url:latest,GEMINI_API_KEY=adam-gemini-api-key:latest,SUPABASE_SERVICE_ROLE_KEY=adam-supabase-service-role-key:latest"
+            --set-env-vars='^@^ENVIRONMENT=production@SUPABASE_URL=https://pdnbjsrxgvxstjcqpxde.supabase.co@CORS_ALLOWED_ORIGIN=https://adamcampus.com@OPENROUTER_REASONING_EFFORT=high@OPENROUTER_REASONING_MAX_TOKENS=16000@NODE_MODEL_OVERRIDES={"schema_designer":"z-ai/glm-5.2","m3_content_generator":"z-ai/glm-5.2","m3_questions_generator":"z-ai/glm-5.2","m5_content_generator":"z-ai/glm-5.2","m5_questions_generator":"z-ai/glm-5.2","m4_content_generator":"google/gemini-3.1-pro-preview"}' \
+            --set-secrets="DATABASE_URL=adam-database-url:latest,GEMINI_API_KEY=adam-gemini-api-key:latest,SUPABASE_SERVICE_ROLE_KEY=adam-supabase-service-role-key:latest,OPENROUTER_API_KEY=adam-openrouter-api-key:latest"
 
       # Advance the floating :latest tag ONLY after a successful deploy, so :latest
       # never points at an image that failed to roll out. The deploy itself is


### PR DESCRIPTION
## Qué hace
Activa en **producción** el ruteo de modelos por-nodo que ya usas localmente:

| Nodo | Modelo (prod tras este PR) |
|---|---|
| `schema_designer`, `m3_content_generator`, `m3_questions_generator`, `m5_content_generator`, `m5_questions_generator` | `z-ai/glm-5.2` (GLM vía OpenRouter) |
| `m4_content_generator` | `google/gemini-3.1-pro-preview` (vía OpenRouter) |

Cambios en `.github/workflows/ci.yml` (deploy):
- `--set-secrets` += `OPENROUTER_API_KEY=adam-openrouter-api-key:latest` (secreto **ya creado** en Secret Manager; el SA `adam-run` ya tiene `secretAccessor` a nivel proyecto).
- `--set-env-vars` += `NODE_MODEL_OVERRIDES` (JSON) + `OPENROUTER_REASONING_EFFORT=high` + `OPENROUTER_REASONING_MAX_TOKENS=16000`.
- Como `NODE_MODEL_OVERRIDES` es JSON (con comas), se usa el **delimitador custom `^@^`** de gcloud para `--set-env-vars` (validado: parsea como JSON íntegro).

## Importante
- **Mergear esto NO despliega.** El ruteo se activa en el **próximo push a `deploy`**.
- Sin `OPENROUTER_API_KEY` el ruteo **degrada limpio a Gemini** (no rompe). Hoy prod corre Gemini-only y funciona.

## ⚠️ Riesgos (de CLAUDE.md) — gatear antes de rollout de flota
- Costo/latencia **~2.5×** (effort=high + 5 nodos GLM).
- Posible **truncación** de structured output bajo reasoning alto (vigilar `schema_designer`).
- **Fallback silencioso a Gemini** si ningún provider soporta tools/JSON bajo `require_parameters` (detectar vía `cost_breakdown.models`).
- Calidad → correr `tests/golden_eval.py` + E2E manual / canary antes de flota.

Independiente de la migración Supabase #488 (ya cerrada). No mergear hasta decidir el rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
