### PR TITLE
fix(serving): SPA history-fallback + quitar /app/ de links de invitación (404 de activación)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ADAM EDU es un Teacher Authoring + Preview MVP en transicion a una plataforma multi-rol con autenticacion real. El repositorio incluye:
 
 - Flujo docente completo: sugerencias en formulario, generacion asincrona con LangGraph, progreso en tiempo real via Supabase Realtime (`postgres_changes`), preview del caso y revision docente de entregas por estudiante.
-- Shell frontend auth-aware (Issue #5): `AuthProvider`, guards por rol, callback OAuth PKCE, helper `sessionStorage` de activacion con TTL 5 minutos, dashboard docente en `/app/teacher/dashboard`, detalle de curso en `/app/teacher/courses/:courseId` y ruta canonica de authoring en `/app/teacher/case-designer` (con compatibilidad via redirect `/app/teacher` -> `/app/teacher/case-designer`).
+- Shell frontend auth-aware (Issue #5): `AuthProvider`, guards por rol, callback OAuth PKCE, helper `sessionStorage` de activacion con TTL 5 minutos, dashboard docente en `/teacher/dashboard`, detalle de curso en `/teacher/courses/:courseId` y ruta canonica de authoring en `/teacher/case-designer` (con compatibilidad via redirect `/teacher` -> `/teacher/case-designer`).
 - Auth perimeter backend (Issue #3): verificacion JWT via JWKS, actor resolution por memberships, `GET /api/auth/me`, endpoints de activacion body-only.
 
 Los flujos de negocio completos de teacher activation, student join y admin provisioning siguen en Issues #6, #7 y #8 respectivamente. El shell actual deja listos los placeholders y contratos de routing para esas historias.
@@ -107,12 +107,12 @@ El frontend usa ese flujo para renderizar el timeline y el `CasePreview` del pro
 
 Rutas funcionales actuales del shell docente (frontend):
 
-- `/app/teacher/dashboard`: dashboard principal del docente.
-- `/app/teacher/courses/:courseId`: detalle del curso con tabs de syllabus, estudiantes y configuracion.
-- `/app/teacher/cases/:assignmentId/entregas`: listado de entregas del caso publicado.
-- `/app/teacher/cases/:assignmentId/entregas/:membershipId`: detalle read-only de una entrega individual.
-- `/app/teacher/case-designer`: entrada canonica al Diseñador de Casos.
-- `/app/teacher`: redirect de compatibilidad hacia `/app/teacher/case-designer`.
+- `/teacher/dashboard`: dashboard principal del docente.
+- `/teacher/courses/:courseId`: detalle del curso con tabs de syllabus, estudiantes y configuracion.
+- `/teacher/cases/:assignmentId/entregas`: listado de entregas del caso publicado.
+- `/teacher/cases/:assignmentId/entregas/:membershipId`: detalle read-only de una entrega individual.
+- `/teacher/case-designer`: entrada canonica al Diseñador de Casos.
+- `/teacher`: redirect de compatibilidad hacia `/teacher/case-designer`.
 
 ### Deploy note for `Assignment.deadline`
 

--- a/backend/src/shared/admin_writes.py
+++ b/backend/src/shared/admin_writes.py
@@ -262,7 +262,7 @@ def _map_course_integrity_error(exc: IntegrityError) -> HTTPException:
 
 
 def _build_teacher_activation_link(raw_token: str) -> str:
-    return f"/app/teacher/activate#invite_token={raw_token}"
+    return f"/teacher/activate#invite_token={raw_token}"
 
 
 def _emit_course_audit_event(

--- a/backend/src/shared/app.py
+++ b/backend/src/shared/app.py
@@ -26,6 +26,8 @@ from sqlalchemy import and_, or_, select, update
 from sqlalchemy.exc import DBAPIError, IntegrityError, OperationalError
 from sqlalchemy.exc import TimeoutError as SATimeoutError
 from sqlalchemy.orm import Session
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.types import Scope
 
 from case_generator.core.authoring import AuthoringService, derive_progress_percentage
 from case_generator.impact_lens import ImpactLensLiteral
@@ -1747,6 +1749,30 @@ async def suggest_context(req: SuggestRequest) -> SuggestResponse:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
+class SPAStaticFiles(StaticFiles):
+    """Static file server with single-page-app history fallback.
+
+    Starlette's ``StaticFiles(html=True)`` serves real files and 404s on any
+    other path. Because the React app uses client-side routing, a fresh
+    navigation / reload / invite link to a route such as ``/teacher/activate`` or
+    ``/join`` has no matching file on disk and returns ``{"detail":"Not Found"}``.
+    This subclass serves ``index.html`` for any such path so the client router can
+    take over.
+
+    The ``/api`` and ``/health`` routes are registered before this mount and take
+    precedence, so they never reach here; we still re-raise for ``/api`` typos so
+    genuine API 404s stay JSON instead of returning the SPA shell.
+    """
+
+    async def get_response(self, path: str, scope: Scope) -> Response:
+        try:
+            return await super().get_response(path, scope)
+        except StarletteHTTPException as exc:
+            if exc.status_code == 404 and not path.startswith("api/"):
+                return await super().get_response("index.html", scope)
+            raise
+
+
 def create_frontend_router(build_dir: str = "../frontend/dist") -> Any:
     build_path = pathlib.Path(__file__).parent.parent.parent / build_dir
     if not build_path.is_dir() or not (build_path / "index.html").is_file():
@@ -1756,7 +1782,7 @@ def create_frontend_router(build_dir: str = "../frontend/dist") -> Any:
             return Response("Frontend not built.", media_type="text/plain", status_code=503)
 
         return Route("/{path:path}", endpoint=dummy_frontend)
-    return StaticFiles(directory=build_path, html=True)
+    return SPAStaticFiles(directory=build_path, html=True)
 
 
 # Serve the SPA at the site root. This MUST stay the last mount: API routes and

--- a/backend/src/shared/course_access_links.py
+++ b/backend/src/shared/course_access_links.py
@@ -21,7 +21,7 @@ def generate_course_access_token() -> str:
 
 
 def serialize_course_access_link(raw_token: str) -> str:
-    return f"/app/join#course_access_token={raw_token}"
+    return f"/join#course_access_token={raw_token}"
 
 
 def course_regeneration_lock_key(course_id: str) -> int:

--- a/backend/src/shared/syllabus_schema.py
+++ b/backend/src/shared/syllabus_schema.py
@@ -124,7 +124,7 @@ class TeacherCourseConfigurationResponse(StrictModel):
     access_link_status: Literal["active", "missing"]
     access_link_id: str | None = None
     access_link_created_at: datetime | None = None
-    join_path: str = "/app/join"
+    join_path: str = "/join"
 
 
 class TeacherCourseDetailResponse(StrictModel):

--- a/backend/tests/test_issue56_admin_writes.py
+++ b/backend/tests/test_issue56_admin_writes.py
@@ -77,7 +77,7 @@ def test_issue56_create_course_with_teacher_membership_creates_initial_access_li
     }
     assert payload["teacher_state"] == "active"
     assert payload["access_link_status"] == "active"
-    assert payload["access_link"].startswith("/app/join#course_access_token=")
+    assert payload["access_link"].startswith("/join#course_access_token=")
 
     raw_token = payload["access_link"].split("=", maxsplit=1)[1]
     stored_link = db.scalar(select(CourseAccessLink).where(CourseAccessLink.course_id == payload["id"]))
@@ -652,7 +652,7 @@ def test_issue56_teacher_invite_persists_full_name_returns_activation_link_and_k
     assert payload["full_name"] == "Diana Lopez"
     assert payload["email"] == "diana.lopez@univ.edu"
     assert payload["status"] == "pending"
-    assert payload["activation_link"].startswith("/app/teacher/activate#invite_token=")
+    assert payload["activation_link"].startswith("/teacher/activate#invite_token=")
 
     invite = db.get(Invite, payload["invite_id"])
     assert invite is not None
@@ -694,7 +694,7 @@ def test_issue56_regenerate_course_access_link_rotates_previous_link_and_keeps_o
     assert response.status_code == 200
     payload = response.json()
     assert payload["course_id"] == course.id
-    assert payload["access_link"].startswith("/app/join#course_access_token=")
+    assert payload["access_link"].startswith("/join#course_access_token=")
     assert original_raw not in payload["access_link"]
 
     db.expire_all()

--- a/backend/tests/test_issue86_teacher_directory.py
+++ b/backend/tests/test_issue86_teacher_directory.py
@@ -148,7 +148,7 @@ def test_issue86_resend_teacher_invite_rotates_hash_and_resets_expiration(
     assert response.status_code == 200, response.text
     payload = response.json()
     assert payload["invite_id"] == invite.id
-    assert payload["activation_link"].startswith("/app/teacher/activate#invite_token=")
+    assert payload["activation_link"].startswith("/teacher/activate#invite_token=")
     db.expire_all()
     refreshed = db.get(Invite, invite.id)
     assert refreshed is not None

--- a/backend/tests/test_issue88_teacher_courses.py
+++ b/backend/tests/test_issue88_teacher_courses.py
@@ -1027,7 +1027,7 @@ def test_issue185_teacher_course_access_link_view_returns_active_metadata(
         "access_link_status": "active",
         "access_link_id": access_link.id,
         "access_link_created_at": access_link.created_at.isoformat().replace("+00:00", "Z"),
-        "join_path": "/app/join",
+        "join_path": "/join",
     }
     assert raw_token not in response.text
 
@@ -1066,7 +1066,7 @@ def test_issue185_teacher_course_access_link_view_returns_missing_without_active
         "access_link_status": "missing",
         "access_link_id": None,
         "access_link_created_at": None,
-        "join_path": "/app/join",
+        "join_path": "/join",
     }
 
 
@@ -1182,7 +1182,7 @@ def test_issue185_teacher_regenerate_course_access_link_supports_password_runtim
     payload = regenerate_response.json()
     assert payload["course_id"] == course.id
     assert payload["access_link_status"] == "active"
-    assert payload["access_link"].startswith("/app/join#course_access_token=")
+    assert payload["access_link"].startswith("/join#course_access_token=")
 
     new_raw = payload["access_link"].split("=", maxsplit=1)[1]
     assert original_raw != new_raw

--- a/backend/tests/test_spa_fallback.py
+++ b/backend/tests/test_spa_fallback.py
@@ -1,0 +1,76 @@
+"""Regression tests for SPA history-fallback serving (invite-link 404).
+
+After the ``/app`` -> site-root move, the SPA is mounted at ``/`` via
+``create_frontend_router``. ``StaticFiles(html=True)`` alone serves only real
+files, so a fresh navigation / reload / invite link to a client-side route such
+as ``/teacher/activate`` or ``/join`` returned ``{"detail":"Not Found"}``. The
+``SPAStaticFiles`` subclass serves ``index.html`` for those paths so the React
+router can take over, while genuine ``/api`` 404s stay JSON.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from shared.app import create_frontend_router
+
+
+@pytest.fixture()
+def spa_client(tmp_path: pathlib.Path) -> TestClient:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<!doctype html><title>ADAM SPA</title>")
+    assets = dist / "assets"
+    assets.mkdir()
+    (assets / "app.js").write_text("console.log('app')")
+
+    app = FastAPI()
+
+    @app.get("/api/ping")
+    def _ping() -> dict[str, bool]:
+        return {"pong": True}
+
+    # Absolute build_dir overrides create_frontend_router's relative resolution.
+    app.mount("/", create_frontend_router(str(dist)), name="frontend")
+    return TestClient(app)
+
+
+def test_root_serves_index(spa_client: TestClient) -> None:
+    response = spa_client.get("/")
+    assert response.status_code == 200
+    assert "ADAM SPA" in response.text
+
+
+def test_real_asset_is_served(spa_client: TestClient) -> None:
+    response = spa_client.get("/assets/app.js")
+    assert response.status_code == 200
+    assert "console.log" in response.text
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/teacher/activate", "/join", "/teacher/dashboard", "/student/dashboard"],
+)
+def test_deep_client_routes_fall_back_to_index(spa_client: TestClient, path: str) -> None:
+    # Invite links / reloads land directly on a deep route; the server must serve
+    # the SPA shell so the client router can read the route + #hash token.
+    response = spa_client.get(path)
+    assert response.status_code == 200, (path, response.status_code, response.text)
+    assert "ADAM SPA" in response.text
+
+
+def test_registered_api_route_takes_precedence(spa_client: TestClient) -> None:
+    response = spa_client.get("/api/ping")
+    assert response.status_code == 200
+    assert response.json() == {"pong": True}
+
+
+def test_unknown_api_path_stays_json_404(spa_client: TestClient) -> None:
+    # Genuine API 404s must NOT be masked by the SPA shell.
+    response = spa_client.get("/api/does-not-exist")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not Found"}

--- a/frontend/src/app/auth/RootRedirect.tsx
+++ b/frontend/src/app/auth/RootRedirect.tsx
@@ -3,7 +3,7 @@ import { useAuth } from "./useAuth";
 import { AppLanding } from "@/app/AppLanding";
 
 /**
- * Handles the root route `/app/`.
+ * Handles the root route `/`.
  *
  * Redirect precedence (deterministic, per Issue #33):
  *  1. must_rotate_password=true      -> /admin/change-password (always wins)

--- a/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
+++ b/frontend/src/features/admin-dashboard/AdminDashboardPage.test.tsx
@@ -276,7 +276,7 @@ describe("AdminDashboardPage", () => {
             id: "course-3",
             title: "Gobierno de Datos",
             code: "DAT-550",
-            access_link: "/app/join#course_access_token=new-course-token",
+            access_link: "/join#course_access_token=new-course-token",
         });
         vi.mocked(api.admin.updateCourse).mockResolvedValue(activeCourse);
         vi.mocked(api.admin.createTeacherInvite).mockResolvedValue({
@@ -284,11 +284,11 @@ describe("AdminDashboardPage", () => {
             full_name: "Maria Perez",
             email: "maria@example.edu",
             status: "pending",
-            activation_link: "/app/teacher/activate#invite_token=abc123",
+            activation_link: "/teacher/activate#invite_token=abc123",
         });
         vi.mocked(api.admin.resendInvite).mockResolvedValue({
             invite_id: "invite-2",
-            activation_link: "/app/teacher/activate#invite_token=resent",
+            activation_link: "/teacher/activate#invite_token=resent",
             expires_at: new Date().toISOString(),
         });
         vi.mocked(api.admin.removeTeacher).mockResolvedValue({
@@ -301,7 +301,7 @@ describe("AdminDashboardPage", () => {
         });
         vi.mocked(api.admin.regenerateCourseAccessLink).mockResolvedValue({
             course_id: activeCourse.id,
-            access_link: "/app/join#course_access_token=rotated-token",
+            access_link: "/join#course_access_token=rotated-token",
             access_link_status: "active",
         });
 
@@ -533,7 +533,7 @@ describe("AdminDashboardPage", () => {
         fireEvent.submit(screen.getByRole("button", { name: "Enviar invitacion" }).closest("form")!);
 
         expect(await screen.findByTestId("teacher-invite-success")).toBeTruthy();
-        expect(screen.getByText("/app/teacher/activate#invite_token=abc123")).toBeTruthy();
+        expect(screen.getByText("/teacher/activate#invite_token=abc123")).toBeTruthy();
         await waitFor(() => {
             expect(api.admin.getTeacherOptions).toHaveBeenCalledTimes(2);
         });
@@ -541,7 +541,7 @@ describe("AdminDashboardPage", () => {
         fireEvent.click(screen.getByRole("button", { name: "Copiar enlace" }));
 
         await waitFor(() => {
-            expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/app/teacher/activate#invite_token=abc123");
+            expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/teacher/activate#invite_token=abc123");
         });
 
         fireEvent.click(screen.getByLabelText("Cerrar modal de invitacion"));
@@ -1051,7 +1051,7 @@ describe("AdminDashboardPage", () => {
             expect(api.admin.regenerateCourseAccessLink).toHaveBeenCalledWith("course-1", expect.anything());
         });
 
-        expect(await screen.findAllByText("/app/join#course_access_token=rotated-token")).toHaveLength(2);
+        expect(await screen.findAllByText("/join#course_access_token=rotated-token")).toHaveLength(2);
     }, 20_000);
 
     it("regenerates a hidden active link directly from the table cell", async () => {
@@ -1064,14 +1064,14 @@ describe("AdminDashboardPage", () => {
             expect(api.admin.regenerateCourseAccessLink).toHaveBeenCalledWith("course-1", expect.anything());
         });
 
-        expect(await screen.findByText("/app/join#course_access_token=rotated-token")).toBeTruthy();
+        expect(await screen.findByText("/join#course_access_token=rotated-token")).toBeTruthy();
     }, 20_000);
 
     it("rolls back the previous regenerated link when a later regeneration fails", async () => {
         vi.mocked(api.admin.regenerateCourseAccessLink)
             .mockResolvedValueOnce({
                 course_id: activeCourse.id,
-                access_link: "/app/join#course_access_token=rotated-token",
+                access_link: "/join#course_access_token=rotated-token",
                 access_link_status: "active",
             })
             .mockRejectedValueOnce(new ApiError(500, "regen failed", "teacher_email_unavailable"));
@@ -1080,13 +1080,13 @@ describe("AdminDashboardPage", () => {
         await screen.findByText("Directorio de Cursos");
 
         fireEvent.click(screen.getByLabelText("Regenerar enlace de Finanzas Corporativas"));
-        expect(await screen.findByText("/app/join#course_access_token=rotated-token")).toBeTruthy();
+        expect(await screen.findByText("/join#course_access_token=rotated-token")).toBeTruthy();
 
         fireEvent.click(screen.getByLabelText("Editar Finanzas Corporativas"));
         fireEvent.click(screen.getByText("Regenerar enlace"));
 
         expect((await screen.findAllByText("No se pudo cargar el selector de docentes porque falta el correo de un docente activo.")).length).toBeGreaterThan(0);
-        expect(screen.getAllByText("/app/join#course_access_token=rotated-token").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("/join#course_access_token=rotated-token").length).toBeGreaterThan(0);
     }, 20_000);
 
     it("does not show the inline regenerate CTA for missing or inactive links", async () => {

--- a/frontend/src/features/admin-dashboard/TeacherDirectoryModal.test.tsx
+++ b/frontend/src/features/admin-dashboard/TeacherDirectoryModal.test.tsx
@@ -99,7 +99,7 @@ describe("TeacherDirectoryModal", () => {
         vi.mocked(api.admin.getTeacherDirectory).mockResolvedValue(directoryResponse);
         vi.mocked(api.admin.resendInvite).mockResolvedValue({
             invite_id: "invite-1",
-            activation_link: "/app/teacher/activate#invite_token=fresh-token",
+            activation_link: "/teacher/activate#invite_token=fresh-token",
             expires_at: "2099-01-08T00:00:00+00:00",
         });
         vi.mocked(api.admin.removeTeacher).mockResolvedValue({
@@ -153,7 +153,7 @@ describe("TeacherDirectoryModal", () => {
         });
         await waitFor(() => {
             expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-                "http://localhost:5173/app/teacher/activate#invite_token=fresh-token",
+                "http://localhost:5173/teacher/activate#invite_token=fresh-token",
             );
         });
         expect(await screen.findByRole("status")).toHaveTextContent("Enlace reenviado y copiado al portapapeles.");

--- a/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
+++ b/frontend/src/features/teacher-course/TeacherCoursePage.test.tsx
@@ -183,7 +183,7 @@ function createCourseDetailResponse(
             access_link_status: "active",
             access_link_id: "access-link-1",
             access_link_created_at: "2026-04-16T10:00:00Z",
-            join_path: "/app/join",
+            join_path: "/join",
         },
     };
 
@@ -201,7 +201,7 @@ function createCourseAccessLinkResponse(
         access_link_status: "active",
         access_link_id: "access-link-1",
         access_link_created_at: "2026-04-16T10:00:00Z",
-        join_path: "/app/join",
+        join_path: "/join",
         ...overrides,
     };
 }
@@ -211,7 +211,7 @@ function createCourseAccessLinkRegenerateResponse(
 ): TeacherCourseAccessLinkRegenerateResponse {
     return {
         course_id: "course-1",
-        access_link: "/app/join#course_access_token=fresh-token-123",
+        access_link: "/join#course_access_token=fresh-token-123",
         access_link_status: "active",
         ...overrides,
     };
@@ -639,7 +639,7 @@ describe("TeacherCoursePage", () => {
             createCourseAccessLinkRegenerateResponse(),
         );
         const expectedAccessLink = new URL(
-            "/app/join#course_access_token=fresh-token-123",
+            "/join#course_access_token=fresh-token-123",
             window.location.origin,
         ).toString();
 
@@ -679,7 +679,7 @@ describe("TeacherCoursePage", () => {
         );
         vi.mocked(api.teacher.regenerateCourseAccessLink).mockResolvedValueOnce(
             createCourseAccessLinkRegenerateResponse({
-                access_link: "/app/join#course_access_token=fresh-token-draft",
+                access_link: "/join#course_access_token=fresh-token-draft",
             }),
         );
 


### PR DESCRIPTION
## Problema

En producción (`adamcampus.com`), **todo link de invitación docente/estudiante daba 404** con `{"detail":"Not Found"}`. Ej.: `https://adamcampus.com/teacher/activate#invite_token=…` → 404.

Ese `{"detail":"Not Found"}` es el 404 de **FastAPI**: la petición `GET /teacher/activate` llegaba al backend y moría ahí. Son **dos residuos del ROOT MOVE** (`/app` → raíz) que quedaron sin migrar:

1. **El SPA no tiene history-fallback.** Se sirve con `StaticFiles(html=True)` en `app.mount("/", ...)` (`shared/app.py`), que solo sirve archivos reales. Cualquier navegación nueva / recarga / link de invitación a una ruta de cliente (`/teacher/activate`, `/join`, `/teacher/dashboard`…) no tiene archivo en disco → `StaticFiles` lanza `HTTPException(404)` → FastAPI lo renderiza como `{"detail":"Not Found"}`. Solo `/` + assets funcionaban.
2. **Los builders de links seguían con el prefijo muerto `/app/`** (`_build_teacher_activation_link`, `serialize_course_access_link`, `join_path`), produciendo `…/app/teacher/activate#…` que ya no existe.

Ambos son necesarios: con solo (1), un link `/app/...` serviría `index.html` pero React Router (basename `/`) no lo matchea → redirige a `/` y **pierde el token**. Con solo (2), `/teacher/activate` seguiría dando 404 por falta de fallback.

## Solución

- **`SPAStaticFiles(StaticFiles)`** (`shared/app.py`): sirve `index.html` en 404 para rutas no-`api/`; re-lanza para typos de `/api` (los 404 de API siguen siendo JSON).
- Quitado el prefijo `/app/` de los 3 builders → rutas raíz (`/teacher/activate`, `/join`).
- Tests (3 backend + 3 frontend) + `README.md` + comentario en `RootRedirect.tsx` actualizados al contrato raíz.
- Nuevo `backend/tests/test_spa_fallback.py` (regresión: deep routes → `index.html`, `/api` typo → JSON 404, assets/API intactos).

## Verificación

- Reproducción 1:1 del `{"detail":"Not Found"}` y validación del fix con la **clase exacta** contra starlette real: `/teacher/activate`, `/join`, `/teacher/dashboard` → `200` index.html; `/api/inexistente` → `404` JSON. ✅
- Frontend: los 3 archivos afectados → **61 tests passed**. ✅
- `mypy` limpio; frontend `eslint` limpio. (La suite backend con DB corre en CI.)

## Notas de deploy

- **Backend-only** (el bundle del SPA no cambia) pero **requiere redeploy** para tomar efecto — no hay workaround por env.
- Tras el deploy, el admin genera links ya en la raíz; un `invite_token` ya emitido sigue válido usando la ruta raíz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
