### PR TITLE
fix(checkpointer): disable prepared statements over Supavisor txn mode (prepare_threshold None)

### DIFF
--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -1029,7 +1029,17 @@ def _langgraph_pool_kwargs() -> dict[str, object]:
     return {
         "autocommit": True,
         "row_factory": dict_row,
-        "prepare_threshold": 0,
+        # MUST be None (NOT 0) to fully DISABLE server-side prepared statements.
+        # In psycopg3, prepare_threshold=0 means "prepare on first use" — it still
+        # creates named prepared statements (`_pg3_0`, ...). With autocommit=True each
+        # statement is its own transaction, so Supavisor transaction mode (:6543) routes
+        # consecutive statements to different physical backends, and a later statement
+        # hits a backend without the prepared statement -> intermittent
+        # `prepared statement "_pg3_0" does not exist` -> durable checkpoint bootstrap fails.
+        # None disables auto-prepare entirely, which is the supported way to run the
+        # checkpointer over a transaction-mode pooler. The main SQLAlchemy engine is a
+        # separate config and is unaffected.
+        "prepare_threshold": None,
         "options": _build_postgres_timeout_options(settings),
     }
 

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 
 import shared.database as database
-from shared.database import Settings, _make_engine
+from shared.database import Settings, _langgraph_pool_kwargs, _make_engine
 
 
 def test_null_pool_when_environment_is_production() -> None:
@@ -81,3 +81,21 @@ def test_connection_level_timeouts_are_configured_via_connect_args(monkeypatch: 
     assert captured_kwargs["connect_args"] == {
         "options": "-c statement_timeout=4321 -c lock_timeout=876"
     }
+
+
+def test_langgraph_pool_disables_prepared_statements() -> None:
+    """LangGraph checkpointer pools MUST disable server-side prepared statements.
+
+    psycopg3 semantics: prepare_threshold=0 means "prepare on first use" (still
+    creates named prepared statements); None means "never prepare". Over Supavisor
+    transaction mode (:6543) named prepared statements break intermittently with
+    `prepared statement "_pg3_0" does not exist`, failing the durable checkpoint
+    bootstrap. This guards against a regression back to 0 / a positive int.
+    """
+    kwargs = _langgraph_pool_kwargs()
+
+    assert "prepare_threshold" in kwargs
+    assert kwargs["prepare_threshold"] is None
+    # autocommit makes every statement its own transaction, which is exactly why
+    # prepared statements cannot be reused across the transaction-mode pooler.
+    assert kwargs["autocommit"] is True


### PR DESCRIPTION
## Problema (producción)

Al generar un caso en prod aparece intermitentemente el error de usuario **"No se pudo inicializar la persistencia durable del proceso de generación"**. Los logs de Cloud Run (`public-api`) muestran la causa exacta:

```
Could not read checkpoint_migrations state before LangGraph setup(): prepared statement "_pg3_0" does not exist
[graph] AsyncPostgresSaver setup failed
AuthoringService: Durable checkpoint runtime failed
```

Es **intermitente** (mismo minuto: a veces éxito, a veces fallo), por eso "Reintentar" a veces funciona.

## Causa raíz

`_langgraph_pool_kwargs()` pasaba `prepare_threshold=0` a psycopg3. Semántica psycopg3:
- `None` → **nunca** prepara (sin prepared statements)
- `0` → **prepara en el primer uso** (crea `_pg3_0`, …) — **no** los desactiva
- `N` → prepara tras N usos

Con `autocommit=True`, cada sentencia es su propia transacción, así que **Supavisor en transaction mode (`:6543`) enruta cada una a un backend físico distinto**. El `PREPARE _pg3_0` ocurre en el backend X; una sentencia posterior cae en el backend Y, donde `_pg3_0` no existe → fallo intermitente de `AsyncPostgresSaver.setup()` / `get_checkpoint_migrations_version`. Apareció tras la migración #488 al nuevo proyecto Supabase (us-east-1), cuyo Supavisor no emula prepared statements entre backends como el anterior.

## Solución

`prepare_threshold=None` en `_langgraph_pool_kwargs()` (compartido por las pools sync y async del checkpointer) → desactiva por completo los prepared statements, que es la forma soportada de correr el checkpointer sobre un pooler en transaction mode.

- **Sin cambio de arquitectura:** se mantiene `:6543` (Supavisor txn mode) y los guardrails de Supabase.
- **Alcance acotado:** solo las pools del checkpointer de LangGraph; el motor SQLAlchemy principal es otra config y no se toca.
- **Rendimiento:** impacto inmensurable (escrituras de checkpoint triviales frente a las llamadas LLM); además los prepared statements estaban fallando, no acelerando nada.
- Test de regresión que fija `prepare_threshold is None`.

## Verificación

- `_langgraph_pool_kwargs()` devuelve `prepare_threshold=None` (validado por import directo).
- `mypy src/shared/database.py`: sin issues.
- El test de regresión (`tests/test_database.py::test_langgraph_pool_disables_prepared_statements`) corre en CI (requiere el `adam_test` DB local/CI; este worktree no tiene Postgres).

⚠️ **merge ≠ deploy** — requiere redeploy (merge a `main` → push a `deploy`) para surtir efecto, y verificación en vivo (generar un caso real) tras el deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)