### PR TITLE
fix(m4-chart): barras de eje doble lado a lado, no superpuestas

### DIFF
--- a/frontend/src/shared/case-viewer/plotlyChartUtils.test.ts
+++ b/frontend/src/shared/case-viewer/plotlyChartUtils.test.ts
@@ -154,12 +154,61 @@ describe("buildLayout — secondary y-axis (M4 investment dual-axis fix)", () =>
         expect((layout.margin as Record<string, unknown>).r).toBe(80);
     });
 
+    it("forces barmode group so the two dual-axis bars render side by side, not overlapping", () => {
+        // Bug: two bar traces on overlaying axes (y + y2) draw at the SAME x-pixel and the second
+        // hides the first (the USD cost bar disappears behind the value bar). barmode group + the
+        // per-trace offsetgroup (see sanitizeTraces) is what offsets them.
+        const layout = buildLayout({}, dualTraces) as Record<string, unknown>;
+        expect(layout.barmode).toBe("group");
+    });
+
     it("does NOT add a yaxis2 for a single-axis chart (byte-identical for non-dual charts)", () => {
         const layout = buildLayout({}, [
             { type: "bar", x: ["a"], y: [1] },
         ]) as Record<string, unknown>;
         expect(layout.yaxis2).toBeUndefined();
+        expect(layout.barmode).toBeUndefined();
         expect((layout.margin as Record<string, unknown>).r).toBe(40);
+    });
+});
+
+describe("sanitizeTraces — dual-axis grouped bars (M4 investment overlap fix)", () => {
+    const dualTraces = [
+        { type: "bar", name: "Inversión (USD)", x: ["Despliegue"], y: [515000] },
+        { type: "bar", name: "Estudiantes retenidos", x: ["Despliegue"], y: [600], yaxis: "y2" },
+    ];
+
+    it("assigns a distinct offsetgroup and a common alignmentgroup to each dual-axis bar", () => {
+        const out = sanitizeTraces(dualTraces);
+        expect(out[0].offsetgroup).toBe("0");
+        expect(out[1].offsetgroup).toBe("1");
+        expect(out[0].offsetgroup).not.toBe(out[1].offsetgroup); // side-by-side, not overlapping
+        expect(out[0].alignmentgroup).toBe("dualY");
+        expect(out[1].alignmentgroup).toBe("dualY");
+    });
+
+    it("does NOT touch offsetgroup for a single-axis bar chart (byte-identical)", () => {
+        const out = sanitizeTraces([{ type: "bar", x: ["a"], y: [1] }]);
+        expect(out[0].offsetgroup).toBeUndefined();
+        expect(out[0].alignmentgroup).toBeUndefined();
+    });
+
+    it("respects a backend-provided offsetgroup", () => {
+        const out = sanitizeTraces([
+            { type: "bar", x: ["a"], y: [1], offsetgroup: "cost" },
+            { type: "bar", x: ["a"], y: [2], yaxis: "y2" },
+        ]);
+        expect(out[0].offsetgroup).toBe("cost"); // kept
+        expect(out[1].offsetgroup).toBe("1"); // assigned
+    });
+
+    it("only groups bar traces, leaving a non-bar trace on a dual-axis chart alone", () => {
+        const out = sanitizeTraces([
+            { type: "bar", x: ["a"], y: [1] },
+            { type: "scatter", x: ["a"], y: [2], yaxis: "y2" },
+        ]);
+        expect(out[0].offsetgroup).toBe("0");
+        expect(out[1].offsetgroup).toBeUndefined();
     });
 });
 

--- a/frontend/src/shared/case-viewer/plotlyChartUtils.ts
+++ b/frontend/src/shared/case-viewer/plotlyChartUtils.ts
@@ -126,7 +126,8 @@ export function validateHeatmapConfig(
 }
 
 export function sanitizeTraces(traces: Record<string, unknown>[]): Record<string, unknown>[] {
-    return traces.map((trace) => {
+    const hasDualY = chartHasDualY(traces);
+    return traces.map((trace, index) => {
         const sanitized = { ...trace };
 
         if (isHeatmapTrace(trace)) {
@@ -216,6 +217,23 @@ export function sanitizeTraces(traces: Record<string, unknown>[]): Record<string
             if (Array.isArray(sanitized.y)) {
                 sanitized.y = sanitized.y.map((value) => value ?? 0);
             }
+
+            // Eje Y doble (M4 Gráfico 1 de inversión, lente no-financiera): el costo en USD
+            // va en el eje `y` y el valor en la unidad de la lente va en `y2` (overlaying).
+            // Dos barras en ejes SUPERPUESTOS se dibujan centradas en la MISMA categoría X →
+            // la segunda traza tapa por completo a la primera (la barra de costo desaparece).
+            // Para renderizarlas lado a lado, cada barra necesita un `offsetgroup` distinto
+            // (más `barmode: "group"` en el layout). Sin esto, Plotly NO desplaza barras que
+            // viven en ejes distintos. Solo afecta a trazas de barra de un gráfico dual-Y;
+            // todo lo demás queda byte-idéntico.
+            if (hasDualY && String(trace.type || "").toLowerCase() === "bar") {
+                if (sanitized.offsetgroup == null) {
+                    sanitized.offsetgroup = String(index);
+                }
+                if (sanitized.alignmentgroup == null) {
+                    sanitized.alignmentgroup = "dualY";
+                }
+            }
         }
 
         return sanitized;
@@ -271,6 +289,11 @@ export function buildLayout(
             side: "right",
             automargin: true,
         };
+
+        // Las dos barras (costo en `y`, valor en `y2`) llevan `offsetgroup` distinto en
+        // sanitizeTraces; `barmode: "group"` las coloca lado a lado en lugar de superpuestas.
+        // Se FUERZA (igual que overlaying/side arriba) para garantizar el render correcto.
+        layout.barmode = "group";
     }
 
     return layout;


### PR DESCRIPTION
## Problema

El **Gráfico 1 de inversión de M4** (ml_ds + clasificación, lente no-financiera — p.ej. caso educativo `learning_outcomes`) muestra **solo una barra**. La barra de **Inversión Total (USD)** desaparece; únicamente se ve la de **Estudiantes Retenidos**, aunque la leyenda lista ambas. Hallado en un caso real ml_ds + Logistic Regression de retención educativa.

## Causa raíz

El fix #544 enruta el costo en USD al eje `y` y el valor en la unidad de la lente al eje `y2` con `overlaying:"y"`. Eso resuelve la **escala** (la barra de valor ya no queda aplastada), pero **dos barras en ejes Y superpuestos se dibujan centradas en la MISMA categoría X y se solapan** — la segunda traza tapa por completo a la primera. Plotly **no** desplaza barras que viven en ejes distintos a menos que cada una tenga un `offsetgroup` distinto (más `barmode:"group"`). Ni el prompt (`build_impact_lens_m4_dual_axis_hint`) ni el frontend lo hacían.

## Fix (determinista, en el render — NO requiere regenerar casos)

Ambos cambios en `frontend/src/shared/case-viewer/plotlyChartUtils.ts`:

- **`sanitizeTraces`**: asigna `offsetgroup` distinto (`String(index)`) + `alignmentgroup` común (`"dualY"`) a cada **traza de barra** cuando el gráfico es dual-Y. Respeta un `offsetgroup` ya provisto por el backend.
- **`buildLayout`**: fuerza `barmode:"group"` cuando `hasDualY` (mismo patrón "garantía estructural" que ya forzaba `overlaying`/`side`).

Resultado: las dos barras se renderizan **lado a lado**, ambas visibles, cada una en su eje. Como el fix vive en el render sobre el `chart spec` ya guardado, **los casos existentes se arreglan al re-desplegar el frontend, sin regenerar nada**.

## Blast radius

Acotado a `hasDualY` (alguna traza con `yaxis:"y2"`) **y** trazas de barra. Todo gráfico de eje único y toda traza no-barra quedan **byte-idénticos**. Hoy el único consumidor de eje doble es el Gráfico 1 de inversión M4 con lente no-financiera.

## Tests

`frontend/src/shared/case-viewer/plotlyChartUtils.test.ts` (+5):
- `buildLayout` fuerza `barmode:"group"` en dual-Y y NO lo añade en eje único.
- `sanitizeTraces` asigna offsetgroup distinto + alignmentgroup común; no toca eje único; respeta offsetgroup provisto; solo agrupa barras (deja en paz un scatter dual-Y).

Verificado local: 16 tests del archivo PASS, `eslint` limpio, `npm run build` OK.

## Seguimiento (no en este PR)
- Defensa en profundidad: añadir `offsetgroup`/`barmode` al hint `build_impact_lens_m4_dual_axis_hint` para que el spec generado ya los traiga (mejora de una vía; no urge — el frontend ya garantiza el render).
- Verificar si el eje primario fija `range:[0,500000]` mientras la inversión es 515k (autorange de Plotly debería absorberlo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)