### PR TITLE
fix(authoring-progress): recalibrar watchdog de silencio (30s+backoff) y poll degradado 20s (#554)

### DIFF
--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -606,7 +606,7 @@ describe("api auth + stream glue", () => {
         expect(removeChannelMock).toHaveBeenCalledTimes(1);
     });
 
-    it("backs off the silence watchdog (BASE → 2×BASE → MAX cap) and resets on a real realtime event", async () => {
+    it("backs off the silence watchdog from BASE, caps at MAX, and resets on a real realtime event", async () => {
         vi.useFakeTimers();
         vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
         vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
@@ -657,25 +657,29 @@ describe("api auth + stream glue", () => {
         );
 
         // Initial snapshot (call 1) + post-SUBSCRIBED reconcile (call 2), both non-terminal.
+        // BASE=30000, MAX=60000 → one doubling (30000→60000) reaches the cap.
         await flushAsyncWorkUntil(() => fetchMock.mock.calls.length >= 2);
         await flushAsyncWork();
         expect(fetchMock).toHaveBeenCalledTimes(2);
 
-        // Fire at BASE → reconcile (call 3) → backoff to 2×BASE.
+        // Fire at BASE → reconcile (call 3) → backoff to min(2×BASE, MAX) = MAX (60000).
         await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_BASE_MS);
         expect(fetchMock).toHaveBeenCalledTimes(3);
 
-        // Fire at 2×BASE → reconcile (call 4) → backoff to MAX (60000×2 = 120000 = MAX).
-        await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_BASE_MS * 2);
+        // The next window is now MAX (60000), not BASE: advancing only BASE must NOT fire.
+        // Proves the delay actually backed off past BASE.
+        await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_BASE_MS);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        // Completing the MAX window fires once (call 4) → delay stays capped at MAX.
+        await vi.advanceTimersByTimeAsync(
+            AUTHORING_REALTIME_SILENCE_MAX_MS - AUTHORING_REALTIME_SILENCE_BASE_MS,
+        );
         expect(fetchMock).toHaveBeenCalledTimes(4);
 
-        // Fire at MAX → reconcile (call 5) → delay stays MAX (capped, not 2×MAX).
+        // A full MAX advance fires exactly once more (call 5). If the delay had doubled past
+        // MAX (to 120000) instead of capping, this MAX-sized advance would NOT fire.
         await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_MAX_MS);
         expect(fetchMock).toHaveBeenCalledTimes(5);
-
-        // Another MAX advance fires exactly once more (call 6) — proves the cap holds.
-        await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_MAX_MS);
-        expect(fetchMock).toHaveBeenCalledTimes(6);
 
         // A real realtime event proves the channel is alive → resets backoff to BASE.
         postgresChangesHandler?.({
@@ -686,9 +690,9 @@ describe("api auth + stream glue", () => {
         });
         await flushAsyncWork();
 
-        // After the reset the watchdog fires again at BASE (call 7), not at the capped MAX.
+        // After the reset the watchdog fires again after only BASE (call 6), not the capped MAX.
         await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_BASE_MS);
-        expect(fetchMock).toHaveBeenCalledTimes(7);
+        expect(fetchMock).toHaveBeenCalledTimes(6);
 
         controller.abort();
         await streamPromise;

--- a/frontend/src/shared/api.test.ts
+++ b/frontend/src/shared/api.test.ts
@@ -18,7 +18,15 @@ vi.mock("@supabase/supabase-js", () => ({
     createClient: createClientMock,
 }));
 
-import { ApiError, api, formatHttpError, resetApiClientForTests } from "./api";
+import {
+    ApiError,
+    api,
+    AUTHORING_PROGRESS_POLL_INTERVAL_MS,
+    AUTHORING_REALTIME_SILENCE_BASE_MS,
+    AUTHORING_REALTIME_SILENCE_MAX_MS,
+    formatHttpError,
+    resetApiClientForTests,
+} from "./api";
 
 async function flushAsyncWork() {
     for (let tick = 0; tick < 10; tick += 1) {
@@ -428,6 +436,7 @@ describe("api auth + stream glue", () => {
     });
 
     it("reconciles a terminal backend failure after realtime channel error", async () => {
+        vi.useFakeTimers();
         vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
         vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
 
@@ -487,7 +496,15 @@ describe("api auth + stream glue", () => {
             );
         vi.stubGlobal("fetch", fetchMock);
 
-        await api.authoring.streamProgress("job-1", (event) => events.push(event));
+        const streamPromise = api.authoring.streamProgress("job-1", (event) => events.push(event));
+
+        // After CHANNEL_ERROR the established channel falls to the degraded poll. The
+        // immediate pollOnce may reuse the still-in-flight reconcile (non-terminal), so
+        // advance one poll interval to let the next poll reconcile the failed state.
+        await flushAsyncWorkUntil(() => fetchMock.mock.calls.length >= 2);
+        await flushAsyncWork();
+        await vi.advanceTimersByTimeAsync(AUTHORING_PROGRESS_POLL_INTERVAL_MS);
+        await streamPromise;
 
         expect(events).toContainEqual({ event: "metadata", data: "{\"status\":\"failed\"}" });
         expect(events).toContainEqual({
@@ -567,10 +584,14 @@ describe("api auth + stream glue", () => {
             );
         vi.stubGlobal("fetch", fetchMock);
 
+        // Pin jitter to exactly 1.0 (factor = 1 - 0.2 + 0.5 * 2 * 0.2) so the silence
+        // watchdog fires at exactly BASE for a deterministic timer advance.
+        vi.spyOn(Math, "random").mockReturnValue(0.5);
+
         const streamPromise = api.authoring.streamProgress("job-silent", (event) => events.push(event));
 
         await flushAsyncWork();
-        await vi.advanceTimersByTimeAsync(3000);
+        await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_BASE_MS);
         await streamPromise;
 
         expect(events).toContainEqual({
@@ -583,6 +604,95 @@ describe("api auth + stream glue", () => {
             data: "{\"canonical_output\":{\"title\":\"Recovered case\"}}",
         });
         expect(removeChannelMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("backs off the silence watchdog (BASE → 2×BASE → MAX cap) and resets on a real realtime event", async () => {
+        vi.useFakeTimers();
+        vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+        vi.stubEnv("VITE_SUPABASE_ANON_KEY", "anon-key");
+        // Pin jitter to exactly 1.0 so each silence delay equals the backoff value.
+        vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+        // Capture the postgres_changes handler so the test can inject a real realtime
+        // event and assert the backoff resets.
+        let postgresChangesHandler: ((payload: { new: unknown }) => void) | undefined;
+        const channel = {
+            on: vi.fn((_event: string, _config: unknown, handler: (payload: { new: unknown }) => void) => {
+                postgresChangesHandler = handler;
+                return channel;
+            }),
+            subscribe: vi.fn((handler: (status: string) => void) => {
+                handler("SUBSCRIBED");
+                return channel;
+            }),
+        };
+        const removeChannelMock = vi.fn().mockResolvedValue(undefined);
+
+        createClientMock.mockImplementationOnce(() => ({
+            auth: { getSession: getSessionMock },
+            channel: vi.fn(() => channel),
+            removeChannel: removeChannelMock,
+        }));
+
+        // Every /progress poll returns a FRESH non-terminal snapshot so the watchdog
+        // keeps backing off; the job never completes during the test. A new Response per
+        // call is required because a Response body can only be read once.
+        const fetchMock = vi.fn().mockImplementation(() =>
+            Promise.resolve(
+                new Response(JSON.stringify({
+                    job_id: "job-backoff",
+                    status: "processing",
+                    current_step: "case_writer",
+                    progress_seq: 1,
+                }), { status: 200, headers: { "Content-Type": "application/json" } }),
+            ),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const controller = new AbortController();
+        const streamPromise = api.authoring.streamProgress(
+            "job-backoff",
+            () => undefined,
+            controller.signal,
+        );
+
+        // Initial snapshot (call 1) + post-SUBSCRIBED reconcile (call 2), both non-terminal.
+        await flushAsyncWorkUntil(() => fetchMock.mock.calls.length >= 2);
+        await flushAsyncWork();
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        // Fire at BASE → reconcile (call 3) → backoff to 2×BASE.
+        await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_BASE_MS);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+
+        // Fire at 2×BASE → reconcile (call 4) → backoff to MAX (60000×2 = 120000 = MAX).
+        await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_BASE_MS * 2);
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+
+        // Fire at MAX → reconcile (call 5) → delay stays MAX (capped, not 2×MAX).
+        await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_MAX_MS);
+        expect(fetchMock).toHaveBeenCalledTimes(5);
+
+        // Another MAX advance fires exactly once more (call 6) — proves the cap holds.
+        await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_MAX_MS);
+        expect(fetchMock).toHaveBeenCalledTimes(6);
+
+        // A real realtime event proves the channel is alive → resets backoff to BASE.
+        postgresChangesHandler?.({
+            new: {
+                status: "processing",
+                task_payload: { current_step: "m3_content_generator", progress_seq: 2 },
+            },
+        });
+        await flushAsyncWork();
+
+        // After the reset the watchdog fires again at BASE (call 7), not at the capped MAX.
+        await vi.advanceTimersByTimeAsync(AUTHORING_REALTIME_SILENCE_BASE_MS);
+        expect(fetchMock).toHaveBeenCalledTimes(7);
+
+        controller.abort();
+        await streamPromise;
+        expect(vi.getTimerCount()).toBe(0);
     });
 
     it("returns a non-generic auth error for forbidden streams", async () => {
@@ -658,7 +768,7 @@ describe("api auth + stream glue", () => {
         const streamPromise = api.authoring.streamProgress("job-1", (event) => events.push(event));
 
         await flushAsyncWork();
-        await vi.advanceTimersByTimeAsync(3000);
+        await vi.advanceTimersByTimeAsync(AUTHORING_PROGRESS_POLL_INTERVAL_MS);
         await streamPromise;
 
         const nodes = events
@@ -756,10 +866,10 @@ describe("api auth + stream glue", () => {
         await flushAsyncWorkUntil(() => fetchMock.mock.calls.length >= 2);
         expect(fetchMock).toHaveBeenCalledTimes(2);
 
-        await vi.advanceTimersByTimeAsync(3000);
+        await vi.advanceTimersByTimeAsync(AUTHORING_PROGRESS_POLL_INTERVAL_MS);
         expect(fetchMock).toHaveBeenCalledTimes(3);
 
-        await vi.advanceTimersByTimeAsync(3000);
+        await vi.advanceTimersByTimeAsync(AUTHORING_PROGRESS_POLL_INTERVAL_MS);
         expect(fetchMock).toHaveBeenCalledTimes(3);
 
         resolvePendingPoll?.(

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -129,9 +129,13 @@ const AUTHORING_REALTIME_SUBSCRIBE_TIMEOUT_MS = 4000;
 // (CHANNEL_ERROR/TIMED_OUT/CLOSED) is handled immediately and separately below, so this
 // is purely time-based recovery. It arms at BASE and backs off exponentially (×2, capped
 // at MAX) on each silent non-terminal reconcile, resetting to BASE on any real realtime
-// event. ±JITTER spreads concurrent clients to avoid a thundering herd. Exported for tests.
+// event. ±JITTER spreads concurrent clients to avoid a thundering herd. MAX is held at 60s
+// (not higher) so the worst case this net exists for — a DROPPED terminal event while the
+// channel stays SUBSCRIBED — is recovered within ~72s (60s × 1.2 jitter) even after the
+// backoff has fully climbed during a long silent stage, while still cutting steady-state
+// polling >90% vs the old 3s. Exported for tests.
 export const AUTHORING_REALTIME_SILENCE_BASE_MS = 30000;
-export const AUTHORING_REALTIME_SILENCE_MAX_MS = 120000;
+export const AUTHORING_REALTIME_SILENCE_MAX_MS = 60000;
 const AUTHORING_REALTIME_SILENCE_JITTER = 0.2;
 
 export class ProgressTransportDegradedError extends Error {
@@ -821,6 +825,10 @@ async function streamRealtimeProgress(
                             }
 
                             settled = true;
+                            // A racing non-terminal realtime event may have armed the
+                            // silence watchdog while this reconcile was in flight; clear it
+                            // so no stale timer lingers past the terminal resolve.
+                            clearSilenceWatchdog();
                             void realtimeClient.removeChannel(channel).then(() => resolve()).catch((error) => reject(error));
                         })
                         .catch((error) => {
@@ -828,6 +836,7 @@ async function streamRealtimeProgress(
                                 return;
                             }
                             settled = true;
+                            clearSilenceWatchdog();
                             void realtimeClient.removeChannel(channel).finally(() => reject(error));
                         });
                     return;

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -111,14 +111,28 @@ interface AuthoringJobRealtimeRow {
 }
 
 const AUTHORING_PROGRESS_STEP_SET = new Set<string>(AUTHORING_PROGRESS_STEP_IDS);
-const AUTHORING_PROGRESS_POLL_INTERVAL_MS = 3000;
+// Degraded full-poll cadence used by pollProgressUntilTerminal() when the realtime
+// WebSocket is fully unavailable (no client) or has died (CHANNEL_ERROR/TIMED_OUT/
+// CLOSED). Realtime is the primary transport; this is the durable fallback, so a 20s
+// cadence detects a terminal state with ample margin on a 15-30min job while keeping
+// load off the shared DB_CRITICAL_ENDPOINT_BUDGET budget. Exported for tests.
+export const AUTHORING_PROGRESS_POLL_INTERVAL_MS = 20000;
 // Increased from 1800ms: cold WebSocket setup on production Supabase (DNS + TLS +
 // Phoenix channel join + JWT validation) can reach ~2s on P99 of 4G connections.
 // After the JWT race fix below, the primary cause of premature watchdog triggers
 // (pre-INITIAL_SESSION CHANNEL_ERROR → self-heal → second attempt hits 1800ms) is
 // eliminated. 4000ms covers P99 without adding unnecessary polling-fallback latency.
 const AUTHORING_REALTIME_SUBSCRIBE_TIMEOUT_MS = 4000;
-const AUTHORING_REALTIME_SILENCE_TIMEOUT_MS = AUTHORING_PROGRESS_POLL_INTERVAL_MS;
+// Silence watchdog: a SAFETY NET (not a heartbeat) for the two realtime failure modes
+// that emit no event — a "half-open" channel that reports SUBSCRIBED but stops
+// delivering, and a dropped terminal `completed` update. Real channel death
+// (CHANNEL_ERROR/TIMED_OUT/CLOSED) is handled immediately and separately below, so this
+// is purely time-based recovery. It arms at BASE and backs off exponentially (×2, capped
+// at MAX) on each silent non-terminal reconcile, resetting to BASE on any real realtime
+// event. ±JITTER spreads concurrent clients to avoid a thundering herd. Exported for tests.
+export const AUTHORING_REALTIME_SILENCE_BASE_MS = 30000;
+export const AUTHORING_REALTIME_SILENCE_MAX_MS = 120000;
+const AUTHORING_REALTIME_SILENCE_JITTER = 0.2;
 
 export class ProgressTransportDegradedError extends Error {
     constructor(message: string) {
@@ -738,6 +752,9 @@ async function streamRealtimeProgress(
         let subscribed = false;
         let subscribeWatchdog: ReturnType<typeof setTimeout> | null = null;
         let silenceWatchdog: ReturnType<typeof setTimeout> | null = null;
+        // Backoff for the silence watchdog: starts at BASE, doubles (capped at MAX) on
+        // each silent non-terminal reconcile, resets to BASE on any real realtime event.
+        let silenceDelayMs = AUTHORING_REALTIME_SILENCE_BASE_MS;
 
         const channel = realtimeClient
             .channel(`authoring-job-${jobId}`)
@@ -761,6 +778,9 @@ async function streamRealtimeProgress(
                         taskPayload.progress_seq,
                         taskPayload.bootstrap_state,
                     );
+                    // A real realtime event proves the channel is alive → reset the
+                    // backoff before re-arming the silence safety net.
+                    silenceDelayMs = AUTHORING_REALTIME_SILENCE_BASE_MS;
                     armSilenceWatchdog();
 
                     const nextStatus = payload.new.status;
@@ -770,6 +790,9 @@ async function streamRealtimeProgress(
                         || nextStatus === "failed_resumable"
                     ) {
                         settled = true;
+                        // Clear the silence watchdog just re-armed above so no stale
+                        // timer lingers after the terminal event resolves the stream.
+                        clearSilenceWatchdog();
                         void emitTerminalEvent(jobId, nextStatus, taskPayload, onEvent)
                             .then(() => realtimeClient.removeChannel(channel))
                             .then(() => resolve())
@@ -868,12 +891,15 @@ async function streamRealtimeProgress(
             }
 
             clearSilenceWatchdog();
+            const jitteredDelayMs =
+                silenceDelayMs
+                * (1 - AUTHORING_REALTIME_SILENCE_JITTER + Math.random() * 2 * AUTHORING_REALTIME_SILENCE_JITTER);
             silenceWatchdog = setTimeout(() => {
                 if (settled) {
                     return;
                 }
 
-                console.warn("[authoring-progress] realtime silence detected", { jobId });
+                console.debug("[authoring-progress] realtime silence detected", { jobId });
                 void reconcileLatestSnapshot()
                     .then((reconciledTerminalState) => {
                         if (settled) {
@@ -887,6 +913,9 @@ async function streamRealtimeProgress(
                             return;
                         }
 
+                        // Channel still silent: back off exponentially (capped) before
+                        // re-arming, so a long backend stage no longer floods polling.
+                        silenceDelayMs = Math.min(silenceDelayMs * 2, AUTHORING_REALTIME_SILENCE_MAX_MS);
                         armSilenceWatchdog();
                     })
                     .catch((error) => {
@@ -898,7 +927,7 @@ async function streamRealtimeProgress(
                         clearSilenceWatchdog();
                         void realtimeClient.removeChannel(channel).finally(() => reject(error));
                     });
-            }, AUTHORING_REALTIME_SILENCE_TIMEOUT_MS);
+            }, jitteredDelayMs);
         }
 
         subscribeWatchdog = setTimeout(() => {


### PR DESCRIPTION
Closes #554.

## Problema

El progreso "en tiempo real" de la generación de casos usa Supabase Realtime (`postgres_changes` en `public.authoring_jobs`) como canal primario. Encima tenía un **watchdog de silencio mal calibrado**: su umbral estaba atado al intervalo de poll y fijado en 3 s (`frontend/src/shared/api.ts:121`, `AUTHORING_REALTIME_SILENCE_TIMEOUT_MS = AUTHORING_PROGRESS_POLL_INTERVAL_MS`). Como entre etapas reales de un caso pasan minutos, con Realtime **sano** el watchdog confundía "etapa larga del backend" con "Realtime muerto" y disparaba `GET /api/authoring/jobs/{id}/progress` **cada 3 s durante todo el caso**.

**Impacto (verificado en código):**
- Cada `/progress` = 2 queries Postgres sobre 1 conexión Supavisor nueva (NullPool en prod): `resolve_current_actor` (`auth.py:538-541`) + `get_owned_job_or_404` (`app.py:347`).
- ~15-30 min/caso ⇒ ~300-600 polls ⇒ ~600-1.200 queries para transmitir ~10 cambios reales; a 200 docentes concurrentes ≈ ~67 req/s de ruido.
- **Riesgo de disponibilidad:** `/progress` adquiere el semáforo **compartido** `DB_CRITICAL_ENDPOINT_BUDGET` (default 64/instancia, `db_resilience.py:40` = un único `BoundedSemaphore` de módulo) que **también cubre `/api/auth/me`** y el intake. Bajo carga, el flood podía 503 el login de otros usuarios.
- Síntoma cosmético: flood de `[authoring-progress] realtime silence detected` en consola.

## Cambios (solo frontend, mismo contrato de API, 100% Supabase-native)

`frontend/src/shared/api.ts`:
- **Desacopla y recalibra** las constantes (exportadas para tests): poll degradado `3000 → 20000`; el silencio deja de ser un heartbeat de 3 s y pasa a **red de seguridad** con `BASE 30s`, backoff `×2` con cap `MAX 120s`, y jitter `±20%`.
- **Backoff + jitter en `armSilenceWatchdog`**: el delay se calcula con jitter; se **resetea a BASE** ante un evento Realtime real (`postgres_changes`, prueba de liveness) y **crece** tras cada reconcile silencioso no-terminal.
- **Hardening**: limpia el watchdog en la rama terminal-vía-Realtime (evita un `setTimeout` colgante por job completado).
- Baja el log de silencio a `console.debug` (ahora raro → mata el flood).

`frontend/src/shared/api.test.ts`: migra los advances atados al `3000` a las constantes exportadas, fija el jitter con `Math.random=0.5` (factor exacto 1.0) y añade un test de **backoff** (BASE → 2×BASE → cap MAX, y reset a BASE ante un evento Realtime real). El test de "terminal failure after channel error" se pasó a fake timers (dependía indirectamente del poll de 3 s vía el timeout de 10 s).

### Por qué estos valores
La muerte real del canal (`CHANNEL_ERROR/TIMED_OUT/CLOSED`) ya se maneja **por evento e inmediato** (`api.ts:813`); el watchdog de silencio solo cubre los fallos sin evento (WebSocket medio-muerto SUBSCRIBED, o un `completed` perdido), así que time-based es lo correcto. El peor caso **realista** de loader colgado es ~30 s (la finalización sigue a un evento de progreso reciente que resetea el backoff); el cap de 120 s solo aplica a huecos genuinamente silenciosos donde no hay terminal que perder. La monotonicidad de `progress_seq` (`emitMonotonicProgress`) y el fallback degradado se preservan.

Traza esperada en un hueco de 4 min entre etapas: dispara ~30s, ~90s, ~210s → ~3 polls en vez de ~80.

## Validación local
- `pnpm --dir frontend run lint` ✅ (sin errores)
- `pnpm --dir frontend run build` ✅ (tsc -b + vite, exit 0)
- `api.test.ts` ✅ 33/33 (incluye el nuevo test de backoff), determinista y rápido.
- Suite completa: verde en re-run. **Nota:** la suite tiene flakiness **pre-existente** de timeout bajo carga paralela en tests lentos de `userEvent` (p.ej. `AuthoringForm.test.tsx`, 105 s en aislamiento) — sin relación con este cambio (toca solo el transporte de progreso); `AuthoringForm.test.tsx` pasa 33/33 en aislamiento. Si `frontend-test` flakea en CI, un re-run pasa.

## Backward-compat (en producción ahora mismo)
Cambio **100% client-side**, mismo endpoint y misma forma de respuesta (`JobProgressResponse`). Un docente con el bundle **viejo** (3 s) y un job en curso sigue polleando a 3 s hasta recargar (entonces el SPA hash-versionado sirve el nuevo bundle); uno con el bundle **nuevo** pollea a 30/20 s. Ambos golpean el mismo `/progress` sin conflicto. **Sin sesión rota.**

## Observabilidad post-deploy (primeras horas)
- `progress_snapshot_reads_total{endpoint=authoring_progress}` (`app.py:1061`) debe **desplomarse** (cientos/caso → un puñado).
- `db_backpressure_503_total{endpoint=auth_me|authoring_progress|authoring_intake}` ≈ 0.
- Manual: generar un caso → `realtime silence detected` ~0 veces; Network tab con un puñado de `/progress`; ningún loader colgado al completar.
- Caso límite: DevTools offline unos segundos (matar el WS) → el fallback degradado recupera (~20 s) y cierra el loader.

## Rollback (concreto)
Por ser client-only: redeploy del bundle anterior vía traffic split de Cloud Run (`docs/deploy.md:189-200`), reversión instantánea, sin migración que deshacer:
```
gcloud run revisions list --service=public-api --region=us-west1
gcloud run services update-traffic public-api --region=us-west1 --to-revisions=REVISION_ANTERIOR=100
```

## Fuera de alcance (respetado del issue)
Pausa por `visibilitychange` (diferido), abaratar el costo unitario de `/progress`, y heartbeats de escritura (anti-patrón explícito del repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
