### PR TITLE
fix(case-viewer): harden Plotly chart render for production resilience

### DIFF
--- a/backend/src/case_generator/prompts/clasificacion/M4_clasificacion/charts.py
+++ b/backend/src/case_generator/prompts/clasificacion/M4_clasificacion/charts.py
@@ -49,12 +49,12 @@ El contexto incluye el análisis de impacto M4 de un modelo de clasificación
 
 ## Gráfico 1: Flujo de Caja y Punto de Equilibrio (Payback) — Pipeline ML
 - **chart_type:** `"bar"` — un único valor en este campo (el schema no admite compuestos).
-  El trace de acumulado se añade como trace `"line"` dentro del array `traces`.
+  El trace de acumulado se añade como trace `"scatter"` con `mode:"lines"` dentro del array `traces`.
 - **Concepto:** Mostrar inversión inicial (infraestructura ML, licencias, datos) →
   flujos netos por período → punto donde el acumulado cruza cero ("Valle de la Muerte").
 - **Traces:**
   - `{{"type": "bar", ...}}`: flujo neto por período (incluir costos de reentrenamiento periódico)
-  - `{{"type": "line", ...}}`: flujo acumulado (cruza cero en el payback period)
+  - `{{"type": "scatter", "mode": "lines", ...}}`: flujo acumulado (cruza cero en el payback period; Plotly NO tiene tipo "line", una línea es scatter con mode "lines")
 - **Datos:** Extraer inversión de Exhibit 1, proyectar flujos netos según la opción
   recomendada en M4 content. Usar el horizonte temporal del caso.
 - **Títulos técnico-financieros:** ej. "ROI del Pipeline ML vs Inversión en Infra".
@@ -106,8 +106,8 @@ El contexto incluye el análisis de impacto M4 de un modelo de clasificación
   "title": "string (orientado al insight financiero del modelo ML)",
   "subtitle": "string",
   "library": "plotly",
-  "chart_type": "waterfall|bar|line",
-  "traces": [{{ "type": "bar|line|scatter", "x": [...], "y": [...], "name": "..." }}],
+  "chart_type": "waterfall|bar|scatter",
+  "traces": [{{ "type": "bar|scatter", "x": [...], "y": [...], "name": "..." }}],
   "layout": {{ "xaxis": {{"title": "..."}}, "yaxis": {{"title": "..."}}, "showlegend": true, "template": "plotly_white" }},
   "source": "Análisis Financiero — {case_id}",
   "notes": "string (insight + método de cálculo + referencia a métricas M3 si aplica)",
@@ -152,12 +152,12 @@ El contexto incluye el análisis de impacto M4 de un modelo de clasificación
 
 ## Gráfico 1: Flujo de Caja y Punto de Equilibrio (Payback) — Pipeline ML
 - **chart_type:** `"bar"` — un único valor en este campo (el schema no admite compuestos).
-  El trace de acumulado se añade como trace `"line"` dentro del array `traces`.
+  El trace de acumulado se añade como trace `"scatter"` con `mode:"lines"` dentro del array `traces`.
 - **Concepto:** Mostrar inversión inicial (infraestructura ML, licencias, datos) →
   flujos netos por período → punto donde el acumulado cruza cero ("Valle de la Muerte").
 - **Traces:**
   - `{{"type": "bar", ...}}`: flujo neto por período (incluir costos de reentrenamiento periódico)
-  - `{{"type": "line", ...}}`: flujo acumulado (cruza cero en el payback period)
+  - `{{"type": "scatter", "mode": "lines", ...}}`: flujo acumulado (cruza cero en el payback period; Plotly NO tiene tipo "line", una línea es scatter con mode "lines")
 - **Datos:** Extraer inversión de Exhibit 1, proyectar flujos netos según la opción
   recomendada en M4 content. Usar el horizonte temporal del caso.
 - **Títulos técnico-financieros:** ej. "ROI del Pipeline ML vs Inversión en Infra".
@@ -196,8 +196,8 @@ El contexto incluye el análisis de impacto M4 de un modelo de clasificación
   "title": "string (orientado al insight financiero del modelo ML)",
   "subtitle": "string",
   "library": "plotly",
-  "chart_type": "waterfall|bar|line",
-  "traces": [{{ "type": "bar|line|scatter", "x": [...], "y": [...], "name": "..." }}],
+  "chart_type": "waterfall|bar|scatter",
+  "traces": [{{ "type": "bar|scatter", "x": [...], "y": [...], "name": "..." }}],
   "layout": {{ "xaxis": {{"title": "..."}}, "yaxis": {{"title": "..."}}, "showlegend": true, "template": "plotly_white" }},
   "source": "Análisis Financiero — {case_id}",
   "notes": "string (insight + método de cálculo + referencia a métricas M3 si aplica)",
@@ -246,13 +246,13 @@ El contexto incluye el análisis de impacto M4 de un modelo de clasificación
 
 ## Gráfico 1: Flujo de Caja y Punto de Equilibrio (Payback) — Pipeline ML
 - **chart_type:** `"bar"` — un único valor en este campo (el schema no admite compuestos).
-  El trace de acumulado se añade como trace `"line"` dentro del array `traces`.
+  El trace de acumulado se añade como trace `"scatter"` con `mode:"lines"` dentro del array `traces`.
 - **Concepto:** Mostrar inversión inicial (infraestructura ML, licencias, datos) →
   flujos netos por período → punto donde el acumulado cruza cero ("Valle de la Muerte").
   Los costos van SIEMPRE en USD; el "retorno" es el VALOR del MARCO DE VALOR monetizado.
 - **Traces:**
   - `{{"type": "bar", ...}}`: flujo neto por período (incluir costos de reentrenamiento periódico)
-  - `{{"type": "line", ...}}`: flujo acumulado (cruza cero en el payback period)
+  - `{{"type": "scatter", "mode": "lines", ...}}`: flujo acumulado (cruza cero en el payback period; Plotly NO tiene tipo "line", una línea es scatter con mode "lines")
 - **Datos:** Extraer inversión de Exhibit 1, proyectar flujos netos según la opción
   recomendada en M4 content. Usar el horizonte temporal del caso.
 - **Títulos técnicos:** ej. "Recuperación de la inversión del Pipeline ML".
@@ -293,8 +293,8 @@ El contexto incluye el análisis de impacto M4 de un modelo de clasificación
   "title": "string (orientado al insight de valor del modelo ML)",
   "subtitle": "string",
   "library": "plotly",
-  "chart_type": "waterfall|bar|line",
-  "traces": [{{ "type": "bar|line|scatter", "x": [...], "y": [...], "name": "..." }}],
+  "chart_type": "waterfall|bar|scatter",
+  "traces": [{{ "type": "bar|scatter", "x": [...], "y": [...], "name": "..." }}],
   "layout": {{ "xaxis": {{"title": "..."}}, "yaxis": {{"title": "..."}}, "showlegend": true, "template": "plotly_white" }},
   "source": "Análisis de Impacto — {case_id}",
   "notes": "string (insight + método de cálculo + referencia a métricas M3 si aplica)",
@@ -360,7 +360,7 @@ determinista a partir de la matriz de costos del caso; NO lo generes tú.)
   proyectado que genera el modelo, expresado en la métrica del MARCO DE VALOR.
   - Si el MARCO DE VALOR es financiero (USD): puedes mostrar la recuperación de la inversión —
     una barra de valor neto por período (DERIVADO aritméticamente del valor anual del M4 ÷ el
-    número de períodos del horizonte) y una traza `"line"` de valor acumulado que cruza la
+    número de períodos del horizonte) y una traza `"scatter"` (con `mode:"lines"`) de valor acumulado que cruza la
     inversión inicial (el punto de recuperación). Usa SOLO cifras del M4/Exhibit 1 o derivadas.
   - Si el MARCO DE VALOR NO es financiero (p. ej. resultados clínicos, de aprendizaje o
     ambientales): muestra la inversión (USD) junto al valor proyectado en la unidad de esa
@@ -393,8 +393,8 @@ determinista a partir de la matriz de costos del caso; NO lo generes tú.)
   "title": "string (orientado al caso de inversión del modelo ML)",
   "subtitle": "string",
   "library": "plotly",
-  "chart_type": "bar|line",
-  "traces": [{{ "type": "bar|line|scatter", "x": [...], "y": [...], "name": "..." }}],
+  "chart_type": "bar|scatter",
+  "traces": [{{ "type": "bar|scatter", "x": [...], "y": [...], "name": "..." }}],
   "layout": {{ "xaxis": {{"title": "..."}}, "yaxis": {{"title": "..."}}, "showlegend": true, "template": "plotly_white" }},
   "source": "Análisis de Impacto — {case_id}",
   "notes": "string (insight + método de cálculo + referencia a métricas M3 si aplica)",

--- a/backend/tests/test_m4_chart_removal.py
+++ b/backend/tests/test_m4_chart_removal.py
@@ -7,7 +7,10 @@ chart was retired: orphan (no §4.x narrative / no M4 question), highest fabrica
 Coverage:
 * New-prompt drift-locks: the 3 live chart prompts instruct 2 charts and never mention the tornado.
 * Legacy-revert drift-locks: the ``*_LEGACY`` snapshots keep the 3-chart / Tornado contract intact,
-  so ``M4_CHART_DROP_SENSITIVITY=false`` is a faithful byte-revert.
+  so ``M4_CHART_DROP_SENSITIVITY=false`` reverts to the 3-chart behavior. (The classification
+  ``*_LEGACY`` prompt's ``line``→``scatter``+``mode:"lines"`` token was modernized in lockstep with
+  the live prompts; this is render-identical — the frontend ``sanitizeTraces`` coerces ``line``→
+  scatter — so the revert stays behaviorally faithful even though it is no longer byte-for-byte.)
 * Dispatch identity: both dispatch tables point at the right constants.
 * ``.format()`` smoke: no stray ``{}`` introduced by the edits (new + legacy).
 * Detector units: ``is_sensitivity_chart`` / ``drop_sensitivity_charts`` (zero-FP, non-mutating, total).
@@ -72,7 +75,19 @@ def test_live_prompt_has_no_tornado(name: str) -> None:
     assert "Gráfico 3" not in _LIVE_PROMPTS[name], f"{name} must renumber away Gráfico 3"
 
 
-# ── 2. Legacy-revert drift-locks (so M4_CHART_DROP_SENSITIVITY=false is a faithful byte-revert) ──
+def test_classification_chart_prompt_emits_scatter_not_invalid_line() -> None:
+    # Plotly.js has NO "line" trace type (a line is scatter + mode:"lines"); the ml_ds+clf chart
+    # prompt was corrected to emit scatter so the LLM stops producing an unrenderable trace.
+    # Scope note: the shared generic ``M4_CHART_GENERATOR_PROMPT`` (and the business prompt derived
+    # from it) still say ``line`` — that is handled render-side by ``sanitizeTraces``' line→scatter
+    # coercion, and completing the generic prompt is a documented defense-in-depth follow-up
+    # (intentionally out of scope to keep the shared-prompt blast radius minimal here).
+    prompt = M4_CHART_PROMPT_CLASSIFICATION
+    assert '"type": "line"' not in prompt, "classification chart prompt must not instruct type:line"
+    assert "bar|line" not in prompt, "classification chart prompt must not list 'line' in the enum hint"
+
+
+# ── 2. Legacy-revert drift-locks (so M4_CHART_DROP_SENSITIVITY=false reverts to 3-chart behavior) ──
 
 
 @pytest.mark.parametrize("name", list(_LEGACY_PROMPTS))

--- a/frontend/src/features/case-preview/PlotlyChartsRenderer.test.tsx
+++ b/frontend/src/features/case-preview/PlotlyChartsRenderer.test.tsx
@@ -32,4 +32,24 @@ describe("PlotlyChartsRenderer", () => {
         expect(await screen.findByTestId("plotly-component")).toHaveTextContent("Graficas renderizadas: 1");
         expect(screen.queryByText("Cargando Gráfico...")).toBeNull();
     });
+
+    it("shows a graceful fallback when all traces are unrenderable (dropped types)", () => {
+        render(
+            <PlotlyChartsRenderer
+                charts={[
+                    {
+                        id: "chart-unrenderable",
+                        title: "Roto",
+                        traces: [{ type: "pie", values: [1, 2] }],
+                        layout: {},
+                    },
+                ]}
+            />,
+        );
+
+        expect(
+            screen.getByText("Datos no disponibles para este gráfico."),
+        ).toBeTruthy();
+        expect(screen.queryByTestId("plotly-component")).toBeNull();
+    });
 });

--- a/frontend/src/shared/case-viewer/ChartErrorBoundary.test.tsx
+++ b/frontend/src/shared/case-viewer/ChartErrorBoundary.test.tsx
@@ -1,0 +1,80 @@
+import { type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ChartErrorBoundary } from "./ChartErrorBoundary";
+
+function Boom(): ReactNode {
+    throw new Error("render exploded");
+}
+
+describe("ChartErrorBoundary", () => {
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        // React logs caught render errors to console.error — silence it so the test
+        // output stays clean (the boundary itself is what we assert on).
+        errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        errorSpy.mockRestore();
+    });
+
+    it("renders children when they do not throw", () => {
+        render(
+            <ChartErrorBoundary fallback={<div>fallback</div>}>
+                <div>healthy chart</div>
+            </ChartErrorBoundary>,
+        );
+
+        expect(screen.getByText("healthy chart")).toBeTruthy();
+        expect(screen.queryByText("fallback")).toBeNull();
+    });
+
+    it("shows the fallback when a child throws during render", () => {
+        render(
+            <ChartErrorBoundary fallback={<div>fallback shown</div>}>
+                <Boom />
+            </ChartErrorBoundary>,
+        );
+
+        expect(screen.getByText("fallback shown")).toBeTruthy();
+    });
+
+    it("re-arms and shows children again when resetKey changes after a crash", () => {
+        const { rerender } = render(
+            <ChartErrorBoundary fallback={<div>fallback shown</div>} resetKey="a">
+                <Boom />
+            </ChartErrorBoundary>,
+        );
+        expect(screen.getByText("fallback shown")).toBeTruthy();
+
+        // New data arrives under a different resetKey (the renderer passes spec.traces) →
+        // the boundary re-arms and renders the now-healthy children, not the stale fallback.
+        rerender(
+            <ChartErrorBoundary fallback={<div>fallback shown</div>} resetKey="b">
+                <div>recovered chart</div>
+            </ChartErrorBoundary>,
+        );
+        expect(screen.getByText("recovered chart")).toBeTruthy();
+    });
+
+    it("stays latched on the fallback when resetKey is unchanged after a crash", () => {
+        const { rerender } = render(
+            <ChartErrorBoundary fallback={<div>fallback shown</div>} resetKey="same">
+                <Boom />
+            </ChartErrorBoundary>,
+        );
+        expect(screen.getByText("fallback shown")).toBeTruthy();
+
+        // Same resetKey (unchanged data) → do NOT retry; avoids a fail→retry→fail flicker.
+        rerender(
+            <ChartErrorBoundary fallback={<div>fallback shown</div>} resetKey="same">
+                <div>should not appear</div>
+            </ChartErrorBoundary>,
+        );
+        expect(screen.getByText("fallback shown")).toBeTruthy();
+        expect(screen.queryByText("should not appear")).toBeNull();
+    });
+});

--- a/frontend/src/shared/case-viewer/ChartErrorBoundary.tsx
+++ b/frontend/src/shared/case-viewer/ChartErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { Component, type ReactNode } from "react";
+
+interface ChartErrorBoundaryProps {
+    children: ReactNode;
+    fallback: ReactNode;
+    /**
+     * When this value changes (compared by `!==`) the boundary re-arms after a crash.
+     * The renderer passes the chart's `traces` array, so a card that crashed on early
+     * partial data during live preview recovers when new data arrives under the SAME
+     * chart id. React Query keeps the reference stable while content is unchanged, so
+     * this does NOT retry a perpetually-failing chart on every poll.
+     */
+    resetKey?: unknown;
+}
+
+interface ChartErrorBoundaryState {
+    crashed: boolean;
+}
+
+/**
+ * Catches SYNCHRONOUS render / lifecycle errors thrown below it — including a failed
+ * `React.lazy` chunk load (e.g. a stale chunk after a deploy) and a synchronous throw
+ * from react-plotly.js — and shows `fallback` instead of crashing the surrounding
+ * module.
+ *
+ * ASYNCHRONOUS plotly.js draw failures are NOT caught here: React error boundaries
+ * never catch errors thrown outside the render/lifecycle cycle (e.g. inside the
+ * `Plotly.react` promise). Those are handled separately by the `onError` prop on the
+ * Plot component. Sibling of `ExhibitErrorBoundary` — kept as its own component so the
+ * working exhibit path is left untouched.
+ */
+export class ChartErrorBoundary extends Component<
+    ChartErrorBoundaryProps,
+    ChartErrorBoundaryState
+> {
+    state: ChartErrorBoundaryState = { crashed: false };
+
+    static getDerivedStateFromError(): ChartErrorBoundaryState {
+        return { crashed: true };
+    }
+
+    componentDidUpdate(prevProps: ChartErrorBoundaryProps) {
+        if (this.state.crashed && prevProps.resetKey !== this.props.resetKey) {
+            this.setState({ crashed: false });
+        }
+    }
+
+    render() {
+        return this.state.crashed ? this.props.fallback : this.props.children;
+    }
+}

--- a/frontend/src/shared/case-viewer/PlotlyChartsRenderer.onError.test.tsx
+++ b/frontend/src/shared/case-viewer/PlotlyChartsRenderer.onError.test.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { EDAChartSpec } from "@/shared/adam-types";
+
+// Mock PlotlyComponent so the lazy Plot fires `onError` the way react-plotly.js does:
+// from the REJECTED `Plotly.react` draw promise — i.e. asynchronously, after mount, NOT
+// during render. The renderer's `onError={() => setRenderFailed(true)}` must then swap in
+// the graceful fallback instead of leaving a broken canvas. (Lives in its own file so the
+// onError-firing mock doesn't interfere with the healthy-render mock used elsewhere.)
+vi.mock("@/shared/case-viewer/PlotlyComponent", () => {
+    // Named + uppercase so eslint's react-hooks/rules-of-hooks treats it as a component.
+    function MockPlot({ onError }: { onError?: (err: Error) => void }) {
+        useEffect(() => {
+            onError?.(new Error("draw rejected"));
+        }, [onError]);
+        return <div data-testid="plotly-component" />;
+    }
+    return { default: MockPlot };
+});
+
+import { PlotlyChartsRenderer } from "./PlotlyChartsRenderer";
+
+const chart: EDAChartSpec = {
+    id: "c1",
+    title: "Ingresos",
+    traces: [{ type: "scatter", x: [1, 2], y: [3, 4] }],
+    layout: {},
+};
+
+describe("PlotlyChartsRenderer — onError fallback", () => {
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        // Plotly draw rejection surfaces via console.error in the mock path; silence it.
+        errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        errorSpy.mockRestore();
+    });
+
+    it("shows the render-failed fallback when the Plot fires onError", async () => {
+        render(<PlotlyChartsRenderer charts={[chart]} />);
+
+        expect(
+            await screen.findByText("No se pudo renderizar este gráfico."),
+        ).toBeTruthy();
+    });
+});

--- a/frontend/src/shared/case-viewer/PlotlyChartsRenderer.tsx
+++ b/frontend/src/shared/case-viewer/PlotlyChartsRenderer.tsx
@@ -1,6 +1,7 @@
-import React, { Suspense, useMemo } from "react";
+import React, { Suspense, useEffect, useMemo, useState } from "react";
 import type { EDAChartSpec } from "@/shared/adam-types";
 
+import { ChartErrorBoundary } from "./ChartErrorBoundary";
 import {
     buildLayout,
     chartHasHeatmap,
@@ -14,7 +15,21 @@ export interface PlotlyChartsRendererProps {
     onRetry?: () => void;
 }
 
+function ChartFallback({ height, message }: { height: number; message: string }) {
+    return (
+        <div
+            className="flex items-center justify-center rounded-lg border border-dashed border-slate-200 bg-slate-50"
+            style={{ height }}
+        >
+            <p className="px-6 text-center text-sm text-slate-400">{message}</p>
+        </div>
+    );
+}
+
 function PlotlyChartCard({ spec }: { spec: EDAChartSpec }) {
+    // Set asynchronously by the Plot's `onError` (a plotly.js draw rejection) — React
+    // error boundaries cannot catch those, so this state drives the fallback instead.
+    const [renderFailed, setRenderFailed] = useState(false);
     const hasHeatmap = chartHasHeatmap(spec.traces || []);
     const chartHeight = hasHeatmap ? 450 : 350;
     const sanitizedTraces = useMemo(
@@ -26,6 +41,12 @@ function PlotlyChartCard({ spec }: { spec: EDAChartSpec }) {
         [spec.layout, sanitizedTraces],
     );
 
+    // Re-arm the failure state when the chart data changes, so a card that failed on a
+    // previous spec retries instead of staying latched on the fallback.
+    useEffect(() => {
+        setRenderFailed(false);
+    }, [spec.traces]);
+
     const hasUnrenderableHeatmap =
         hasHeatmap &&
         sanitizedTraces.some(
@@ -33,6 +54,19 @@ function PlotlyChartCard({ spec }: { spec: EDAChartSpec }) {
                 String(trace.type || "").toLowerCase() === "heatmap" &&
                 (!trace.z || (Array.isArray(trace.z) && trace.z.length === 0)),
         );
+
+    // No renderable traces survived sanitisation (e.g. an unregistered trace type was
+    // dropped) → graceful placeholder instead of an empty Plotly canvas.
+    const hasNoRenderableData = sanitizedTraces.length === 0;
+
+    const showFallback =
+        renderFailed || hasUnrenderableHeatmap || hasNoRenderableData;
+
+    const fallbackMessage = renderFailed
+        ? "No se pudo renderizar este gráfico."
+        : hasUnrenderableHeatmap
+          ? "Datos de la matriz no disponibles para este gráfico."
+          : "Datos no disponibles para este gráfico.";
 
     return (
         <div className="relative rounded-xl border border-slate-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
@@ -43,36 +77,40 @@ function PlotlyChartCard({ spec }: { spec: EDAChartSpec }) {
             </div>
 
             <div className="mt-2 w-full overflow-hidden" style={{ minHeight: chartHeight }}>
-                {hasUnrenderableHeatmap ? (
-                    <div
-                        className="flex items-center justify-center rounded-lg border border-dashed border-slate-200 bg-slate-50"
-                        style={{ height: chartHeight }}
-                    >
-                        <p className="px-6 text-center text-sm text-slate-400">
-                            Datos de la matriz no disponibles para este gráfico.
-                        </p>
-                    </div>
+                {showFallback ? (
+                    <ChartFallback height={chartHeight} message={fallbackMessage} />
                 ) : (
-                    <Suspense
+                    <ChartErrorBoundary
+                        resetKey={spec.traces}
                         fallback={
-                            <div className="flex w-full items-center justify-center rounded-lg bg-slate-50/50" style={{ height: chartHeight }}>
-                                <div className="flex flex-col items-center gap-3">
-                                    <div className="h-5 w-5 animate-spin rounded-full border-2 border-slate-200 border-t-slate-400" />
-                                    <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                                        Cargando Gráfico...
-                                    </span>
-                                </div>
-                            </div>
+                            <ChartFallback
+                                height={chartHeight}
+                                message="No se pudo renderizar este gráfico."
+                            />
                         }
                     >
-                        <Plot
-                            data={sanitizedTraces}
-                            layout={layoutConfig}
-                            config={{ responsive: true, displayModeBar: false }}
-                            useResizeHandler={true}
-                            style={{ width: "100%", height: `${chartHeight}px` }}
-                        />
-                    </Suspense>
+                        <Suspense
+                            fallback={
+                                <div className="flex w-full items-center justify-center rounded-lg bg-slate-50/50" style={{ height: chartHeight }}>
+                                    <div className="flex flex-col items-center gap-3">
+                                        <div className="h-5 w-5 animate-spin rounded-full border-2 border-slate-200 border-t-slate-400" />
+                                        <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                                            Cargando Gráfico...
+                                        </span>
+                                    </div>
+                                </div>
+                            }
+                        >
+                            <Plot
+                                data={sanitizedTraces}
+                                layout={layoutConfig}
+                                config={{ responsive: true, displayModeBar: false }}
+                                useResizeHandler={true}
+                                onError={() => setRenderFailed(true)}
+                                style={{ width: "100%", height: `${chartHeight}px` }}
+                            />
+                        </Suspense>
+                    </ChartErrorBoundary>
                 )}
             </div>
 

--- a/frontend/src/shared/case-viewer/PlotlyComponent.tsx
+++ b/frontend/src/shared/case-viewer/PlotlyComponent.tsx
@@ -7,6 +7,12 @@ import scatter from "plotly.js/lib/scatter";
 import violin from "plotly.js/lib/violin";
 import waterfall from "plotly.js/lib/waterfall";
 
+// Partial Plotly build: only these six trace modules are bundled. Their trace `type`s
+// are mirrored in `REGISTERED_TRACE_TYPES` (plotlyChartUtils.ts), which sanitizeTraces
+// uses to drop any trace whose type has no module here (it would otherwise render
+// nothing). Keep the two lists in sync — the const-lock test in plotlyChartUtils.test.ts
+// fails if `REGISTERED_TRACE_TYPES` changes without a conscious update. The names are
+// kept in plotlyChartUtils (plotly-free) so this heavy bundle stays out of the eager chunk.
 Plotly.register([bar, box, heatmap, scatter, violin, waterfall]);
 
 const PlotlyComponent = createPlotlyComponent(Plotly);

--- a/frontend/src/shared/case-viewer/plotlyChartUtils.test.ts
+++ b/frontend/src/shared/case-viewer/plotlyChartUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildLayout, sanitizeTraces } from "./plotlyChartUtils";
+import { buildLayout, REGISTERED_TRACE_TYPES, sanitizeTraces } from "./plotlyChartUtils";
 
 function makeZ(rows: number, cols: number): number[][] {
     return Array.from({ length: rows }, (_, r) =>
@@ -288,5 +288,73 @@ describe("sanitizeTraces — heatmap zmin/zmax range", () => {
         // dataMin=0 ≠ dataMax=1 → rama else (sin cambio), mismo 0..1.
         expect(out.zmin).toBe(0);
         expect(out.zmax).toBe(1);
+    });
+});
+
+describe("sanitizeTraces — invalid 'line' trace coercion (render fix)", () => {
+    // Plotly.js has NO "line" trace type, but the M4 chart prompt instructs {type:"line"}
+    // for the cumulative-flow line. Without coercion that trace silently does not render.
+    it("coerces type:'line' to scatter + mode:'lines'", () => {
+        const [out] = sanitizeTraces([{ type: "line", x: [1, 2], y: [3, 4] }]);
+        expect(out.type).toBe("scatter");
+        expect(out.mode).toBe("lines");
+    });
+
+    it("is case-insensitive when coercing 'line'", () => {
+        const [out] = sanitizeTraces([{ type: "Line", x: [1], y: [2] }]);
+        expect(out.type).toBe("scatter");
+        expect(out.mode).toBe("lines");
+    });
+
+    it("preserves an explicit mode already set on a line trace", () => {
+        const [out] = sanitizeTraces([
+            { type: "line", mode: "lines+markers", x: [1], y: [2] },
+        ]);
+        expect(out.type).toBe("scatter");
+        expect(out.mode).toBe("lines+markers");
+    });
+
+    it("does not touch a real scatter trace's mode", () => {
+        const [out] = sanitizeTraces([{ type: "scatter", x: [1], y: [2] }]);
+        expect(out.type).toBe("scatter");
+        expect(out.mode).toBeUndefined();
+    });
+});
+
+describe("sanitizeTraces — unrenderable trace-type allowlist (render fix)", () => {
+    it("drops a trace whose type has no registered Plotly module", () => {
+        const out = sanitizeTraces([
+            { type: "bar", x: ["a"], y: [1] },
+            { type: "pie", values: [1, 2], labels: ["a", "b"] },
+        ]);
+        expect(out).toHaveLength(1);
+        expect(out[0].type).toBe("bar");
+    });
+
+    it("returns an empty array when every trace is unrenderable", () => {
+        const out = sanitizeTraces([{ type: "indicator", value: 42 }]);
+        expect(out).toEqual([]);
+    });
+
+    it("keeps a trace with no explicit type (Plotly defaults it to scatter)", () => {
+        const out = sanitizeTraces([{ x: [1, 2], y: [3, 4] }]);
+        expect(out).toHaveLength(1);
+    });
+
+    it("keeps every registered trace type", () => {
+        const out = sanitizeTraces(
+            REGISTERED_TRACE_TYPES.map((type) => ({ type, x: [1], y: [2] })),
+        );
+        expect(out).toHaveLength(REGISTERED_TRACE_TYPES.length);
+    });
+});
+
+describe("REGISTERED_TRACE_TYPES", () => {
+    it("matches the partial Plotly bundle registered in PlotlyComponent.tsx", () => {
+        // Drift lock: these must match the modules registered in PlotlyComponent.tsx.
+        // If the partial bundle changes, update both this list and that registration.
+        expect([...REGISTERED_TRACE_TYPES].sort()).toEqual(
+            ["bar", "box", "heatmap", "scatter", "violin", "waterfall"].sort(),
+        );
     });
 });

--- a/frontend/src/shared/case-viewer/plotlyChartUtils.ts
+++ b/frontend/src/shared/case-viewer/plotlyChartUtils.ts
@@ -125,10 +125,35 @@ export function validateHeatmapConfig(
     return { valid: errors.length === 0, errors, warnings, normalizedZ, zMin, zMax };
 }
 
+// The trace `type`s whose Plotly modules are registered in the partial bundle
+// (PlotlyComponent.tsx). A trace with any other type has no module and would render
+// nothing, so sanitizeTraces drops it. Kept here (not imported from PlotlyComponent)
+// so the heavy plotly.js bundle stays out of the eager chunk. The drift-lock test in
+// plotlyChartUtils.test.ts pins this list; keep it in sync with the modules registered
+// in PlotlyComponent.tsx.
+export const REGISTERED_TRACE_TYPES: readonly string[] = [
+    "bar",
+    "box",
+    "heatmap",
+    "scatter",
+    "violin",
+    "waterfall",
+];
+
 export function sanitizeTraces(traces: Record<string, unknown>[]): Record<string, unknown>[] {
     const hasDualY = chartHasDualY(traces);
-    return traces.map((trace, index) => {
+    const mapped = traces.map((trace, index) => {
         const sanitized = { ...trace };
+
+        // Plotly.js has NO "line" trace type — a line is scatter + mode:"lines". The M4
+        // chart prompt instructs {type:"line"} for the cumulative-flow line, which would
+        // silently not render. Coerce it, preserving any explicit mode already set.
+        if (String(sanitized.type ?? "").trim().toLowerCase() === "line") {
+            sanitized.type = "scatter";
+            if (sanitized.mode == null) {
+                sanitized.mode = "lines";
+            }
+        }
 
         if (isHeatmapTrace(trace)) {
             const validation = validateHeatmapConfig(trace);
@@ -237,6 +262,20 @@ export function sanitizeTraces(traces: Record<string, unknown>[]): Record<string
         }
 
         return sanitized;
+    });
+
+    // Drop any trace whose type has no registered Plotly module (after the coercion
+    // above): the partial bundle cannot draw it, so it would render nothing. A trace
+    // with no explicit type defaults to "scatter" in Plotly and is kept.
+    return mapped.filter((trace) => {
+        const type = String(trace.type ?? "").trim().toLowerCase();
+        if (type && !REGISTERED_TRACE_TYPES.includes(type)) {
+            console.warn(
+                `[sanitizeTraces] dropping trace with unrenderable type "${type}"`,
+            );
+            return false;
+        }
+        return true;
     });
 }
 


### PR DESCRIPTION
## Context

Charts in M2/M4 are JSON specs (`EDAChartSpec`) drawn client-side by react-plotly.js (React 19 · react-plotly.js 2.6.0 · plotly.js 3.4.0). The render path had no failure handling: a malformed trace, an invalid trace type, or a failed `React.lazy` chunk load could blank a chart or crash the whole module. This hardens the **shared, model-independent** render path, so it also fixes already-generated cases without regeneration.

## What changed

- **`ChartErrorBoundary` + `onError` (two-layer resilience).** The boundary catches synchronous render errors and a failed lazy-chunk import; the Plot's `onError` prop catches async plotly.js draw rejections (which a React error boundary cannot). Either degrades to a graceful fallback instead of a broken canvas. The boundary re-arms on `spec.traces` (aligned with the `renderFailed` reset) so a transient failure on early live-preview data recovers when good data arrives under the same chart id — and does **not** retry a perpetually-failing chart (React Query keeps the ref stable for unchanged content).
- **`sanitizeTraces` type safety.** Coerces the invalid `type:"line"` (Plotly.js has no `line` type — a line is `scatter`+`mode:"lines"`) to scatter, and drops traces whose type has no registered Plotly module (`REGISTERED_TRACE_TYPES`), with an empty-data fallback rather than a silent blank.
- **Backend root cause.** The M4 ml_ds+clf chart prompts now emit `scatter`+`mode` instead of the invalid `line`. The shared generic prompt still uses `line` (handled by the frontend coercion); completing it is a documented defense-in-depth follow-up to keep the shared-prompt blast radius minimal.

## Verification

- Frontend: **587 tests** pass (incl. new onError / resetKey-reset / line-coercion / unknown-type-drop coverage), `eslint` clean, `tsc -b && vite build` clean, Plotly bundle isolation preserved (PlotlyComponent stays a separate lazy ~1.2MB chunk; `index` does not statically import it).
- Backend: the M4 chart-prompt suite (incl. a new positive `no type:line` lock) passes; prompt `.format()` placeholders verified intact.

## Review

Reviewed via three independent adversarial passes (production failure modes, React 19 + react-plotly.js correctness verified against the installed `factory.js`, test coverage/maintainability). All findings remediated: error-boundary latch asymmetry, missing failure-path tests, stale comments, `.trim()` robustness, and an honest legacy byte-revert note.

## Out of scope (deferred, documented)

Fase 2 of the plan: a backend renderability validator and a `null`/`NaN`→gap change in `sanitizeTraces` (regression risk on bar charts → its own change), plus completing the generic-prompt `line`→`scatter`. None affect user-facing rendering (the frontend coercion is the guarantee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)