### PR TITLE
fix(m1-questions): de-churn M1 discussion-questions anchor → domain-neutral for any ml_ds+clf case

### DIFF
--- a/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/questions.py
+++ b/backend/src/case_generator/prompts/clasificacion/M1_clasificacion/questions.py
@@ -35,10 +35,14 @@ _M1_CLASSIFICATION_ANCHOR_QUESTIONS = """
 
 **P2 (analysis) — cuando {student_profile} = "ml_ds":**
 P2 debe pedir al estudiante que realice las dos siguientes operaciones analíticas:
-  (a) Proponga una definición operacional precisa de la variable objetivo del negocio.
-      Ejemplo guía: "¿Qué constituye exactamente un cliente 'en riesgo' según los
-      datos disponibles? ¿Cómo lo mediría con los datos del Exhibit 2? ¿En qué ventana
-      temporal?". La respuesta esperada debe ser una definición medible, no una intuición.
+  (a) Proponga una definición operacional precisa de la variable objetivo del negocio,
+      expresada como dos estados mutuamente excluyentes (ocurre / no ocurre) de la entidad
+      del caso (cliente, transacción, solicitud u otra, según el dilema). Ejemplo guía, a
+      ADAPTAR al dominio del caso (no asumas retención): "¿Qué condición concreta y medible
+      marca que la entidad presentó el evento objetivo según los datos disponibles? ¿Cómo lo
+      mediría con los datos del Exhibit 2? ¿Bajo qué criterio de observación —y, cuando el
+      caso lo implique, en qué ventana temporal— se declara el evento?". La respuesta esperada
+      debe ser una definición medible de dos estados (ocurre / no ocurre), no una intuición.
   (b) Formule UNA hipótesis falsable conectando una característica del caso con el
       evento objetivo. Ejemplo: "Si la variable X aumenta, la probabilidad del evento Y
       debería subir porque…" — sustentado en Exhibit 1 o 2, no en intuición general.
@@ -54,8 +58,8 @@ de costo EXCLUSIVAMENTE de la matriz de costos del caso provista a continuación
 {cost_matrix_block}
 
   - Costo de acción innecesaria: enmarca cuánto pierde la empresa si interviene con
-    clientes/unidades que NO presentarían el evento (usa la cifra de "acción innecesaria"
-    del bloque de arriba).
+    entidades (clientes, transacciones o solicitudes) que NO presentarían el evento (usa la
+    cifra de "acción innecesaria" del bloque de arriba).
   - Costo de omisión: enmarca cuánto pierde si NO actúa con quienes SÍ presentarían el
     evento (usa la cifra de "omisión" del bloque de arriba).
   Estas cifras son PREMISAS del enunciado y NO provienen de un Exhibit: fija el campo

--- a/backend/tests/test_m1_clasificacion_dispatch.py
+++ b/backend/tests/test_m1_clasificacion_dispatch.py
@@ -25,6 +25,9 @@ from case_generator.prompts import (
     CASE_WRITER_PROMPT_BY_FAMILY,
     CASE_WRITER_PROMPT_CLASSIFICATION,
 )
+from case_generator.prompts.clasificacion.M1_clasificacion.questions import (
+    _M1_CLASSIFICATION_ANCHOR_QUESTIONS,
+)
 
 # ── Sentinel strings that MUST appear in the classification anchor blocks ─────
 # These are unique to the classification prompts; their presence proves the
@@ -231,3 +234,51 @@ class TestClassificationPromptsLongerThanGeneric:
         assert len(CASE_QUESTIONS_PROMPT_CLASSIFICATION) > len(CASE_QUESTIONS_PROMPT), (
             "CASE_QUESTIONS_PROMPT_CLASSIFICATION must be longer than the generic prompt"
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. M1 questions anchor is domain-neutral (de-churn — works for ANY clf case)
+# ─────────────────────────────────────────────────────────────────────────────
+# The P2 guiding example + P3 cost framing used to hardcode churn/retention
+# entity-flavor ("cliente 'en riesgo'", "¿En qué ventana temporal?",
+# "clientes/unidades") — the lone M1 surface the #346/#382/#383 de-churn campaign
+# missed (the architect + writer anchors of the same module were already de-churned).
+# These guards keep the anchor entity/domain-neutral so a fraude / mora / aprobación
+# case is coherent, while preserving the load-bearing P2/P3 scaffolding. Prompt-only
+# fix (no kill-switch), mirroring the #346 precedent; a runtime "ban churn vocab in
+# OUTPUT" guard would false-positive on legitimate churn cases (g13 fixture proves
+# they exist), so the correct deterministic teeth for a prompt-guidance defect is
+# this text-shape drift-lock on the anchor.
+
+class TestQuestionsAnchorDomainNeutral:
+    """The M1 classification questions anchor must be entity/domain-neutral (de-churn)."""
+
+    def test_m1_questions_anchor_is_domain_neutral_not_churn(self) -> None:
+        """No churn/retention entity hardcode in P2(a) or P3; entity-neutral framing present.
+        Mirrors #346's test_eda_text_ml_ds_not_churn_hardcoded for the M2 EDA narrative."""
+        low = _M1_CLASSIFICATION_ANCHOR_QUESTIONS.lower()
+        assert "en riesgo" not in low, "M1 P2 example still uses churn 'en riesgo' framing"
+        assert "clientes/unidades" not in low, "M1 P3 still hardcodes 'clientes/unidades'"
+        # entity-neutral vocabulary (mirrors the writer's clientes/transacciones/solicitudes)
+        assert "transacción" in low, "M1 anchor is not entity-neutral (no 'transacción')"
+        assert "solicitud" in low, "M1 anchor is not entity-neutral (no 'solicitud')"
+        assert "evento objetivo" in low, "M1 anchor lost the neutral 'evento objetivo' framing"
+
+    def test_m1_questions_p2_binary_and_anti_churn_framing(self) -> None:
+        """P2(a) frames the target as a binary event (two mutually-exclusive states), coherent
+        with the binary-only contract (#350), and steers the LLM to adapt to the case domain
+        instead of assuming retention. Binariness is plain-language — no DS jargon leaks."""
+        low = _M1_CLASSIFICATION_ANCHOR_QUESTIONS.lower()
+        assert "ocurre / no ocurre" in low, "P2(a) lost the binary (ocurre / no ocurre) framing"
+        assert "no asumas retención" in low, "P2(a) lost the anti-churn domain steer"
+
+    def test_m1_questions_anchor_preserves_load_bearing_structure(self) -> None:
+        """De-churning must NOT drop the load-bearing P2/P3 scaffolding or the format placeholders."""
+        anchor = _M1_CLASSIFICATION_ANCHOR_QUESTIONS
+        assert "definición operacional" in anchor  # P2(a)
+        assert "Exhibit 2" in anchor  # P2(a) measurement anchor
+        assert "hipótesis falsable" in anchor  # P2(b) preserved
+        assert "PROHIBIDO pedir que el estudiante elija un algoritmo" in anchor
+        assert "Coherencia obligatoria de opciones" in anchor  # P3 option coherence (#412)
+        assert "{cost_matrix_block}" in anchor  # P3 cost grounding placeholder (#361)
+        assert "{pregunta_eje}" in anchor


### PR DESCRIPTION
## Problem

The **M1 discussion-questions** anchor (`_M1_CLASSIFICATION_ANCHOR_QUESTIONS`) was the last M1 surface the de-churn campaign (#346/#382/#383) never reached — it still hardcoded **churn/retention framing**, incoherent for any non-churn classification case (fraud, mora, aprobación):

- **P2(a) guiding example**: `"¿Qué constituye exactamente un cliente 'en riesgo' … ¿En qué ventana temporal?"` — churn entity-state + a forced churn observation-window. For a fraud (instantaneous) or loan-approval (point-in-time) case, a student is asked to define an observation window for an event that has none.
- **P3 cost framing**: `"clientes/unidades que NO presentarían el evento"` — customer-flavored entity hardcode.

By contrast the **architect** and **writer** anchors of the same module were already de-churned (`fraud_flag`/`default_60d`/`approval_flag`; `clientes/transacciones/solicitudes`), and P2's own `(b)` clause was already neutral (`"el evento Y"`) — the leak was internal to the block.

## Fix (surgical, prompt-only, no kill-switch — mirrors #346)

Two in-place edits inside the anchor:

1. **P2(a)** → entity/domain-neutral (`la entidad del caso (cliente, transacción, solicitud u otra…)`), binary framing in plain language (`dos estados mutuamente excluyentes (ocurre / no ocurre)`, coherent with the binary-only contract #350, **no DS jargon** — no literal "binario"), explicit steer `(no asumas retención)`, and the observation window kept **inviting but CONDITIONAL** (`cuando el caso lo implique`) so it still fits churn/late-delivery cases (writer #362 friction) without forcing it on fraud/approval.
2. **P3 cost framing** → `entidades (clientes, transacciones o solicitudes)`.

Every load-bearing piece is preserved: operational definition, measurability, the Exhibit 2 measurement anchor, P2(b) falsifiable hypothesis, the `PROHIBIDO … algoritmo` boundary, option coherence #412, the `{cost_matrix_block}` (#361) and `{pregunta_eje}` placeholders, and M1→M5 verdict phrasing #557. Assembly (`base + anchor`) unchanged → #364 DRY lock holds.

Prompt-only improvement (revert = git). A runtime "ban churn vocab in OUTPUT" guard was deliberately rejected — it would false-positive on legitimate churn cases (the `g13` fixture proves they exist) — so the deterministic teeth for a prompt-guidance defect is a **text-shape drift-lock** on the anchor.

## Scope / safety

- **ml_ds-gated** P2 block → `business+clf` behavior unchanged; `rf_only`/`lr_rf_contrast` benefit identically (entity de-churn is variant-agnostic). M1 stays algorithm-agnostic (not made LR-aware).
- No schema / state / migration / frontend / `case_sanitization` change; **architect prompt + its SHA untouched**; writer anchor untouched.
- Zero blast-radius verified: no test present-asserts the removed strings; `"clientes/unidades"` had a single consumer (this file); no SHA/business/golden lock on the questions prompt.

## Tests

Adds `TestQuestionsAnchorDomainNeutral` (3 drift-locks, mirroring #346's `test_eda_text_ml_ds_not_churn_hardcoded`): domain-neutrality (no `en riesgo`/`clientes/unidades`; entity-neutral terms present), binary + anti-churn framing, and load-bearing-structure preservation.

**Validation:** targeted M1 suite green (156 + 134 incl. the new locks, writer-friction #362, M6 guide), `mypy src` clean, full backend suite **3730 passed / 26 skipped**. The single `test_spa_fallback::test_unknown_api_path_stays_json_404` failure is **pre-existing and unrelated** (confirmed still failing with these changes stashed — a local SPA-fallback/frontend-build environment condition; CI runs it in a clean env).

Reviewed via an adversarial plan review + a 3-angle max-effort code review (prompt correctness, test-lock efficacy, conventions/cross-file) — **zero correctness defects**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)