### PR TITLE
chore(deploy): actualizar NODE_MODEL_OVERRIDES de prod (routing de modelos LLM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
             --max-instances=4 \
             --no-cpu-throttling \
             --memory=2Gi --cpu=2 --timeout=3600 \
-            --set-env-vars='^@^ENVIRONMENT=production@SUPABASE_URL=https://pdnbjsrxgvxstjcqpxde.supabase.co@CORS_ALLOWED_ORIGIN=https://adamcampus.com@OPENROUTER_REASONING_EFFORT=high@OPENROUTER_REASONING_MAX_TOKENS=16000@NODE_MODEL_OVERRIDES={"schema_designer":"z-ai/glm-5.2","m3_content_generator":"z-ai/glm-5.2","m3_questions_generator":"z-ai/glm-5.2","m5_content_generator":"z-ai/glm-5.2","m5_questions_generator":"z-ai/glm-5.2","m4_content_generator":"google/gemini-3.1-pro-preview"}' \
+            --set-env-vars='^@^ENVIRONMENT=production@SUPABASE_URL=https://pdnbjsrxgvxstjcqpxde.supabase.co@CORS_ALLOWED_ORIGIN=https://adamcampus.com@OPENROUTER_REASONING_EFFORT=high@OPENROUTER_REASONING_MAX_TOKENS=16000@NODE_MODEL_OVERRIDES={"schema_designer":"gemini-3.5-flash","m3_content_generator":"google/gemini-3.5-flash","m3_questions_generator":"google/gemini-3-flash-preview","m5_content_generator":"z-ai/glm-5.2","m5_questions_generator":"google/gemini-3-flash-preview","m4_content_generator":"gemini-3.1-pro-preview"}' \
             --set-secrets="DATABASE_URL=adam-database-url:latest,GEMINI_API_KEY=adam-gemini-api-key:latest,SUPABASE_SERVICE_ROLE_KEY=adam-supabase-service-role-key:latest,OPENROUTER_API_KEY=adam-openrouter-api-key:latest"
 
       # Advance the floating :latest tag ONLY after a successful deploy, so :latest


### PR DESCRIPTION
## Qué

Actualiza el routing de modelos LLM en el deploy a Cloud Run (`public-api`) cambiando únicamente el JSON de `NODE_MODEL_OVERRIDES` en el step *"Deploy to Cloud Run"* de `.github/workflows/ci.yml`.

| nodo | antes | ahora |
|---|---|---|
| schema_designer | `z-ai/glm-5.2` | `gemini-3.5-flash` (Gemini directo) |
| m3_content_generator | `z-ai/glm-5.2` | `google/gemini-3.5-flash` (OpenRouter) |
| m3_questions_generator | `z-ai/glm-5.2` | `google/gemini-3-flash-preview` (OpenRouter) |
| m5_content_generator | `z-ai/glm-5.2` | `z-ai/glm-5.2` (sin cambio) |
| m5_questions_generator | `z-ai/glm-5.2` | `google/gemini-3-flash-preview` (OpenRouter) |
| m4_content_generator | `google/gemini-3.1-pro-preview` | `gemini-3.1-pro-preview` (Gemini directo) |

## Por qué

Ajuste de routing de modelos ya verificado en local. `.env` local no llega a prod; el valor efectivo vive en `ci.yml` (patrón de #550).

## Alcance

- Solo cambia el JSON de `NODE_MODEL_OVERRIDES` (delimitador `^@^`, resto de env-vars y `--set-secrets` intactos).
- `OPENROUTER_API_KEY` + `GEMINI_API_KEY` siguen requeridos (4 nodos usan OpenRouter, m4/schema_designer usan Gemini directo).
- Sin cambios de código de producto. Se refleja en prod al promover `main` → `deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)