### PR TITLE
fix(authoring): disable psycopg3 prepared statements on ORM engine + harden finalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
             --min-instances=0 \
             --max-instances=4 \
             --no-cpu-throttling \
-            --memory=2Gi --cpu=2 --timeout=3600 \
+            --memory=8Gi --cpu=4 --timeout=3600 \
             --set-env-vars='^@^ENVIRONMENT=production@SUPABASE_URL=https://pdnbjsrxgvxstjcqpxde.supabase.co@CORS_ALLOWED_ORIGIN=https://adamcampus.com@OPENROUTER_REASONING_EFFORT=high@OPENROUTER_REASONING_MAX_TOKENS=16000@NODE_MODEL_OVERRIDES={"schema_designer":"gemini-3.5-flash","m3_content_generator":"google/gemini-3.5-flash","m3_questions_generator":"google/gemini-3-flash-preview","m5_content_generator":"z-ai/glm-5.2","m5_questions_generator":"google/gemini-3-flash-preview","m4_content_generator":"gemini-3.1-pro-preview"}' \
             --set-secrets="DATABASE_URL=adam-database-url:latest,GEMINI_API_KEY=adam-gemini-api-key:latest,SUPABASE_SERVICE_ROLE_KEY=adam-supabase-service-role-key:latest,OPENROUTER_API_KEY=adam-openrouter-api-key:latest"
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -67,6 +67,11 @@ def run_migrations_online() -> None:
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        # Disable psycopg3 server-side prepared statements under Supavisor
+        # transaction mode (:6543) — same reason as the app ORM engine
+        # (_build_connect_args) and the LangGraph checkpointer pool in
+        # shared/database.py. Harmless on a direct connection.
+        connect_args={"prepare_threshold": None},
     )
 
     with connectable.connect() as connection:

--- a/backend/src/case_generator/core/authoring.py
+++ b/backend/src/case_generator/core/authoring.py
@@ -638,6 +638,89 @@ def _next_progress_payload(
     return payload
 
 
+async def _force_job_failed(
+    job_id: str,
+    *,
+    error_code: str,
+    error_trace: str | None = None,
+    max_attempts: int = 3,
+) -> bool:
+    """Last-resort guarantee that a job leaves ``processing`` after a finalization error.
+
+    Status-only UPDATE on a fresh short-lived session, DECOUPLED from artifact
+    orphaning so a heavy/failing cleanup write can never keep the job stuck at
+    100%. Bounded retry with short async backoff (hard cap < ~1s), idempotent
+    (only flips a row still in ``processing``), and NEVER raises.
+
+    Returns True if the job is out of ``processing`` (we flipped it, or a
+    concurrent writer already did), False if every attempt failed.
+
+    LIMITATION: uses the same ORM engine, so it recovers transient/isolated
+    failures, not a systemic outage or a killed process (deploy drain / OOM) —
+    those need the stuck-job reaper (documented follow-up).
+    """
+    payload = _next_progress_payload(
+        None,
+        status=AUTHORING_JOB_STATUS_FAILED,
+        current_step="failed",
+        error_code=error_code,
+        error_trace=error_trace or error_code,
+    )
+    for attempt in range(1, max_attempts + 1):
+        db = SessionLocal()
+        try:
+            result = db.execute(
+                update(AuthoringJob)
+                .where(
+                    AuthoringJob.id == job_id,
+                    AuthoringJob.status == AUTHORING_JOB_STATUS_PROCESSING,
+                )
+                .values(
+                    status=AUTHORING_JOB_STATUS_FAILED,
+                    task_payload=payload,
+                )
+            )
+            db.commit()
+            # Session.execute() of a Core UPDATE returns a CursorResult at runtime;
+            # cast so mypy accepts .rowcount (typed as bare Result).
+            rowcount = cast(Any, result).rowcount
+            if rowcount and rowcount > 0:
+                logger.error(
+                    "AuthoringService: Emergency FAILED write succeeded for Job %s (attempt %d/%d).",
+                    job_id,
+                    attempt,
+                    max_attempts,
+                )
+            else:
+                logger.info(
+                    "AuthoringService: Job %s already out of `processing`; emergency write skipped.",
+                    job_id,
+                )
+            return True
+        except Exception as exc:
+            logger.warning(
+                "AuthoringService: Emergency FAILED write attempt %d/%d failed for Job %s: %s",
+                attempt,
+                max_attempts,
+                job_id,
+                exc,
+            )
+            try:
+                db.rollback()
+            except Exception:
+                pass
+        finally:
+            db.close()
+        if attempt < max_attempts:
+            await asyncio.sleep(0.1 * attempt)
+    logger.critical(
+        "AuthoringService: Emergency FAILED write EXHAUSTED for Job %s; "
+        "it may remain in `processing` until the stuck-job reaper runs.",
+        job_id,
+    )
+    return False
+
+
 def _derive_output_depth(payload: Mapping[str, Any]) -> str | None:
     """Determine the graph output depth from the current intake payload."""
     case_type = payload.get("caseType", "harvard_only")
@@ -1398,36 +1481,43 @@ class AuthoringService:
             db.commit()
             logger.info("AuthoringService: Successfully promoted to V5 and completed Job %s", job_id)
         except Exception:
+            error_trace = traceback.format_exc()
             logger.error(
                 "AuthoringService: Failure updating final state for Job %s: %s",
                 job_id,
-                traceback.format_exc(),
+                error_trace,
             )
-            db.rollback()
-            db = SessionLocal()
             try:
-                job = db.query(AuthoringJob).filter(AuthoringJob.id == job_id).first()
-                if job is not None and job.status != AUTHORING_JOB_STATUS_FAILED:
-                    job.status = AUTHORING_JOB_STATUS_FAILED
-                    current_payload = _next_progress_payload(
-                        job.task_payload,
-                        status=AUTHORING_JOB_STATUS_FAILED,
-                        current_step="failed",
-                        error_code="finalization_error",
-                        error_trace=traceback.format_exc(),
-                    )
-                    job.task_payload = current_payload
-                    ArtifactManager.orphan_job_artifacts(db, job_id)
-                    db.commit()
-                    logger.error(
-                        "AuthoringService: Job %s marked as FAILED after final-state exception.",
-                        job_id,
-                    )
-            except Exception as inner_exc:
-                logger.error("AuthoringService: Could not persist failure state for Job %s: %s", job_id, inner_exc)
                 db.rollback()
-            finally:
-                db.close()
+            except Exception:
+                pass
+            db.close()
+            # Guarantee the job leaves `processing` even if the finalization commit
+            # failed. Status-only write on a fresh session with bounded retry —
+            # DECOUPLED from artifact orphaning (cleanup) so a slow/failing orphan
+            # write can never keep the job stuck at 100%. Never raises.
+            marked = await _force_job_failed(
+                job_id,
+                error_code="finalization_error",
+                error_trace=error_trace,
+            )
+            if marked:
+                # Best-effort artifact cleanup AFTER the status is safely persisted.
+                cleanup_db = SessionLocal()
+                try:
+                    ArtifactManager.orphan_job_artifacts(cleanup_db, job_id)
+                except Exception as cleanup_exc:
+                    logger.warning(
+                        "AuthoringService: Best-effort artifact orphaning failed for Job %s: %s",
+                        job_id,
+                        cleanup_exc,
+                    )
+                    try:
+                        cleanup_db.rollback()
+                    except Exception:
+                        pass
+                finally:
+                    cleanup_db.close()
             return
         finally:
             db.close()

--- a/backend/src/shared/database.py
+++ b/backend/src/shared/database.py
@@ -624,9 +624,21 @@ def _build_postgres_timeout_options(s: Settings) -> str:
     )
 
 
-def _build_connect_args(s: Settings) -> dict[str, str]:
-    """Set session-level statement and lock timeout for every DB connection."""
-    return {"options": _build_postgres_timeout_options(s)}
+def _build_connect_args(s: Settings) -> dict[str, object]:
+    """Session-level statement/lock timeout + disable psycopg3 server-side
+    prepared statements for every ORM DB connection.
+
+    prepare_threshold=None is REQUIRED under Supavisor transaction mode (:6543):
+    without it psycopg3 assigns fixed prepared-statement names (`_pg3_N`) that
+    collide across pooled backends under concurrency -> DuplicatePreparedStatement
+    on commit -> a job's completion write fails and it hangs in `processing`.
+    Mirrors the checkpointer pool config in `_langgraph_pool_kwargs` (which the
+    comment there noted the main SQLAlchemy engine did NOT yet share).
+    """
+    return {
+        "options": _build_postgres_timeout_options(s),
+        "prepare_threshold": None,
+    }
 
 
 def _make_engine(s: Settings) -> Engine:

--- a/backend/tests/test_authoring_progress_resilience.py
+++ b/backend/tests/test_authoring_progress_resilience.py
@@ -17,6 +17,7 @@ from case_generator.core.authoring import (
     BOOTSTRAP_STATE_INITIALIZING,
     CANONICAL_TIMELINE_STEP_IDS,
     AuthoringService,
+    _force_job_failed,
     _persist_intermediate_progress_step,
     _to_canonical_progress_step,
 )
@@ -1164,6 +1165,79 @@ def test_run_job_duplicate_retry_race_allows_only_one_checkpoint_attempt(
     assert payload.get("error_code") == "checkpoint_unavailable"
     assert payload.get("last_known_step") == "case_writer"
     orphan_mock.assert_not_called()
+
+
+def test_force_job_failed_marks_processing_job_failed(db, seed_identity) -> None:
+    """The finalization safety net flips a stuck `processing` job to `failed`.
+
+    Guarantees a finalization error can never leave a job hung at 100% in
+    `processing` (the production bug: DuplicatePreparedStatement on the completion
+    commit AND on the recovery commit -> job stuck forever).
+    """
+    teacher_id = str(uuid.uuid4())
+    seed_identity(user_id=teacher_id, email="teacher-force-failed@example.edu", role="teacher")
+
+    job = _seed_processing_job(db, teacher_id)
+
+    marked = asyncio.run(_force_job_failed(job.id, error_code="finalization_error"))
+    assert marked is True
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+    assert refreshed.status == "failed"
+    payload = dict(refreshed.task_payload or {})
+    assert payload.get("progress_status") == "failed"
+    assert payload.get("current_step") == "failed"
+    assert payload.get("error_code") == "finalization_error"
+
+
+def test_force_job_failed_is_idempotent_when_not_processing(db, seed_identity) -> None:
+    """Never clobbers a job that already left `processing` (idempotent no-op)."""
+    teacher_id = str(uuid.uuid4())
+    seed_identity(user_id=teacher_id, email="teacher-force-idempotent@example.edu", role="teacher")
+
+    job = _seed_authoring_job(db, teacher_id, status="completed")
+
+    marked = asyncio.run(_force_job_failed(job.id, error_code="finalization_error"))
+    assert marked is True  # no-op success: 0 rows matched, nothing to fix
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+    assert refreshed.status == "completed"
+
+
+def test_force_job_failed_recovers_after_transient_commit_failure(
+    db,
+    seed_identity,
+    monkeypatch,
+) -> None:
+    """A transient commit failure is retried; the job still ends up `failed`."""
+    teacher_id = str(uuid.uuid4())
+    seed_identity(user_id=teacher_id, email="teacher-force-retry@example.edu", role="teacher")
+
+    job = _seed_processing_job(db, teacher_id)
+
+    original_commit = OrmSession.commit
+    state = {"commit_calls": 0}
+
+    def flaky_commit(self, *args, **kwargs):
+        state["commit_calls"] += 1
+        if state["commit_calls"] == 1:
+            raise RuntimeError("transient commit failure")
+        return original_commit(self, *args, **kwargs)
+
+    monkeypatch.setattr(OrmSession, "commit", flaky_commit)
+
+    marked = asyncio.run(_force_job_failed(job.id, error_code="finalization_error"))
+    assert marked is True
+    assert state["commit_calls"] >= 2  # first attempt failed, retried
+
+    db.expire_all()
+    refreshed = db.get(AuthoringJob, job.id)
+    assert refreshed is not None
+    assert refreshed.status == "failed"
 
 
 async def test_run_job_same_thread_retry_preserves_checkpoint_lineage_and_rebuilds_runtime(

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -13,7 +13,12 @@ from typing import Any
 import pytest
 
 import shared.database as database
-from shared.database import Settings, _langgraph_pool_kwargs, _make_engine
+from shared.database import (
+    Settings,
+    _build_connect_args,
+    _langgraph_pool_kwargs,
+    _make_engine,
+)
 
 
 def test_null_pool_when_environment_is_production() -> None:
@@ -78,9 +83,10 @@ def test_connection_level_timeouts_are_configured_via_connect_args(monkeypatch: 
         )
     )
 
-    assert captured_kwargs["connect_args"] == {
-        "options": "-c statement_timeout=4321 -c lock_timeout=876"
-    }
+    connect_args = captured_kwargs["connect_args"]
+    assert connect_args["options"] == "-c statement_timeout=4321 -c lock_timeout=876"
+    # prepare_threshold MUST ride along (Supavisor transaction-mode safety).
+    assert connect_args["prepare_threshold"] is None
 
 
 def test_langgraph_pool_disables_prepared_statements() -> None:
@@ -99,3 +105,43 @@ def test_langgraph_pool_disables_prepared_statements() -> None:
     # autocommit makes every statement its own transaction, which is exactly why
     # prepared statements cannot be reused across the transaction-mode pooler.
     assert kwargs["autocommit"] is True
+
+
+def test_build_connect_args_disables_prepared_statements() -> None:
+    """The main ORM engine MUST also disable psycopg3 server-side prepared
+    statements — the gap the checkpointer comment flagged as "unaffected".
+
+    Over Supavisor transaction mode (:6543) psycopg3's fixed `_pg3_N` names
+    collide across pooled backends under concurrency -> DuplicatePreparedStatement
+    on commit -> a job's completion write fails and it hangs in `processing`.
+    prepare_threshold MUST be None (not 0). Guards the fix in _build_connect_args.
+    """
+    args = _build_connect_args(
+        Settings(
+            database_url="postgresql+psycopg://u:p@localhost:5434/db",
+            environment="development",
+        )
+    )
+    assert "prepare_threshold" in args
+    assert args["prepare_threshold"] is None
+    # The pre-existing timeout options must still be present.
+    assert "options" in args
+
+
+def test_orm_engine_live_connection_disables_prepared_statements() -> None:
+    """End-to-end proof (not just the dict): the ORM engine's LIVE psycopg3
+    connection reports prepare_threshold=None, confirming SQLAlchemy forwards
+    connect_args to psycopg.connect(). Requires a reachable Postgres (test DB).
+    """
+    eng = _make_engine(
+        Settings(
+            database_url=database.settings.database_url,
+            environment="development",
+        )
+    )
+    try:
+        with eng.connect() as conn:
+            driver_connection = conn.connection.driver_connection
+            assert driver_connection.prepare_threshold is None
+    finally:
+        eng.dispose()


### PR DESCRIPTION
## Problem
Generaciones concurrentes se quedaban colgadas en 100% (`processing`) y nunca mostraban el caso final. Causa raíz (confirmada en logs de Cloud Run + código): el engine ORM corre psycopg3 sobre el pooler de Supavisor en **modo transacción (:6543)** SIN desactivar los prepared statements del servidor. Bajo concurrencia los nombres fijos `_pg3_N` colisionan entre backends del pooler → `DuplicatePreparedStatement` en el commit de completado **y** en el commit de recuperación → el job queda en `processing` para siempre.

## Cambios
- **Root cause** — `shared/database.py` `_build_connect_args`: `prepare_threshold=None` (espeja `_langgraph_pool_kwargs`; cubre prod NullPool + dev). Verificado en el fuente instalado de psycopg 3.3.3 que `None` desactiva la preparación **incluso en `executemany`** (el path exacto que falló).
- **Robustez** — `core/authoring.py`: el handler de error de finalización DESACOPLA el write `status=FAILED` del orphan de artifacts y lo garantiza con `_force_job_failed` (status-only, reintento acotado, idempotente, nunca lanza) → ningún error de finalización deja un job colgado en `processing`.
- **Consistencia** — `alembic/env.py`: mismo `prepare_threshold=None` bajo el pooler.
- **Capacidad** — `ci.yml`: Cloud Run 2vCPU/2GiB → 4vCPU/8GiB (cabecera para generaciones concurrentes; ya validado live).
- **Tests** — unit de `prepare_threshold` + integración de conexión VIVA; 3 tests del hardening de finalización; arreglado el assert de igualdad exacta de `connect_args`.

## Validación
- `pytest tests/test_database.py` (11) + `test_authoring_progress_resilience.py` completo (33, incl. `alembic upgrade` + finalización de `run_job` + hardening) + `test_authoring_live_preview.py` (12) — todos verdes.
- `mypy src` limpio (122 archivos).
- **Gate LIVE antes del piloto** (merge ≠ deploy): lanzar 2–6 generaciones concurrentes, confirmar que llegan a `completed` y la UI transiciona; sin `DuplicatePreparedStatement` en logs; revisión sirve 4vCPU/8GiB.

## Follow-ups (antes de escalar a cientos; NO en este PR)
Reaper de jobs colgados, hook de pre-shutdown (deploy-drain), watchdog de frontend, gates de escala (tier Supabase / max-instances / cuota LLM). Ver plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)